### PR TITLE
Parse simple MLIR operations, regions, and blocks.

### DIFF
--- a/Test/MlirParser.lean
+++ b/Test/MlirParser.lean
@@ -13,9 +13,9 @@ def testParseOp (s : String) : IO Unit :=
   | some (ctx, _) =>
     match ParserState.fromInput (s.toByteArray) with
     | .ok parser =>
-      match ((parseOp none).run (MlirParserState.mk ctx)).run parser with
-      | .ok (op, state) _ => Printer.printOperation state.ctx op
-      | .error err _ => .error err
+      match (parseOp none).run (MlirParserState.mk ctx) parser with
+      | .ok (op, state, _) => Printer.printOperation state.ctx op
+      | .error err => .error err
     | .error err => .error err
   | none => .error "internal error: failed to create IR context"
 


### PR DESCRIPTION
Currently, the limitations are:
* Operations have no operands, results, attributes, successors, or properties.
* Blocks have no arguments.
* Regions have always a single block.
* Operations have at most one region.

We should also do the following:
* Create a `!` variant of our IR rewrites so that we don't have to provide proofs or `(by sorry)` in our code
* Have a monad for our `Rewriter`, so that we don't have to `<- get` and `<- set` our context manually.