### PR TITLE
Improved error messages on parser failures

### DIFF
--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -6,17 +6,51 @@ import Veir.Verifier
 open Veir.Parser
 open Veir
 
+private def bytePosToLineCol (input : ByteArray) (pos : Nat) : Nat × Nat := Id.run do
+  let mut line := 1
+  let mut col := 1
+  let endPos := Nat.min pos input.size
+  let mut i := 0
+  while i < endPos do
+    if input.getD i 0 = '\n'.toUInt8 then
+      line := line + 1
+      col := 1
+    else
+      col := col + 1
+    i := i + 1
+  (line, col)
+
+private def lineBoundsAt (input : ByteArray) (pos : Nat) : Nat × Nat := Id.run do
+  let p := Nat.min pos input.size
+  let mut start := p
+  while start > 0 && input.getD (start - 1) 0 != '\n'.toUInt8 do
+    start := start - 1
+  let mut stop := p
+  while stop < input.size && input.getD stop 0 != '\n'.toUInt8 do
+    stop := stop + 1
+  (start, stop)
+
+private def parserFailureContext (state : ParserState) : String := Id.run do
+  let tok := state.currentToken
+  let pos := tok.slice.start
+  let (line, col) := bytePosToLineCol state.input pos
+  let tokText := (String.fromUTF8? (tok.slice.of state.input)).getD "<non-utf8>"
+  let (lineStart, lineStop) := lineBoundsAt state.input pos
+  let lineText := (String.fromUTF8? (({ start := lineStart, stop := lineStop } : Lexer.Slice).of state.input)).getD "<non-utf8 line>"
+  let caret := String.ofList (List.replicate (Nat.max (col - 1) 0) ' ') ++ "^"
+  s!"at line {line}, column {col} (byte {pos}) near token {tok.kind} '{tokText}'\n{lineText}\n{caret}"
+
 def parseOperation (filename : String) : ExceptT String IO (IRContext × OperationPtr) := do
   let fileContent ← IO.FS.readBinFile filename
   let some (ctx, _) := IRContext.create
     | throw "Failed to create IR context"
   match ParserState.fromInput fileContent with
   | .ok parser =>
-    match (parseOp none).run (MlirParserState.fromContext ctx) parser with
-    | .ok (op, state, _) =>
+    match (StateT.run (parseOp none) (MlirParserState.fromContext ctx)).run parser with
+    | .ok (op, state) _ =>
       return (state.ctx, op)
-    | .error errMsg =>
-      throw s!"Error parsing operation: {errMsg}"
+    | .error errMsg parserState =>
+      throw s!"Error parsing operation: {errMsg}\n{parserFailureContext parserState}"
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
 


### PR DESCRIPTION
Adds better error messages on parser failures, for example:

```
Error: Error parsing operation: attribute expected
at line 8, column 52 (byte 422) near token exclamationIdent '!felt.type'
      "struct.member"() <{sym_name = "val", type = !felt.type}> {llzk.pub} : () -> ()
``` 

Also, vibe-coded by AI and zero testing, but @math-fehr  wanted to have this here 