### PR TITLE
IR: use a whitespace to separate `:` [NFC]

### DIFF
--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -305,10 +305,10 @@ decreasing_by
 
 def FunctionType.toString (type : FunctionType) : String :=
   let inputs := String.intercalate ", " (type.inputs.toList.map Attribute.toString)
-  let outputs := match _: type.outputs.size with
+  let outputs := match _ : type.outputs.size with
   | 0 => "()"
   | 1 =>
-    match _: type.outputs[0] with
+    match _ : type.outputs[0] with
     | .functionType _ => s!"({type.outputs[0].toString})"
     | output => output.toString
   | _ =>

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -14,21 +14,21 @@ public section
 namespace Veir
 
 structure OperationPtr where
-  id: Nat
+  id : Nat
 deriving Inhabited, Repr, DecidableEq
 
 instance : Hashable OperationPtr where
   hash opPtr := hash opPtr.id
 
 structure BlockPtr where
-  id: Nat
+  id : Nat
 deriving Inhabited, Repr, DecidableEq
 
 instance : Hashable BlockPtr where
   hash blockPtr := hash blockPtr.id
 
 structure RegionPtr where
-  id: Nat
+  id : Nat
 deriving Inhabited, Repr, DecidableEq
 
 instance : Hashable RegionPtr where
@@ -40,32 +40,32 @@ abbrev Location := Unit
 A pointer to an operation result.
 -/
 structure OpResultPtr where
-  op: OperationPtr
-  index: Nat
+  op : OperationPtr
+  index : Nat
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
 A pointer to an operation operand.
 -/
 structure OpOperandPtr where
-  op: OperationPtr
-  index: Nat
+  op : OperationPtr
+  index : Nat
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
 A pointer to an operation block operand.
 -/
 structure BlockOperandPtr where
-  op: OperationPtr
-  index: Nat
+  op : OperationPtr
+  index : Nat
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
 A pointer to a block argument.
 -/
 structure BlockArgumentPtr where
-  block: BlockPtr
-  index: Nat
+  block : BlockPtr
+  index : Nat
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
@@ -73,26 +73,26 @@ The base class for operation results and block arguments.
 -/
 structure ValueImpl where
   /-- `type` is used to distinguish between OpResult and BlockArgument -/
-  type: TypeAttr
-  firstUse: Option OpOperandPtr
+  type : TypeAttr
+  firstUse : Option OpOperandPtr
 deriving Inhabited, Repr, Hashable
 
 /--
 The definition of an operation result.
 -/
 structure OpResult extends ValueImpl where
-  index: Nat
+  index : Nat
   /-- `owner` should be computed from index and the layout -/
-  owner: OperationPtr
+  owner : OperationPtr
 deriving Inhabited, Repr, Hashable
 
 /--
 The definition of a block argument.
 -/
 structure BlockArgument extends ValueImpl where
-  index: Nat
-  loc: Location
-  owner: BlockPtr
+  index : Nat
+  loc : Location
+  owner : BlockPtr
 deriving Inhabited, Repr, Hashable
 
 /--
@@ -100,8 +100,8 @@ An MLIR SSA value.
 A value is either an operation result, or a block argument.
 -/
 inductive ValuePtr where
-  | opResult (ptr: OpResultPtr)
-  | blockArgument (ptr: BlockArgumentPtr)
+  | opResult (ptr : OpResultPtr)
+  | blockArgument (ptr : BlockArgumentPtr)
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 -- As in MLIR, an OpResultPtr can be coerced to a ValuePtr
@@ -119,8 +119,8 @@ It is either pointing to the next use field of the previous operand,
 or to the first use field of a value definition.
 -/
 inductive OpOperandPtrPtr where
-  | operandNextUse (ptr: OpOperandPtr)
-  | valueFirstUse (ptr: ValuePtr)
+  | operandNextUse (ptr : OpOperandPtr)
+  | valueFirstUse (ptr : ValuePtr)
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
@@ -129,12 +129,12 @@ It contains a pointer to the SSA value it uses, and links to the previous
 and next use of that value.
 -/
 structure OpOperand where
-  nextUse: Option OpOperandPtr
+  nextUse : Option OpOperandPtr
   -- I am not sure why, but some parts of MLIR consider this to be an optional.
-  -- For example, the `IROperandBase::removeFromCurrent` method checks for null.
-  back: OpOperandPtrPtr
-  owner: OperationPtr
-  value: ValuePtr
+  -- For example, the `IROperandBase ::removeFromCurrent` method checks for null.
+  back : OpOperandPtrPtr
+  owner : OperationPtr
+  value : ValuePtr
 deriving Inhabited, Repr, Hashable
 
 /--
@@ -144,8 +144,8 @@ It is either pointing to the next use field of the previous block operand,
 or to the first use field of a block.
 -/
 inductive BlockOperandPtrPtr where
-  | blockOperandNextUse (ptr: BlockOperandPtr)
-  | blockFirstUse (ptr: BlockPtr)
+  | blockOperandNextUse (ptr : BlockOperandPtr)
+  | blockFirstUse (ptr : BlockPtr)
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 /--
@@ -154,31 +154,31 @@ It contains a pointer to the block it uses, and links to the previous
 and next use of that block.
 -/
 structure BlockOperand where
-  nextUse: Option BlockOperandPtr
-  back: BlockOperandPtrPtr
-  owner: OperationPtr
-  value: BlockPtr
+  nextUse : Option BlockOperandPtr
+  back : BlockOperandPtrPtr
+  owner : OperationPtr
+  value : BlockPtr
 deriving Inhabited, Repr, Hashable
 
 /--
 An MLIR operation.
 -/
 structure Operation where
-  results: Array OpResult
+  results : Array OpResult
   -- This is the operation pointer start
-  prev: Option OperationPtr
-  next: Option OperationPtr
-  parent: Option BlockPtr
-  -- We do not support those features yet:
-  -- location: Location
-  -- orderIndex: Nat
-  opType: OpCode
-  attrs: DictionaryAttr
+  prev : Option OperationPtr
+  next : Option OperationPtr
+  parent : Option BlockPtr
+  -- We do not support those features yet :
+  -- location : Location
+  -- orderIndex : Nat
+  opType : OpCode
+  attrs : DictionaryAttr
   -- This should be replaced with an arbitrary user object
-  properties: propertiesOf opType
-  blockOperands: Array BlockOperand
-  regions: Array RegionPtr
-  operands: Array OpOperand
+  properties : propertiesOf opType
+  blockOperands : Array BlockOperand
+  regions : Array RegionPtr
+  operands : Array OpOperand
 deriving Inhabited, Repr, Hashable
 
 theorem Operation.default_operands_eq : (default : Operation).operands = #[] := by rfl
@@ -190,14 +190,14 @@ theorem Operation.default_results_eq : (default : Operation).results = #[] := by
 An MLIR block.
 -/
 structure Block where
-  firstUse: Option BlockOperandPtr
-  prev: Option BlockPtr
-  next: Option BlockPtr
-  parent: Option RegionPtr
-  -- validOpOrder: Bool      -- Unsupported yet
-  firstOp: Option OperationPtr
-  lastOp: Option OperationPtr
-  arguments: Array BlockArgument
+  firstUse : Option BlockOperandPtr
+  prev : Option BlockPtr
+  next : Option BlockPtr
+  parent : Option RegionPtr
+  -- validOpOrder : Bool      -- Unsupported yet
+  firstOp : Option OperationPtr
+  lastOp : Option OperationPtr
+  arguments : Array BlockArgument
 deriving Inhabited, Repr, Hashable
 
 theorem Block.default_arguments_eq : (default : Block).arguments = #[] := by rfl
@@ -206,9 +206,9 @@ theorem Block.default_arguments_eq : (default : Block).arguments = #[] := by rfl
 An MLIR region.
 -/
 structure Region where
-  firstBlock: Option BlockPtr
-  lastBlock: Option BlockPtr
-  parent: Option OperationPtr
+  firstBlock : Option BlockPtr
+  lastBlock : Option BlockPtr
+  parent : Option OperationPtr
 deriving Inhabited, Repr, Hashable
 
 /--
@@ -217,16 +217,16 @@ It contains a top-level Module operation, and a maps from pointers to
 operations, blocks, and regions.
 -/
 structure IRContext where
-  operations: HashMap OperationPtr Operation
-  blocks: HashMap BlockPtr Block
-  regions: HashMap RegionPtr Region
-  nextID: Nat
+  operations : HashMap OperationPtr Operation
+  blocks : HashMap BlockPtr Block
+  regions : HashMap RegionPtr Region
+  nextID : Nat
 deriving Inhabited, Repr
 
 /-! Empty objects. -/
 
 @[expose]
-def Operation.empty (opType: OpCode) (prop : propertiesOf opType) : Operation :=
+def Operation.empty (opType : OpCode) (prop : propertiesOf opType) : Operation :=
   { results := #[]
     prev := none
     next := none
@@ -266,26 +266,26 @@ OperationPtr accessors
 namespace OperationPtr
 
 @[local grind]
-def InBounds (op: OperationPtr) (ctx: IRContext) : Prop :=
+def InBounds (op : OperationPtr) (ctx : IRContext) : Prop :=
   op ∈ ctx.operations
 
-def get (ptr: OperationPtr) (ctx: IRContext) (inBounds: ptr.InBounds ctx := by grind) : Operation :=
+def get (ptr : OperationPtr) (ctx : IRContext) (inBounds : ptr.InBounds ctx := by grind) : Operation :=
   ctx.operations[ptr]'(by unfold InBounds at inBounds; grind)
 
-def get! (ptr: OperationPtr) (ctx: IRContext) : Operation :=
+def get! (ptr : OperationPtr) (ctx : IRContext) : Operation :=
   ctx.operations[ptr]!
 @[grind _=_]
 theorem get!_eq_get {ptr : OperationPtr} (hin : ptr.InBounds ctx) :
     ptr.get! ctx = (ptr.get ctx hin) := by
   grind [get, get!, InBounds]
 
-def getOpType (op: OperationPtr) (ctx: IRContext) (inBounds: op.InBounds ctx) : OpCode :=
+def getOpType (op : OperationPtr) (ctx : IRContext) (inBounds : op.InBounds ctx) : OpCode :=
   (op.get ctx (by grind)).opType
 
-def getNumOperands (op: OperationPtr) (ctx: IRContext) (inBounds: op.InBounds ctx := by grind) : Nat :=
+def getNumOperands (op : OperationPtr) (ctx : IRContext) (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).operands.size
 
-def getNumOperands! (op: OperationPtr) (ctx: IRContext) : Nat :=
+def getNumOperands! (op : OperationPtr) (ctx : IRContext) : Nat :=
   (op.get! ctx).operands.size
 
 @[grind _=_]
@@ -298,7 +298,7 @@ theorem getNumOperands!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getNumOperands! ctx = op.getNumOperands! ctx' := by
   grind [getNumOperands!]
 
-def getOpOperand (op: OperationPtr) (index: Nat) : OpOperandPtr :=
+def getOpOperand (op : OperationPtr) (index : Nat) : OpOperandPtr :=
   { op := op, index := index }
 
 @[simp, grind =]
@@ -311,23 +311,23 @@ theorem getOpOperand_op {op : OperationPtr} {index : Nat} :
     (getOpOperand op index).op = op := by
   grind [getOpOperand]
 
-def getOperand (op: OperationPtr) (ctx: IRContext) (index: Nat)
-    (inBounds: op.InBounds ctx := by grind) (h: index < getNumOperands op ctx inBounds := by grind) : ValuePtr :=
+def getOperand (op : OperationPtr) (ctx : IRContext) (index : Nat)
+    (inBounds : op.InBounds ctx := by grind) (h : index < getNumOperands op ctx inBounds := by grind) : ValuePtr :=
   ((op.get ctx (by grind)).operands[index]'(by grind [getNumOperands])).value
 
-def getOperand! (op: OperationPtr) (ctx: IRContext) (index: Nat) : ValuePtr :=
+def getOperand! (op : OperationPtr) (ctx : IRContext) (index : Nat) : ValuePtr :=
   ((op.get! ctx).operands[index]!).value
 
 @[grind _=_]
 theorem getOperand!_eq_getOperand {op : OperationPtr} {index : Nat}
-    {hin} (h: index < op.getNumOperands ctx hin) {hin'} :
+    {hin} (h : index < op.getNumOperands ctx hin) {hin'} :
     op.getOperand! ctx index = op.getOperand ctx index hin' h := by
   grind [getOperand, getOperand!]
 
-def getNumSuccessors (op: OperationPtr) (ctx: IRContext) (inBounds: op.InBounds ctx := by grind) : Nat :=
+def getNumSuccessors (op : OperationPtr) (ctx : IRContext) (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).blockOperands.size
 
-def getNumSuccessors! (op: OperationPtr) (ctx: IRContext) : Nat :=
+def getNumSuccessors! (op : OperationPtr) (ctx : IRContext) : Nat :=
   (op.get! ctx).blockOperands.size
 
 @[grind _=_]
@@ -340,7 +340,7 @@ theorem getNumSuccessors!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getNumSuccessors! ctx = op.getNumSuccessors! ctx' := by
   grind [getNumSuccessors!]
 
-def getBlockOperand (op: OperationPtr) (index: Nat) : BlockOperandPtr :=
+def getBlockOperand (op : OperationPtr) (index : Nat) : BlockOperandPtr :=
   { op := op, index := index }
 
 @[simp, grind =]
@@ -353,23 +353,23 @@ theorem getBlockOperand_op {op : OperationPtr} {index : Nat} :
     (getBlockOperand op index).op = op := by
   grind [getBlockOperand]
 
-def getSuccessor (op: OperationPtr) (ctx: IRContext) (index: Nat)
-    (inBounds: op.InBounds ctx := by grind) (h: index < getNumSuccessors op ctx inBounds := by grind) : BlockPtr :=
+def getSuccessor (op : OperationPtr) (ctx : IRContext) (index : Nat)
+    (inBounds : op.InBounds ctx := by grind) (h : index < getNumSuccessors op ctx inBounds := by grind) : BlockPtr :=
   ((op.get ctx (by grind)).blockOperands[index]'(by grind [getNumSuccessors])).value
 
-def getSuccessor! (op: OperationPtr) (ctx: IRContext) (index: Nat) : BlockPtr :=
+def getSuccessor! (op : OperationPtr) (ctx : IRContext) (index : Nat) : BlockPtr :=
   ((op.get! ctx).blockOperands[index]!).value
 
 @[grind _=_]
 theorem getSuccessor!_eq_getSuccessor {op : OperationPtr} {index : Nat}
-    {hin} (h: index < op.getNumSuccessors ctx hin) {hin'} :
+    {hin} (h : index < op.getNumSuccessors ctx hin) {hin'} :
     op.getSuccessor! ctx index = op.getSuccessor ctx index hin' h := by
   grind [getSuccessor, getSuccessor!]
 
-def getNumResults (op: OperationPtr) (ctx: IRContext) (inBounds: op.InBounds ctx := by grind) : Nat :=
+def getNumResults (op : OperationPtr) (ctx : IRContext) (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).results.size
 
-def getNumResults! (op: OperationPtr) (ctx: IRContext) : Nat :=
+def getNumResults! (op : OperationPtr) (ctx : IRContext) : Nat :=
   (op.get! ctx).results.size
 
 @[grind _=_]
@@ -382,7 +382,7 @@ theorem getNumResults!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getNumResults! ctx = op.getNumResults! ctx' := by
   grind [getNumResults!]
 
-def getResult (op: OperationPtr) (index: Nat) : OpResultPtr :=
+def getResult (op : OperationPtr) (index : Nat) : OpResultPtr :=
   { op := op, index := index }
 
 @[simp, grind =]
@@ -399,11 +399,11 @@ theorem eq_getResult_of_OpResultPtr_op_eq {res : OpResultPtr} :
     res.op = op → res = op.getResult res.index := by
   grind [getResult, cases OpResultPtr]
 
-def getNumRegions (op: OperationPtr) (ctx: IRContext)
-    (inBounds: op.InBounds ctx := by grind) : Nat :=
+def getNumRegions (op : OperationPtr) (ctx : IRContext)
+    (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).regions.size
 
-def getNumRegions! (op: OperationPtr) (ctx: IRContext) : Nat :=
+def getNumRegions! (op : OperationPtr) (ctx : IRContext) : Nat :=
   (op.get! ctx).regions.size
 
 @[grind _=_]
@@ -416,12 +416,12 @@ theorem getNumRegions!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getNumRegions! ctx = op.getNumRegions! ctx' := by
   grind [getNumRegions!]
 
-def getRegion (op: OperationPtr) (ctx: IRContext) (index: Nat)
-  (inBounds: op.InBounds ctx := by grind) (iInBounds: index < op.getNumRegions ctx inBounds := by grind) : RegionPtr :=
+def getRegion (op : OperationPtr) (ctx : IRContext) (index : Nat)
+  (inBounds : op.InBounds ctx := by grind) (iInBounds : index < op.getNumRegions ctx inBounds := by grind) : RegionPtr :=
   (op.get ctx (by grind)).regions[index]'(by grind [getNumRegions])
 
 @[grind funCC]
-def getRegion! (op: OperationPtr) (ctx: IRContext) (index: Nat) : RegionPtr :=
+def getRegion! (op : OperationPtr) (ctx : IRContext) (index : Nat) : RegionPtr :=
   (op.get! ctx).regions[index]!
 
 @[grind _=_]
@@ -435,62 +435,62 @@ theorem getRegion!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getRegion! ctx = op.getRegion! ctx' := by
   grind [get!, getRegion!]
 
-def set (ptr: OperationPtr) (ctx: IRContext) (newOp: Operation) : IRContext :=
+def set (ptr : OperationPtr) (ctx : IRContext) (newOp : Operation) : IRContext :=
   {ctx with operations := ctx.operations.insert ptr newOp}
 
-def setNextOp (op: OperationPtr) (ctx: IRContext) (newNext : Option OperationPtr)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setNextOp (op : OperationPtr) (ctx : IRContext) (newNext : Option OperationPtr)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx
   op.set ctx { oldOp with next := newNext}
 
-def setNextOp! (op: OperationPtr) (ctx: IRContext) (newNext : Option OperationPtr) : IRContext :=
+def setNextOp! (op : OperationPtr) (ctx : IRContext) (newNext : Option OperationPtr) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with next := newNext}
 
 @[grind _=_]
-theorem setNextOp!_eq_setNextOp {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setNextOp!_eq_setNextOp {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setNextOp! ctx newNext = op.setNextOp ctx newNext inBounds := by
   grind [setNextOp, setNextOp!]
 
-def setPrevOp (op: OperationPtr) (ctx: IRContext) (newPrev: Option OperationPtr)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setPrevOp (op : OperationPtr) (ctx : IRContext) (newPrev : Option OperationPtr)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx { oldOp with prev := newPrev}
 
-def setPrevOp! (op: OperationPtr) (ctx: IRContext) (newPrev: Option OperationPtr) : IRContext :=
+def setPrevOp! (op : OperationPtr) (ctx : IRContext) (newPrev : Option OperationPtr) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with prev := newPrev}
 
 @[grind _=_]
-theorem setPrevOp!_eq_setPrevOp {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setPrevOp!_eq_setPrevOp {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setPrevOp! ctx newPrev = op.setPrevOp ctx newPrev inBounds := by
   grind [setPrevOp, setPrevOp!]
 
-def setParent (op: OperationPtr) (ctx: IRContext) (newParent: Option BlockPtr)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setParent (op : OperationPtr) (ctx : IRContext) (newParent : Option BlockPtr)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx { oldOp with parent := newParent}
 
-def setParent! (op: OperationPtr) (ctx: IRContext) (newParent: Option BlockPtr) : IRContext :=
+def setParent! (op : OperationPtr) (ctx : IRContext) (newParent : Option BlockPtr) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with parent := newParent}
 
 @[grind _=_]
-theorem setParent!_eq_setParent {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setParent!_eq_setParent {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setParent! ctx newParent = op.setParent ctx newParent inBounds := by
   grind [setParent, setParent!]
 
-def setRegions (op: OperationPtr) (ctx: IRContext) (newRegions: Array RegionPtr)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setRegions (op : OperationPtr) (ctx : IRContext) (newRegions : Array RegionPtr)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx { oldOp with regions := newRegions}
 
-def setRegions! (op: OperationPtr) (ctx: IRContext) (newRegions: Array RegionPtr) : IRContext :=
+def setRegions! (op : OperationPtr) (ctx : IRContext) (newRegions : Array RegionPtr) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with regions := newRegions}
 
 @[grind _=_]
-theorem setRegions!_eq_setRegions {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setRegions!_eq_setRegions {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setRegions! ctx newRegions = op.setRegions ctx newRegions inBounds := by
   grind [setRegions, setRegions!]
 
@@ -502,21 +502,21 @@ def pushRegion! (op : OperationPtr) (ctx : IRContext) (reg : RegionPtr) :=
   op.setRegions! ctx ((op.get! ctx).regions.push reg)
 
 @[grind _=_]
-theorem pushRegion!_eq_pushRegion {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem pushRegion!_eq_pushRegion {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.pushRegion ctx newRegion = op.pushRegion ctx newRegion inBounds := by
   grind [setRegions, setRegions!]
 
-def setResults (op: OperationPtr) (ctx: IRContext) (newResults: Array OpResult)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setResults (op : OperationPtr) (ctx : IRContext) (newResults : Array OpResult)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx { oldOp with results := newResults}
 
-def setResults! (op: OperationPtr) (ctx: IRContext) (newResults: Array OpResult) : IRContext :=
+def setResults! (op : OperationPtr) (ctx : IRContext) (newResults : Array OpResult) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with results := newResults}
 
 @[grind _=_]
-theorem setResults!_eq_setResults {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setResults!_eq_setResults {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setResults! ctx newResults = op.setResults ctx newResults inBounds := by
   grind [setResults, setResults!]
 
@@ -528,22 +528,22 @@ def pushResult! (op : OperationPtr) (ctx : IRContext) (resultS : OpResult) : IRC
   op.setResults! ctx ((op.get! ctx).results.push resultS)
 
 @[grind _=_]
-theorem pushResult!_eq_pushResult {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem pushResult!_eq_pushResult {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.pushResult! ctx resultS = op.pushResult ctx resultS inBounds := by
   grind [pushResult, pushResult!]
 
-def setBlockOperands (op: OperationPtr) (ctx: IRContext) (newOperands: Array BlockOperand)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setBlockOperands (op : OperationPtr) (ctx : IRContext) (newOperands : Array BlockOperand)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx {oldOp with blockOperands := newOperands}
 
-def setBlockOperands! (op: OperationPtr) (ctx: IRContext) (newOperands: Array BlockOperand) :
+def setBlockOperands! (op : OperationPtr) (ctx : IRContext) (newOperands : Array BlockOperand) :
     IRContext :=
   let oldOp := op.get! ctx
   op.set ctx {oldOp with blockOperands := newOperands}
 
 @[grind _=_]
-theorem setBlockOperands!_eq_setBlockOperands {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setBlockOperands!_eq_setBlockOperands {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setBlockOperands! ctx newOperands = op.setBlockOperands ctx newOperands inBounds := by
   grind [setBlockOperands, setBlockOperands!]
 
@@ -557,21 +557,21 @@ def pushBlockOperand! (op : OperationPtr) (ctx : IRContext) (operands : BlockOpe
 
 @[grind _=_]
 theorem pushBlockOperand!_eq_pushBlockOperand
-    {op : OperationPtr} (inBounds: op.InBounds ctx) :
+    {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.pushBlockOperand! ctx operands = op.pushBlockOperand ctx operands inBounds := by
   grind [pushBlockOperand, pushBlockOperand!]
 
-def setOperands (op: OperationPtr) (ctx: IRContext) (newOperands: Array OpOperand)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setOperands (op : OperationPtr) (ctx : IRContext) (newOperands : Array OpOperand)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx { oldOp with operands := newOperands}
 
-def setOperands! (op: OperationPtr) (ctx: IRContext) (newOperands: Array OpOperand) : IRContext :=
+def setOperands! (op : OperationPtr) (ctx : IRContext) (newOperands : Array OpOperand) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with operands := newOperands}
 
 @[grind _=_]
-theorem setOperands!_eq_setOperands {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setOperands!_eq_setOperands {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setOperands! ctx newOperands = op.setOperands ctx newOperands inBounds := by
   grind [setOperands, setOperands!]
 
@@ -583,21 +583,21 @@ def pushOperand! (op : OperationPtr) (ctx : IRContext) (operands : OpOperand) : 
   op.setOperands! ctx ((op.get! ctx).operands.push operands)
 
 @[grind _=_]
-theorem pushOperand!_eq_pushOperand {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem pushOperand!_eq_pushOperand {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.pushOperand! ctx operands = op.pushOperand ctx operands inBounds := by
   grind [pushOperand, pushOperand!]
 
-def setAttributes (op: OperationPtr) (ctx: IRContext) (newAttrs: DictionaryAttr)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+def setAttributes (op : OperationPtr) (ctx : IRContext) (newAttrs : DictionaryAttr)
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   let oldOp := op.get ctx
   op.set ctx { oldOp with attrs := newAttrs}
 
-def setAttributes! (op: OperationPtr) (ctx: IRContext) (newAttrs: DictionaryAttr) : IRContext :=
+def setAttributes! (op : OperationPtr) (ctx : IRContext) (newAttrs : DictionaryAttr) : IRContext :=
   let oldOp := op.get! ctx
   op.set ctx { oldOp with attrs := newAttrs}
 
 @[grind _=_]
-theorem setAttributes!_eq_setAttributes {op : OperationPtr} (inBounds: op.InBounds ctx) :
+theorem setAttributes!_eq_setAttributes {op : OperationPtr} (inBounds : op.InBounds ctx) :
     op.setAttributes! ctx newAttrs = op.setAttributes ctx newAttrs inBounds := by
   grind [setAttributes, setAttributes!]
 
@@ -615,19 +615,19 @@ def getProperties! (op : OperationPtr) (ctx : IRContext) (opCode : OpCode) : pro
     default
 
 @[grind _=_]
-theorem getProperties!_eq_getProperties {op : OperationPtr} (inBounds: op.InBounds ctx)
+theorem getProperties!_eq_getProperties {op : OperationPtr} (inBounds : op.InBounds ctx)
     (hprop : (op.get! ctx).opType = opCode) :
     op.getProperties! ctx opCode = op.getProperties ctx opCode inBounds (by grind) := by
   grind [getProperties, getProperties!]
 
 def setProperties (op : OperationPtr) (ctx : IRContext)
     (newProperties : propertiesOf opCode)
-    (inBounds: op.InBounds ctx := by grind)
+    (inBounds : op.InBounds ctx := by grind)
     (hprop : (op.get ctx inBounds).opType = opCode := by grind) : IRContext :=
   let oldOp := op.get ctx (by grind)
   op.set ctx { oldOp with properties := hprop ▸ newProperties }
 
-def setProperties! (op: OperationPtr) (ctx: IRContext)
+def setProperties! (op : OperationPtr) (ctx : IRContext)
   (newProperties : propertiesOf opCode)
   (hprop : (op.get! ctx).opType = opCode := by grind) : IRContext :=
   let oldOp := op.get! ctx
@@ -635,7 +635,7 @@ def setProperties! (op: OperationPtr) (ctx: IRContext)
 
 @[grind _=_]
 theorem setProperties!_eq_setProperties {op : OperationPtr}
-    (newProperties : propertiesOf opCode) (inBounds: op.InBounds ctx)
+    (newProperties : propertiesOf opCode) (inBounds : op.InBounds ctx)
     (hprop : (op.get ctx inBounds).opType = opCode) :
     op.setProperties! ctx newProperties =
     op.setProperties ctx newProperties inBounds := by
@@ -643,7 +643,7 @@ theorem setProperties!_eq_setProperties {op : OperationPtr}
 
 @[grind]
 def nextOperand (op : OperationPtr) (ctx : IRContext)
-    (inBounds: op.InBounds ctx := by grind) : OpOperandPtr :=
+    (inBounds : op.InBounds ctx := by grind) : OpOperandPtr :=
   .mk op (op.getNumOperands ctx (by grind))
 
 @[grind]
@@ -652,7 +652,7 @@ def nextOperand! (op : OperationPtr) (ctx : IRContext) : OpOperandPtr :=
 
 @[grind]
 def nextBlockOperand (op : OperationPtr) (ctx : IRContext)
-    (inBounds: op.InBounds ctx := by grind) : BlockOperandPtr :=
+    (inBounds : op.InBounds ctx := by grind) : BlockOperandPtr :=
   .mk op (op.getNumSuccessors ctx (by grind))
 
 @[grind]
@@ -661,7 +661,7 @@ def nextBlockOperand! (op : OperationPtr) (ctx : IRContext) : BlockOperandPtr :=
 
 @[grind]
 def nextResult (op : OperationPtr) (ctx : IRContext)
-    (inBounds: op.InBounds ctx := by grind) : OpResultPtr :=
+    (inBounds : op.InBounds ctx := by grind) : OpResultPtr :=
   .mk op (op.getNumResults ctx (by grind))
 
 @[grind]
@@ -681,7 +681,7 @@ def allocEmpty (ctx : IRContext) (opType : OpCode) (properties : propertiesOf op
 -- We still keep it as an API consistency.
 set_option linter.unusedVariables false in
 def dealloc (op : OperationPtr) (ctx : IRContext)
-    (inBounds: op.InBounds ctx := by grind) : IRContext :=
+    (inBounds : op.InBounds ctx := by grind) : IRContext :=
   { ctx with operations := ctx.operations.erase op }
 
 end OperationPtr
@@ -693,7 +693,7 @@ end OperationPtr
 namespace OpOperandPtr
 
 @[local grind]
-def InBounds (operand: OpOperandPtr) (ctx: IRContext) : Prop :=
+def InBounds (operand : OpOperandPtr) (ctx : IRContext) : Prop :=
   ∃ h, operand.index < (operand.op.get ctx h).operands.size
 
 theorem inBounds_def : InBounds opr ctx ↔ ∃ h, opr.index < opr.op.getNumOperands ctx h := by
@@ -706,10 +706,10 @@ theorem InBounds_iff (operand : OpOperandPtr) (ctx : IRContext) :
     operand.InBounds ctx :=
   by grind [inBounds_def]
 
-def get (operand: OpOperandPtr) (ctx: IRContext) (operandIn: operand.InBounds ctx := by grind) : OpOperand :=
+def get (operand : OpOperandPtr) (ctx : IRContext) (operandIn : operand.InBounds ctx := by grind) : OpOperand :=
   (operand.op.get ctx (by grind [InBounds])).operands[operand.index]'(by grind [InBounds, OperationPtr.getNumOperands])
 
-def get! (operand: OpOperandPtr) (ctx: IRContext) : OpOperand :=
+def get! (operand : OpOperandPtr) (ctx : IRContext) : OpOperand :=
   (operand.op.get! ctx).operands[operand.index]!
 
 @[grind _=_]
@@ -722,15 +722,15 @@ theorem get!_eq_of_OperationPtr_get!_eq {opr : OpOperandPtr} :
     opr.get! ctx = opr.get! ctx' := by
   grind [OperationPtr.get!, get!]
 
-def set (operand: OpOperandPtr) (ctx: IRContext) (newOperand: OpOperand)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def set (operand : OpOperandPtr) (ctx : IRContext) (newOperand : OpOperand)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let op := operand.op.get ctx
   { ctx with
     operations := ctx.operations.insert operand.op
       { op with
         operands := op.operands.set operand.index newOperand (by grind)} }
 
-def set! (operand: OpOperandPtr) (ctx: IRContext) (newOperand: OpOperand) : IRContext :=
+def set! (operand : OpOperandPtr) (ctx : IRContext) (newOperand : OpOperand) : IRContext :=
   let op := operand.op.get! ctx
   { ctx with
     operations := ctx.operations.insert operand.op
@@ -738,63 +738,63 @@ def set! (operand: OpOperandPtr) (ctx: IRContext) (newOperand: OpOperand) : IRCo
         operands := op.operands.set! operand.index newOperand } }
 
 @[grind _=_]
-theorem set!_eq_set {operand : OpOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem set!_eq_set {operand : OpOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.set! ctx newOperand = operand.set ctx newOperand inBounds := by
   grind [set, set!]
 
-def setNextUse (operand: OpOperandPtr) (ctx: IRContext) (newNextUse: Option OpOperandPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setNextUse (operand : OpOperandPtr) (ctx : IRContext) (newNextUse : Option OpOperandPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with nextUse := newNextUse }
 
-def setNextUse! (operand: OpOperandPtr) (ctx: IRContext) (newNextUse: Option OpOperandPtr) : IRContext :=
+def setNextUse! (operand : OpOperandPtr) (ctx : IRContext) (newNextUse : Option OpOperandPtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with nextUse := newNextUse }
 
 @[grind _=_]
-theorem setNextUse!_eq_setNextUse {operand : OpOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setNextUse!_eq_setNextUse {operand : OpOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setNextUse! ctx newNextUse = operand.setNextUse ctx newNextUse inBounds := by
   grind [setNextUse, setNextUse!]
 
-def setBack (operand: OpOperandPtr) (ctx: IRContext) (newBack: OpOperandPtrPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setBack (operand : OpOperandPtr) (ctx : IRContext) (newBack : OpOperandPtrPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with back := newBack }
 
-def setBack! (operand: OpOperandPtr) (ctx: IRContext) (newBack: OpOperandPtrPtr) : IRContext :=
+def setBack! (operand : OpOperandPtr) (ctx : IRContext) (newBack : OpOperandPtrPtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with back := newBack }
 
 @[grind _=_]
-theorem setBack!_eq_setBack {operand : OpOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setBack!_eq_setBack {operand : OpOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setBack! ctx newBack = operand.setBack ctx newBack inBounds := by
   grind [setBack, setBack!]
 
-def setOwner (operand: OpOperandPtr) (ctx: IRContext) (newOwner: OperationPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setOwner (operand : OpOperandPtr) (ctx : IRContext) (newOwner : OperationPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with owner := newOwner }
 
-def setOwner! (operand: OpOperandPtr) (ctx: IRContext) (newOwner: OperationPtr) : IRContext :=
+def setOwner! (operand : OpOperandPtr) (ctx : IRContext) (newOwner : OperationPtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with owner := newOwner }
 
 @[grind _=_]
-theorem setOwner!_eq_setOwner {operand : OpOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setOwner!_eq_setOwner {operand : OpOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setOwner! ctx newOwner = operand.setOwner ctx newOwner inBounds := by
   grind [setOwner, setOwner!]
 
-def setValue (operand: OpOperandPtr) (ctx: IRContext) (newValue: ValuePtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setValue (operand : OpOperandPtr) (ctx : IRContext) (newValue : ValuePtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with value := newValue }
 
-def setValue! (operand: OpOperandPtr) (ctx: IRContext) (newValue: ValuePtr) : IRContext :=
+def setValue! (operand : OpOperandPtr) (ctx : IRContext) (newValue : ValuePtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with value := newValue }
 
 @[grind _=_]
-theorem setValue!_eq_setValue {operand : OpOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setValue!_eq_setValue {operand : OpOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setValue! ctx newValue = operand.setValue ctx newValue inBounds := by
   grind [setValue, setValue!]
 
@@ -813,7 +813,7 @@ theorem OperationPtr.getOperand_eq_OpOperandPtr_get :
 namespace BlockOperandPtr
 
 @[local grind]
-def InBounds (operand: BlockOperandPtr) (ctx: IRContext) : Prop :=
+def InBounds (operand : BlockOperandPtr) (ctx : IRContext) : Prop :=
   ∃ h, operand.index < (operand.op.get ctx h).blockOperands.size
 
 theorem inBounds_def :
@@ -827,9 +827,9 @@ theorem inBounds_of_OperationPtr_inBounds {operand : BlockOperandPtr} {ctx : IRC
     operand.InBounds ctx :=
   by grind [inBounds_def]
 
-def get (operand: BlockOperandPtr) (ctx: IRContext) (operandIn: operand.InBounds ctx := by grind) : BlockOperand :=
+def get (operand : BlockOperandPtr) (ctx : IRContext) (operandIn : operand.InBounds ctx := by grind) : BlockOperand :=
   (operand.op.get ctx (by grind [InBounds])).blockOperands[operand.index]'(by grind [InBounds])
-def get! (operand: BlockOperandPtr) (ctx: IRContext) : BlockOperand :=
+def get! (operand : BlockOperandPtr) (ctx : IRContext) : BlockOperand :=
   operand.op.get! ctx |>.blockOperands[operand.index]!
 @[grind _=_]
 theorem get!_eq_get {ptr : BlockOperandPtr} (hin : ptr.InBounds ctx) :
@@ -841,14 +841,14 @@ theorem get!_eq_of_OperationPtr_get!_eq {opr : BlockOperandPtr} :
     opr.get! ctx = opr.get! ctx' := by
   grind [OperationPtr.get!, get!]
 
-def set (operand: BlockOperandPtr) (ctx: IRContext) (newOperand: BlockOperand) (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def set (operand : BlockOperandPtr) (ctx : IRContext) (newOperand : BlockOperand) (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let op := operand.op.get ctx
   { ctx with
     operations := ctx.operations.insert operand.op
       { op with
         blockOperands := op.blockOperands.set operand.index newOperand (by grind)} }
 
-def set! (operand: BlockOperandPtr) (ctx: IRContext) (newOperand: BlockOperand) : IRContext :=
+def set! (operand : BlockOperandPtr) (ctx : IRContext) (newOperand : BlockOperand) : IRContext :=
   let op := operand.op.get! ctx
   { ctx with
     operations := ctx.operations.insert operand.op
@@ -856,63 +856,63 @@ def set! (operand: BlockOperandPtr) (ctx: IRContext) (newOperand: BlockOperand) 
         blockOperands := op.blockOperands.set! operand.index newOperand } }
 
 @[grind _=_]
-theorem set!_eq_set {operand : BlockOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem set!_eq_set {operand : BlockOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.set! ctx newOperand = operand.set ctx newOperand inBounds := by
   grind [set, set!]
 
-def setNextUse (operand: BlockOperandPtr) (ctx: IRContext) (newNextUse: Option BlockOperandPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setNextUse (operand : BlockOperandPtr) (ctx : IRContext) (newNextUse : Option BlockOperandPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with nextUse := newNextUse }
 
-def setNextUse! (operand: BlockOperandPtr) (ctx: IRContext) (newNextUse: Option BlockOperandPtr) :
+def setNextUse! (operand : BlockOperandPtr) (ctx : IRContext) (newNextUse : Option BlockOperandPtr) :
     IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with nextUse := newNextUse }
 
 @[grind _=_]
-theorem setNextUse!_eq_setNextUse {operand : BlockOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setNextUse!_eq_setNextUse {operand : BlockOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setNextUse! ctx newNextUse = operand.setNextUse ctx newNextUse inBounds := by
   grind [setNextUse, setNextUse!]
 
-def setBack (operand: BlockOperandPtr) (ctx: IRContext) (newBack: BlockOperandPtrPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setBack (operand : BlockOperandPtr) (ctx : IRContext) (newBack : BlockOperandPtrPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with back := newBack }
 
-def setBack! (operand: BlockOperandPtr) (ctx: IRContext) (newBack: BlockOperandPtrPtr) : IRContext :=
+def setBack! (operand : BlockOperandPtr) (ctx : IRContext) (newBack : BlockOperandPtrPtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with back := newBack }
 
-theorem setBack!_eq_setBack {operand : BlockOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setBack!_eq_setBack {operand : BlockOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setBack! ctx newBack = operand.setBack ctx newBack inBounds := by
   grind [setBack, setBack!]
 
-def setOwner (operand: BlockOperandPtr) (ctx: IRContext) (newOwner: OperationPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setOwner (operand : BlockOperandPtr) (ctx : IRContext) (newOwner : OperationPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with owner := newOwner }
 
-def setOwner! (operand: BlockOperandPtr) (ctx: IRContext) (newOwner: OperationPtr) : IRContext :=
+def setOwner! (operand : BlockOperandPtr) (ctx : IRContext) (newOwner : OperationPtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with owner := newOwner }
 
 @[grind _=_]
-theorem setOwner!_eq_setOwner {operand : BlockOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setOwner!_eq_setOwner {operand : BlockOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setOwner! ctx newOwner = operand.setOwner ctx newOwner inBounds := by
   grind [setOwner, setOwner!]
 
-def setValue (operand: BlockOperandPtr) (ctx: IRContext) (newValue: BlockPtr)
-    (operandIn: operand.InBounds ctx := by grind) : IRContext :=
+def setValue (operand : BlockOperandPtr) (ctx : IRContext) (newValue : BlockPtr)
+    (operandIn : operand.InBounds ctx := by grind) : IRContext :=
   let oldOperand := operand.get ctx
   operand.set ctx { oldOperand with value := newValue }
 
-def setValue! (operand: BlockOperandPtr) (ctx: IRContext) (newValue: BlockPtr) : IRContext :=
+def setValue! (operand : BlockOperandPtr) (ctx : IRContext) (newValue : BlockPtr) : IRContext :=
   let oldOperand := operand.get! ctx
   operand.set! ctx { oldOperand with value := newValue }
 
 @[grind _=_]
-theorem setValue!_eq_setValue {operand : BlockOperandPtr} (inBounds: operand.InBounds ctx) :
+theorem setValue!_eq_setValue {operand : BlockOperandPtr} (inBounds : operand.InBounds ctx) :
     operand.setValue! ctx newValue = operand.setValue ctx newValue inBounds := by
   grind [setValue, setValue!]
 
@@ -925,14 +925,14 @@ end BlockOperandPtr
 namespace OpResultPtr
 
 @[local grind]
-def InBounds (result: OpResultPtr) (ctx: IRContext) : Prop :=
+def InBounds (result : OpResultPtr) (ctx : IRContext) : Prop :=
   ∃ h, result.index < (result.op.get ctx h).results.size
 
 theorem inBounds_def : InBounds res ctx ↔ ∃ h, res.index < res.op.getNumResults ctx h := by
   rfl
 
 @[grind .]
-theorem inBounds_OperationPtr_getNumResults! (result: OpResultPtr) (ctx: IRContext) (h: result.InBounds ctx) :
+theorem inBounds_OperationPtr_getNumResults! (result : OpResultPtr) (ctx : IRContext) (h : result.InBounds ctx) :
     result.index < result.op.getNumResults! ctx := by
   simp [OperationPtr.getNumResults!, OperationPtr.get!]
   grind [OperationPtr.get]
@@ -944,10 +944,10 @@ theorem inBounds_of {result : OpResultPtr} :
     result.InBounds ctx :=
   by grind [InBounds, OperationPtr.getNumResults!]
 
-def get (result: OpResultPtr) (ctx: IRContext) (resultIn: result.InBounds ctx := by grind) : OpResult :=
+def get (result : OpResultPtr) (ctx : IRContext) (resultIn : result.InBounds ctx := by grind) : OpResult :=
   (result.op.get ctx (by grind [InBounds])).results[result.index]'(by grind [InBounds])
 
-def get! (result: OpResultPtr) (ctx: IRContext) : OpResult :=
+def get! (result : OpResultPtr) (ctx : IRContext) : OpResult :=
   (result.op.get! ctx).results[result.index]!
 
 @[grind _=_]
@@ -960,62 +960,62 @@ theorem get!_eq_of_OperationPtr_get!_eq {res : OpResultPtr} :
     res.get! ctx = res.get! ctx' := by
   grind [OperationPtr.get!, get!]
 
-def set (result: OpResultPtr) (ctx: IRContext) (newresult: OpResult) (resultIn: result.InBounds ctx := by grind) : IRContext :=
+def set (result : OpResultPtr) (ctx : IRContext) (newresult : OpResult) (resultIn : result.InBounds ctx := by grind) : IRContext :=
   let op := result.op.get ctx
   { ctx with
     operations := ctx.operations.insert result.op
       { op with results := op.results.set result.index newresult (by grind)} }
 
-def set! (result: OpResultPtr) (ctx: IRContext) (newresult: OpResult) : IRContext :=
+def set! (result : OpResultPtr) (ctx : IRContext) (newresult : OpResult) : IRContext :=
   let op := result.op.get! ctx
   { ctx with
     operations := ctx.operations.insert result.op
       { op with results := op.results.set! result.index newresult } }
 
 @[grind _=_]
-theorem set!_eq_set {result : OpResultPtr} (inBounds: result.InBounds ctx) :
+theorem set!_eq_set {result : OpResultPtr} (inBounds : result.InBounds ctx) :
     result.set! ctx newresult = result.set ctx newresult inBounds := by
   grind [set, set!]
 
-def setType (result: OpResultPtr) (ctx: IRContext) (newType: TypeAttr)
-    (resultIn: result.InBounds ctx := by grind) : IRContext :=
+def setType (result : OpResultPtr) (ctx : IRContext) (newType : TypeAttr)
+    (resultIn : result.InBounds ctx := by grind) : IRContext :=
   let oldResult := result.get ctx
   result.set ctx { oldResult with type := newType }
 
-def setType! (result: OpResultPtr) (ctx: IRContext) (newType: TypeAttr) : IRContext :=
+def setType! (result : OpResultPtr) (ctx : IRContext) (newType : TypeAttr) : IRContext :=
   let oldResult := result.get! ctx
   result.set! ctx { oldResult with type := newType }
 
 @[grind _=_]
-theorem setType!_eq_setType {result : OpResultPtr} (inBounds: result.InBounds ctx) :
+theorem setType!_eq_setType {result : OpResultPtr} (inBounds : result.InBounds ctx) :
     result.setType! ctx newType = result.setType ctx newType inBounds := by
   grind [setType, setType!]
 
-def setFirstUse (result: OpResultPtr) (ctx: IRContext) (newFirstUse: Option OpOperandPtr)
-    (resultIn: result.InBounds ctx := by grind) : IRContext :=
+def setFirstUse (result : OpResultPtr) (ctx : IRContext) (newFirstUse : Option OpOperandPtr)
+    (resultIn : result.InBounds ctx := by grind) : IRContext :=
   let oldResult := result.get ctx
   result.set ctx { oldResult with firstUse := newFirstUse }
 
-def setFirstUse! (result: OpResultPtr) (ctx: IRContext) (newFirstUse: Option OpOperandPtr) : IRContext :=
+def setFirstUse! (result : OpResultPtr) (ctx : IRContext) (newFirstUse : Option OpOperandPtr) : IRContext :=
   let oldResult := result.get! ctx
   result.set! ctx { oldResult with firstUse := newFirstUse }
 
 @[grind _=_]
-theorem setFirstUse!_eq_setFirstUse {result : OpResultPtr} (inBounds: result.InBounds ctx) :
+theorem setFirstUse!_eq_setFirstUse {result : OpResultPtr} (inBounds : result.InBounds ctx) :
     result.setFirstUse! ctx newFirstUse = result.setFirstUse ctx newFirstUse inBounds := by
   grind [setFirstUse, setFirstUse!]
 
-def setOwner (result: OpResultPtr) (ctx: IRContext) (newOwner: OperationPtr)
-    (resultIn: result.InBounds ctx := by grind) : IRContext :=
+def setOwner (result : OpResultPtr) (ctx : IRContext) (newOwner : OperationPtr)
+    (resultIn : result.InBounds ctx := by grind) : IRContext :=
   let oldResult := result.get ctx
   result.set ctx { oldResult with owner := newOwner }
 
-def setOwner! (result: OpResultPtr) (ctx: IRContext) (newOwner: OperationPtr) : IRContext :=
+def setOwner! (result : OpResultPtr) (ctx : IRContext) (newOwner : OperationPtr) : IRContext :=
   let oldResult := result.get! ctx
   result.set! ctx { oldResult with owner := newOwner }
 
 @[grind _=_]
-theorem setOwner!_eq_setOwner {result : OpResultPtr} (inBounds: result.InBounds ctx) :
+theorem setOwner!_eq_setOwner {result : OpResultPtr} (inBounds : result.InBounds ctx) :
     result.setOwner! ctx newOwner = result.setOwner ctx newOwner inBounds := by
   grind [setOwner, setOwner!]
 
@@ -1027,108 +1027,108 @@ end OpResultPtr
 
 namespace BlockPtr
 
-def InBounds (block: BlockPtr) (ctx: IRContext) : Prop :=
+def InBounds (block : BlockPtr) (ctx : IRContext) : Prop :=
   block ∈ ctx.blocks
 
-def get (ptr: BlockPtr) (ctx: IRContext) (inBounds: ptr.InBounds ctx := by grind) : Block :=
+def get (ptr : BlockPtr) (ctx : IRContext) (inBounds : ptr.InBounds ctx := by grind) : Block :=
   ctx.blocks[ptr]'(by unfold InBounds at inBounds; grind)
 
-def get! (ptr: BlockPtr) (ctx: IRContext) : Block := ctx.blocks[ptr]!
+def get! (ptr : BlockPtr) (ctx : IRContext) : Block := ctx.blocks[ptr]!
 
 @[grind _=_]
 theorem get!_eq_get {ptr : BlockPtr} (hin : ptr.InBounds ctx) :
     ptr.get! ctx = ptr.get ctx hin := by
   grind [get, get!]
 
-def set (ptr: BlockPtr) (ctx: IRContext) (newBlock: Block) : IRContext :=
+def set (ptr : BlockPtr) (ctx : IRContext) (newBlock : Block) : IRContext :=
   {ctx with blocks := ctx.blocks.insert ptr newBlock}
 
-def setParent (block: BlockPtr) (ctx: IRContext) (newParent: Option RegionPtr)
-    (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setParent (block : BlockPtr) (ctx : IRContext) (newParent : Option RegionPtr)
+    (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx
   block.set ctx { oldBlock with parent := newParent}
 
-def setParent! (block: BlockPtr) (ctx: IRContext) (newParent: Option RegionPtr) : IRContext :=
+def setParent! (block : BlockPtr) (ctx : IRContext) (newParent : Option RegionPtr) : IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx {oldBlock with parent := newParent}
 
 @[grind _=_]
-theorem setParent!_eq_setParent {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setParent!_eq_setParent {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setParent! ctx newParent = block.setParent ctx newParent inBounds := by
   grind [setParent, setParent!]
 
-def setFirstUse (block: BlockPtr) (ctx: IRContext) (newFirstUse: Option BlockOperandPtr)
-    (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setFirstUse (block : BlockPtr) (ctx : IRContext) (newFirstUse : Option BlockOperandPtr)
+    (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx
   block.set ctx { oldBlock with firstUse := newFirstUse}
 
-def setFirstUse! (block: BlockPtr) (ctx: IRContext) (newFirstUse: Option BlockOperandPtr) : IRContext :=
+def setFirstUse! (block : BlockPtr) (ctx : IRContext) (newFirstUse : Option BlockOperandPtr) : IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx {oldBlock with firstUse := newFirstUse}
 
 @[grind _=_]
-theorem setFirstUse!_eq_setFirstUse {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setFirstUse!_eq_setFirstUse {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setFirstUse! ctx newFirstUse = block.setFirstUse ctx newFirstUse inBounds := by
   grind [setFirstUse, setFirstUse!]
 
-def setFirstOp (block: BlockPtr) (ctx: IRContext) (newFirstOp: Option OperationPtr)
-    (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setFirstOp (block : BlockPtr) (ctx : IRContext) (newFirstOp : Option OperationPtr)
+    (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx
   block.set ctx { oldBlock with firstOp := newFirstOp}
 
-def setFirstOp! (block: BlockPtr) (ctx: IRContext) (newFirstOp: Option OperationPtr) : IRContext :=
+def setFirstOp! (block : BlockPtr) (ctx : IRContext) (newFirstOp : Option OperationPtr) : IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx {oldBlock with firstOp := newFirstOp}
 
 @[grind _=_]
-theorem setFirstOp!_eq_setFirstOp {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setFirstOp!_eq_setFirstOp {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setFirstOp! ctx newFirstOp = block.setFirstOp ctx newFirstOp inBounds := by
   grind [setFirstOp, setFirstOp!]
 
-def setLastOp (block: BlockPtr) (ctx: IRContext) (newLastOp: Option OperationPtr)
-    (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setLastOp (block : BlockPtr) (ctx : IRContext) (newLastOp : Option OperationPtr)
+    (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx
   block.set ctx { oldBlock with lastOp := newLastOp}
 
-def setLastOp! (block: BlockPtr) (ctx: IRContext) (newLastOp: Option OperationPtr) : IRContext :=
+def setLastOp! (block : BlockPtr) (ctx : IRContext) (newLastOp : Option OperationPtr) : IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx {oldBlock with lastOp := newLastOp}
 
 @[grind _=_]
-theorem setLastOp!_eq_setLastOp {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setLastOp!_eq_setLastOp {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setLastOp! ctx newLastOp = block.setLastOp ctx newLastOp inBounds := by
   grind [setLastOp, setLastOp!]
 
-def setNextBlock (block: BlockPtr) (ctx: IRContext) (newNext: Option BlockPtr)
-    (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setNextBlock (block : BlockPtr) (ctx : IRContext) (newNext : Option BlockPtr)
+    (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx
   block.set ctx { oldBlock with next := newNext}
 
-def setNextBlock! (block: BlockPtr) (ctx: IRContext) (newNext: Option BlockPtr) : IRContext :=
+def setNextBlock! (block : BlockPtr) (ctx : IRContext) (newNext : Option BlockPtr) : IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx {oldBlock with next := newNext}
 
 @[grind _=_]
-theorem setNextBlock!_eq_setNextBlock {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setNextBlock!_eq_setNextBlock {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setNextBlock! ctx newNext = block.setNextBlock ctx newNext inBounds := by
   grind [setNextBlock, setNextBlock!]
 
-def setPrevBlock (block: BlockPtr) (ctx: IRContext) (newPrev: Option BlockPtr)
-    (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setPrevBlock (block : BlockPtr) (ctx : IRContext) (newPrev : Option BlockPtr)
+    (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx
   block.set ctx { oldBlock with prev := newPrev}
 
-def setPrevBlock! (block: BlockPtr) (ctx: IRContext) (newPrev: Option BlockPtr) : IRContext :=
+def setPrevBlock! (block : BlockPtr) (ctx : IRContext) (newPrev : Option BlockPtr) : IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx {oldBlock with prev := newPrev}
 
 @[grind _=_]
-theorem setPrevBlock!_eq_setPrevBlock {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setPrevBlock!_eq_setPrevBlock {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setPrevBlock! ctx newPrev = block.setPrevBlock ctx newPrev inBounds := by
   grind [setPrevBlock, setPrevBlock!]
 
-def allocEmpty (ctx: IRContext) : Option (IRContext × BlockPtr) :=
-  let newBlockPtr: BlockPtr := ⟨ctx.nextID⟩
+def allocEmpty (ctx : IRContext) : Option (IRContext × BlockPtr) :=
+  let newBlockPtr : BlockPtr := ⟨ctx.nextID⟩
   let ctx : IRContext := { ctx with nextID := ctx.nextID + 1}
   if _ : ctx.blocks.contains newBlockPtr then none else
   let ctx := newBlockPtr.set ctx Block.empty
@@ -1138,10 +1138,10 @@ theorem allocEmpty_def (heq : allocEmpty ctx = some (ctx', ptr')) :
     ctx' = set ⟨ctx.nextID⟩ {ctx with nextID := ctx.nextID + 1} Block.empty := by
   grind [allocEmpty]
 
-def getNumArguments (block: BlockPtr) (ctx: IRContext) (inBounds: block.InBounds ctx := by grind) : Nat :=
+def getNumArguments (block : BlockPtr) (ctx : IRContext) (inBounds : block.InBounds ctx := by grind) : Nat :=
   (block.get ctx (by grind)).arguments.size
 
-def getNumArguments! (block: BlockPtr) (ctx: IRContext) : Nat :=
+def getNumArguments! (block : BlockPtr) (ctx : IRContext) : Nat :=
   (block.get! ctx).arguments.size
 
 @[grind _=_]
@@ -1154,7 +1154,7 @@ theorem getNumArguments!_eq_of_BlockPtr_get!_eq {block : BlockPtr} :
     block.getNumArguments! ctx = block.getNumArguments! ctx' := by
   grind [getNumArguments!]
 
-def getArgument (block: BlockPtr) (index: Nat) : BlockArgumentPtr :=
+def getArgument (block : BlockPtr) (index : Nat) : BlockArgumentPtr :=
   { block := block, index := index }
 
 @[simp, grind =]
@@ -1167,18 +1167,18 @@ theorem getArgument_block {block : BlockPtr} {index : Nat} :
     (getArgument block index).block = block := by
   grind [getArgument]
 
-def setArguments (block: BlockPtr) (ctx: IRContext)
-    (newArguments: Array BlockArgument) (inBounds: block.InBounds ctx := by grind) : IRContext :=
+def setArguments (block : BlockPtr) (ctx : IRContext)
+    (newArguments : Array BlockArgument) (inBounds : block.InBounds ctx := by grind) : IRContext :=
   let oldBlock := block.get ctx (by grind)
   block.set ctx { oldBlock with arguments := newArguments }
 
-def setArguments! (block: BlockPtr) (ctx: IRContext) (newArguments: Array BlockArgument) :
+def setArguments! (block : BlockPtr) (ctx : IRContext) (newArguments : Array BlockArgument) :
     IRContext :=
   let oldBlock := block.get! ctx
   block.set ctx { oldBlock with arguments := newArguments }
 
 @[grind _=_]
-theorem setArguments!_eq_setArguments {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem setArguments!_eq_setArguments {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.setArguments! ctx newArguments = block.setArguments ctx newArguments inBounds := by
   grind [setArguments, setArguments!]
 
@@ -1190,7 +1190,7 @@ def pushArgument! (block : BlockPtr) (ctx : IRContext) (result : BlockArgument) 
   block.setArguments! ctx ((block.get! ctx).arguments.push result)
 
 @[grind _=_]
-theorem pushArgument!_eq_pushArgument {block : BlockPtr} (inBounds: block.InBounds ctx) :
+theorem pushArgument!_eq_pushArgument {block : BlockPtr} (inBounds : block.InBounds ctx) :
     block.pushArgument! ctx result = block.pushArgument ctx result inBounds := by
   grind [pushArgument, pushArgument!]
 
@@ -1203,13 +1203,13 @@ end BlockPtr
 namespace BlockArgumentPtr
 
 @[local grind]
-def InBounds (arg: BlockArgumentPtr) (ctx: IRContext) : Prop :=
+def InBounds (arg : BlockArgumentPtr) (ctx : IRContext) : Prop :=
   ∃ h, arg.index < (arg.block.get ctx h).arguments.size
 
-def get (arg: BlockArgumentPtr) (ctx: IRContext) (argIn: arg.InBounds ctx := by grind) : BlockArgument :=
+def get (arg : BlockArgumentPtr) (ctx : IRContext) (argIn : arg.InBounds ctx := by grind) : BlockArgument :=
   (arg.block.get ctx (by grind [InBounds])).arguments[arg.index]'(by grind [InBounds])
 
-def get! (arg: BlockArgumentPtr) (ctx: IRContext) : BlockArgument :=
+def get! (arg : BlockArgumentPtr) (ctx : IRContext) : BlockArgument :=
   (arg.block.get! ctx).arguments[arg.index]!
 
 @[grind _=_]
@@ -1222,86 +1222,86 @@ theorem get!_eq_of_BlockPtr_get!_eq {arg : BlockArgumentPtr} :
     arg.get! ctx = arg.get! ctx' := by
   grind [BlockPtr.get!, get!]
 
-def set (arg: BlockArgumentPtr) (ctx: IRContext) (newresult: BlockArgument) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def set (arg : BlockArgumentPtr) (ctx : IRContext) (newresult : BlockArgument) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   let block := arg.block.get ctx
   { ctx with
     blocks := ctx.blocks.insert arg.block
       { block with arguments := block.arguments.set arg.index newresult (by grind)} }
 
-def set! (arg: BlockArgumentPtr) (ctx: IRContext) (newresult: BlockArgument) : IRContext :=
+def set! (arg : BlockArgumentPtr) (ctx : IRContext) (newresult : BlockArgument) : IRContext :=
   let block := arg.block.get! ctx
   { ctx with
     blocks := ctx.blocks.insert arg.block
       { block with arguments := block.arguments.set! arg.index newresult } }
 
 @[grind _=_]
-theorem set!_eq_set {arg : BlockArgumentPtr} (inBounds: arg.InBounds ctx) :
+theorem set!_eq_set {arg : BlockArgumentPtr} (inBounds : arg.InBounds ctx) :
     arg.set! ctx newresult = arg.set ctx newresult inBounds := by
   grind [set, set!]
 
-def setType (arg: BlockArgumentPtr) (ctx: IRContext) (newType: TypeAttr) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setType (arg : BlockArgumentPtr) (ctx : IRContext) (newType : TypeAttr) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   let oldResult := arg.get ctx
   arg.set ctx { oldResult with type := newType }
 
-def setType! (arg: BlockArgumentPtr) (ctx: IRContext) (newType: TypeAttr) : IRContext :=
+def setType! (arg : BlockArgumentPtr) (ctx : IRContext) (newType : TypeAttr) : IRContext :=
   let oldResult := arg.get! ctx
   arg.set! ctx { oldResult with type := newType }
 
 @[grind _=_]
-theorem setType!_eq_setType {arg : BlockArgumentPtr} (inBounds: arg.InBounds ctx) :
+theorem setType!_eq_setType {arg : BlockArgumentPtr} (inBounds : arg.InBounds ctx) :
     arg.setType! ctx newType = arg.setType ctx newType inBounds := by
   grind [setType, setType!]
 
-def setFirstUse (arg: BlockArgumentPtr) (ctx: IRContext) (newFirstUse: Option OpOperandPtr) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setFirstUse (arg : BlockArgumentPtr) (ctx : IRContext) (newFirstUse : Option OpOperandPtr) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   let oldResult := arg.get ctx
   arg.set ctx { oldResult with firstUse := newFirstUse }
 
-def setFirstUse! (arg: BlockArgumentPtr) (ctx: IRContext) (newFirstUse: Option OpOperandPtr) :
+def setFirstUse! (arg : BlockArgumentPtr) (ctx : IRContext) (newFirstUse : Option OpOperandPtr) :
     IRContext :=
   let oldResult := arg.get! ctx
   arg.set! ctx {oldResult with firstUse := newFirstUse}
 
 @[grind _=_]
-theorem setFirstUse!_eq_setFirstUse {arg : BlockArgumentPtr} (inBounds: arg.InBounds ctx) :
+theorem setFirstUse!_eq_setFirstUse {arg : BlockArgumentPtr} (inBounds : arg.InBounds ctx) :
     arg.setFirstUse! ctx newFirstUse = arg.setFirstUse ctx newFirstUse inBounds := by
   grind [setFirstUse, setFirstUse!]
 
-def setIndex (arg: BlockArgumentPtr) (ctx: IRContext) (newIndex: Nat) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setIndex (arg : BlockArgumentPtr) (ctx : IRContext) (newIndex : Nat) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   let oldResult := arg.get ctx
   arg.set ctx { oldResult with index := newIndex }
 
-def setIndex! (arg: BlockArgumentPtr) (ctx: IRContext) (newIndex: Nat) : IRContext :=
+def setIndex! (arg : BlockArgumentPtr) (ctx : IRContext) (newIndex : Nat) : IRContext :=
   let oldResult := arg.get! ctx
   arg.set! ctx {oldResult with index := newIndex}
 
 @[grind _=_]
-theorem setIndex!_eq_setIndex {arg : BlockArgumentPtr} (inBounds: arg.InBounds ctx) :
+theorem setIndex!_eq_setIndex {arg : BlockArgumentPtr} (inBounds : arg.InBounds ctx) :
     arg.setIndex! ctx newIndex = arg.setIndex ctx newIndex inBounds := by
   grind [setIndex, setIndex!]
 
-def setLoc (arg: BlockArgumentPtr) (ctx: IRContext) (newLoc: Location) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setLoc (arg : BlockArgumentPtr) (ctx : IRContext) (newLoc : Location) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   let oldResult := arg.get ctx
   arg.set ctx { oldResult with loc := newLoc }
 
-def setLoc! (arg: BlockArgumentPtr) (ctx: IRContext) (newLoc: Location) : IRContext :=
+def setLoc! (arg : BlockArgumentPtr) (ctx : IRContext) (newLoc : Location) : IRContext :=
   let oldResult := arg.get! ctx
   arg.set! ctx {oldResult with loc := newLoc}
 
 @[grind _=_]
-theorem setLoc!_eq_setLoc {arg : BlockArgumentPtr} (inBounds: arg.InBounds ctx) :
+theorem setLoc!_eq_setLoc {arg : BlockArgumentPtr} (inBounds : arg.InBounds ctx) :
     arg.setLoc! ctx newLoc = arg.setLoc ctx newLoc inBounds := by
   grind [setLoc, setLoc!]
 
-def setOwner (arg: BlockArgumentPtr) (ctx: IRContext) (newOwner: BlockPtr) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setOwner (arg : BlockArgumentPtr) (ctx : IRContext) (newOwner : BlockPtr) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   let oldResult := arg.get ctx
   arg.set ctx { oldResult with owner := newOwner }
 
-def setOwner! (arg: BlockArgumentPtr) (ctx: IRContext) (newOwner: BlockPtr) : IRContext :=
+def setOwner! (arg : BlockArgumentPtr) (ctx : IRContext) (newOwner : BlockPtr) : IRContext :=
   let oldResult := arg.get! ctx
   arg.set! ctx {oldResult with owner := newOwner}
 
 @[grind _=_]
-theorem setOwner!_eq_setOwner {arg : BlockArgumentPtr} (inBounds: arg.InBounds ctx) :
+theorem setOwner!_eq_setOwner {arg : BlockArgumentPtr} (inBounds : arg.InBounds ctx) :
     arg.setOwner! ctx newOwner = arg.setOwner ctx newOwner inBounds := by
   grind [setOwner, setOwner!]
 
@@ -1318,21 +1318,21 @@ inductive InBounds : ValuePtr → IRContext → Prop
 | block_argument ptr ctx : ptr.InBounds ctx → (blockArgument ptr).InBounds ctx
 
 @[simp, grind=]
-theorem inBounds_opResult (ptr: OpResultPtr) (ctx: IRContext) :
+theorem inBounds_opResult (ptr : OpResultPtr) (ctx : IRContext) :
     (opResult ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
 @[simp, grind=]
-theorem inBounds_blockArg (ptr: BlockArgumentPtr) (ctx: IRContext) :
+theorem inBounds_blockArg (ptr : BlockArgumentPtr) (ctx : IRContext) :
     (blockArgument ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
-def getType (arg: ValuePtr) (ctx: IRContext) (argIn: arg.InBounds ctx := by grind) : TypeAttr :=
+def getType (arg : ValuePtr) (ctx : IRContext) (argIn : arg.InBounds ctx := by grind) : TypeAttr :=
   match arg with
   | opResult ptr => (ptr.get ctx (by grind)).type
   | blockArgument ptr => (ptr.get ctx (by grind)).type
 
-def getType! (arg: ValuePtr) (ctx: IRContext) : TypeAttr :=
+def getType! (arg : ValuePtr) (ctx : IRContext) : TypeAttr :=
   match arg with
   | opResult ptr => (ptr.get! ctx).type
   | blockArgument ptr => (ptr.get! ctx).type
@@ -1342,12 +1342,12 @@ theorem getType!_eq_getType {ptr : ValuePtr} (hin : ptr.InBounds ctx) :
     ptr.getType! ctx = ptr.getType ctx hin := by
   unfold getType getType!; grind
 
-def getFirstUse (arg: ValuePtr) (ctx: IRContext) (argIn: arg.InBounds ctx := by grind) : Option OpOperandPtr :=
+def getFirstUse (arg : ValuePtr) (ctx : IRContext) (argIn : arg.InBounds ctx := by grind) : Option OpOperandPtr :=
   match arg with
   | opResult ptr => (ptr.get ctx).firstUse
   | blockArgument ptr => (ptr.get ctx).firstUse
 
-def getFirstUse! (arg: ValuePtr) (ctx: IRContext) : Option OpOperandPtr :=
+def getFirstUse! (arg : ValuePtr) (ctx : IRContext) : Option OpOperandPtr :=
   match arg with
   | opResult ptr => (ptr.get! ctx).firstUse
   | blockArgument ptr => (ptr.get! ctx).firstUse
@@ -1380,17 +1380,17 @@ theorem getFirstUse!_blockArgument_eq {ba : BlockArgumentPtr} {ctx : IRContext} 
 /--
 Returns true if the value has any uses.
 -/
-def hasUses (value: ValuePtr) (ctx: IRContext) (valueIn: value.InBounds ctx := by grind) : Bool :=
+def hasUses (value : ValuePtr) (ctx : IRContext) (valueIn : value.InBounds ctx := by grind) : Bool :=
   (value.getFirstUse ctx (by grind)).isSome
 
-theorem hasUses_def {value : ValuePtr} (valueIn: value.InBounds ctx) :
+theorem hasUses_def {value : ValuePtr} (valueIn : value.InBounds ctx) :
     value.hasUses ctx = (value.getFirstUse ctx).isSome := by
   rfl
 
 /--
 Returns true if the value has any uses.
 -/
-def hasUses! (value: ValuePtr) (ctx: IRContext) : Bool :=
+def hasUses! (value : ValuePtr) (ctx : IRContext) : Bool :=
   (value.getFirstUse! ctx).isSome
 
 @[grind _=_]
@@ -1402,57 +1402,57 @@ theorem hasUses!_def {value : ValuePtr} :
     value.hasUses! ctx = (value.getFirstUse! ctx).isSome := by
   grind [hasUses!]
 
-def setType (arg: ValuePtr) (ctx: IRContext) (newType: TypeAttr) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setType (arg : ValuePtr) (ctx : IRContext) (newType : TypeAttr) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   match arg with
   | opResult ptr => ptr.setType ctx newType
   | blockArgument ptr => ptr.setType ctx newType
 
-def setType! (arg: ValuePtr) (ctx: IRContext) (newType: TypeAttr) : IRContext :=
+def setType! (arg : ValuePtr) (ctx : IRContext) (newType : TypeAttr) : IRContext :=
   match arg with
   | opResult ptr => ptr.setType! ctx newType
   | blockArgument ptr => ptr.setType! ctx newType
 
 @[grind _=_]
-theorem setType!_eq_setType {arg : ValuePtr} (inBounds: arg.InBounds ctx) :
+theorem setType!_eq_setType {arg : ValuePtr} (inBounds : arg.InBounds ctx) :
     arg.setType! ctx newType = arg.setType ctx newType inBounds := by
   grind [setType, setType!, cases ValuePtr]
 
-def setFirstUse (arg: ValuePtr) (ctx: IRContext) (newFirstUse: Option OpOperandPtr) (argIn: arg.InBounds ctx := by grind) : IRContext :=
+def setFirstUse (arg : ValuePtr) (ctx : IRContext) (newFirstUse : Option OpOperandPtr) (argIn : arg.InBounds ctx := by grind) : IRContext :=
   match arg with
   | opResult ptr => ptr.setFirstUse ctx newFirstUse
   | blockArgument ptr => ptr.setFirstUse ctx newFirstUse
 
-def setFirstUse! (arg: ValuePtr) (ctx: IRContext) (newFirstUse: Option OpOperandPtr) : IRContext :=
+def setFirstUse! (arg : ValuePtr) (ctx : IRContext) (newFirstUse : Option OpOperandPtr) : IRContext :=
   match arg with
   | opResult ptr => ptr.setFirstUse! ctx newFirstUse
   | blockArgument ptr => ptr.setFirstUse! ctx newFirstUse
 
 @[grind _=_]
-theorem setFirstUse!_eq_setFirstUse {arg : ValuePtr} (inBounds: arg.InBounds ctx) :
+theorem setFirstUse!_eq_setFirstUse {arg : ValuePtr} (inBounds : arg.InBounds ctx) :
     arg.setFirstUse! ctx newFirstUse = arg.setFirstUse ctx newFirstUse inBounds := by
   grind [setFirstUse, setFirstUse!, cases ValuePtr]
 
 @[simp, grind =]
-theorem setFirstUse_OpResultPtr (ptr: OpResultPtr) (ctx: IRContext)
-    (ptrIn: (opResult ptr).InBounds ctx) (newFirstUse: Option OpOperandPtr) :
+theorem setFirstUse_OpResultPtr (ptr : OpResultPtr) (ctx : IRContext)
+    (ptrIn : (opResult ptr).InBounds ctx) (newFirstUse : Option OpOperandPtr) :
     (opResult ptr).setFirstUse ctx newFirstUse ptrIn = ptr.setFirstUse ctx newFirstUse := by
   unfold setFirstUse; grind
 
 @[simp, grind =]
-theorem setFirstUse_BlockArgumentPtr (ptr: BlockArgumentPtr) (ctx: IRContext)
-    (ptrIn: (blockArgument ptr).InBounds ctx) (newFirstUse: Option OpOperandPtr) :
+theorem setFirstUse_BlockArgumentPtr (ptr : BlockArgumentPtr) (ctx : IRContext)
+    (ptrIn : (blockArgument ptr).InBounds ctx) (newFirstUse : Option OpOperandPtr) :
     (blockArgument ptr).setFirstUse ctx newFirstUse ptrIn = ptr.setFirstUse ctx newFirstUse := by
   unfold setFirstUse; rfl
 
 @[simp, grind =]
-theorem setType_OpResultPtr (ptr: OpResultPtr) (ctx: IRContext)
-    (ptrIn: (opResult ptr).InBounds ctx) (newType: TypeAttr) :
+theorem setType_OpResultPtr (ptr : OpResultPtr) (ctx : IRContext)
+    (ptrIn : (opResult ptr).InBounds ctx) (newType : TypeAttr) :
     (opResult ptr).setType ctx newType ptrIn = ptr.setType ctx newType := by
   unfold setType; rfl
 
 @[simp, grind =]
-theorem setType_BlockArgumentPtr (ptr: BlockArgumentPtr) (ctx: IRContext)
-    (ptrIn: (blockArgument ptr).InBounds ctx) (newType: TypeAttr) :
+theorem setType_BlockArgumentPtr (ptr : BlockArgumentPtr) (ctx : IRContext)
+    (ptrIn : (blockArgument ptr).InBounds ctx) (newType : TypeAttr) :
     (blockArgument ptr).setType ctx newType ptrIn = ptr.setType ctx newType := by
   unfold setType; rfl
 
@@ -1464,26 +1464,26 @@ end ValuePtr
 
 namespace OpOperandPtrPtr
 
-inductive InBounds (ctx: IRContext) : OpOperandPtrPtr → Prop
+inductive InBounds (ctx : IRContext) : OpOperandPtrPtr → Prop
   | operandNextUseInBounds ptr : ptr.InBounds ctx → (operandNextUse ptr).InBounds ctx
   | valueFirstUseInBounds ptr : ptr.InBounds ctx → (valueFirstUse ptr).InBounds ctx
 
 @[simp, grind=]
-theorem inBounds_operandNextUse (ptr: OpOperandPtr) (ctx: IRContext) :
+theorem inBounds_operandNextUse (ptr : OpOperandPtr) (ctx : IRContext) :
     (operandNextUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
 @[simp, grind=]
-theorem inBounds_valueFirstUse (ptr: ValuePtr) (ctx: IRContext) :
+theorem inBounds_valueFirstUse (ptr : ValuePtr) (ctx : IRContext) :
     (valueFirstUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
-def get (ptrPtr: OpOperandPtrPtr) (ctx: IRContext) (ptrPtrIn: ptrPtr.InBounds ctx := by grind) : Option OpOperandPtr :=
+def get (ptrPtr : OpOperandPtrPtr) (ctx : IRContext) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : Option OpOperandPtr :=
   match ptrPtr with
   | operandNextUse ptr => (ptr.get ctx).nextUse
   | valueFirstUse val => val.getFirstUse ctx (by grind)
 
-def get! (ptrPtr: OpOperandPtrPtr) (ctx: IRContext) : Option OpOperandPtr :=
+def get! (ptrPtr : OpOperandPtrPtr) (ctx : IRContext) : Option OpOperandPtr :=
   match ptrPtr with
   | operandNextUse ptr => (ptr.get! ctx).nextUse
   | valueFirstUse val => val.getFirstUse! ctx
@@ -1494,50 +1494,50 @@ theorem get!_eq_get {ptrPtr : OpOperandPtrPtr} (hin : ptrPtr.InBounds ctx) :
   unfold get get!; grind
 
 @[simp, grind =]
-theorem get_operandNextUse_eq {ptr: OpOperandPtr} {ctx: IRContext} {ptrIn: ptr.InBounds ctx} :
+theorem get_operandNextUse_eq {ptr : OpOperandPtr} {ctx : IRContext} {ptrIn : ptr.InBounds ctx} :
     (operandNextUse ptr).get ctx (by grind) = (ptr.get ctx).nextUse := by
   grind [get]
 
 @[simp, grind =]
-theorem get!_operandNextUse_eq {ptr: OpOperandPtr} {ctx: IRContext} :
+theorem get!_operandNextUse_eq {ptr : OpOperandPtr} {ctx : IRContext} :
     (operandNextUse ptr).get! ctx = (ptr.get! ctx).nextUse := by
   grind [get!]
 
 @[simp, grind =]
-theorem get_valueFirstUse_eq {ptr: ValuePtr} {ctx: IRContext} {ptrIn: ptr.InBounds ctx} :
+theorem get_valueFirstUse_eq {ptr : ValuePtr} {ctx : IRContext} {ptrIn : ptr.InBounds ctx} :
     (valueFirstUse ptr).get ctx (by grind) = ptr.getFirstUse ctx := by
   grind [get]
 
 @[simp, grind =]
-theorem get!_valueFirstUse_eq {ptr: ValuePtr} {ctx: IRContext} :
+theorem get!_valueFirstUse_eq {ptr : ValuePtr} {ctx : IRContext} :
     (valueFirstUse ptr).get! ctx = ptr.getFirstUse! ctx := by
   grind [get!]
 
-def set (ptrPtr: OpOperandPtrPtr) (ctx: IRContext) (newValue: Option OpOperandPtr) (ptrPtrIn: ptrPtr.InBounds ctx := by grind) : IRContext :=
+def set (ptrPtr : OpOperandPtrPtr) (ctx : IRContext) (newValue : Option OpOperandPtr) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : IRContext :=
   match ptrPtr with
   | operandNextUse ptr =>
     ptr.setNextUse ctx newValue
   | valueFirstUse val =>
     val.setFirstUse ctx newValue
 
-def set! (ptrPtr: OpOperandPtrPtr) (ctx: IRContext) (newValue: Option OpOperandPtr) : IRContext :=
+def set! (ptrPtr : OpOperandPtrPtr) (ctx : IRContext) (newValue : Option OpOperandPtr) : IRContext :=
   match ptrPtr with
   | operandNextUse ptr =>
     ptr.setNextUse! ctx newValue
   | valueFirstUse val =>
     val.setFirstUse! ctx newValue
 
-theorem set!_eq_set {ptrPtr : OpOperandPtrPtr} (inBounds: ptrPtr.InBounds ctx) :
+theorem set!_eq_set {ptrPtr : OpOperandPtrPtr} (inBounds : ptrPtr.InBounds ctx) :
     ptrPtr.set! ctx newValue = ptrPtr.set ctx newValue inBounds := by
   grind [set, set!, cases OpOperandPtrPtr]
 
 @[simp]
-theorem set_operandNextUse (ptr: OpOperandPtr) (ctx: IRContext) (newValue: Option OpOperandPtr) (ptrIn: (operandNextUse ptr).InBounds ctx) :
+theorem set_operandNextUse (ptr : OpOperandPtr) (ctx : IRContext) (newValue : Option OpOperandPtr) (ptrIn : (operandNextUse ptr).InBounds ctx) :
     (operandNextUse ptr).set ctx newValue ptrIn = ptr.setNextUse ctx newValue := by
   unfold set; rfl
 
 @[simp]
-theorem set_valueFirstUse (ptr: ValuePtr) (ctx: IRContext) (ptrIn: (valueFirstUse ptr).InBounds ctx) (newValue: Option OpOperandPtr) :
+theorem set_valueFirstUse (ptr : ValuePtr) (ctx : IRContext) (ptrIn : (valueFirstUse ptr).InBounds ctx) (newValue : Option OpOperandPtr) :
     (valueFirstUse ptr).set ctx newValue ptrIn = ptr.setFirstUse ctx newValue := by
   unfold set; rfl
 
@@ -1549,66 +1549,66 @@ end OpOperandPtrPtr
 
 namespace RegionPtr
 
-def InBounds (region: RegionPtr) (ctx: IRContext) : Prop :=
+def InBounds (region : RegionPtr) (ctx : IRContext) : Prop :=
   region ∈ ctx.regions
 
-def get (ptr: RegionPtr) (ctx: IRContext) (inBounds: ptr.InBounds ctx := by grind) : Region :=
+def get (ptr : RegionPtr) (ctx : IRContext) (inBounds : ptr.InBounds ctx := by grind) : Region :=
   ctx.regions[ptr]'(by unfold InBounds at inBounds; grind)
 
-def get! (ptr: RegionPtr) (ctx: IRContext) : Region := ctx.regions[ptr]!
+def get! (ptr : RegionPtr) (ctx : IRContext) : Region := ctx.regions[ptr]!
 
 @[grind _=_]
 theorem get!_eq_get {ptr : RegionPtr} (hin : ptr.InBounds ctx) :
     ptr.get! ctx = ptr.get ctx hin := by
   grind [get, get!]
 
-def set (ptr: RegionPtr) (ctx: IRContext) (newRegion: Region) : IRContext :=
+def set (ptr : RegionPtr) (ctx : IRContext) (newRegion : Region) : IRContext :=
   {ctx with regions := ctx.regions.insert ptr newRegion}
 
-def setParent (region: RegionPtr) (ctx: IRContext) (newParent: OperationPtr)
-    (inBounds: region.InBounds ctx := by grind) : IRContext :=
+def setParent (region : RegionPtr) (ctx : IRContext) (newParent : OperationPtr)
+    (inBounds : region.InBounds ctx := by grind) : IRContext :=
   let oldRegion := region.get ctx (by grind)
   region.set ctx { oldRegion with parent := newParent}
 
-def setParent! (region: RegionPtr) (ctx: IRContext) (newParent: OperationPtr) : IRContext :=
+def setParent! (region : RegionPtr) (ctx : IRContext) (newParent : OperationPtr) : IRContext :=
   let oldRegion := region.get! ctx
   region.set ctx {oldRegion with parent := newParent}
 
 @[grind _=_]
-theorem setParent!_eq_setParent {region : RegionPtr} (inBounds: region.InBounds ctx) :
+theorem setParent!_eq_setParent {region : RegionPtr} (inBounds : region.InBounds ctx) :
     region.setParent! ctx newParent = region.setParent ctx newParent inBounds := by
   grind [setParent, setParent!]
 
-def setFirstBlock (region: RegionPtr) (ctx: IRContext) (newFirstBlock: Option BlockPtr)
-    (inBounds: region.InBounds ctx := by grind) : IRContext :=
+def setFirstBlock (region : RegionPtr) (ctx : IRContext) (newFirstBlock : Option BlockPtr)
+    (inBounds : region.InBounds ctx := by grind) : IRContext :=
   let oldRegion := region.get ctx (by grind)
   region.set ctx { oldRegion with firstBlock := newFirstBlock}
 
-def setFirstBlock! (region: RegionPtr) (ctx: IRContext) (newFirstBlock: Option BlockPtr) : IRContext :=
+def setFirstBlock! (region : RegionPtr) (ctx : IRContext) (newFirstBlock : Option BlockPtr) : IRContext :=
   let oldRegion := region.get! ctx
   region.set ctx {oldRegion with firstBlock := newFirstBlock}
 
 @[grind _=_]
-theorem setFirstBlock!_eq_setFirstBlock {region : RegionPtr} (inBounds: region.InBounds ctx) :
+theorem setFirstBlock!_eq_setFirstBlock {region : RegionPtr} (inBounds : region.InBounds ctx) :
     region.setFirstBlock! ctx newFirstBlock = region.setFirstBlock ctx newFirstBlock inBounds := by
   grind [setFirstBlock, setFirstBlock!]
 
-def setLastBlock (region: RegionPtr) (ctx: IRContext) (newLastBlock: Option BlockPtr)
-    (inBounds: region.InBounds ctx := by grind) : IRContext :=
+def setLastBlock (region : RegionPtr) (ctx : IRContext) (newLastBlock : Option BlockPtr)
+    (inBounds : region.InBounds ctx := by grind) : IRContext :=
   let oldRegion := region.get ctx (by grind)
   region.set ctx { oldRegion with lastBlock := newLastBlock}
 
-def setLastBlock! (region: RegionPtr) (ctx: IRContext) (newLastBlock: Option BlockPtr) : IRContext :=
+def setLastBlock! (region : RegionPtr) (ctx : IRContext) (newLastBlock : Option BlockPtr) : IRContext :=
   let oldRegion := region.get! ctx
   region.set ctx {oldRegion with lastBlock := newLastBlock}
 
 @[grind _=_]
-theorem setLastBlock!_eq_setLastBlock {region : RegionPtr} (inBounds: region.InBounds ctx) :
+theorem setLastBlock!_eq_setLastBlock {region : RegionPtr} (inBounds : region.InBounds ctx) :
     region.setLastBlock! ctx newLastBlock = region.setLastBlock ctx newLastBlock inBounds := by
   grind [setLastBlock, setLastBlock!]
 
-def allocEmpty (ctx: IRContext) : Option (IRContext × RegionPtr) :=
-  let newRegionPtr: RegionPtr := ⟨ctx.nextID⟩
+def allocEmpty (ctx : IRContext) : Option (IRContext × RegionPtr) :=
+  let newRegionPtr : RegionPtr := ⟨ctx.nextID⟩
   let region := Region.empty
   let ctx := { ctx with nextID := ctx.nextID + 1}
   if _ : ctx.regions.contains newRegionPtr then none else
@@ -1624,26 +1624,26 @@ end RegionPtr
 namespace BlockOperandPtrPtr
 
 @[local grind]
-inductive InBounds (ctx: IRContext) : BlockOperandPtrPtr → Prop
+inductive InBounds (ctx : IRContext) : BlockOperandPtrPtr → Prop
   | blockOperandNextUseInBounds ptr : ptr.InBounds ctx → (blockOperandNextUse ptr).InBounds ctx
   | blockFirstUseInBounds ptr : ptr.InBounds ctx → (blockFirstUse ptr).InBounds ctx
 
 @[simp, grind=]
-theorem inBounds_operandNextUse (ptr: BlockOperandPtr) (ctx: IRContext) :
+theorem inBounds_operandNextUse (ptr : BlockOperandPtr) (ctx : IRContext) :
     (blockOperandNextUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind
 
 @[simp, grind=]
-theorem inBounds_valueFirstUse (ptr: BlockPtr) (ctx: IRContext) :
+theorem inBounds_valueFirstUse (ptr : BlockPtr) (ctx : IRContext) :
     (blockFirstUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind
 
-def get (ptrPtr: BlockOperandPtrPtr) (ctx: IRContext) (ptrPtrIn: ptrPtr.InBounds ctx := by grind) : Option BlockOperandPtr :=
+def get (ptrPtr : BlockOperandPtrPtr) (ctx : IRContext) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : Option BlockOperandPtr :=
   match ptrPtr with
   | blockOperandNextUse ptr => (ptr.get ctx).nextUse
   | blockFirstUse val => (val.get ctx (by grind)).firstUse
 
-def get! (ptrPtr: BlockOperandPtrPtr) (ctx: IRContext) : Option BlockOperandPtr :=
+def get! (ptrPtr : BlockOperandPtrPtr) (ctx : IRContext) : Option BlockOperandPtr :=
   match ptrPtr with
   | blockOperandNextUse ptr => (ptr.get! ctx).nextUse
   | blockFirstUse val => (val.get! ctx).firstUse
@@ -1663,29 +1663,29 @@ theorem get_firstUse_eq {bl : BlockPtr} {h : bl.InBounds ctx} :
     (blockFirstUse bl).get ctx = (bl.get ctx).firstUse := by
   grind [get]
 
-def set (ptrPtr: BlockOperandPtrPtr) (ctx: IRContext) (newValue: Option BlockOperandPtr) (ptrPtrIn: ptrPtr.InBounds ctx := by grind) : IRContext :=
+def set (ptrPtr : BlockOperandPtrPtr) (ctx : IRContext) (newValue : Option BlockOperandPtr) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : IRContext :=
   match ptrPtr with
   | blockOperandNextUse ptr => ptr.setNextUse ctx newValue
   | blockFirstUse val => val.setFirstUse ctx newValue
 
-def set! (ptrPtr: BlockOperandPtrPtr) (ctx: IRContext) (newValue: Option BlockOperandPtr) :
+def set! (ptrPtr : BlockOperandPtrPtr) (ctx : IRContext) (newValue : Option BlockOperandPtr) :
     IRContext :=
   match ptrPtr with
   | blockOperandNextUse ptr => ptr.setNextUse! ctx newValue
   | blockFirstUse val => val.setFirstUse! ctx newValue
 
 @[grind _=_]
-theorem set!_eq_set {ptrPtr : BlockOperandPtrPtr} (inBounds: ptrPtr.InBounds ctx) :
+theorem set!_eq_set {ptrPtr : BlockOperandPtrPtr} (inBounds : ptrPtr.InBounds ctx) :
     ptrPtr.set! ctx newValue = ptrPtr.set ctx newValue inBounds := by
   grind [set, set!, cases BlockOperandPtrPtr]
 
 @[simp, grind =]
-theorem set_operandNextUse_eq {ptr: BlockOperandPtr} {ptrIn: ptr.InBounds ctx} {newValue: Option BlockOperandPtr} :
+theorem set_operandNextUse_eq {ptr : BlockOperandPtr} {ptrIn : ptr.InBounds ctx} {newValue : Option BlockOperandPtr} :
     (blockOperandNextUse ptr).set ctx newValue = ptr.setNextUse ctx newValue := by
   rfl
 
 @[simp, grind =]
-theorem set_blockFirstUse_eq {ptr: BlockPtr} {ptrIn: ptr.InBounds ctx} {newValue: Option BlockOperandPtr} :
+theorem set_blockFirstUse_eq {ptr : BlockPtr} {ptrIn : ptr.InBounds ctx} {newValue : Option BlockOperandPtr} :
     (blockFirstUse ptr).set ctx newValue = ptr.setFirstUse ctx newValue := by
   rfl
 
@@ -1693,8 +1693,8 @@ end BlockOperandPtrPtr
 
 namespace OperationPtr
 
-def hasUses.loop (op: OperationPtr) (ctx : IRContext) (index : Nat)
-    (opIn: op.InBounds ctx := by grind)
+def hasUses.loop (op : OperationPtr) (ctx : IRContext) (index : Nat)
+    (opIn : op.InBounds ctx := by grind)
     (hresult : index < op.getNumResults ctx := by grind) : Bool :=
   if ((op.getResult index).get ctx).firstUse.isSome then
     true
@@ -1703,14 +1703,14 @@ def hasUses.loop (op: OperationPtr) (ctx : IRContext) (index : Nat)
     | 0 => false
     | index' + 1 => hasUses.loop op ctx index'
 
-def hasUses (op: OperationPtr) (ctx: IRContext) (opIn: op.InBounds ctx := by grind) : Bool :=
+def hasUses (op : OperationPtr) (ctx : IRContext) (opIn : op.InBounds ctx := by grind) : Bool :=
   let numResults := op.getNumResults ctx
-  if h: numResults = 0 then
+  if h : numResults = 0 then
     false
   else
     hasUses.loop op ctx (numResults - 1)
 
-def hasUses!.loop (op: OperationPtr) (ctx : IRContext) (index : Nat) : Bool :=
+def hasUses!.loop (op : OperationPtr) (ctx : IRContext) (index : Nat) : Bool :=
   if ((op.getResult index).get! ctx).firstUse.isSome then
     true
   else
@@ -1718,7 +1718,7 @@ def hasUses!.loop (op: OperationPtr) (ctx : IRContext) (index : Nat) : Bool :=
     | 0 => false
     | index' + 1 => hasUses!.loop op ctx index'
 
-def hasUses! (op: OperationPtr) (ctx: IRContext) : Bool :=
+def hasUses! (op : OperationPtr) (ctx : IRContext) : Bool :=
   let numResults := op.getNumResults! ctx
   if numResults = 0 then
     false
@@ -1726,7 +1726,7 @@ def hasUses! (op: OperationPtr) (ctx: IRContext) : Bool :=
     hasUses!.loop op ctx (numResults - 1)
 
 theorem hasUses!.loop_eq_hasUses_loop {op : OperationPtr} (ctx : IRContext) (index : Nat)
-    (opIn: op.InBounds ctx)
+    (opIn : op.InBounds ctx)
     (hresult : index < op.getNumResults ctx := by grind) :
     hasUses!.loop op ctx index = hasUses.loop op ctx index opIn hresult := by
   induction index

--- a/Veir/IR/DeallocLemmas.lean
+++ b/Veir/IR/DeallocLemmas.lean
@@ -41,7 +41,7 @@ theorem Std.ExtHashSet.fromSuccessors.mem_ne :
 
 @[grind =]
 theorem Std.ExtHashSet.fromSuccessors.mem_iff
-    (inBounds: operand.InBounds ctx) :
+    (inBounds : operand.InBounds ctx) :
     (operand ∈ (Std.ExtHashSet.fromSuccessors ctx op) ↔ operand.op = op) := by
   simp only [Std.ExtHashSet.fromSuccessors]
   simp only [Std.ExtHashSet.mem_ofList, List.contains_eq_mem, List.mem_map,
@@ -64,7 +64,7 @@ theorem Std.ExtHashSet.fromOperands.mem_ne :
 
 @[grind =]
 theorem Std.ExtHashSet.fromOperands.mem_iff
-    (inBounds: operand.InBounds ctx) :
+    (inBounds : operand.InBounds ctx) :
     (operand ∈ (Std.ExtHashSet.fromOperands ctx op) ↔ operand.op = op) := by
   simp only [Std.ExtHashSet.fromOperands]
   simp only [Std.ExtHashSet.mem_ofList, List.contains_eq_mem, List.mem_map,
@@ -213,7 +213,7 @@ theorem IRContext.fieldsInBounds_OperationPtr_dealloc {ctx : IRContext} {inBound
         simp (disch := grind) only [OpOperandPtr.get!_OperationPtr_dealloc]
         simp only [← GenericPtr.iff_value]
         apply OpOperandPtr.dealloc.inBounds_dealloc_genericPtr; grind
-        cases hvalue: (operand.get! ctx).value; rotate_left 1; grind
+        cases hvalue : (operand.get! ctx).value; rotate_left 1; grind
         rename_i opRes
         simp only
         intro howner

--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -13,40 +13,40 @@ public section
   These are the predicates that ensures that all pointers in a program are in bounds.
 -/
 
-structure OpResult.FieldsInBounds (res: OpResult) (ctx: IRContext) : Prop where
+structure OpResult.FieldsInBounds (res : OpResult) (ctx : IRContext) : Prop where
   firstUse_inBounds : res.firstUse.maybe OpOperandPtr.InBounds ctx
-  owner_inBounds: res.owner.InBounds ctx
+  owner_inBounds : res.owner.InBounds ctx
 
-structure OpOperand.FieldsInBounds (operand: OpOperand) (ctx: IRContext) : Prop where
+structure OpOperand.FieldsInBounds (operand : OpOperand) (ctx : IRContext) : Prop where
   nextUse_inBounds : operand.nextUse.maybe OpOperandPtr.InBounds ctx
-  back_inBounds: operand.back.InBounds ctx
-  owner_inBounds: operand.owner.InBounds ctx
-  value_inBounds: operand.value.InBounds ctx
+  back_inBounds : operand.back.InBounds ctx
+  owner_inBounds : operand.owner.InBounds ctx
+  value_inBounds : operand.value.InBounds ctx
 
-structure BlockOperand.FieldsInBounds (operand: BlockOperand) (ctx: IRContext) : Prop where
+structure BlockOperand.FieldsInBounds (operand : BlockOperand) (ctx : IRContext) : Prop where
   nextUse_inBounds : operand.nextUse.maybe BlockOperandPtr.InBounds ctx
-  back_inBounds: operand.back.InBounds ctx
-  owner_inBounds: operand.owner.InBounds ctx
-  value_inBounds: operand.value.InBounds ctx
+  back_inBounds : operand.back.InBounds ctx
+  owner_inBounds : operand.owner.InBounds ctx
+  value_inBounds : operand.value.InBounds ctx
 
-structure Operation.FieldsInBounds (operation: OperationPtr) (ctx: IRContext) (hin : operation.InBounds ctx) : Prop where
-  results_inBounds (res : OpResultPtr) (hres: res.InBounds ctx) : res.op = operation → (res.get ctx).FieldsInBounds ctx
+structure Operation.FieldsInBounds (operation : OperationPtr) (ctx : IRContext) (hin : operation.InBounds ctx) : Prop where
+  results_inBounds (res : OpResultPtr) (hres : res.InBounds ctx) : res.op = operation → (res.get ctx).FieldsInBounds ctx
   prev_inBounds : (operation.get ctx hin).prev.maybe OperationPtr.InBounds ctx
   next_inBounds : (operation.get ctx hin).next.maybe OperationPtr.InBounds ctx
   parent_inBounds : (operation.get ctx hin).parent.maybe BlockPtr.InBounds ctx
   blockOperands_inBounds (operand : BlockOperandPtr) (h : operand.InBounds ctx):
     operand.op = operation → BlockOperand.FieldsInBounds (operand.get ctx h) ctx
-  regions_inBounds i (hi: i < operation.getNumRegions ctx hin) :
+  regions_inBounds i (hi : i < operation.getNumRegions ctx hin) :
     (operation.getRegion ctx i hin hi).InBounds ctx
   operands_inBounds (operand : OpOperandPtr) (h : operand.InBounds ctx):
     operand.op = operation → OpOperand.FieldsInBounds (operand.get ctx h) ctx
 
-structure BlockArgument.FieldsInBounds (arg: BlockArgument) (ctx: IRContext) : Prop where
+structure BlockArgument.FieldsInBounds (arg : BlockArgument) (ctx : IRContext) : Prop where
   firstUse_inBounds : arg.firstUse.maybe OpOperandPtr.InBounds ctx
-  owner_inBounds: arg.owner.InBounds ctx
+  owner_inBounds : arg.owner.InBounds ctx
 
 @[local grind]
-structure Block.FieldsInBounds (block: BlockPtr) (ctx: IRContext) (hin : block.InBounds ctx) : Prop where
+structure Block.FieldsInBounds (block : BlockPtr) (ctx : IRContext) (hin : block.InBounds ctx) : Prop where
   firstUse_inBounds : (block.get ctx hin).firstUse.maybe BlockOperandPtr.InBounds ctx
   prev_inBounds : (block.get ctx hin).prev.maybe BlockPtr.InBounds ctx
   next_inBounds : (block.get ctx hin).next.maybe BlockPtr.InBounds ctx
@@ -57,18 +57,18 @@ structure Block.FieldsInBounds (block: BlockPtr) (ctx: IRContext) (hin : block.I
     arg.block = block → (arg.get ctx h).FieldsInBounds ctx
 
 @[local grind]
-structure Region.FieldsInBounds (region: Region) (ctx: IRContext) : Prop where
-  firstBlock_inBounds block: region.firstBlock = some block → block.InBounds ctx
-  lastBlock_inBounds block: region.lastBlock = some block → block.InBounds ctx
-  parent_inBounds parent: region.parent = some parent → parent.InBounds ctx
+structure Region.FieldsInBounds (region : Region) (ctx : IRContext) : Prop where
+  firstBlock_inBounds block : region.firstBlock = some block → block.InBounds ctx
+  lastBlock_inBounds block : region.lastBlock = some block → block.InBounds ctx
+  parent_inBounds parent : region.parent = some parent → parent.InBounds ctx
 
 /--
     Ensures that all pointers referenced by any structure in the context are in bounds.
 -/
-structure IRContext.FieldsInBounds (ctx: IRContext) : Prop where
-  operations_inBounds (op: OperationPtr) opIn: Operation.FieldsInBounds op ctx opIn
-  blocks_inBounds (block: BlockPtr) blockIn: Block.FieldsInBounds block ctx blockIn
-  regions_inBounds (region: RegionPtr) regionIn: (region.get ctx regionIn).FieldsInBounds ctx
+structure IRContext.FieldsInBounds (ctx : IRContext) : Prop where
+  operations_inBounds (op : OperationPtr) opIn : Operation.FieldsInBounds op ctx opIn
+  blocks_inBounds (block : BlockPtr) blockIn : Block.FieldsInBounds block ctx blockIn
+  regions_inBounds (region : RegionPtr) regionIn : (region.get ctx regionIn).FieldsInBounds ctx
 
 attribute [local grind =] Option.maybe_def
 
@@ -415,54 +415,54 @@ grind_pattern BlockOperandPtrPtr.get!_inBounds => (ptr.get! ctx), ctx.FieldsInBo
 end BlockOperandPtrPtr
 
 @[grind .]
-theorem OperationPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OperationPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem OperationPtr.get_fieldsInBounds (ctx : IRContext) (ptr : OperationPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     Operation.FieldsInBounds ptr ctx ptrInBounds := by
   grind [IRContext.FieldsInBounds]
 
 @[grind .]
-theorem BlockPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem BlockPtr.get_fieldsInBounds (ctx : IRContext) (ptr : BlockPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     Block.FieldsInBounds ptr ctx ptrInBounds := by
   grind [IRContext.FieldsInBounds]
 
 @[grind .]
-theorem RegionPtr.get_fieldsInBounds (ctx: IRContext) (ptr: RegionPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem RegionPtr.get_fieldsInBounds (ctx : IRContext) (ptr : RegionPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     (ptr.get ctx (by grind)).FieldsInBounds ctx := by
   grind [IRContext.FieldsInBounds]
 
 @[grind .]
-theorem OpResultPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OpResultPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem OpResultPtr.get_fieldsInBounds (ctx : IRContext) (ptr : OpResultPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     (ptr.get ctx).FieldsInBounds ctx := by
   have opInBounds := OperationPtr.get_fieldsInBounds ctx ptr.op ctxInBounds (by grind)
   grind
 
 @[grind .]
-theorem OpOperandPtr.get_fieldsInBounds (ctx: IRContext) (ptr: OpOperandPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem OpOperandPtr.get_fieldsInBounds (ctx : IRContext) (ptr : OpOperandPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     OpOperand.FieldsInBounds (ptr.get ctx ptrInBounds) ctx := by
   have opInBounds := OperationPtr.get_fieldsInBounds ctx ptr.op ctxInBounds (by grind)
   grind
 
 @[grind .]
-theorem BlockOperandPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockOperandPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem BlockOperandPtr.get_fieldsInBounds (ctx : IRContext) (ptr : BlockOperandPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     BlockOperand.FieldsInBounds (ptr.get ctx ptrInBounds) ctx := by
   have opInBounds := OperationPtr.get_fieldsInBounds ctx ptr.op ctxInBounds (by grind)
   grind
 
 @[grind .]
-theorem BlockArgumentPtr.get_fieldsInBounds (ctx: IRContext) (ptr: BlockArgumentPtr)
-    (ctxInBounds: ctx.FieldsInBounds)
-    (ptrInBounds: ptr.InBounds ctx) :
+theorem BlockArgumentPtr.get_fieldsInBounds (ctx : IRContext) (ptr : BlockArgumentPtr)
+    (ctxInBounds : ctx.FieldsInBounds)
+    (ptrInBounds : ptr.InBounds ctx) :
     (ptr.get ctx (by grind)).FieldsInBounds ctx := by
   have blockInBounds :=
     BlockPtr.get_fieldsInBounds ctx ptr.block ctxInBounds (by grind)
@@ -472,13 +472,13 @@ end get
 
 /- Preservation theorems for FieldsInBounds -/
 
-theorem Operation.fieldsInBounds_unchanged {op: OperationPtr} (ctx ctx' : IRContext)
-    (opInBounds: op.InBounds ctx)
+theorem Operation.fieldsInBounds_unchanged {op : OperationPtr} (ctx ctx' : IRContext)
+    (opInBounds : op.InBounds ctx)
     (opInBounds': op.InBounds ctx')
     (hh : ctx.FieldsInBounds)
     (hFIB : Operation.FieldsInBounds op ctx opInBounds)
-    (hSameInBounds: ∀ ptr, GenericPtr.InBounds ptr ctx ↔ GenericPtr.InBounds ptr ctx')
-    (hSameOps: ∀ op opInBounds, OperationPtr.get op ctx opInBounds = OperationPtr.get op ctx' (by grind)) :
+    (hSameInBounds : ∀ ptr, GenericPtr.InBounds ptr ctx ↔ GenericPtr.InBounds ptr ctx')
+    (hSameOps : ∀ op opInBounds, OperationPtr.get op ctx opInBounds = OperationPtr.get op ctx' (by grind)) :
     Operation.FieldsInBounds op ctx' (by grind) := by
   have heq : op.get! ctx = op.get! ctx' := by grind
   constructor
@@ -498,12 +498,12 @@ theorem Operation.fieldsInBounds_unchanged {op: OperationPtr} (ctx ctx' : IRCont
     have := @OpOperandPtr.get!_eq_of_OperationPtr_get!_eq
     constructor <;> grind
 
-theorem Block.fieldsInBounds_unchanged (block: BlockPtr) (ctx ctx' : IRContext)
-    (blockInBounds: block.InBounds ctx)
+theorem Block.fieldsInBounds_unchanged (block : BlockPtr) (ctx ctx' : IRContext)
+    (blockInBounds : block.InBounds ctx)
     (blockInBounds': block.InBounds ctx')
     (hh : ctx.FieldsInBounds)
     (_hFIB : Block.FieldsInBounds block ctx blockInBounds)
-    (hSameInBounds: ∀ ptr, GenericPtr.InBounds ptr ctx ↔ GenericPtr.InBounds ptr ctx')
+    (hSameInBounds : ∀ ptr, GenericPtr.InBounds ptr ctx ↔ GenericPtr.InBounds ptr ctx')
     (hSameBlocks : ∀ block blockInBounds, BlockPtr.get block ctx blockInBounds = BlockPtr.get block ctx' (by grind)) :
     Block.FieldsInBounds block ctx' blockInBounds' := by
   constructor
@@ -516,11 +516,11 @@ theorem Block.fieldsInBounds_unchanged (block: BlockPtr) (ctx ctx' : IRContext)
   · intros
     constructor <;> grind [BlockArgumentPtr.get!_eq_of_BlockPtr_get!_eq]
 
-theorem Region.fieldsInBounds_unchanged (region: RegionPtr) (ctx ctx' : IRContext)
-    (regionInBounds: region.InBounds ctx)
+theorem Region.fieldsInBounds_unchanged (region : RegionPtr) (ctx ctx' : IRContext)
+    (regionInBounds : region.InBounds ctx)
     (regionInBounds': region.InBounds ctx')
     (hFIB : (region.get ctx regionInBounds).FieldsInBounds ctx)
-    (hSameInBounds: ∀ ptr, GenericPtr.InBounds ptr ctx → GenericPtr.InBounds ptr ctx')
+    (hSameInBounds : ∀ ptr, GenericPtr.InBounds ptr ctx → GenericPtr.InBounds ptr ctx')
     (hSameRegions : ∀ region regionInBounds, RegionPtr.get region ctx regionInBounds = RegionPtr.get region ctx' (by grind)) :
     (region.get ctx' (by grind)).FieldsInBounds ctx' := by
   grind
@@ -529,7 +529,7 @@ attribute [local grind] OpResult.FieldsInBounds BlockArgument.FieldsInBounds
   OpOperand.FieldsInBounds BlockOperand.FieldsInBounds Operation.FieldsInBounds
   Block.FieldsInBounds Region.FieldsInBounds BlockOperandPtrPtr.InBounds
 
-macro "prove_fieldsInBounds_operation" ctx:ident : tactic => `(tactic|
+macro "prove_fieldsInBounds_operation" ctx:ident: tactic => `(tactic|
   (rintro hctx
    constructor
    · intros op hop
@@ -550,7 +550,7 @@ macro "prove_fieldsInBounds_operation" ctx:ident : tactic => `(tactic|
      apply Block.fieldsInBounds_unchanged (ctx := $ctx) <;> grind
    · grind))
 
-macro "prove_fieldsInBounds_block" ctx:ident : tactic => `(tactic|
+macro "prove_fieldsInBounds_block" ctx:ident: tactic => `(tactic|
   (intros hctx
    constructor
    · intros
@@ -568,7 +568,7 @@ macro "prove_fieldsInBounds_block" ctx:ident : tactic => `(tactic|
    · intros
      apply Region.fieldsInBounds_unchanged (ctx := $ctx) <;> grind))
 
-macro "prove_fieldsInBounds_region" ctx:ident : tactic => `(tactic|
+macro "prove_fieldsInBounds_region" ctx:ident: tactic => `(tactic|
   (intros hctx
    constructor
    · intros


### PR DESCRIPTION
This change changes `(a: Nat)` to `(a : Nat)` to ensure consistent formatting in the `IR/` directory. Currently, both variants are used.

No functional change intended.