### PR TITLE
ci: add linter

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -16,3 +16,4 @@ jobs:
         with:
           build-args: "--iofail"
           test: true
+          lint: true

--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -1,5 +1,15 @@
 {"version": "1.1.0",
  "packagesDir": ".lake/packages",
- "packages": [],
+ "packages":
+ [{"url": "https://github.com/leanprover-community/batteries",
+   "type": "git",
+   "subDir": null,
+   "scope": "leanprover-community",
+   "rev": "5ba0380f2fb45c69448d80429ef6c22bf5973cfa",
+   "name": "batteries",
+   "manifestFile": "lake-manifest.json",
+   "inputRev": "main",
+   "inherited": false,
+   "configFile": "lakefile.toml"}],
  "name": "VeIR",
  "lakeDir": ".lake"}

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -2,9 +2,15 @@ name = "VeIR"
 version = "0.1.0"
 defaultTargets = ["veir-opt"]
 testRunner = "Test"
+lintDriver = "batteries/runLinter"
 
 [leanOptions]
 experimental.module = true
+
+[[require]]
+name = "batteries"
+scope = "leanprover-community"
+rev = "main"
 
 [[lean_lib]]
 name = "Veir"


### PR DESCRIPTION
Supercedes #98.

From https://github.com/leanprover-community/mathlib4/wiki/Setting-up-linting-and-testing-for-your-Lean-project#adding-a-linter

Limitations:
1. It only lints modules that are `defaultTargets`, so right now it only lints `veir-opt`.
2. To lint everything without modifying `defaultTargets`, needs leanprover/lean-action#150 and leanprover-community/batteries#1619.

Feel free to (force) push on top of this branch or copy the changes to #98.