### PR TITLE
Add Basic Ops from HEIR's `mod_arith` dialect 

### DIFF
--- a/Test/ModArith/identity.mlir
+++ b/Test/ModArith/identity.mlir
@@ -1,0 +1,20 @@
+// RUN: veir-opt %s | filecheck %s
+
+"builtin.module"() ({
+^bb0():
+  %0 = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
+  %1 = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
+  %2 = "mod_arith.add"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+  %3 = "mod_arith.sub"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+  %4 = "mod_arith.mul"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+}) : () -> ()
+
+
+// CHECK:       "builtin.module"() ({
+// CHECK-NEXT:   ^4():
+// CHECK-NEXT:     %{{.*}} = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:     %{{.*}} = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:     %{{.*}} = "mod_arith.add"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:     %{{.*}} = "mod_arith.sub"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:     %{{.*}} = "mod_arith.mul"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -146,3 +146,11 @@ macro "#assert " e:term : command =>
 
 #assert expectSuccessAttr "#foo<bar>" (UnregisteredAttr.mk "#foo<bar>" false)
 #assert expectSuccessAttr "#test.test<bar>" (UnregisteredAttr.mk "#test.test<bar>" false)
+
+/-! ## Modarith type -/
+
+#assert expectSuccessType "!mod_arith.int<17>" (ModArithType.mk 17 none)
+#assert expectSuccessType "!mod_arith.int<257 : i32>" (ModArithType.mk 257 (some (IntegerType.mk 32)))
+#assert expectSuccessAttr "!mod_arith.int<17>" (ModArithType.mk 17 none)
+#assert expectErrorType "!mod_arith.int<>" "modarith type modulus expected"
+#assert expectErrorType "!mod_arith.int<17 : x>" "integer type expected after ':' in modarith type"

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -77,6 +77,15 @@ structure UnregisteredAttr where
   isType : Bool
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/--
+  The `!mod_arith.int` type from HEIR's modarith dialect.
+  The modulus type annotation is optional in syntax.
+-/
+structure ModArithType where
+  modulus : Int
+  modulusType : Option IntegerType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 mutual
 
 /--
@@ -132,6 +141,8 @@ inductive Attribute
 | functionType (type : FunctionType)
 /-- An attribute from an unknown dialect. -/
 | unregisteredAttr (attr : UnregisteredAttr)
+/-- HEIR modarith type -/
+| modArithType (type : ModArithType)
 deriving Inhabited, Repr, Hashable
 
 end
@@ -245,6 +256,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match ArrayAttr.decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case modArithType.modArithType type1 type2 =>
+    exact (match decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -275,6 +290,12 @@ instance : ToString UnitAttr where
 
 instance : ToString UnregisteredAttr where
   toString attr := attr.value
+
+instance : ToString ModArithType where
+  toString type := s!"!mod_arith.int<{type.modulus}" ++
+    (match type.modulusType with
+    | some modulusType => s!" : {modulusType}"
+    | none => "") ++ ">"
 
 mutual
 
@@ -338,6 +359,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .dictionaryAttr attr => attr.toString
   | .unregisteredAttr attr => ToString.toString attr
   | .functionType type => type.toString
+  | .modArithType type => ToString.toString type
 termination_by sizeOf attr
 
 end
@@ -383,6 +405,9 @@ instance : Coe DictionaryAttr Attribute where
 instance : Coe FunctionType Attribute where
   coe type := .functionType type
 
+instance : Coe ModArithType Attribute where
+  coe type := .modArithType type
+
 /-!
   ## TypeAttr definition
 
@@ -406,6 +431,7 @@ def isType (attr : Attribute) : Bool :=
   | .dictionaryAttr _ => false
   | .unregisteredAttr attr => attr.isType
   | .functionType _ => true
+  | .modArithType _ => true
 
 @[simp, grind =]
 theorem isType_integerType type : (integerType type).isType = true := by rfl
@@ -414,6 +440,8 @@ theorem isType_unregistered unregistered :
   (unregisteredAttr unregistered).isType = unregistered.isType := by rfl
 @[simp, grind =]
 theorem isType_functionType type : (functionType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_modArithType type : (modArithType type).isType = true := by rfl
 
 end Attribute
 
@@ -451,6 +479,9 @@ instance : Coe IntegerType TypeAttr where
 
 instance : Coe FunctionType TypeAttr where
   coe type := ⟨.functionType type, by rfl⟩
+
+instance : Coe ModArithType TypeAttr where
+  coe type := ⟨.modArithType type, by rfl⟩
 
 end
 end Veir

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -169,6 +169,13 @@ inductive Riscv where
 | packw
 
 @[opcodes]
+inductive Mod_Arith where
+| add
+| constant
+| mul
+| sub
+
+@[opcodes]
 inductive Test where
 | test
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -199,6 +199,30 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   let value := (Slice.mk startPos endPos).of (← getThe ParserState).input
   return some (UnregisteredAttr.mk (String.fromUTF8! value) false)
 
+
+/--
+  Parse HEIR's modarith type, if present.
+  Its syntax is `!mod_arith.int<modulus>` or `!mod_arith.int<modulus : iN>`.
+-/
+def parseOptionalModArithType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "mod_arith.int".toByteArray then
+    return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let some modulus ← parseOptionalInteger false false
+    | throw "modarith type modulus expected"
+  let modulusType ←
+    if ← parseOptionalPunctuation ":" then
+      some <$> parseIntegerType "integer type expected after ':' in modarith type"
+    else
+      pure none
+  parsePunctuation ">"
+  return some (ModArithType.mk modulus modulusType)
+
 mutual
 
 /--
@@ -232,6 +256,8 @@ partial def parseOptionalFunctionType : AttrParserM (Option FunctionType) := do
 partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
   if let some integerType ← parseOptionalIntegerType then
     return some integerType
+  if let some modArithType ← parseOptionalModArithType then
+    return some modArithType
   if let some dialectType ← parseOptionalDialectType then
     return some dialectType
   else if let some functionType := ← parseOptionalFunctionType then

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -146,6 +146,24 @@ def RISCVImmediateProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attr
   return { value := intAttr }
 
 /--
+  Properties of the `mod_arith.constant` operation.
+-/
+structure ModArithConstantProperties where
+  value : IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def ModArithConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String ModArithConstantProperties := do
+  if attrDict.size > 1 then
+    throw s!"mod_arith.constant: expected only 'value' property, but got {attrDict.size} properties"
+  let some attr := attrDict["value".toUTF8]?
+    | throw "mod_arith.constant: missing 'value' property"
+  let .integerAttr intAttr := attr
+    | throw s!"mod_arith.constant: expected 'value' to be an integer attribute, but got {attr}"
+  return { value := intAttr }
+
+
+/--
   A type family that maps an operation code to the type of its properties.
   For operations that do not have any properties, the type is `Unit`.
 -/
@@ -200,6 +218,7 @@ match opCode with
 | .riscv_bexti => RISCVImmediateProperties
 | .riscv_binvi => RISCVImmediateProperties
 | .riscv_bseti => RISCVImmediateProperties
+| .mod_arith_constant => ModArithConstantProperties
 | _ => Unit
 
 instance : HasOpInfo OpCode where
@@ -276,6 +295,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   case riscv_bexti => exact (RISCVImmediateProperties.fromAttrDict attrDict)
   case riscv_binvi => exact (RISCVImmediateProperties.fromAttrDict attrDict)
   case riscv_bseti => exact (RISCVImmediateProperties.fromAttrDict attrDict)
+  case mod_arith_constant => exact (ModArithConstantProperties.fromAttrDict attrDict)
   all_goals exact (Except.ok ())
 
 /--
@@ -317,7 +337,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .riscv_li  | .riscv_lui | .riscv_auipc | .riscv_andi | .riscv_ori | .riscv_xori
   | .riscv_addi | .riscv_slti | .riscv_sltiu | .riscv_addiw | .riscv_slli | .riscv_srli | .riscv_srai
   | .riscv_slliw | .riscv_srliw | .riscv_sraiw | .riscv_rori | .riscv_roriw | .riscv_slliuw
-  | .riscv_bclri | .riscv_bexti | .riscv_binvi | .riscv_bseti =>
+  | .riscv_bclri | .riscv_bexti | .riscv_binvi | .riscv_bseti | .mod_arith_constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
   | _ =>
     Std.HashMap.emptyWithCapacity 0

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -538,6 +538,47 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  /- MOD_ARITH -/
+  | .mod_arith_add => do
+    if op.getNumOperands ctx opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .mod_arith_constant => do
+    if op.getNumOperands ctx opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .mod_arith_mul => do
+    if op.getNumOperands ctx opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .mod_arith_sub => do
+    if op.getNumOperands ctx opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
   /- RISCV -/
   | .riscv_li => do
     if op.getNumOperands ctx opIn ≠ 0 then


### PR DESCRIPTION
This commit adds basic syntax and parsing for HEIR's [ModArith](https://heir.dev/docs/dialects/modarith/) dialect designed to model modular arithmetic.

* adds the `!mod_arith.int<...>` type, which takes an Integer Attribute that specifies both the modulus and container type, e.g., `!mod_arith.int< 17 : i64>` (or `!mod_arith.int<17>`, with the container type defaulting to  `i64`).

* Adds `add`,`sub`, and `mul` binary ops and `mod_arith.constant` that works analogously to arith.constant