### PR TITLE
Increase CI benchmark alert-threshold to 500%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.ref == 'refs/heads/main' }}
-          alert-threshold: "110%"
+          alert-threshold: "400%"
           comment-on-alert: false
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           comment-always: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION
Our benchmarks are currently very noisy. Let's move the noise threashold up to avoid continious failing benchmark runs in CI.