### PR TITLE
Refactor a bit `insertOp?`

### DIFF
--- a/Veir/Rewriter/GetSetInBounds.lean
+++ b/Veir/Rewriter/GetSetInBounds.lean
@@ -136,7 +136,7 @@ theorem BlockPtr.lastOp!_insertOp? {block : BlockPtr} :
     else
       (block.get! ctx).lastOp := by
   simp only [Rewriter.insertOp?]
-  grind [InsertPoint.block!, InsertPoint.next]
+  grind (splits := 20)
 
 grind_pattern BlockPtr.lastOp!_insertOp? =>
   Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp


### PR DESCRIPTION
Instead of matching on the insertion point, we directly using `insertPoint.prev` and insertPoint.next`