### PR TITLE
Add test cases for LLVM.sub

### DIFF
--- a/Test/Interpreter/LLVM/sub.mlir
+++ b/Test/Interpreter/LLVM/sub.mlir
@@ -1,0 +1,10 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  %lhs = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %rhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %x = "llvm.sub"(%lhs, %rhs) : (i32, i32) -> i32
+  "func.return"(%x) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000002#32]

--- a/Test/Interpreter/LLVM/sub_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_overflow.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  %lhs = "llvm.constant"() <{ "value" = 200 : i8 }> : () -> i8
+  %rhs = "llvm.constant"() <{ "value" = 80 : i8 }> : () -> i8
+  %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
+  %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+  %nuw = "llvm.sub"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+  %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+  "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x78#8, poison, 0x78#8, poison]

--- a/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  %lhs = "llvm.constant"() <{ "value" = 100 : i8 }> : () -> i8
+  %rhs = "llvm.constant"() <{ "value" = 220 : i8 }> : () -> i8
+  %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
+  %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+  %nuw = "llvm.sub"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+  %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+  "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x88#8, poison, poison, poison]

--- a/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  %lhs = "llvm.constant"() <{ "value" = 200 : i8 }> : () -> i8
+  %rhs = "llvm.constant"() <{ "value" = 200 : i8 }> : () -> i8
+  %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
+  %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+  %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+  %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+  "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x90#8, 0x90#8, poison, poison]


### PR DESCRIPTION
It seems we forgot to add test cases for `LLVM.sub`.