### PR TITLE
LLVM/Byte: reduce imports

### DIFF
--- a/Veir/Dialects/LLVM/Byte/Examples.lean
+++ b/Veir/Dialects/LLVM/Byte/Examples.lean
@@ -1,9 +1,9 @@
 module
 
 import Std.Tactic.BVDecide
-public import Veir.Dialects.LLVM.Int.Basic
-import all Veir.Dialects.LLVM.Byte.Basic
+import Veir.Dialects.LLVM.Byte.Basic
 import all Veir.Dialects.LLVM.Byte.Lemmas
+
 
 namespace Veir.Dialects.LLVM.Byte
 

--- a/Veir/Dialects/LLVM/Byte/Lemmas.lean
+++ b/Veir/Dialects/LLVM/Byte/Lemmas.lean
@@ -1,6 +1,5 @@
 module
 
-public import Veir.Dialects.LLVM.Int.Basic
 import all Veir.Dialects.LLVM.Byte.Basic
 
 namespace Veir.Dialects.LLVM.Byte


### PR DESCRIPTION
This removes some obviously unnecessary imports.