### PR TITLE
Add `StringAttr` attribute

### DIFF
--- a/Test/Builtin/attributes.mlir
+++ b/Test/Builtin/attributes.mlir
@@ -2,12 +2,18 @@
 
 "builtin.module"() ({
 ^bb0():
-  %5 = "test.test"() : () -> ((i32) -> (i32))
-  %5 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+  %1 = "test.test"() : () -> ((i32) -> (i32))
+  %2 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+  %3 = "test.test"() <{str = "hello world"}> : () -> i32
+  %4 = "test.test"() <{empty = ""}> : () -> i32
+  %5 = "test.test"() <{escaped = "line1\nline2\ttab"}> : () -> i32
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %5 = "test.test"() : () -> ((i32) -> i32)
-// CHECK-NEXT:     %6 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> ((i32) -> i32)
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> i32
 // CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -103,3 +103,11 @@ macro "#assert " e:term : command =>
 
 #assert expectErrorAttr "0 : 2" "integer type expected after ':' in integer attribute"
 #assert expectSuccessAttr "0 : i32" (IntegerAttr.mk 0 (IntegerType.mk 32))
+
+/-! ## String attributes -/
+
+#assert expectSuccessAttr "\"hello\"" (StringAttr.mk "hello".toByteArray)
+#assert expectSuccessAttr "\"\"" (StringAttr.mk "".toByteArray)
+#assert expectSuccessAttr "\"\\\"\"" (StringAttr.mk "\\\"".toByteArray)
+#assert expectSuccessAttr "\"hello world\"" (StringAttr.mk "hello world".toByteArray)
+#assert expectMissingAttr "hello"  -- bare identifier, not a string attribute

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -70,6 +70,25 @@ def parseOptionalIntegerAttr : AttrParserM (Option IntegerAttr) := do
   let integerType ← parseIntegerType "integer type expected after ':' in integer attribute"
   return some (IntegerAttr.mk value integerType)
 
+/--
+  Parse a string attribute, if present.
+  Its syntax is a string literal enclosed in double quotes, e.g., `"foo"`.
+-/
+def parseOptionalStringAttr : AttrParserM (Option StringAttr) := do
+  let some str ← parseOptionalStringLiteral
+    | return none
+  return some (StringAttr.mk str.toByteArray)
+
+/--
+  Parse a string attribute.
+  Its syntax is a string literal enclosed in double quotes, e.g., `"foo"`.
+-/
+def parseStringAttr (errorMsg : String := "string attribute expected") :
+    AttrParserM StringAttr := do
+  match ← parseOptionalStringAttr with
+  | some stringAttr => return stringAttr
+  | none => throw errorMsg
+
 mutual
 
 /--
@@ -124,6 +143,8 @@ partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
     return some type.val
   else if let some integerAttr ← parseOptionalIntegerAttr then
     return some integerAttr
+  else if let some stringAttr ← parseOptionalStringAttr then
+    return some stringAttr
   else
     return none
 


### PR DESCRIPTION
It just contains a string element, represented as a byte array.
We will add filecheck tests for printing string attributes when properties are properly supported.