### PR TITLE
Add a basic pass pipeline infrastructure

### DIFF
--- a/Test/test-veir-opt.mlir
+++ b/Test/test-veir-opt.mlir
@@ -1,5 +1,9 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: veir-opt %s -p=print-ir,print-ir 2>&1 | filecheck %s
 
 "builtin.module"() ({}) : () -> ()
 
-// CHECK: "builtin.module"() ({}) : () -> ()
+// CHECK:      // -----// IR Dump //----- //
+// CHECK-NEXT: "builtin.module"() ({}) : () -> ()
+// CHECK-NEXT: // -----// IR Dump //----- //
+// CHECK-NEXT: "builtin.module"() ({}) : () -> ()
+// CHECK-NEXT: "builtin.module"() ({}) : () -> ()

--- a/Veir/Pass.lean
+++ b/Veir/Pass.lean
@@ -1,0 +1,81 @@
+module
+
+public import Veir.IR.Basic
+public import Veir.IR.WellFormed
+public import Veir.Properties
+public import Veir.Verifier
+
+/-!
+  # Compilation passes
+
+  This file contains the definition of a compilation pass type and a generic pass pipeline.
+-/
+
+namespace Veir
+
+public section
+
+/-- A compilation pass. -/
+structure Pass (OpInfo : Type) [HasOpInfo OpInfo] where
+  /--
+    Human-readable unique identifier for the pass,
+    used for registration and pipeline configuration.
+  -/
+  name : String
+  /-- Brief explanation of what the pass does, for documentation and tooling. -/
+  description : String
+  /--
+    Execute the pass over the given IR context rooted at `op`.
+    Returns the context on success, or an error message on failure.
+  -/
+  run :
+    ∀ (ctx : { ctx' : IRContext OpInfo // ctx'.WellFormed }) (op : OperationPtr),
+    op.InBounds ctx.val →
+    ExceptT String IO { ctx' : IRContext OpInfo // ctx'.WellFormed }
+
+/-- An ordered sequence of passes to run in succession. -/
+structure PassPipeline (OpInfo : Type) [HasOpInfo OpInfo] where
+  /-- The ordered list of passes to run -/
+  passes : Array (Pass OpInfo)
+
+namespace PassPipeline
+
+/--
+  Parse a comma-separated list of pass names into a `PassPipeline`, looking each name up in
+  `registry`. Returns an error if any pass name does not exist in the registry.
+-/
+def ofString? {OpInfo : Type} [HasOpInfo OpInfo]
+    (registry : Std.HashMap String (Pass OpInfo)) (s : String) :
+    Except String (PassPipeline OpInfo) := do
+  let names := s.splitOn ","
+  let passes ← names.mapM fun name =>
+    match registry.get? name with
+    | some pass => .ok pass
+    | none => .error s!"unknown pass: '{name}'"
+  return { passes := passes.toArray }
+
+/--
+  Run each pass in the pipeline in order, verifying the IR after each pass.
+  Returns the final context on success, or an error message on failure.
+-/
+def run (pipeline : PassPipeline OpCode)
+    (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed })
+    (moduleOp : OperationPtr) :
+    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+  let mut currentCtx := ctx
+  for pass in pipeline.passes do
+    if h : moduleOp.InBounds currentCtx.val then
+      let ctx' ← try pass.run currentCtx moduleOp h
+                 catch errMsg => throw s!"pass '{pass.name}' failed: {errMsg}"
+      if let .error errMsg := ctx'.val.verify then
+        throw s!"verification failed after pass '{pass.name}': {errMsg}"
+      currentCtx := ctx'
+    else
+      throw s!"module is not in bounds before pass '{pass.name}'"
+  return currentCtx
+
+end PassPipeline
+
+end -- public section
+
+end Veir

--- a/Veir/Passes/PrintIR.lean
+++ b/Veir/Passes/PrintIR.lean
@@ -1,0 +1,19 @@
+import Veir.Pass
+import Veir.Printer
+
+namespace Veir
+
+def PrintIRPass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed })
+    (op : OperationPtr) (_ : op.InBounds ctx.val) :
+    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+
+  IO.eprintln "// -----// IR Dump //----- //"
+
+  let stdErr ← IO.getStderr
+  IO.withStdout stdErr (Printer.printModule ctx.val op)
+  return ctx
+
+public def PrintIRPass : Pass OpCode :=
+  { name := "print-ir"
+    description := "Print the IR on the stderr stream."
+    run := PrintIRPass.impl }

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -3,9 +3,53 @@ import Veir.Printer
 import Veir.IR.Basic
 import Veir.Verifier
 import Veir.Properties
+import Veir.Pass
+import Veir.Passes.PrintIR
 
 open Veir.Parser
 open Veir
+
+/--
+  A map of all available compilation passes, keyed by their unique names.
+-/
+def availablePasses : Std.HashMap String (Pass OpCode) :=
+  (Std.HashMap.emptyWithCapacity 1)
+    |>.insert PrintIRPass.name PrintIRPass
+
+/--
+  Arguments for the `veir-opt` command-line tool, parsed from the CLI.
+-/
+structure VeirOptArgs where
+  /-- The input filename. -/
+  filename : String
+  /-- List of passes to run. -/
+  passes : PassPipeline OpCode
+
+/--
+  Parse the `-p` flag to construct a pass pipeline.
+  Returns an error if the flag is malformed or if any pass name is unknown.
+-/
+def parsePipelineOption (args : List String) : Except String (PassPipeline OpCode) := do
+  let passesFlags := args.filter (·.startsWith "-p=")
+  match passesFlags with
+  | [] => return { passes := #[] }
+  | [flag] =>
+    let arg := (flag.drop 3).toString
+    match PassPipeline.ofString? availablePasses arg with
+    | .ok pipeline => return pipeline
+    | .error errMsg => .error s!"Error parsing -p flag: {errMsg}"
+  | _ => .error "Expected at most one -p flag."
+
+/--
+  Parse CLI arguments. Returns an error if the arguments are malformed.
+-/
+def parseArgs (args : List String) : Except String VeirOptArgs := do
+  let (flags, positional) := args.partition (·.startsWith "-")
+  let [filename] := positional
+    | .error "Expected exactly one positional argument for the input filename."
+  -- Parses the `-p` flag if present.
+  let pipeline ← parsePipelineOption flags
+  return VeirOptArgs.mk filename pipeline
 
 def parseOperation (filename : String) : ExceptT String IO (IRContext OpCode × OperationPtr) := do
   let fileContent ← IO.FS.readBinFile filename
@@ -21,16 +65,23 @@ def parseOperation (filename : String) : ExceptT String IO (IRContext OpCode × 
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
 
+set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
-  match args with
-  | [filename] =>
+  match parseArgs args with
+  | .error errMsg =>
+    IO.eprintln s!"Error: {errMsg}"
+    IO.eprintln "Usage: veir-opt <filename> [-p=\"pass1,pass2,...\"]"
+  | .ok { filename, passes } =>
     match ← parseOperation filename with
-    | .ok (ctx, op) =>
-      match ctx.verify with
-      | .ok _ => Veir.Printer.printOperation ctx op
-      | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"
-  | _ =>
-    IO.eprintln "Wrong number of arguments."
-    IO.eprintln "Usage: veir-opt <filename>"
+    | .ok (ctx, op) =>
+      match ctx.verify with
+      | .error errMsg =>
+        IO.eprintln s!"Error verifying input program: {errMsg}"
+      | .ok _ =>
+        match ← passes.run ⟨ctx, by sorry⟩ op with
+        | .error errMsg =>
+          IO.eprintln s!"Error: {errMsg}"
+        | .ok finalCtx =>
+          Veir.Printer.printOperation finalCtx op


### PR DESCRIPTION
This adds a simple pass pipeline infrastructure, and adds support for it in veir-opt.
As an example, I added a `print-ir` pass that prints the IR in stderr, similar to the same pass in MLIR.
Passes can be ran with `veir-opt filename.mlir -p=pass1,pass2`