### PR TITLE
Fix indentation of ending bracket of region

### DIFF
--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -112,6 +112,21 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "builtin.module"() ({
   ^4():
+    "builtin.module"() ({
+      ^6():
+        %7 = "arith.constant"() <{ "value" = 13 : i64 }> : () -> i64
+    }) : () -> ()
+}) : () -> ()-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+  "builtin.module"() ({
+    %a = "arith.constant"() <{ "value" = 13 : i64 }> : () -> i64
+  }) : () -> ()
+}) : () -> ()"#
+
+/--
+  info: "builtin.module"() ({
+  ^4():
     "test.test"() [^5] : () -> ()
   ^5():
     "test.test"() [^7] : () -> ()

--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -147,10 +147,12 @@ partial def printRegion (ctx: IRContext) (region: Region) (indent: Nat := 0) : I
   IO.print "{"
   match region.firstBlock with
   | none =>
+    printIndent indent
     IO.print "}"
   | some blockPtr =>
     IO.println ""
     printBlockList ctx blockPtr (indent + 1)
+    printIndent indent
     IO.print "}"
 
 partial def printRegions (ctx: IRContext) (op: OperationPtr) (indent: Nat := 0) : IO Unit := do


### PR DESCRIPTION
The closing bracket of regions was not printed with indentation. This now fixes it.