### PR TITLE
Add benchmark profiling and regression tracking to

### DIFF
--- a/.github/scripts/run_benchmarks.sh
+++ b/.github/scripts/run_benchmarks.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Runs all benchmarks and outputs results in github-action-benchmark JSON format.
+# Usage: ./run_benchmarks.sh [count] [pc]
+#   count: tree size (default: 1000)
+#   pc:    program counter param (default: 50)
+
+set -euo pipefail
+
+COUNT="${1:-1000}"
+PC="${2:-50}"
+
+BENCHMARKS=(
+  "add-fold-worklist"
+  "add-fold-worklist-local"
+  "add-zero-worklist"
+  "add-zero-reuse-worklist"
+  "mul-two-worklist"
+  "add-fold-forwards"
+  "add-zero-forwards"
+  "add-zero-reuse-forwards"
+  "mul-two-forwards"
+  "add-zero-reuse-first"
+  "add-zero-lots-of-reuse-first"
+)
+
+OUTPUT_FILE="${BENCHMARK_OUTPUT:-benchmark-results.json}"
+
+echo "[" > "$OUTPUT_FILE"
+first=true
+
+for bench in "${BENCHMARKS[@]}"; do
+  echo "Running benchmark: $bench (count=$COUNT, pc=$PC)" >&2
+
+  # Capture benchmark output
+  # Output format from Benchmarks.lean time function: "{name} time (s): {float}"
+  raw_output=$(lake exe run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || {
+    echo "  FAILED: $bench" >&2
+    echo "  Output: $raw_output" >&2
+    continue
+  }
+
+  # Extract "rewrite time (s): <float>" -- this is the main metric we care about
+  rewrite_secs=$(echo "$raw_output" | sed -n 's/.*rewrite time (s): \([0-9.]*\).*/\1/p')
+  create_secs=$(echo "$raw_output" | sed -n 's/.*create time (s): \([0-9.]*\).*/\1/p')
+
+  if [ -z "$rewrite_secs" ] && [ -z "$create_secs" ]; then
+    echo "  Could not parse timing for $bench, skipping" >&2
+    echo "  Raw output: $raw_output" >&2
+    continue
+  fi
+
+  # Emit separate entries for create and rewrite phases
+  for phase_name in create rewrite; do
+    if [ "$phase_name" = "create" ]; then
+      secs="$create_secs"
+    else
+      secs="$rewrite_secs"
+    fi
+    [ -z "$secs" ] && continue
+
+    # Convert seconds (float) to nanoseconds (integer) using awk
+    value_ns=$(echo "$secs" | awk '{printf "%.0f", $1 * 1000000000}')
+
+    if [ "$first" = true ]; then
+      first=false
+    else
+      echo "," >> "$OUTPUT_FILE"
+    fi
+
+    cat >> "$OUTPUT_FILE" <<ENTRY
+  {
+    "name": "${bench}/${phase_name}",
+    "unit": "ns",
+    "value": $value_ns,
+    "extra": "count=$COUNT pc=$PC ${phase_name}=${secs}s"
+  }
+ENTRY
+
+    echo "  $bench/$phase_name: ${secs}s" >&2
+  done
+done
+
+echo "" >> "$OUTPUT_FILE"
+echo "]" >> "$OUTPUT_FILE"
+
+echo "Benchmark results written to $OUTPUT_FILE" >&2

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,6 +17,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Ensure gh-pages branch exists
+        run: |
+          if ! git ls-remote --exit-code origin gh-pages > /dev/null 2>&1; then
+            echo "Creating gh-pages branch"
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git switch --orphan gh-pages
+            git commit --allow-empty -m "Initialize gh-pages for benchmark data"
+            git push origin gh-pages
+            git checkout "$GITHUB_SHA"
+          fi
+
       - name: Build the project
         uses: leanprover/lean-action@v1
         with:
@@ -27,8 +39,7 @@ jobs:
           chmod +x .github/scripts/run_benchmarks.sh
           .github/scripts/run_benchmarks.sh 1000 100
 
-      - name: Store benchmark result (main branch)
-        if: github.ref == 'refs/heads/main'
+      - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: VeIR Benchmarks
@@ -36,25 +47,12 @@ jobs:
           output-file-path: benchmark-results.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-          auto-push: true
+          auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "110%"
           comment-on-alert: true
-          fail-on-alert: false
-
-      - name: Compare benchmark result (PRs)
-        if: github.event_name == 'pull_request'
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: VeIR Benchmarks
-          tool: customSmallerIsBetter
-          output-file-path: benchmark-results.json
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: dev/bench
-          auto-push: false
-          alert-threshold: "110%"
-          comment-on-alert: true
-          fail-on-alert: true
-          comment-always: true
+          fail-on-alert: ${{ github.event_name == 'pull_request' }}
+          comment-always: ${{ github.event_name == 'pull_request' }}
+          save-data-file: ${{ github.ref == 'refs/heads/main' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload benchmark results artifact

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,65 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the project
+        uses: leanprover/lean-action@v1
+        with:
+          build-args: "--iofail"
+
+      - name: Run benchmarks
+        run: |
+          chmod +x .github/scripts/run_benchmarks.sh
+          .github/scripts/run_benchmarks.sh 1000 100
+
+      - name: Store benchmark result (main branch)
+        if: github.ref == 'refs/heads/main'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: VeIR Benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-results.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          alert-threshold: "110%"
+          comment-on-alert: true
+          fail-on-alert: false
+
+      - name: Compare benchmark result (PRs)
+        if: github.event_name == 'pull_request'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: VeIR Benchmarks
+          tool: customSmallerIsBetter
+          output-file-path: benchmark-results.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: false
+          alert-threshold: "110%"
+          comment-on-alert: true
+          fail-on-alert: true
+          comment-always: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload benchmark results artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: benchmark-results.json


### PR DESCRIPTION
## Summary                                                             
  - Add a new CI workflow that runs all 11 rewrite benchmarks on every   
  push to `main` and on PRs 
  - PRs that regress any benchmark by >10% will fail CI and get a comment
   with the comparison 