### PR TITLE
ci: update-lean-nightly actually try a build before posting a PR

### DIFF
--- a/.github/workflows/update-lean-nightly-version.yml
+++ b/.github/workflows/update-lean-nightly-version.yml
@@ -50,6 +50,13 @@ jobs:
         env:
           LAKE_NO_CACHE: true
 
+      - uses: leanprover/lean-action@v1
+        id: build
+        continue-on-error: true
+        with:
+          build-args: "--iofail"
+          test: true
+
       - name: Create Pull Request
         id: create-pr
         uses: peter-evans/create-pull-request@v7


### PR DESCRIPTION
This shows us already in the action if the build will succeed. For now one has to look explicitly in the action run if the build succeeded. In the future, we will hook this up with a notification bot.