### PR TITLE
Print properties in a generic way

### DIFF
--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -97,6 +97,20 @@ def printBlockOperands (ctx: IRContext) (op: OperationPtr) : IO Unit := do
     IO.print s!", ^{(op.getSuccessor! ctx index).id}"
   IO.print "]"
 
+def printOpProperties (ctx : IRContext) (op : OperationPtr) : IO Unit := do
+  let opType := (op.get! ctx).opType
+  let properties := op.getProperties! ctx opType
+  let attrDict := Properties.toAttrDict opType properties
+  if attrDict.size = 0 then return
+  IO.print " <{ "
+  let mut first := true
+  for (key, value) in attrDict.toList do
+    if !first then
+      IO.print ", "
+    IO.print s!"\"{String.fromUTF8! key}\" = {value}"
+    first := false
+  IO.print " }>"
+
 mutual
 partial def printOpList (ctx: IRContext) (op: OperationPtr) (indent: Nat := 0) : IO Unit := do
   printOperation ctx op indent
@@ -155,10 +169,8 @@ partial def printOperation (ctx: IRContext) (op: OperationPtr) (indent: Nat := 0
   printOpResults ctx op
   IO.print s!"\"{String.fromUTF8! opStruct.opType.name}\""
   printOpOperands ctx op
-  if h : opStruct.opType = .arith_constant then
-    IO.print s!" <\{ \"value\" = {(h ▸ opStruct.properties).value} }>"
-  else
-    printBlockOperands ctx op
+  printOpProperties ctx op
+  printBlockOperands ctx op
   if op.getNumRegions! ctx > 0 then
     IO.print " "
     printRegions ctx op indent

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -52,5 +52,16 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   case arith_constant => exact (ArithConstantProperties.fromAttrDict attrDict)
   all_goals exact (Except.ok ())
 
+/--
+  Converts the properties of an operation into a dictionary of attributes.
+-/
+def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
+    Std.HashMap ByteArray Attribute :=
+  match opCode with
+  | .arith_constant =>
+    (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
+  | _ =>
+    Std.HashMap.emptyWithCapacity 0
+
 end
 end Veir


### PR DESCRIPTION
Properties were hardcoded for arith.constant, now
they should work for any operation