### PR TITLE
instruction selection: tests should live in the same `bb`

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/icmp.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp.mlir
@@ -9,73 +9,55 @@
         // CHECK-NEXT: [[C:%.*]] = "riscv.xor"([[A]], [[B]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "riscv.sltiu"([[C]]) <{"value" = 1 : i64}> : (!reg) -> !reg
         // CHECK-NEXT: [[E:%.*]] = "builtin.unrealized_conversion_cast"([[D]]) : (!reg) -> i1
-
-    ^bb1(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{predicate = 1 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.xor"([[A]], [[B]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !reg
         // CHECK-NEXT: [[E:%.*]] = "riscv.sltu"([[D]], [[C]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[F:%.*]] = "builtin.unrealized_conversion_cast"([[E]]) : (!reg) -> i1
- 
-    ^bb2(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.slt"([[A]], [[B]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (!reg) -> i1
-        
-    ^bb3(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 3 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.slt"([[B]], [[A]]) : (!reg, !reg) -> !reg
         // note: operands are swapped – rhs before lhs
         // CHECK-NEXT: [[D:%.*]] = "riscv.xori"([[C]]) <{"value" = 1 : i64}> : (!reg) -> !reg
         // CHECK-NEXT: [[E:%.*]] = "builtin.unrealized_conversion_cast"([[D]]) : (!reg) -> i1
-        
-    ^bb4(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.slt"([[B]], [[A]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (!reg) -> i1
-        
-    ^bb5(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 5 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.slt"([[A]], [[B]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "riscv.xori"([[C]]) <{"value" = 1 : i64}> : (!reg) -> !reg
         // CHECK-NEXT: [[E:%.*]] = "builtin.unrealized_conversion_cast"([[D]]) : (!reg) -> i1
-        
-    ^bb6(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 6 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.sltu"([[A]], [[B]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (!reg) -> i1
-        
-    ^bb7(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 7 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.sltu"([[B]], [[A]]) : (!reg, !reg) -> !reg
         // note: operands are swapped – rhs before lhs
         // CHECK-NEXT: [[D:%.*]] = "riscv.xori"([[C]]) <{"value" = 1 : i64}> : (!reg) -> !reg
         // CHECK-NEXT: [[E:%.*]] = "builtin.unrealized_conversion_cast"([[D]]) : (!reg) -> i1
-        
-    ^bb8(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 8 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.sltu"([[B]], [[A]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (!reg) -> i1
-        
-    ^bb9(%a: i64, %b: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 9 : i64}> : (i64, i64) -> i1
-        // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[B:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: [[C:%.*]] = "riscv.sltu"([[A]], [[B]]) : (!reg, !reg) -> !reg
         // CHECK-NEXT: [[D:%.*]] = "riscv.xori"([[C]]) <{"value" = 1 : i64}> : (!reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() ({
-    ^bb0(%a: i32, %b: i32):
+    ^bb0(%a: i32, %b: i32, %c: i64):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
-        // CHECK:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
+        // CHECK:           "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
         // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-        %r = "llvm.icmp"(%a, %b) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
+        %r = "llvm.icmp"(%c, %b) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
         // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
-        %r = "llvm.icmp"(%a, %b) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
+        %r = "llvm.icmp"(%c, %c) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
         // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
   }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
@@ -5,18 +5,12 @@
     ^bb0(%a: i32, %b: i32):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
         // CHECK:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
-        
-    ^bb1(%a: i32, %b: i32):
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-        // CHECK:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-        
-    ^bb2(%a: i64, %b: i32):
+        // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
-        // CHECK:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
-    
-    ^bb3(%a: i64, %b: i64):
+        // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
         %r = "llvm.icmp"(%a, %b) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
-        // CHECK:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
+        // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Passes/InstructionSelection/RISCV64/mul.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/mul.mlir
@@ -8,24 +8,18 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        
-    ^bb1(%a: i64, %b: i64):
         %mul = "llvm.mul"(%a, %b) <{nsw}> : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        
-    ^bb2(%a: i64, %b: i64):
         %mul = "llvm.mul"(%a, %b) <{nuw}> : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-    
-    ^bb3(%a: i64, %b: i64):
         %mul = "llvm.mul"(%a, %b) <{nuw, nsw}> : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/or.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or.mlir
@@ -8,10 +8,8 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-    
-    ^bb1(%a: i64, %b: i64):
         %add = "llvm.or"(%a, %b) <{disjoint}> : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
@@ -5,9 +5,7 @@
     ^bb0(%a: i32, %b: i32):
         %add = "llvm.or"(%a, %b) : (i32, i32) -> i32
         // CHECK: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-        
-    ^bb1(%a: i32, %b: i32):
         %add = "llvm.or"(%a, %b) <{disjoint}>: (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) <{disjoint}> : (i32, i32) -> i32
+        // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) <{disjoint}> : (i32, i32) -> i32
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv.mlir
@@ -8,10 +8,8 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.div"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        
-    ^bb1(%a: i64, %b: i64):
         %sdiv = "llvm.sdiv"(%a, %b) <{exact}> : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.div"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/udiv.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv.mlir
@@ -8,10 +8,8 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.divu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        
-    ^bb1(%a: i64, %b: i64):
         %udiv = "llvm.udiv"(%a, %b) <{exact}> : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.divu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64


### PR DESCRIPTION
In #386 I learned that we should have all the tests living in the same block or in different `func.func`, so I am retroactively fixing the instruction selection test cases that did not abide to these rules and have one basic block (with multiple operations and checks) per test. 