### PR TITLE
Add WellFormed lemmas for insertIntoCurrent

### DIFF
--- a/Mlir/Core/WellFormed.lean
+++ b/Mlir/Core/WellFormed.lean
@@ -181,7 +181,7 @@ theorem IRContext.ValuePtr_UseDefChainWellFormed_unchanged
     valuePtr.WellFormedUseDefChain ctx' array  (by grind) := by
   constructor <;> grind [ValuePtr.WellFormedUseDefChain]
 
-theorem IRContext.BlockPtr_UseDefChainWellFormed_unchanged
+theorem BlockPtr.WellFormedUseDefChain_unchanged
     (hWf : blockPtr.WellFormedUseDefChain ctx array valuePtrInBounds)
     (valuePtrInBounds' : blockPtr.InBounds ctx')
     (hSameFirstUse : (blockPtr.get! ctx).firstUse = (blockPtr.get! ctx').firstUse)
@@ -196,7 +196,7 @@ theorem IRContext.BlockPtr_UseDefChainWellFormed_unchanged
     blockPtr.WellFormedUseDefChain ctx' array := by
   constructor <;> grind [BlockPtr.WellFormedUseDefChain]
 
-theorem IRContext.OperationChainWellFormed_unchanged
+theorem BlockPtr.OperationChainWellFormed_unchanged
     (hWf : blockPtr.OperationChainWellFormed ctx array blockPtrInBounds)
     (blockPtrInBounds' : blockPtr.InBounds ctx')
     (hSameFirstOp : (blockPtr.get! ctx).firstOp = (blockPtr.get! ctx').firstOp)
@@ -229,7 +229,7 @@ theorem BlockPtr.OperationChainWellFormed_array_toList_Nodup
   simp only [List.pairwise_iff_getElem]
   grind [BlockPtr.OperationChainWellFormed_array_injective]
 
-theorem IRContext.BlockChainWellFormed_unchanged
+theorem RegionPtr.BlockChainWellFormed_unchanged
     (hWf : regionPtr.BlockChainWellFormed ctx array regionPtrInBounds)
     (regionPtrInBounds' : regionPtr.InBounds ctx')
     (hSameFirst : (regionPtr.get! ctx).firstBlock = (regionPtr.get! ctx').firstBlock)
@@ -249,7 +249,7 @@ theorem IRContext.BlockChainWellFormed_unchanged
     regionPtr.BlockChainWellFormed ctx' array regionPtrInBounds' := by
   constructor <;> grind [RegionPtr.BlockChainWellFormed]
 
-theorem IRContext.Operation_WellFormed_unchanged
+theorem Operation.WellFormed_unchanged
     (hWf : (opPtr.get ctx opPtrInBounds).WellFormed ctx opPtr opPtrInBounds)
     (hInBounds' : Operation.FieldsInBounds opPtr ctx' opPtrInBounds')
     (hSameNumOperands :
@@ -282,7 +282,7 @@ theorem IRContext.Operation_WellFormed_unchanged
     (opPtr.get! ctx').WellFormed ctx' opPtr opPtrInBounds' := by
   constructor <;> grind [Operation.WellFormed]
 
-theorem IRContext.Block_WellFormed_unchanged
+theorem Block.WellFormed_unchanged
     (hWf : (blockPtr.get! ctx).WellFormed ctx blockPtr blockPtrInBounds)
     (hInBounds' : Block.FieldsInBounds blockPtr ctx' blockPtrInBounds')
     (hSameNumArguments : blockPtr.getNumArguments! ctx = blockPtr.getNumArguments! ctx')
@@ -295,7 +295,7 @@ theorem IRContext.Block_WellFormed_unchanged
     (blockPtr.get! ctx').WellFormed ctx' blockPtr blockPtrInBounds' := by
   constructor <;> grind [Block.WellFormed]
 
-theorem IRContext.Region_WellFormed_unchanged
+theorem Region.WellFormed_unchanged
     (hWf : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr)
     (hInBounds' : (regionPtr.get! ctx').FieldsInBounds ctx')
     (hSameParentOp : (regionPtr.get! ctx).parent = (regionPtr.get! ctx').parent)

--- a/Mlir/Rewriter/LinkedList/WellFormed.lean
+++ b/Mlir/Rewriter/LinkedList/WellFormed.lean
@@ -63,6 +63,14 @@ theorem ValuePtr.WellFormedUseDefChainMissingLink_unchanged
     valuePtr.WellFormedUseDefChainMissingLink ctx' array (by grind) missingUses := by
   constructor <;> grind [ValuePtr.WellFormedUseDefChainMissingLink]
 
+theorem ValuePtr.WellFormedUseDefChainMissingLink.ValuePtr_getFirstUse_ne_of_value_ne
+    {use use' : OpOperandPtr}
+    (valueNe : (use.get! ctx).value ≠ (use'.get! ctx).value)
+    {valueInBounds}
+    (hWF : (use.get! ctx).value.WellFormedUseDefChainMissingLink ctx array valueInBounds missingUses) :
+    (use.get! ctx).value.getFirstUse! ctx ≠ some use' := by
+  grind [ValuePtr.WellFormedUseDefChainMissingLink]
+
 /- OpOperandPtr.setValue -/
 
 theorem ValuePtr.WellFormedUseDefChainMissingLink_OpOperandPtr_setValue_of_WellFormedUseDefChainMissingLink
@@ -82,14 +90,6 @@ theorem ValuePtr.WellFormedUseDefChainMissingLink_OpOperandPtr_setValue_of_WellF
   constructor <;> grind [ValuePtr.WellFormedUseDefChain, ValuePtr.WellFormedUseDefChainMissingLink]
 
 /- OpOperandPtr.insertIntoCurrent -/
-
-theorem ValuePtr.WellFormedUseDefChainMissingLink.ValuePtr_getFirstUse_ne_of_value_ne
-    {use use' : OpOperandPtr}
-    (valueNe : (use.get! ctx).value ≠ (use'.get! ctx).value)
-    {valueInBounds}
-    (hWF : (use.get! ctx).value.WellFormedUseDefChainMissingLink ctx array valueInBounds missingUses) :
-    (use.get! ctx).value.getFirstUse! ctx ≠ some use' := by
-  grind [ValuePtr.WellFormedUseDefChainMissingLink]
 
 theorem OpOperandPtr.get!_insertIntoCurrent_of_value_ne
     (ctxInBounds : ctx.FieldsInBounds) {use use' : OpOperandPtr}
@@ -139,6 +139,41 @@ theorem ValuePtr.WellFormedUseDefChain_insertIntoCurrent_other
     value.WellFormedUseDefChain (use.insertIntoCurrent ctx (by grind) ctxInBounds) array (by grind) := by
   apply IRContext.ValuePtr_UseDefChainWellFormed_unchanged (ctx := ctx) <;> try grind [ValuePtr.WellFormedUseDefChainMissingLink, ValuePtr.WellFormedUseDefChain]
 
+theorem BlockPtr.WellFormedUseDefChain_OpOperandPtr_insertIntoCurrent
+    {block : BlockPtr} {blockInBounds} {use : OpOperandPtr} {useInBounds}
+    (hWF : block.WellFormedUseDefChain ctx array blockInBounds) :
+    block.WellFormedUseDefChain (use.insertIntoCurrent ctx useInBounds ctxInBounds) array (by grind) := by
+  apply BlockPtr.WellFormedUseDefChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.OperationChainWellFormed_OpOperandPtr_insertIntoCurrent
+    {block : BlockPtr} {blockInBounds} {use : OpOperandPtr} {useInBounds}
+    (hWF : block.OperationChainWellFormed ctx array blockInBounds) :
+    block.OperationChainWellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) array (by grind) := by
+  apply BlockPtr.OperationChainWellFormed_unchanged (ctx := ctx) <;> grind
+
+theorem RegionPtr.BlockChainWellFormed_OpOperandPtr_insertIntoCurrent
+    {region : RegionPtr} {regionInBounds} {use : OpOperandPtr} {useInBounds}
+    (hWF : region.BlockChainWellFormed ctx array regionInBounds) :
+    region.BlockChainWellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) array (by grind) := by
+  apply RegionPtr.BlockChainWellFormed_unchanged (ctx := ctx) <;> grind
+
+theorem Operation.WellFormed_OpOperandPtr_insertIntoCurrent
+    {opPtr : OperationPtr} {opInBounds} {use : OpOperandPtr} {useInBounds}
+    (hWF : (opPtr.get! ctx).WellFormed ctx opPtr opInBounds) :
+    (opPtr.get! (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) opPtr (by grind) := by
+  apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+
+theorem Block.WellFormed_OpOperandPtr_insertIntoCurrent
+    {blockPtr : BlockPtr} {blockInBounds} {use : OpOperandPtr} {useInBounds}
+    (hWF : (blockPtr.get! ctx).WellFormed ctx blockPtr blockInBounds) :
+    (blockPtr.get! (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) blockPtr (by grind) := by
+  apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+
+theorem Region.WellFormed_OpOperandPtr_insertIntoCurrent
+    {regionPtr : RegionPtr} (regionInBounds : regionPtr.InBounds ctx) {use : OpOperandPtr} {useInBounds}
+    (hWF : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr) :
+    (RegionPtr.get! regionPtr (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) regionPtr := by
+  apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
 
 -- OLD LEMMAS
 

--- a/Mlir/Rewriter/WellFormed/Rewriter/Operation.lean
+++ b/Mlir/Rewriter/WellFormed/Rewriter/Operation.lean
@@ -593,7 +593,7 @@ theorem BlockPtr.OperationChainWellFormed_Rewriter_insertOp?_other
     (ipParent : InsertPoint.block ip ctx ipInBounds ≠ some blockPtr) :
       blockPtr.OperationChainWellFormed ctx' array (by grind) := by
   have ipWf : ip.Wf ctx newOp := by rcases ip <;> grind
-  apply IRContext.OperationChainWellFormed_unchanged (ctx := ctx) <;> grind
+  apply BlockPtr.OperationChainWellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem BlockPtr.OperationChainWellFormed_Rewriter_insertOp?_self
     (hWf : BlockPtr.operationList blockPtr ctx ctxWellFormed blockInBounds = array)
@@ -786,7 +786,7 @@ theorem Rewriter.insertOp?_WellFormed (ctx : IRContext) (hctx : ctx.WellFormed)
     intros block hblock
     have ⟨array, harray⟩ := h₃ block (by grind)
     exists array
-    apply IRContext.BlockPtr_UseDefChainWellFormed_unchanged (ctx := ctx) <;>
+    apply BlockPtr.WellFormedUseDefChain_unchanged (ctx := ctx) <;>
       grind
   case opChain =>
     intros block hblock
@@ -800,7 +800,7 @@ theorem Rewriter.insertOp?_WellFormed (ctx : IRContext) (hctx : ctx.WellFormed)
     intros region hregion
     have ⟨array, harray⟩ := h₅ region (by grind)
     exists array
-    apply IRContext.BlockChainWellFormed_unchanged harray <;> grind
+    apply RegionPtr.BlockChainWellFormed_unchanged harray <;> grind
   case operations =>
     intros op hop
     have : op.InBounds ctx := by grind

--- a/Mlir/Rewriter/WellFormed/Rewriter/Value.lean
+++ b/Mlir/Rewriter/WellFormed/Rewriter/Value.lean
@@ -122,26 +122,26 @@ theorem Rewriter.replaceUse_WellFormed (ctx: IRContext) (use : OpOperandPtr) (ne
       intros blockPtr blockPtrInBounds
       have ⟨array, harray⟩ := hWf.blockUseDefChains blockPtr (by grind)
       exists array
-      apply IRContext.BlockPtr_UseDefChainWellFormed_unchanged (ctx := ctx) <;> grind [replaceUse]
+      apply BlockPtr.WellFormedUseDefChain_unchanged (ctx := ctx) <;> grind [replaceUse]
     case opChain =>
       intros blockPtr blockPtrInBounds
       have ⟨chain, hchain⟩ := hWf.opChain blockPtr (by grind)
       exists chain
-      apply IRContext.OperationChainWellFormed_unchanged (ctx := ctx) <;> grind
+      apply BlockPtr.OperationChainWellFormed_unchanged (ctx := ctx) <;> grind
     case blockChain =>
       intros regionPtr regionPtrInBounds
       have ⟨chain, hchain⟩ := hWf.blockChain regionPtr (by grind)
       exists chain
-      apply IRContext.BlockChainWellFormed_unchanged (ctx := ctx) <;> grind
+      apply RegionPtr.BlockChainWellFormed_unchanged (ctx := ctx) <;> grind
     case operations =>
       intros opPtr opPtrInBounds
-      apply IRContext.Operation_WellFormed_unchanged (ctx := ctx) <;> sorry -- missing GetSet lemmas
+      apply Operation.WellFormed_unchanged (ctx := ctx) <;> sorry -- missing GetSet lemmas
     case blocks =>
       intros blockPtr blockPtrInBounds
-      apply IRContext.Block_WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
+      apply Block.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
     case regions =>
       intros regionPtr regionPtrInBounds
-      apply IRContext.Region_WellFormed_unchanged (ctx := ctx) <;> sorry -- missing GetSet lemmas
+      apply Region.WellFormed_unchanged (ctx := ctx) <;> sorry -- missing GetSet lemmas
 
 theorem Rewriter.replaceValue?_WellFormed (ctx: IRContext) (oldValue: ValuePtr) (newValue: ValuePtr)
     (oldIn: oldValue.InBounds ctx)


### PR DESCRIPTION
This adds the simpler lemmas about WellFormedness for `insertIntoCurrent`
It also renames some old lemmas