### PR TITLE
Refactor README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Verified Intermediate Representation
 
-VeIR is a compiler infrastructure written in Lean that offers both:
-(a) an [MLIR](https://mlir.llvm.org/)-style imperative design and
-(b) (optional) ITP-level verification.
+VeIR is a compiler infrastructure written in Lean that offers both an
+[MLIR](https://mlir.llvm.org/)-style imperative design and
+(optional) ITP-level verification.
 VeIR connects with MLIR via the MLIR textual format, making it
 easy to combine MLIR and VeIR tooling.
 


### PR DESCRIPTION
Reformat README for improved readability by dropping the explicit enumeration of `a` and `b`.