### PR TITLE
Add parsing of integer literals

### DIFF
--- a/Test/Parser.lean
+++ b/Test/Parser.lean
@@ -103,17 +103,17 @@ section parseInteger
 
 -- Test with hexadecimal integers
 /--
-  info: "Error: internal error: failed converting '[48, 120, 102, 102]' to an integer literal"
+  info: "Success: (some 1375488932539311409843695)"
 -/
 #guard_msgs in
 #eval testParser "0x0123456789abcdefABCDEF" (parseOptionalInteger false false)
 
--- Test parseOptionalInteger with negative integers and hex when allowed
+-- Test with negative integers and hex when allowed
 /--
-  info: "Error: "
+  info: "Success: (some -240)"
 -/
 #guard_msgs in
-#eval testParser "-0xff" (parseOptionalInteger false true)
+#eval testParser "-0xf0" (parseOptionalInteger false true)
 
 -- Test parseOptionalInteger with negative integers and hex when disallowed
 /--

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -20,6 +20,42 @@ def UInt8.isHexDigit (c : UInt8) : Bool :=
 def ByteArray.getD (ba : ByteArray) (i : Nat) (default : UInt8) : UInt8 :=
   if h : i < ba.size then ba[i] else default
 
+/--
+  Convert a hexadecimal digit character to its Nat value.
+-/
+def Char.hexValue? (c : Char) : Option Nat :=
+  match c with
+  | '0' => some 0
+  | '1' => some 1
+  | '2' => some 2
+  | '3' => some 3
+  | '4' => some 4
+  | '5' => some 5
+  | '6' => some 6
+  | '7' => some 7
+  | '8' => some 8
+  | '9' => some 9
+  | 'a' | 'A' => some 0xA
+  | 'b' | 'B' => some 0xB
+  | 'c' | 'C' => some 0xC
+  | 'd' | 'D' => some 0xD
+  | 'e' | 'E' => some 0xE
+  | 'f' | 'F' => some 0xF
+  | _ => none
+
+/--
+  Parse a sequence of hexadecimal digit characters into a Nat.
+-/
+def ByteArray.hexToNat? (str : ByteArray) : Option Nat := Id.run do
+  let mut res := 0
+  for h: i in 2...(str.size) do
+    let hexValue := (Char.ofUInt8 (str[i]'(by simp [Membership.mem] at h; grind))).hexValue?
+    if let some value := hexValue then
+      res := value + (res <<< 4)
+    else
+      return none
+  some res
+
 set_option warn.sorry false in
 @[grind .]
 theorem Array.back_popWhile {as : Array α} {p : α → Bool} (h : 0 < (as.popWhile p).size) :

--- a/Veir/Parser/Parser.lean
+++ b/Veir/Parser/Parser.lean
@@ -202,7 +202,12 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : m (Optio
 
   -- Convert the integer literal token to an Int
   if let some intToken := intToken then
-    let value := (String.fromUTF8? (intToken.slice.of ((← get).input))).bind String.toNat?
+    let slice := intToken.slice.of ((← get).input)
+    let value :=
+      if ∃ (_: slice.size > 2), slice[1] == 'x'.toUInt8 || slice[1] == 'X'.toUInt8 then
+        slice.hexToNat?
+      else
+        (String.fromUTF8? slice).bind String.toNat?
     if let some value := value then
       if isNegative then
         return some (Int.negOfNat value)


### PR DESCRIPTION
Integer literals are either booleans, decimal integers, or hexadecimal integers. They can also have a leading `-`.