### PR TITLE
Build `veir-interpret` by default

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "VeIR"
 version = "0.1.0"
-defaultTargets = ["veir-opt", "run-benchmarks", "Veir"]
+defaultTargets = ["veir-opt", "veir-interpret", "run-benchmarks", "Veir"]
 testRunner = "UnitTest"
 moreLeanArgs = ["--tstack=400000"]
 moreServerArgs = ["--tstack=400000"]


### PR DESCRIPTION
Otherwise, a successful `lake build` may still leave some build failures unexposed.