### PR TITLE
Add `DenseArrayAttr`

### DIFF
--- a/Test/Builtin/attributes.mlir
+++ b/Test/Builtin/attributes.mlir
@@ -14,6 +14,8 @@
   %12 = "test.test"() {arr = []} : () -> i32
   %13 = "test.test"() {arr = [unit]} : () -> i32
   %14 = "test.test"() {arr = [0 : i32, "hello"]} : () -> i32
+  %15 = "test.test"() {da = array<i8>} : () -> i32
+  %16 = "test.test"() {da = array<i32: 10, 42>} : () -> i32
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
@@ -30,4 +32,6 @@
 // CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = []} : () -> i32
 // CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [unit]} : () -> i32
 // CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [0 : i32, "hello"]} : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i8>} : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i32: 10, 42>} : () -> i32
 // CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -137,6 +137,14 @@ macro "#assert " e:term : command =>
   (ArrayAttr.mk #[IntegerAttr.mk 1 (IntegerType.mk 32), StringAttr.mk "foo".toByteArray])
 #assert expectSuccessAttr "[[]]" (ArrayAttr.mk #[ArrayAttr.mk #[]])
 
+/-! ## Dense array attribute -/
+
+#assert expectSuccessAttr "array<i8>" (DenseArrayAttr.mk (IntegerType.mk 8) #[])
+#assert expectSuccessAttr "array<i32: 10, 42>" (DenseArrayAttr.mk (IntegerType.mk 32) #[10, 42])
+#assert expectSuccessAttr "array<i64: -1>" (DenseArrayAttr.mk (IntegerType.mk 64) #[-1])
+#assert expectSuccessAttr "array<i16: 0>" (DenseArrayAttr.mk (IntegerType.mk 16) #[0])
+#assert expectErrorAttr "array<>" "integer type expected in dense array attribute"
+
 /-! ## Dialect type -/
 
 #assert expectSuccessType "!foo<bar>" ⟨UnregisteredAttr.mk "!foo<bar>" true, by grind⟩

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -80,6 +80,16 @@ structure UnitAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  An array of integer attributes.
+  The values are stored as an array of integers, and an associated integer type.
+  Note that the integers are not necessarily in the range of the integer type.
+-/
+structure DenseArrayAttr where
+  elementType : IntegerType
+  values : Array Int
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   An attribute from an unknown dialect.
   It can be either a type attribute or a non-type attribute.
 -/
@@ -150,6 +160,8 @@ inductive Attribute
 | unitAttr (attr : UnitAttr)
 /-- Array attribute -/
 | arrayAttr (attr : ArrayAttr)
+/-- Dense array attribute -/
+| denseArrayAttr (attr : DenseArrayAttr)
 /-- Dictionary attribute -/
 | dictionaryAttr (attr : DictionaryAttr)
 /-- Function type -/
@@ -283,6 +295,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case denseArrayAttr.denseArrayAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -326,6 +342,12 @@ instance : ToString StringAttr where
 
 instance : ToString UnitAttr where
   toString _ := "unit"
+
+instance : ToString DenseArrayAttr where
+  toString attr :=
+    let values := if attr.values.isEmpty then ""
+      else ": " ++ String.intercalate ", " (attr.values.toList.map ToString.toString)
+    s!"array<{attr.elementType}{values}>"
 
 instance : ToString UnregisteredAttr where
   toString attr := attr.value
@@ -397,6 +419,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .stringAttr attr => ToString.toString attr
   | .unitAttr attr => ToString.toString attr
   | .arrayAttr attr => attr.toString
+  | .denseArrayAttr attr => ToString.toString attr
   | .dictionaryAttr attr => attr.toString
   | .unregisteredAttr attr => ToString.toString attr
   | .functionType type => type.toString
@@ -440,6 +463,9 @@ instance : Coe UnregisteredAttr Attribute where
 instance : Coe ArrayAttr Attribute where
   coe attr := .arrayAttr attr
 
+instance : Coe DenseArrayAttr Attribute where
+  coe attr := .denseArrayAttr attr
+
 instance : Coe DictionaryAttr Attribute where
   coe attr := .dictionaryAttr attr
 
@@ -469,6 +495,7 @@ def isType (attr : Attribute) : Bool :=
   | .stringAttr _ => false
   | .unitAttr _ => false
   | .arrayAttr _ => false
+  | .denseArrayAttr _ => false
   | .dictionaryAttr _ => false
   | .unregisteredAttr attr => attr.isType
   | .functionType _ => true

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -120,6 +120,21 @@ def parseOptionalUnitAttr : AttrParserM (Option UnitAttr) := do
     return some UnitAttr.mk
   return none
 
+/--
+  Parse a dense array attribute, if present.
+  Its syntax is `array<iN>` or `array<iN: v1, v2, ...>`.
+-/
+def parseOptionalDenseArrayAttr : AttrParserM (Option DenseArrayAttr) := do
+  if !(← parseOptionalKeyword "array".toByteArray) then
+    return none
+  parsePunctuation "<"
+  let elementType ← parseIntegerType "integer type expected in dense array attribute"
+  let mut values : Array Int := #[]
+  if ← parseOptionalPunctuation ":" then
+    values ← parseList (parseInteger false true)
+  parsePunctuation ">"
+  return some (DenseArrayAttr.mk elementType values)
+
 def isClosingBracket (kind : TokenKind) : Bool :=
   kind = .greater || kind = .rParen || kind = .rSquare || kind = .rBrace
 
@@ -355,6 +370,8 @@ partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
     return some integerAttr
   else if let some stringAttr ← parseOptionalStringAttr then
     return some stringAttr
+  else if let some denseArrayAttr ← parseOptionalDenseArrayAttr then
+    return some denseArrayAttr
   else if let some unitAttr ← parseOptionalUnitAttr then
     return some unitAttr
   else if let some arrayAttr ← parseOptionalArrayAttr then


### PR DESCRIPTION
This is a builtin attribute that we need to represent any operation that has multiple variadic operands, results, or regions