### PR TITLE
Change comment-on-alert to false in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "110%"
-          comment-on-alert: true
+          comment-on-alert: false
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           comment-always: ${{ github.event_name == 'pull_request' }}
           save-data-file: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
This hides the benchmark noise we are currently seeing, e.g., in https://github.com/opencompl/veir/pull/401.