### PR TITLE
modules are not experimental anymore

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -3,9 +3,6 @@ version = "0.1.0"
 defaultTargets = ["veir-opt", "run-benchmarks", "Veir"]
 testRunner = "UnitTest"
 
-[leanOptions]
-experimental.module = true
-
 [[lean_lib]]
 name = "Veir"
 root = "Veir"


### PR DESCRIPTION
Hence, we remove the now deprecated option.