### PR TITLE
Add well-formedness lemma for Rewriter.insertOp?

### DIFF
--- a/Veir/Rewriter/WellFormed/Rewriter/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Rewriter/Operation.lean
@@ -8,7 +8,6 @@ namespace Veir
 
 section InsertOp
 
-unseal Rewriter.insertOp? in
 theorem Rewriter.insertOp?_WellFormed (ctx : IRContext) (hctx : ctx.WellFormed)
     (newOp : OperationPtr) (ip : InsertPoint)
     (newOpIn : newOp.InBounds ctx := by grind)


### PR DESCRIPTION
This finishes the proof using the lemmas we defined for `insertIntoCurrent`