### PR TITLE
ci: lean update - only create PRs if update available

### DIFF
--- a/.github/workflows/update-lean-nightly-version.yml
+++ b/.github/workflows/update-lean-nightly-version.yml
@@ -38,8 +38,8 @@ jobs:
         with:
           branch: auto-lean-update-${{steps.mldate.outputs.date}}
 
-#      - if: steps.check-branch-exists.outputs.exists == 'true'
-#        run: Skip any updates
+      - if: steps.check-branch-exists.outputs.exists == 'true'
+        run: Skip any updates
 
       - name: Set Lean Toolchain Date
         if: steps.check-branch-exists.outputs.exists == 'true'


### PR DESCRIPTION
This establishes the default behavior of trying to create a PR in case an update is available.