### PR TITLE
Improve grind patterns for InBounds lemmas

### DIFF
--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -13,31 +13,22 @@ namespace Veir
   These are the predicates that ensures that all pointers in a program are in bounds.
 -/
 
-@[local grind]
 structure OpResult.FieldsInBounds (res: OpResult) (ctx: IRContext) : Prop where
   firstUse_inBounds : res.firstUse.maybe OpOperandPtr.InBounds ctx
   owner_inBounds: res.owner.InBounds ctx
 
-@[local grind]
-structure BlockArgument.FieldsInBounds (arg: BlockArgument) (ctx: IRContext) : Prop where
-  firstUse_inBounds : arg.firstUse.maybe OpOperandPtr.InBounds ctx
-  owner_inBounds: arg.owner.InBounds ctx
-
-@[local grind]
 structure OpOperand.FieldsInBounds (operand: OpOperand) (ctx: IRContext) : Prop where
   nextUse_inBounds : operand.nextUse.maybe OpOperandPtr.InBounds ctx
   back_inBounds: operand.back.InBounds ctx
   owner_inBounds: operand.owner.InBounds ctx
   value_inBounds: operand.value.InBounds ctx
 
-@[local grind]
 structure BlockOperand.FieldsInBounds (operand: BlockOperand) (ctx: IRContext) : Prop where
   nextUse_inBounds : operand.nextUse.maybe BlockOperandPtr.InBounds ctx
   back_inBounds: operand.back.InBounds ctx
   owner_inBounds: operand.owner.InBounds ctx
   value_inBounds: operand.value.InBounds ctx
 
-@[local grind]
 structure Operation.FieldsInBounds (operation: OperationPtr) (ctx: IRContext) (hin : operation.InBounds ctx) : Prop where
   results_inBounds (res : OpResultPtr) (hres: res.InBounds ctx) : res.op = operation → (res.get ctx).FieldsInBounds ctx
   prev_inBounds : (operation.get ctx hin).prev.maybe OperationPtr.InBounds ctx
@@ -49,6 +40,10 @@ structure Operation.FieldsInBounds (operation: OperationPtr) (ctx: IRContext) (h
     (operation.getRegion ctx i hin hi).InBounds ctx
   operands_inBounds (operand : OpOperandPtr) (h : operand.InBounds ctx):
     operand.op = operation → OpOperand.FieldsInBounds (operand.get ctx h) ctx
+
+structure BlockArgument.FieldsInBounds (arg: BlockArgument) (ctx: IRContext) : Prop where
+  firstUse_inBounds : arg.firstUse.maybe OpOperandPtr.InBounds ctx
+  owner_inBounds: arg.owner.InBounds ctx
 
 @[local grind]
 structure Block.FieldsInBounds (block: BlockPtr) (ctx: IRContext) (hin : block.InBounds ctx) : Prop where
@@ -80,32 +75,370 @@ attribute [grind .] IRContext.FieldsInBounds.topLevelOp_inBounds
 
 attribute [local grind =] Option.maybe_def
 
+section get
+
 /-
   Theorems combining `get` methods with `IRContext.fieldsInBounds`.
+  These should be the only theorems that unfolds the `FieldsInBounds
+  structures.
 -/
 
-@[grind →]
+variable {ctx : IRContext}
+
+attribute [local grind] IRContext.FieldsInBounds
+  OpOperand.FieldsInBounds BlockOperand.FieldsInBounds
+  Operation.FieldsInBounds Block.FieldsInBounds Region.FieldsInBounds
+
+section OpResultPtr
+
+variable {res : OpResultPtr}
+attribute [local grind] OpResult.FieldsInBounds
+
+theorem OpResultPtr.firstUse!_inBounds :
+    ctx.FieldsInBounds →
+    res.InBounds ctx →
+    (res.get! ctx).firstUse.maybe OpOperandPtr.InBounds ctx := by
+  grind
+
+grind_pattern OpResultPtr.firstUse!_inBounds => (res.get! ctx).firstUse, ctx.FieldsInBounds
+
+theorem OpResultPtr.owner!_inBounds :
+    ctx.FieldsInBounds →
+    res.InBounds ctx →
+    (res.get! ctx).owner.InBounds ctx := by
+  grind
+
+grind_pattern OpResultPtr.owner!_inBounds => (res.get! ctx).owner, ctx.FieldsInBounds
+
+end OpResultPtr
+
+section BlockArgument
+
+variable {arg : BlockArgumentPtr}
+attribute [local grind] BlockArgument.FieldsInBounds
+
+theorem BlockArgumentPtr.firstUse!_inBounds :
+    ctx.FieldsInBounds →
+    arg.InBounds ctx →
+    (arg.get! ctx).firstUse.maybe OpOperandPtr.InBounds ctx := by
+  intros
+  have : arg.block.InBounds ctx := by grind
+  grind
+
+grind_pattern BlockArgumentPtr.firstUse!_inBounds => (arg.get! ctx).firstUse, ctx.FieldsInBounds
+
+theorem BlockArgumentPtr.owner!_inBounds :
+    ctx.FieldsInBounds →
+    arg.InBounds ctx →
+    (arg.get! ctx).owner.InBounds ctx := by
+  intros
+  have : arg.block.InBounds ctx := by grind
+  grind
+
+grind_pattern BlockArgumentPtr.owner!_inBounds => (arg.get! ctx).owner, ctx.FieldsInBounds
+
+end BlockArgument
+
+section OpOperand
+
+variable {operand : OpOperandPtr}
+attribute [local grind] OpOperand.FieldsInBounds
+
+theorem OpOperandPtr.nextUse!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).nextUse.maybe OpOperandPtr.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern OpOperandPtr.nextUse!_inBounds => (operand.get! ctx).nextUse, ctx.FieldsInBounds
+
+theorem OpOperandPtr.back!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).back.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern OpOperandPtr.back!_inBounds => (operand.get! ctx).back, ctx.FieldsInBounds
+
+theorem OpOperandPtr.owner!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).owner.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern OpOperandPtr.owner!_inBounds => (operand.get! ctx).owner, ctx.FieldsInBounds
+
+theorem OpOperandPtr.value!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).value.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern OpOperandPtr.value!_inBounds => (operand.get! ctx).value, ctx.FieldsInBounds
+
+end OpOperand
+
+section BlockOperand
+
+variable {operand : BlockOperandPtr}
+attribute [local grind] BlockOperand.FieldsInBounds
+
+theorem BlockOperandPtr.nextUse!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).nextUse.maybe BlockOperandPtr.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern BlockOperandPtr.nextUse!_inBounds => (operand.get! ctx).nextUse, ctx.FieldsInBounds
+
+theorem BlockOperandPtr.back!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).back.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern BlockOperandPtr.back!_inBounds => (operand.get! ctx).back, ctx.FieldsInBounds
+
+theorem BlockOperandPtr.owner!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).owner.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern BlockOperandPtr.owner!_inBounds => (operand.get! ctx).owner, ctx.FieldsInBounds
+
+theorem BlockOperandPtr.value!_inBounds :
+    ctx.FieldsInBounds →
+    operand.InBounds ctx →
+    (operand.get! ctx).value.InBounds ctx := by
+  intros
+  have : operand.op.InBounds ctx := by grind
+  grind
+
+grind_pattern BlockOperandPtr.value!_inBounds => (operand.get! ctx).value, ctx.FieldsInBounds
+
+end BlockOperand
+
+section Operation
+
+variable {operation : OperationPtr}
+attribute [local grind] Operation.FieldsInBounds
+
+theorem OperationPtr.prev!_inBounds :
+    ctx.FieldsInBounds →
+    operation.InBounds ctx →
+    (operation.get! ctx).prev.maybe OperationPtr.InBounds ctx := by
+  intros
+  grind
+
+grind_pattern OperationPtr.prev!_inBounds => (operation.get! ctx).prev, ctx.FieldsInBounds
+
+theorem OperationPtr.next!_inBounds :
+    ctx.FieldsInBounds →
+    operation.InBounds ctx →
+    (operation.get! ctx).next.maybe OperationPtr.InBounds ctx := by
+  intros
+  grind
+
+grind_pattern OperationPtr.next!_inBounds => (operation.get! ctx).next, ctx.FieldsInBounds
+
+theorem OperationPtr.parent!_inBounds :
+    ctx.FieldsInBounds →
+    operation.InBounds ctx →
+    (operation.get! ctx).parent.maybe BlockPtr.InBounds ctx := by
+  intros
+  grind
+
+grind_pattern OperationPtr.parent!_inBounds => (operation.get! ctx).parent, ctx.FieldsInBounds
+
+theorem OperationPtr.getRegions!_inBounds :
+    ctx.FieldsInBounds →
+    operation.InBounds ctx →
+    i < operation.getNumRegions! ctx →
+    (operation.getRegion! ctx i).InBounds ctx := by
+  intros
+  grind
+
+grind_pattern OperationPtr.getRegions!_inBounds => (operation.getRegion! ctx i), ctx.FieldsInBounds
+
+end Operation
+
+section Block
+
+variable {block : BlockPtr}
+
+attribute [local grind] Block.FieldsInBounds
+
+theorem BlockPtr.firstUse!_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    (block.get! ctx).firstUse.maybe BlockOperandPtr.InBounds ctx := by
+  grind
+
+grind_pattern BlockPtr.firstUse!_inBounds => (block.get! ctx).firstUse, ctx.FieldsInBounds
+
+theorem BlockPtr.prev!_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    (block.get! ctx).prev.maybe BlockPtr.InBounds ctx := by
+  grind
+
+grind_pattern BlockPtr.prev!_inBounds => (block.get! ctx).prev, ctx.FieldsInBounds
+
+theorem BlockPtr.next!_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    (block.get! ctx).next.maybe BlockPtr.InBounds ctx := by
+  grind
+
+grind_pattern BlockPtr.next!_inBounds => (block.get! ctx).next, ctx.FieldsInBounds
+
+theorem BlockPtr.parent!_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    (block.get! ctx).parent.maybe RegionPtr.InBounds ctx := by
+  grind
+
+grind_pattern BlockPtr.parent!_inBounds => (block.get! ctx).parent, ctx.FieldsInBounds
+
+theorem BlockPtr.firstOp!_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    (block.get! ctx).firstOp.maybe OperationPtr.InBounds ctx := by
+  grind
+
+grind_pattern BlockPtr.firstOp!_inBounds => (block.get! ctx).firstOp, ctx.FieldsInBounds
+
+theorem BlockPtr.lastOp!_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    (block.get! ctx).lastOp.maybe OperationPtr.InBounds ctx := by
+  grind
+
+grind_pattern BlockPtr.lastOp!_inBounds => (block.get! ctx).lastOp, ctx.FieldsInBounds
+
+theorem BlockPtr.arguments_inBounds :
+    ctx.FieldsInBounds →
+    block.InBounds ctx →
+    i < block.getNumArguments! ctx →
+    (block.getArgument i).InBounds ctx := by
+  intros
+  grind
+
+grind_pattern BlockPtr.arguments_inBounds => (block.getArgument i), ctx.FieldsInBounds
+
+end Block
+
+section Region
+
+variable {region : RegionPtr}
+
+attribute [local grind] Region.FieldsInBounds
+
+theorem RegionPtr.firstBlock!_inBounds :
+    ctx.FieldsInBounds →
+    region.InBounds ctx →
+    (region.get! ctx).firstBlock.maybe BlockPtr.InBounds ctx := by
+  grind
+
+grind_pattern RegionPtr.firstBlock!_inBounds => (region.get! ctx).firstBlock, ctx.FieldsInBounds
+
+theorem RegionPtr.lastBlock!_inBounds :
+    ctx.FieldsInBounds →
+    region.InBounds ctx →
+    (region.get! ctx).lastBlock.maybe BlockPtr.InBounds ctx := by
+  grind
+
+grind_pattern RegionPtr.lastBlock!_inBounds => (region.get! ctx).lastBlock, ctx.FieldsInBounds
+
+theorem RegionPtr.parent!_inBounds :
+    ctx.FieldsInBounds →
+    region.InBounds ctx →
+    (region.get! ctx).parent.maybe OperationPtr.InBounds ctx := by
+  grind
+
+grind_pattern RegionPtr.parent!_inBounds => (region.get! ctx).parent, ctx.FieldsInBounds
+
+end Region
+
+section ValuePtr
+
+variable {value : ValuePtr}
+
+theorem ValuePtr.getFirstUse!_inBounds :
+    ctx.FieldsInBounds →
+    value.InBounds ctx →
+    (value.getFirstUse! ctx).maybe OpOperandPtr.InBounds ctx := by
+  cases value <;> grind
+
+grind_pattern ValuePtr.getFirstUse!_inBounds => (value.getFirstUse! ctx), ctx.FieldsInBounds
+
+end ValuePtr
+
+section OpOperandPtrPtr
+
+variable {ptr : OpOperandPtrPtr}
+
+theorem OpOperandPtrPtr.get!_inBounds :
+    ctx.FieldsInBounds →
+    ptr.InBounds ctx →
+    (ptr.get! ctx).maybe OpOperandPtr.InBounds ctx := by
+  cases ptr <;> grind
+
+grind_pattern OpOperandPtrPtr.get!_inBounds => (ptr.get! ctx), ctx.FieldsInBounds
+
+end OpOperandPtrPtr
+
+section BlockOperandPtrPtr
+
+variable {ptr : BlockOperandPtrPtr}
+
+theorem BlockOperandPtrPtr.get!_inBounds :
+    ctx.FieldsInBounds →
+    ptr.InBounds ctx →
+    (ptr.get! ctx).maybe BlockOperandPtr.InBounds ctx := by
+  cases ptr <;> grind
+
+grind_pattern BlockOperandPtrPtr.get!_inBounds => (ptr.get! ctx), ctx.FieldsInBounds
+
+end BlockOperandPtrPtr
+
+@[grind .]
 theorem OperationPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OperationPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
     Operation.FieldsInBounds ptr ctx ptrInBounds := by
   grind [IRContext.FieldsInBounds]
 
-@[grind →]
+@[grind .]
 theorem BlockPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
     Block.FieldsInBounds ptr ctx ptrInBounds := by
   grind [IRContext.FieldsInBounds]
 
-@[grind →]
+@[grind .]
 theorem RegionPtr.get_fieldsInBounds (ctx: IRContext) (ptr: RegionPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
     (ptr.get ctx (by grind)).FieldsInBounds ctx := by
   grind [IRContext.FieldsInBounds]
 
-@[grind →]
+@[grind .]
 theorem OpResultPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OpResultPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
@@ -113,7 +446,7 @@ theorem OpResultPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OpResultPtr)
   have opInBounds := OperationPtr.get_fieldsInBounds ctx ptr.op ctxInBounds (by grind)
   grind
 
-@[grind →]
+@[grind .]
 theorem OpOperandPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OpOperandPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
@@ -121,7 +454,7 @@ theorem OpOperandPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OpOperandPtr)
   have opInBounds := OperationPtr.get_fieldsInBounds ctx ptr.op ctxInBounds (by grind)
   grind
 
-@[grind →]
+@[grind .]
 theorem BlockOperandPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockOperandPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
@@ -129,7 +462,7 @@ theorem BlockOperandPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockOperandPt
   have opInBounds := OperationPtr.get_fieldsInBounds ctx ptr.op ctxInBounds (by grind)
   grind
 
-@[grind →]
+@[grind .]
 theorem BlockArgumentPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockArgumentPtr)
     (ctxInBounds: ctx.FieldsInBounds)
     (ptrInBounds: ptr.InBounds ctx) :
@@ -138,43 +471,7 @@ theorem BlockArgumentPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockArgument
     BlockPtr.get_fieldsInBounds ctx ptr.block ctxInBounds (by grind)
   grind
 
-@[grind <=]
-theorem ValuePtr.getFirstUse_inBounds (ctx: IRContext) (ptr: ValuePtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx)
-    (hGet: ptr.getFirstUse ctx (by grind) = some operandPtr) :
-    operandPtr.InBounds ctx := by
-  cases ptr <;> grind
-
-@[grind →]
-theorem OpOperandPtrPtr.get_inBounds (ctx: IRContext) (ptr: OpOperandPtrPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx)
-    (opOperandPtr: OpOperandPtr)
-    (hGet: ptr.get ctx (by grind) = some opOperandPtr) :
-    opOperandPtr.InBounds ctx := by
-  cases ptr <;> grind
-
-@[grind →]
-theorem BlockOperandPtrPtr.get_inBounds (ctx: IRContext) (ptr: BlockOperandPtrPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx)
-    (blockOperandPtr: BlockOperandPtr)
-    (hGet: ptr.get ctx (by grind) = some blockOperandPtr) :
-    blockOperandPtr.InBounds ctx := by
-  cases ptr <;> grind
-
-@[grind .]
-theorem OperationPtr.getOperand_inBounds (ctx: IRContext) (ptr: OperationPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (h₁: ptr.InBounds ctx)
-    (h₂ : idx < (ptr.getNumOperands ctx h₁)) :
-    (ptr.getOperand ctx idx h₁ h₂).InBounds ctx := by
-  let opr : OpOperandPtr := .mk ptr idx
-  have : opr.InBounds ctx := by grind [OpOperandPtr.inBounds_def]
-  have := ctxInBounds.operations_inBounds ptr h₁ |>.operands_inBounds opr this (by rfl)
-  grind
-
+end get
 
 /- Preservation theorems for FieldsInBounds -/
 
@@ -188,7 +485,8 @@ theorem Operation.fieldsInBounds_unchanged {op: OperationPtr} (ctx ctx' : IRCont
     Operation.FieldsInBounds op ctx' (by grind) := by
   have heq : op.get! ctx = op.get! ctx' := by grind
   constructor
-  · grind [OpResultPtr.get!_eq_of_OperationPtr_get!_eq]
+  · intros
+    constructor <;> grind [→ OpResultPtr.get!_eq_of_OperationPtr_get!_eq]
   · grind
   · grind
   · grind
@@ -197,7 +495,7 @@ theorem Operation.fieldsInBounds_unchanged {op: OperationPtr} (ctx ctx' : IRCont
     constructor <;> grind
   · have ha := OperationPtr.getRegion!_eq_of_OperationPtr_get!_eq heq
     have hb := OperationPtr.getNumRegions!_eq_of_OperationPtr_get!_eq heq
-    grind (gen := 20)
+    grind [IRContext.FieldsInBounds, Operation.FieldsInBounds]
   · intros opr hopr heq
     have : opr.op.get! ctx = opr.op.get! ctx' := by grind
     have := @OpOperandPtr.get!_eq_of_OperationPtr_get!_eq
@@ -206,11 +504,20 @@ theorem Operation.fieldsInBounds_unchanged {op: OperationPtr} (ctx ctx' : IRCont
 theorem Block.fieldsInBounds_unchanged (block: BlockPtr) (ctx ctx' : IRContext)
     (blockInBounds: block.InBounds ctx)
     (blockInBounds': block.InBounds ctx')
+    (hh : ctx.FieldsInBounds)
     (hFIB : Block.FieldsInBounds block ctx blockInBounds)
     (hSameInBounds: ∀ ptr, GenericPtr.InBounds ptr ctx ↔ GenericPtr.InBounds ptr ctx')
     (hSameBlocks : ∀ block blockInBounds, BlockPtr.get block ctx blockInBounds = BlockPtr.get block ctx' (by grind)) :
     Block.FieldsInBounds block ctx' blockInBounds' := by
-  constructor <;> grind [BlockArgumentPtr.get!_eq_of_BlockPtr_get!_eq]
+  constructor
+  · grind
+  · grind
+  · grind
+  · grind
+  · grind
+  · grind
+  · intros
+    constructor <;> grind [BlockArgumentPtr.get!_eq_of_BlockPtr_get!_eq]
 
 theorem Region.fieldsInBounds_unchanged (region: RegionPtr) (ctx ctx' : IRContext)
     (regionInBounds: region.InBounds ctx)
@@ -254,7 +561,15 @@ macro "prove_fieldsInBounds_block" ctx:ident : tactic => `(tactic|
    · intros
      apply Operation.fieldsInBounds_unchanged (ctx := $ctx) <;> grind
    · intros block blockIn
-     constructor <;> grind
+     constructor
+     · grind
+     · grind
+     · grind
+     · grind
+     · grind
+     · grind
+     · intros
+       constructor <;> grind
    · intros
      apply Region.fieldsInBounds_unchanged (ctx := $ctx) <;> grind))
 
@@ -365,7 +680,11 @@ theorem OperationPtr.allocEmpty_fieldsInBounds (heq : allocEmpty ctx type = some
       · rintro opr hopr heq
         constructor <;> grind
   · intros bl hbl
-    constructor <;> grind
+    constructor <;> try grind [BlockArgument.FieldsInBounds]
+    intros
+    constructor
+    · grind
+    · grind
   · grind
 
 @[grind .]
@@ -442,7 +761,8 @@ theorem BlockPtr.allocEmpty_fieldsInBounds (heq : allocEmpty ctx = some (ctx', p
   · grind
   · intros op hop
     constructor
-    · grind
+    · intros
+      constructor <;> grind
     · grind
     · grind
     · grind
@@ -452,7 +772,11 @@ theorem BlockPtr.allocEmpty_fieldsInBounds (heq : allocEmpty ctx = some (ctx', p
     · rintro opr hopr heq
       constructor <;> grind
   · intros bl hbl
-    constructor <;> grind [=> BlockPtr.allocEmpty_genericPtr_iff', Block.empty]
+    constructor
+    case arguments_inBounds =>
+      intros
+      constructor <;> grind [=> BlockPtr.allocEmpty_genericPtr_iff', Block.empty]
+    all_goals grind [=> BlockPtr.allocEmpty_genericPtr_iff', Block.empty]
   · grind
 
 @[grind .]
@@ -492,7 +816,7 @@ theorem OpOperandPtrPtr.set_fieldsInBounds_maybe (hnew : newPtr.maybe OpOperandP
     case arguments_inBounds =>
       intros ba hba heq
       rcases opOperandPtr with _ | val
-      · grind
+      · constructor <;> grind
       · cases val <;> grind
     all_goals grind
   · intros

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -4138,7 +4138,7 @@ theorem OpResultPtr.get!_ValuePtr_setType {opResult : OpResultPtr} :
       { opResult.get! ctx with type := newType }
     else
       opResult.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumOperands!_ValuePtr_setType {operation : OperationPtr} :
@@ -4349,7 +4349,7 @@ theorem OpResultPtr.get!_ValuePtr_setFirstUse {opResult : OpResultPtr} :
       { opResult.get! ctx with firstUse := newFirstUse }
     else
       opResult.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumOperands!_ValuePtr_setFirstUse {operation : OperationPtr} :
@@ -4572,7 +4572,7 @@ theorem OpOperandPtr.get!_OpOperandPtrPtr_set {opOperand : OpOperandPtr} :
       { opOperand.get! ctx with nextUse := newPtr }
     else
       opOperand.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumResults!_OpOperandPtrPtr_set {operation : OperationPtr} :
@@ -4587,7 +4587,7 @@ theorem OpResultPtr.get!_OpOperandPtrPtr_set {opResult : OpResultPtr} :
       { opResult.get! ctx with firstUse := newPtr }
     else
       opResult.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumOperands!_OpOperandPtrPtr_set {operation : OperationPtr} :
@@ -4638,7 +4638,7 @@ theorem BlockArgumentPtr.get!_OpOperandPtrPtr_set {arg : BlockArgumentPtr} :
       { arg.get! ctx with firstUse := newPtr }
     else
       arg.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem RegionPtr.get!_OpOperandPtrPtr_set {region : RegionPtr} :
@@ -4790,7 +4790,7 @@ theorem OperationPtr.results!.size_BlockOperandPtrPtr_set {operation : Operation
 theorem OpOperandPtr.get!_BlockOperandPtrPtr_set {opOperand : OpOperandPtr} :
     opOperand.get! (BlockOperandPtrPtr.set ptr' ctx newPtr hptr') =
     opOperand.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumResults!_BlockOperandPtrPtr_set {operation : OperationPtr} :
@@ -4817,7 +4817,7 @@ theorem BlockOperandPtr.get!_BlockOperandPtrPtr_set {blockOperand : BlockOperand
       { blockOperand.get! ctx with nextUse := newPtr }
     else
       blockOperand.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumSuccessors!_BlockOperandPtrPtr_set {operation : OperationPtr} :
@@ -4856,7 +4856,7 @@ theorem BlockPtr.getNumArguments!_BlockOperandPtrPtr_set {block : BlockPtr} :
 theorem BlockArgumentPtr.get!_BlockOperandPtrPtr_set {arg : BlockArgumentPtr} :
     arg.get! (BlockOperandPtrPtr.set ptr' ctx newPtr hptr') =
     arg.get! ctx := by
-  grind (splits := 20)
+  grind
 
 @[simp, grind =]
 theorem RegionPtr.get!_BlockOperandPtrPtr_set {region : RegionPtr} :

--- a/Veir/IR/Grind.lean
+++ b/Veir/IR/Grind.lean
@@ -7,43 +7,6 @@ namespace Veir
 
 public section
 
-namespace OpResult.FieldsInBounds
-attribute [grind .] firstUse_inBounds owner_inBounds
-end OpResult.FieldsInBounds
-
-namespace BlockArgument.FieldsInBounds
-attribute [grind .] firstUse_inBounds owner_inBounds
-end BlockArgument.FieldsInBounds
-
-namespace OpOperand.FieldsInBounds
-attribute [grind .] nextUse_inBounds back_inBounds owner_inBounds value_inBounds
-end OpOperand.FieldsInBounds
-
-namespace BlockOperand.FieldsInBounds
-attribute [grind .] nextUse_inBounds back_inBounds owner_inBounds value_inBounds
-end BlockOperand.FieldsInBounds
-
-namespace Operation.FieldsInBounds
-attribute [grind .]
-  results_inBounds prev_inBounds next_inBounds parent_inBounds
-  blockOperands_inBounds regions_inBounds operands_inBounds
-end Operation.FieldsInBounds
-
-namespace Block.FieldsInBounds
-attribute [grind .]
-  firstUse_inBounds prev_inBounds next_inBounds parent_inBounds firstOp_inBounds
-  lastOp_inBounds arguments_inBounds
-end Block.FieldsInBounds
-
-namespace Region.FieldsInBounds
-attribute [grind .] firstBlock_inBounds lastBlock_inBounds parent_inBounds
-end Region.FieldsInBounds
-
-namespace IRContext.FieldsInBounds
-attribute [grind .] topLevelOp_inBounds operations_inBounds blocks_inBounds regions_inBounds
-end IRContext.FieldsInBounds
-
-
 attribute [local grind =] Option.maybe_def
 
 @[grind =_]

--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -87,7 +87,8 @@ theorem ValuePtr.DefUse.getFirstUse!_eq_of_back_eq_valueFirstUse
     (heq : (firstUse.get! ctx).back = .valueFirstUse value) :
     value.getFirstUse! ctx = some firstUse := by
   have : (firstUse.get! ctx).value = value := by grind [ValuePtr.DefUse.value!_eq_of_back!_eq_valueFirstUse]
-  grind [ValuePtr.DefUse, Array.getElem?_of_mem]
+  have ⟨i, iInBounds, hi⟩ := Array.getElem_of_mem hInArray
+  cases i <;> grind [ValuePtr.DefUse]
 
 theorem ValuePtr.DefUse_back_eq_of_getFirstUse
     {firstUse : OpOperandPtr}
@@ -113,7 +114,9 @@ theorem ValuePtr.DefUse_array_injective
     ∀ (i j : Nat) iInBounds jInBounds, i ≠ j →
     array[i]'iInBounds ≠ array[j]'jInBounds := by
   intros i
-  induction i <;> grind (splits := 20) [ValuePtr.DefUse]
+  induction i
+  · grind [ValuePtr.DefUse]
+  · rintro (_|⟨_⟩) <;> grind [ValuePtr.DefUse]
 
 theorem ValuePtr.DefUse_array_toList_Nodup
     (hWF : ValuePtr.DefUse value ctx array hvalue) :
@@ -338,7 +341,9 @@ theorem BlockPtr.DefUse_array_injective
     ∀ (i j : Nat) iInBounds jInBounds, i ≠ j →
     array[i]'iInBounds ≠ array[j]'jInBounds := by
   intros i
-  induction i <;> grind (splits := 20)
+  induction i
+  · grind
+  · rintro ⟨_|_⟩ <;> grind
 
 theorem BlockPtr.DefUse_array_toList_Nodup
     (hWF : BlockPtr.DefUse block ctx array missingUses) :
@@ -732,7 +737,7 @@ theorem Operation.WellFormed_unchanged
     (hSameRegions :
       ∀ i, i < opPtr.getNumRegions! ctx → opPtr.getRegion! ctx i = opPtr.getRegion! ctx' i) :
     (opPtr.get! ctx').WellFormed ctx' opPtr opPtrInBounds' := by
-  constructor <;> grind [Operation.WellFormed]
+  constructor <;> grind [Operation.WellFormed, Operation.FieldsInBounds]
 
 theorem Block.WellFormed_unchanged
     (hWf : (blockPtr.get! ctx).WellFormed ctx blockPtr blockPtrInBounds)
@@ -798,7 +803,7 @@ theorem OperationPtr.getParent_prev_eq
     (hblock : BlockPtr.OpChain block ctx array)
     (hprev : (OperationPtr.get! opPtr ctx).prev = some prevOp) :
     (prevOp.get! ctx).parent = some block := by
-  grind (splits := 20) [BlockPtr.OpChain, Array.getElem?_of_mem]
+  grind [BlockPtr.OpChain, Array.getElem?_of_mem]
 
 theorem BlockPtr.OpChain_prev_ne
     (hop : OperationPtr.InBounds op ctx)

--- a/Veir/Rewriter/GetSetInBounds.lean
+++ b/Veir/Rewriter/GetSetInBounds.lean
@@ -136,7 +136,7 @@ theorem BlockPtr.lastOp!_insertOp? {block : BlockPtr} :
     else
       (block.get! ctx).lastOp := by
   simp only [Rewriter.insertOp?]
-  grind (splits := 20)
+  grind
 
 grind_pattern BlockPtr.lastOp!_insertOp? =>
   Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp

--- a/Veir/Rewriter/LinkedList/Basic.lean
+++ b/Veir/Rewriter/LinkedList/Basic.lean
@@ -84,7 +84,7 @@ def BlockOperandPtr.insertIntoCurrent (ctx: IRContext) (operandPtr: BlockOperand
   let ctx := block.setFirstUse ctx operandPtr
   match hNextUse: newNextUse with
   | none => ctx
-  | some nextUse => nextUse.setBack ctx (BlockOperandPtrPtr.blockOperandNextUse operandPtr) (by grind (ematch := 20))
+  | some nextUse => nextUse.setBack ctx (BlockOperandPtrPtr.blockOperandNextUse operandPtr) (by grind)
 
 @[grind .]
 theorem BlockOperandPtr.insertIntoCurrent_fieldsInBounds :


### PR DESCRIPTION
Only add `x.InBounds` in the context if `x` is in the context *and* `ctx.FieldsInBounds` is available.
This reduces the amount of things in the `grind` context, and speeds up a bit our proofs.