### PR TITLE
Parse `cf.br` op

### DIFF
--- a/Test/Cf/identity.mlir
+++ b/Test/Cf/identity.mlir
@@ -1,0 +1,17 @@
+// RUN: veir-opt %s | filecheck %s
+
+"builtin.module"() ({
+  ^4():
+    "func.func"() ({
+      ^6(%arg6_0 : i32):
+        "cf.br"(%arg6_0) [^6] : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^4():
+// CHECK-NEXT:     "func.func"() ({
+// CHECK-NEXT:       ^6(%arg6_0 : i32):
+// CHECK-NEXT:         "cf.br"(%arg6_0) [^6] : (i32) -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -64,6 +64,11 @@ inductive Func where
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
+inductive Cf where
+| br
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[opcodes]
 inductive Llvm where
 | constant
 | and

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -311,6 +311,8 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     all_goals exact (Except.ok ())
   case func =>
     all_goals exact (Except.ok ())
+  case cf =>
+    all_goals exact (Except.ok ())
   case builtin =>
     all_goals exact (Except.ok ())
   case arith op =>

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -372,6 +372,15 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  /- CF -/
+  | .cf .br => do
+    if op.getNumResults ctx opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 1 then
+      throw "Expected 1 successor"
+    pure ()
   /- TEST -/
   | .test .test => do
     pure ()


### PR DESCRIPTION
This adds the `cf.br` op to the parser and the verifier.
Note that I don't verify that the number of arguments is consistent with the destination block. This is not a local invariant, so it seemed out of scope for the current verifier.
