### PR TITLE
print arith.constant with empty operand list

### DIFF
--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -57,8 +57,8 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "arith.addi"() ({
   ^4():
-    %5 = "arith.constant"() { "value" = 0 : i32 } : () -> i32
-    %6 = "arith.constant"() { "value" = 0 : i32 } : () -> i32
+    %5 = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+    %6 = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
     %7 = "arith.muli"(%5, %6) : (i32, i32) -> i32
 }) : () -> ()
 -/
@@ -90,7 +90,7 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "builtin.module"() ({
   ^4():
-    %5 = "arith.constant"() { "value" = 0 : i32 } : () -> i64
+    %5 = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i64
 }) : () -> ()-/
 #guard_msgs in
 #eval! testParseOp "\"builtin.module\"() ({

--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -396,7 +396,7 @@ def testBench (benchmark: String) (n: Nat) : IO Unit := do
 /--
 info: "builtin.module"() ({
   ^2():
-    %34 = "arith.constant"() { "value" = 52 : i32 } : () -> i32
+    %34 = "arith.constant"() <{ "value" = 52 : i32 }> : () -> i32
     "test.test"(%34) : (i32) -> ()
 }) : () -> ()
 -/
@@ -406,7 +406,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %34 = "arith.constant"() { "value" = 52 : i32 } : () -> i32
+    %34 = "arith.constant"() <{ "value" = 52 : i32 }> : () -> i32
     "test.test"(%34) : (i32) -> ()
 }) : () -> ()
 -/
@@ -416,7 +416,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     "test.test"(%3) : (i32) -> ()
 }) : () -> ()
 -/
@@ -426,7 +426,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     "test.test"(%3) : (i32) -> ()
 }) : () -> ()
 -/
@@ -436,7 +436,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     %34 = "arith.addi"(%3, %3) : (i32, i32) -> i32
     %33 = "arith.addi"(%34, %34) : (i32, i32) -> i32
     %32 = "arith.addi"(%33, %33) : (i32, i32) -> i32
@@ -456,7 +456,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     %25 = "arith.addi"(%3, %3) : (i32, i32) -> i32
     %26 = "arith.addi"(%25, %25) : (i32, i32) -> i32
     %27 = "arith.addi"(%26, %26) : (i32, i32) -> i32
@@ -476,8 +476,8 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
-    %4 = "arith.constant"() { "value" = 0 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
+    %4 = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
     %5 = "arith.addi"(%3, %4) : (i32, i32) -> i32
     %6 = "arith.addi"(%5, %4) : (i32, i32) -> i32
     %7 = "arith.addi"(%6, %4) : (i32, i32) -> i32
@@ -492,7 +492,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     "test.test"(%3) : (i32) -> ()
 }) : () -> ()
 -/
@@ -502,7 +502,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     "test.test"(%3) : (i32) -> ()
 }) : () -> ()
 -/
@@ -512,8 +512,8 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
-    %4 = "arith.constant"() { "value" = 0 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
+    %4 = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
     %6 = "arith.addi"(%3, %4) : (i32, i32) -> i32
     %7 = "arith.addi"(%6, %4) : (i32, i32) -> i32
     %8 = "arith.addi"(%7, %4) : (i32, i32) -> i32
@@ -527,8 +527,8 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
-    %4 = "arith.constant"() { "value" = 0 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
+    %4 = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
     %5 = "arith.addi"(%3, %4) : (i32, i32) -> i32
     %6 = "arith.addi"(%5, %5) : (i32, i32) -> i32
     %7 = "arith.addi"(%6, %5) : (i32, i32) -> i32
@@ -544,7 +544,7 @@ info: "builtin.module"() ({
 /--
 info: "builtin.module"() ({
   ^2():
-    %3 = "arith.constant"() { "value" = 42 : i32 } : () -> i32
+    %3 = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
     %6 = "arith.addi"(%3, %3) : (i32, i32) -> i32
     %7 = "arith.addi"(%6, %3) : (i32, i32) -> i32
     %8 = "arith.addi"(%7, %3) : (i32, i32) -> i32

--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -154,7 +154,7 @@ partial def printOperation (ctx: IRContext) (op: OperationPtr) (indent: Nat := 0
   IO.print s!"\"{String.fromUTF8! opStruct.opType.name}\""
   printOpOperands ctx op
   if opStruct.opType = .arith_constant then
-    IO.print s!" \{ \"value\" = {opStruct.properties} : i32 }"
+    IO.print s!" <\{ \"value\" = {opStruct.properties} : i32 }>"
   else
     printBlockOperands ctx op
   if op.getNumRegions! ctx > 0 then


### PR DESCRIPTION
We previously printed a mix of generic and custom syntax, which could not be parsed. We no longer special-case `arith.constant` with respect to operand parsing and print generic attribute syntax for its value.