### PR TITLE
instruction selection: `llvm.select`

### DIFF
--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -602,6 +602,48 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry
 
+set_option warn.sorry false in
+/-- llvm.select ->
+      bb0:
+        riscv.addi sp 16
+        riscv.mv arg1
+        riscv.mv arg0
+        riscv.riscv.andi a2 1
+        riscv.sd 8(sp)
+        /- if condition `a0` is true, jump to `.LBB0_2` -/
+        riscv.bnez a0 .LBB0_2
+      bb1 :
+        riscvld 0
+        riscvsd 8(sp)
+      .LBB0_2
+        riscv.ld a0(sp)
+        riscv.addi sp 16
+        .cfi_def_cfa_offset 0
+      -/
+def select (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+    Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, _) := matchLshr op rewriter.ctx | return rewriter
+  /- only support `i64` -/
+  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  if ltype.bitwidth ≠ 64 then return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  if rtype.bitwidth ≠ 64 then return rewriter
+
+  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let .integerType type' := type.val | rewriter
+  if type'.bitwidth ≠ 64 then return rewriter
+  /- First, cast the operands to registers -/
+  let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- Actual `riscv.srl` -/
+  let (rewriter, mulOp) ← rewriter.createOp (.riscv .srl) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- Cast back result for type consistency-/
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
+      #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry
 
 /-! # Pass implementation -/
 

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -628,23 +628,7 @@ def select (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if ltype.bitwidth ≠ 64 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-
-  let type := ((op.getResult 0).get! rewriter.ctx).type
-  let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
-  /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Actual `riscv.srl` -/
-  let (rewriter, mulOp) ← rewriter.createOp (.riscv .srl) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Cast back result for type consistency-/
-  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
-      #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
-
+  sorry
 /-! # Pass implementation -/
 
 set_option warn.sorry false in

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -124,3 +124,7 @@ def matchLshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
 def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .sub)) := do
   let (op, properties) ← matchOp op ctx (.llvm .sub) 2
   return (op[0]!, op[1]!, properties)
+
+def matchSelect (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × ValuePtr × propertiesOf (.llvm .select)) := do
+  let (op, properties) ← matchOp op ctx (.llvm .select) 3
+  return (op[0]!, op[1]!, op[2]!, properties)

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -544,6 +544,9 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
+    if let .integerType cType := ((op.getOperands! ctx)[0]!.getType! ctx).val then
+        if cType.bitwidth ≠ 1 then
+          throw "Condition must have `i1` type."
     pure ()
   | .llvm .trunc => do
     if op.getNumOperands ctx opIn ≠ 1 then


### PR DESCRIPTION
Adds the instructions selection pattern (with branching) for `llvm.select` operation. 
We ignore the `ld` and `sd` operations for the time being and focus on the construction of the correct blocks. 
We also update the verifier to check the width of the predicate of the operation (`i1`) 
We implement the RISCV assembly branching operation `bnez` following #391, without introducing its semantics.