### PR TITLE
Fix llvm.udiv test case

### DIFF
--- a/Test/Interpreter/LLVM/udiv.mlir
+++ b/Test/Interpreter/LLVM/udiv.mlir
@@ -8,8 +8,8 @@
   %negtwo = "llvm.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.udiv"(%lhs, %rhs) : (i32, i32) -> i32
   %y = "llvm.udiv"(%lhs, %zero) : (i32, i32) -> i32
-  %a = "llvm.sdiv"(%negthree, %negtwo) : (i32, i32) -> i32
+  %a = "llvm.udiv"(%negthree, %negtwo) : (i32, i32) -> i32
   "func.return"(%x, %y, %a) : (i32, i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x0000002b#32, poison, 0x00000001#32]
+// CHECK: Program output: #[0x0000002b#32, poison, 0x00000000#32]


### PR DESCRIPTION
There was a leftover `sdiv` instruction in this test case.