### PR TITLE
fix `Reg` type

### DIFF
--- a/Veir/Data/RISCV/Reg/Basic.lean
+++ b/Veir/Data/RISCV/Reg/Basic.lean
@@ -117,14 +117,12 @@ def slli (shamt : BitVec 6) (rs1 : Reg) : Reg :=
 def srli (shamt : BitVec 6) (rs1 : Reg) : Reg :=
   ⟨rs1.val >>> shamt⟩
 
-
 /--
   Performs arithmetic right shift on the value in register rs1 by the shift amount held in the
   lower 6 bits of the immediate in RV64.
 -/
 def srai (shamt : BitVec 6) (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64 (BitVec.sshiftRight' rs1.val shamt)⟩
-
 
 /--
   Adds the registers rs1 and rs2 and stores the result in rd. Arithmetic overflow is ignored and
@@ -133,14 +131,12 @@ def srai (shamt : BitVec 6) (rs1 : Reg) : Reg :=
 def add (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val + rs2.val⟩
 
-
 /--
   Subtracts the register rs2 from rs1 and stores the result in rd. Arithmetic overflow is ignored and
   the result is simply the low 64 bits of the result.
 -/
 def sub (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val - rs2.val⟩
-
 
 /--
   Performs logical left shift on the value in register rs1 by the shift amount held in the lower 5
@@ -151,32 +147,25 @@ def sll (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := (BitVec.extractLsb 5 0 rs2.val);
   ⟨rs1.val <<< shamt⟩
 
-
 /--
   Place the value 1 in register rd if register rs1 is less than register rs2 when both are treated
   as signed numbers, else 0 is written to rd.
 -/
 def slt (rs2 : Reg) (rs1 : Reg) : Reg :=
-
   ⟨BitVec.setWidth 64 (BitVec.ofBool (BitVec.slt rs1.val rs2.val))⟩
-
 
 /--
   Place the value 1 in register rd if register rs1 is less than register rs2 when both are treated
   as unsigned numbers, else 0 is written to rd.
 -/
 def sltu (rs2 : Reg) (rs1 : Reg) : Reg :=
-
   ⟨BitVec.setWidth 64 (BitVec.ofBool (BitVec.ult rs1.val rs2.val))⟩
-
 
 /--
   Performs bitwise XOR on registers rs1 and rs2 and place the result in rd.
 -/
 def xor (rs2 : Reg) (rs1 : Reg) : Reg :=
-
   ⟨rs1.val ^^^ rs2.val⟩
-
 
 /--
   Logical right shift on the value in register rs1 by the shift amount held in the lower 5 bits of
@@ -187,7 +176,6 @@ def srl (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := (BitVec.extractLsb 5 0 rs2.val)
   ⟨rs1.val >>> shamt⟩
 
-
 /--
   Performs arithmetic right shift on the value in register rs1 by the shift amount held in the
   lower 5 bits of register rs2.
@@ -195,20 +183,17 @@ def srl (rs2 : Reg) (rs1 : Reg) : Reg :=
 def sra (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.sshiftRight' rs1.val (BitVec.extractLsb 5 0 rs2.val)⟩
 
-
 /--
   Performs bitwise OR on registers rs1 and rs2 and place the result in rd.
 -/
 def or (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val ||| rs2.val⟩
 
-
 /--
   Performs bitwise AND on registers rs1 and rs2 and place the result in rd.
 -/
 def and (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val &&& rs2.val⟩
-
 
 /--
   Performs logical left shift on the lowest 32 bits of the value in rs1 by the shift amount held in
@@ -217,7 +202,6 @@ def and (rs2 : Reg) (rs1 : Reg) : Reg :=
 def slliw (shamt : BitVec 5) (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64 ((BitVec.extractLsb' 0 32 rs1.val) <<< shamt)⟩
 
-
 /--
   Performs logical right shift on the lowest 32 bits of the value in rs1 by the shift amount held in
   the lower 5 bits of the immediate. Encodings with $imm[5] neq 0$ are reserved.
@@ -225,14 +209,12 @@ def slliw (shamt : BitVec 5) (rs1 : Reg) : Reg :=
 def srliw (shamt : BitVec 5) (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64 ((BitVec.extractLsb' 0 32 rs1.val) >>> shamt)⟩
 
-
 /--
   Performs arithmetic right shift on the lowest 32 bits of rs1 by the shift amount held
   in the lower 5 bits of the immediate. Encodings with $imm[5] neq 0$ are reserved.
 -/
 def sraiw (shamt : BitVec 5) (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64 (BitVec.sshiftRight' (BitVec.extractLsb 31 0 rs1.val) shamt)⟩
-
 
 /--
   Adds the lowest 32 bits of rs1 and the lowest 32 bits of rs2, and stores the result in rd.
@@ -244,7 +226,6 @@ def addw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs2w := BitVec.extractLsb' 0 32 rs2.val
   ⟨BitVec.signExtend 64 (BitVec.add rs1w rs2w)⟩
 
-
 /--
   Subtract the lowest 32 bits of rs1 and the lowest 32 bits of rs2, and stores the result in rd.
   Arithmetic overflow is ignored and the lowest 32 bits of the result are sign-extended to 64 bits and
@@ -254,7 +235,6 @@ def subw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs1w := BitVec.extractLsb' 0 32 rs1.val
   let rs2w := BitVec.extractLsb' 0 32 rs2.val
   ⟨BitVec.signExtend 64 (BitVec.sub rs1w rs2w)⟩
-
 
 /--
   Performs logical left shift on the lowest 32 bits of rs1 by the shift amount held in
@@ -267,7 +247,6 @@ def sllw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := BitVec.extractLsb' 0 5 rs2w;
   ⟨BitVec.signExtend 64 (rs1w <<< shamt)⟩
 
-
 /--
   Performs logical right shift on the lowest 32 bits of rs1 by the shift amount held in
   the lowest 5 bits of rs2, and produce a 32-bit result that is sign-extended to 64 bits and
@@ -279,7 +258,6 @@ def srlw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := BitVec.extractLsb' 0 5 rs2w;
   ⟨BitVec.signExtend 64 (rs1w >>> shamt)⟩
 
-
 /--
   Performs arithmetic right shift on the lowest 32 bits of rs1 by the shift amount held
   in the lowest 5 bits of rs2, and produce a 32-bit result that is sign-extended to 64 bits and
@@ -290,7 +268,6 @@ def sraw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs2w := BitVec.extractLsb 4 0 rs2.val
   ⟨BitVec.signExtend 64 (BitVec.sshiftRight' rs1w rs2w)⟩
 
-
 /-! # M Extension for Integer Multiplication and Division -/
 
 /--
@@ -299,13 +276,11 @@ def sraw (rs2 : Reg) (rs1 : Reg) : Reg :=
 def rem (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val.srem rs2.val⟩
 
-
 /--
   Perform a 64-bits by 64-bits unsigned integer reminder of rs1 by rs2.
 -/
 def remu (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val.umod rs2.val⟩
-
 
 /--
   Perform a 32-bits by 32-bits signed integer reminder of rs1 by rs2.
@@ -315,7 +290,6 @@ def remw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs2w := BitVec.extractLsb 31 0 rs2.val
   ⟨BitVec.signExtend 64 (rs1w.srem rs2w)⟩
 
-
 /--
   Perform a 32-bits by 32-bits unsigned integer reminder of rs1 by rs2.
 -/
@@ -324,20 +298,17 @@ def remuw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs2w := BitVec.extractLsb 31 0 rs2.val
   ⟨BitVec.signExtend 64 (rs1w.umod rs2w)⟩
 
-
 /--
   Performs a 64-bits times 64-bits multiplication of signed rs1 by signed rs2.
 -/
 def mul (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs2.val * rs1.val⟩
 
-
 /--
   Performs a 64-bits times 64-bits multiplication of signed rs1 by signed rs2 and places the highest 64 bits in the destination register.
 -/
 def mulh (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb 127 64 ((BitVec.signExtend 129 rs1.val) * (BitVec.signExtend 129 rs2.val))⟩
-
 
 /--
   Performs a 64-bits times 64-bits multiplication of unsigned rs1 by unsigned rs2 and places the highest 64 bits in the destination register.
@@ -346,13 +317,11 @@ def mulhu (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb 127 64
   (BitVec.extractLsb' 0 128 ((BitVec.zeroExtend 128 rs1.val) * (BitVec.zeroExtend 128 rs2.val)))⟩
 
-
 /--
   Performs a 64-bits times 64-bits multiplication of signed rs1 by unsigned rs2 and places the highest 64 bits in the destination register.
 -/
 def mulhsu (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb 127 64 (((BitVec.signExtend 129 rs1.val) * (BitVec.zeroExtend 129 rs2.val)))⟩
-
 
 /--
   Multiplies the lowest 32 bits of rs1 by the lowest 32 bits of rs2,
@@ -364,7 +333,6 @@ def mulw (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64
     (((BitVec.extractLsb 31 0 rs1w) * (BitVec.extractLsb 31 0 rs2w)))⟩
 
-
 /--
   Perform a 64-bits by 64-bits signed integer division of rs1 by rs2, rounding towards zero.
 -/
@@ -373,7 +341,6 @@ def div (rs2 : Reg) (rs1 : Reg) : Reg :=
     ⟨-1#64⟩
   else
     ⟨rs1.val.sdiv rs2.val⟩
-
 
 /--
   Performs signed division of the lowest 32 bits of rs1 by the lowest 32 bits of rs2
@@ -384,13 +351,11 @@ def divw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs2w := BitVec.extractLsb 31 0 rs2.val
   ⟨BitVec.signExtend 64 (if rs2w = 0#32 then  -1#32 else rs1w.sdiv rs2w)⟩
 
-
 /--
   Perform a 64-bits by 64-bits unsigned integer division of rs1 by rs2.
 -/
 def divu (rs2 : Reg) (rs1 : Reg) : Reg :=
   if rs2.val = 0#64 then ⟨(-1)⟩ else ⟨rs1.val.udiv rs2.val⟩
-
 
 /--
   Performs unsigned division of the lowest 32 bits of rs1 by the lowest 32 bits of rs2,
@@ -400,7 +365,6 @@ def divuw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let rs1w := BitVec.extractLsb 31 0 rs1.val
   let rs2w := BitVec.extractLsb 31 0 rs2.val
   ⟨BitVec.signExtend 64 (if rs2w = 0#32 then -1#32 else rs1w.udiv rs2w)⟩
-
 
 /-! # "B" Extension for Bit Manipulation -/
 
@@ -413,7 +377,6 @@ def divuw (rs2 : Reg) (rs1 : Reg) : Reg :=
 def adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.extractLsb 31 0 rs1.val) <<< 0#2 + rs2.val⟩
 
-
 /--
  This instruction performs an 64-bits addition of two addends.
  The first addend is rs2. The second addend is the unsigned value formed by extracting the
@@ -421,7 +384,6 @@ def adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
 -/
 def sh1adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.extractLsb 31 0 rs1.val) <<< 1#2 + rs2.val⟩
-
 
 /--
   This instruction performs an 64-bits addition of two addends.
@@ -431,7 +393,6 @@ def sh1adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
 def sh2adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.extractLsb 31 0 rs1.val) <<< 2#2 + rs2.val⟩
 
-
 /--
     This instruction performs an 64-bits addition of two addends.
     The first addend is rs2. The second addend is the unsigned value formed by extracting the
@@ -440,22 +401,17 @@ def sh2adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
 def sh3adduw (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.extractLsb 31 0 rs1.val) <<< 3#2 + rs2.val⟩
 
-
 /--
   This instruction shifts rs1 to the left by 1 bit and adds it to rs2.
 -/
 def sh1add (rs2 : Reg) (rs1 : Reg) : Reg :=
-
   ⟨rs1.val <<< 1#2 + rs2.val⟩
-
 
 /--
   This instruction shifts rs1 to the left by 2 places and adds it to rs2.
 -/
 def sh2add (rs2 : Reg) (rs1 : Reg) : Reg :=
-
   ⟨rs1.val <<< 2#2 + rs2.val⟩
-
 
 /--
   This instruction shifts rs1 to the left by 3 places and adds it to rs2.
@@ -463,15 +419,12 @@ def sh2add (rs2 : Reg) (rs1 : Reg) : Reg :=
 def sh3add (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val <<< 3#2 + rs2.val⟩
 
-
 /--
   This instruction takes the least-significant word of rs1, zero-extends it,
   and shifts it left by the immediate.
 -/
 def slliuw (shamt : BitVec 6) (rs1 : Reg) : Reg :=
   ⟨(BitVec.zeroExtend 64 (BitVec.extractLsb 31 0 rs1.val)) <<< shamt⟩
-
-
 
 /-! ## Zbb: Basic bit-manipulation -/
 
@@ -481,13 +434,11 @@ def slliuw (shamt : BitVec 6) (rs1 : Reg) : Reg :=
 def andn (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val &&& ~~~rs2.val⟩
 
-
 /--
   This instruction performs the bitwise logical OR operation between rs1 and the bitwise inversion of rs2.
 -/
 def orn (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val ||| ~~~rs2.val⟩
-
 
 /--
   This instruction performs the bit-wise exclusive-NOR operation on rs1 and rs2.
@@ -495,13 +446,11 @@ def orn (rs2 : Reg) (rs1 : Reg) : Reg :=
 def xnor (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨~~~ (rs1.val ^^^ rs2.val)⟩
 
-
 /--
   This instruction returns the larger of two signed integers.
 -/
 def max (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb' 0 64 (if BitVec.slt rs2.val rs1.val then rs1.val else rs2.val)⟩
-
 
 /--
   This instruction returns the larger of two unsigned integers.
@@ -509,20 +458,17 @@ def max (rs2 : Reg) (rs1 : Reg) : Reg :=
 def maxu (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb' 0 64 (if BitVec.ult rs2.val rs1.val then rs1.val else rs2.val)⟩
 
-
 /--
   This instruction returns the smaller of two signed integers.
 -/
 def min (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb' 0 64 (if BitVec.slt rs1.val rs2.val then rs1.val else rs2.val)⟩
 
-
 /--
   This instruction returns the smaller of two unsigned integers.
 -/
 def minu (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨BitVec.extractLsb' 0 64 (if BitVec.ult rs1.val rs2.val then rs1.val else rs2.val)⟩
-
 
 /--
   This instruction performs a rotate left of rs1 by the amount in least-significant log2(64) bits of rs2.
@@ -531,14 +477,12 @@ def rol (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := BitVec.extractLsb 5 0 rs2.val
   ⟨(rs1.val <<< shamt) ||| (rs1.val >>> (64#6 - shamt))⟩
 
-
 /--
   This instruction performs a rotate right of rs1 by the amount in least-significant log2(64) bits of rs2.
 -/
 def ror (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := BitVec.extractLsb 5 0 rs2.val
   ⟨(rs1.val >>> shamt) ||| (rs1.val <<< (64#6 - shamt))⟩
-
 
 /--
   This instruction performs a rotate left on the least-significant word of rs1 by the amount in
@@ -550,7 +494,6 @@ def rolw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := BitVec.extractLsb 4 0 rs2.val
   ⟨BitVec.signExtend 64 ((rs1w <<< shamt) ||| (rs1w >>> (32#5 - shamt)))⟩
 
-
 /--
   This instruction performs a rotate right on the least-significant word of rs1 by the amount in
   least-significant 5 bits of rs2.
@@ -561,14 +504,12 @@ def rorw (rs2 : Reg) (rs1 : Reg) : Reg :=
   let shamt := BitVec.extractLsb 4 0 rs2.val
   ⟨BitVec.signExtend 64 ((rs1w >>> shamt) ||| (rs1w <<< (32#5 - shamt)))⟩
 
-
 /--
   This instruction sign-extends the least-significant byte in the source to 64 by copying the
   most-significant bit in the byte (i.e., bit 7) to all of the more-significant bits.
 -/
 def sextb (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64 (BitVec.extractLsb 7 0 rs1.val)⟩
-
 
 /--
   This instruction sign-extends the least-significant halfword in rs to 64 by copying the
@@ -577,13 +518,11 @@ def sextb (rs1 : Reg) : Reg :=
 def sexth (rs1 : Reg) : Reg :=
   ⟨BitVec.signExtend 64 (BitVec.extractLsb 15 0 rs1.val)⟩
 
-
 /--
   Zero-extend halfword.
 -/
 def zexth (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.extractLsb 15 0 rs1.val)⟩
-
 
 /--
   This instruction counts the number of 0’s before the first 1, starting at the most-significant bit
@@ -593,7 +532,6 @@ def zexth (rs1 : Reg) : Reg :=
 def clz (rs1 : Reg) : Reg :=
   ⟨BitVec.clz rs1.val⟩
 
-
 /--
   This instruction counts the number of 0’s before the first 1 starting at bit 31 and progressing
   to bit 0. Accordingly, if the least-significant word is 0, the output is 32, and if the
@@ -602,7 +540,6 @@ def clz (rs1 : Reg) : Reg :=
 def clzw (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.clz (BitVec.extractLsb 31 0 rs1.val))⟩
 
-
 /--
   This instruction counts the number of 0’s before the first 1, starting at the least-significant
   bit (i.e., 0) and progressing to the most-significant bit (i.e., 64-1). Accordingly, if the
@@ -610,7 +547,6 @@ def clzw (rs1 : Reg) : Reg :=
 -/
 def ctz (rs1 : Reg) : Reg :=
   ⟨BitVec.ctz rs1.val⟩
-
 
 /--
   This instruction counts the number of 0’s before the first 1, starting at the least-significant
@@ -621,7 +557,6 @@ def ctz (rs1 : Reg) : Reg :=
 def ctzw (rs1 : Reg) : Reg :=
   ⟨BitVec.zeroExtend 64 (BitVec.ctz (BitVec.extractLsb 31 0 rs1.val))⟩
 
-
 /--
   This instruction performs a rotate right on the least-significant word of rs1 by the amount in the
   least-significant log2(64) bits of shamt. The resulting word value is sign-extended by
@@ -631,14 +566,12 @@ def roriw (shamt : BitVec 5) (rs1 : Reg) : Reg :=
   let rs1w := BitVec.extractLsb 31 0 rs1.val
   ⟨BitVec.signExtend 64 ((rs1w >>> shamt) ||| (rs1w <<< (32 - shamt)))⟩
 
-
 /--
   This instruction performs a rotate right of rs1 by the amount in the least-significant log2(64)
   bits of shamt. For RV32, the encodings corresponding to shamt[5]=1 are reserved.
 -/
 def rori (shamt : BitVec 6) (rs1 : Reg) : Reg :=
   ⟨(rs1.val >>> shamt) ||| (rs1.val <<< (64 - shamt))⟩
-
 
 /-! ## Zbc: Carry-less multiplication -/
 
@@ -651,7 +584,6 @@ def rori (shamt : BitVec 6) (rs1 : Reg) : Reg :=
 def bclr (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val &&& (~~~((BitVec.zeroExtend 64 1#1) <<< (BitVec.extractLsb 5 0 rs2.val)))⟩
 
-
 /--
   This instruction returns a single bit extracted from rs1 at the index specified in rs2.
   The index is read from the lower log2(64) bits of rs2.
@@ -661,7 +593,6 @@ def bext (rs2 : Reg) (rs1 : Reg) : Reg :=
     (if (rs1.val &&&
       ((BitVec.setWidth 64 1#1) <<< (BitVec.extractLsb 5 0 rs2.val)) != 0#64) then 1#1 else 0#1)⟩
 
-
 /--
   This instruction returns rs1 with a single bit inverted at the index specified in rs2.
   The index is read from the lower log2(64) bits of rs2.
@@ -669,14 +600,12 @@ def bext (rs2 : Reg) (rs1 : Reg) : Reg :=
 def binv (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val ^^^ ((BitVec.zeroExtend 64 1#1) <<< (BitVec.extractLsb 5 0 rs2.val))⟩
 
-
 /--
   This instruction returns rs1 with a single bit set at the index specified in rs2.
   The index is read from the lower log2(64) bits of rs2.
 -/
 def bset (rs2 : Reg) (rs1 : Reg) : Reg :=
   ⟨rs1.val ||| ((BitVec.zeroExtend 64 1#1) <<< (BitVec.extractLsb 5 0 rs2.val))⟩
-
 
 /--
   This instruction returns rs1 with a single bit cleared at the index specified in shamt.
@@ -686,14 +615,12 @@ def bset (rs2 : Reg) (rs1 : Reg) : Reg :=
 def bclri (shamt : BitVec 6) (rs1 : Reg) : Reg :=
   ⟨rs1.val &&& (~~~((BitVec.setWidth 64 1#1) <<< shamt))⟩
 
-
 /--
   This instruction returns a single bit extracted from rs1 at the index specified in shamt.
   The index is read from the lower log2(64) bits of shamt.
   For RV32, the encodings corresponding to shamt[5]=1 are reserved.
 -/
 def bexti (shamt : BitVec 6) (rs1 : Reg) : Reg :=
-
   ⟨BitVec.setWidth 64 (if (rs1.val &&& ((BitVec.setWidth 64 1#1) <<< shamt)) != 0#64 then 1#1 else 0#1)⟩
 
 /--


### PR DESCRIPTION
This PR introduces a proper definition for the `Reg` type, which is un/wrapped in the RISCV semantics. 