### PR TITLE
[ci] Fix noise in benchmarks 

### DIFF
--- a/.github/scripts/run_benchmarks.sh
+++ b/.github/scripts/run_benchmarks.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 # Runs all benchmarks and outputs results in github-action-benchmark JSON format.
-# Usage: ./run_benchmarks.sh [count] [pc]
-#   count: tree size (default: 1000)
-#   pc:    program counter param (default: 50)
+# Each benchmark is run multiple times; the median is reported to reduce noise.
+# Usage: ./run_benchmarks.sh [count] [pc] [iterations]
+#   count:      tree size (default: 1000)
+#   pc:         program counter param (default: 50)
+#   iterations: number of runs per benchmark for median (default: 5)
 
 set -euo pipefail
 
 COUNT="${1:-1000}"
 PC="${2:-50}"
+ITERATIONS="${3:-5}"
 
 BENCHMARKS=(
   "add-fold-worklist"
@@ -25,38 +28,52 @@ BENCHMARKS=(
 
 OUTPUT_FILE="${BENCHMARK_OUTPUT:-benchmark-results.json}"
 
+# Compute median of a list of numbers passed as arguments.
+median() {
+  local sorted
+  sorted=($(printf '%s\n' "$@" | sort -g))
+  local n=${#sorted[@]}
+  local mid=$((n / 2))
+  if (( n % 2 == 1 )); then
+    echo "${sorted[$mid]}"
+  else
+    echo "${sorted[$mid - 1]}" "${sorted[$mid]}" | awk '{printf "%.9f", ($1 + $2) / 2}'
+  fi
+}
+
 echo "[" > "$OUTPUT_FILE"
 first=true
 
 for bench in "${BENCHMARKS[@]}"; do
-  echo "Running benchmark: $bench (count=$COUNT, pc=$PC)" >&2
+  echo "Running benchmark: $bench (count=$COUNT, pc=$PC, iterations=$ITERATIONS)" >&2
 
-  # Capture benchmark output
-  # Output format from Benchmarks.lean time function: "{name} time (s): {float}"
-  raw_output=$(lake exe run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || {
-    echo "  FAILED: $bench" >&2
-    echo "  Output: $raw_output" >&2
-    continue
-  }
+  create_times=()
+  rewrite_times=()
 
-  # Extract "rewrite time (s): <float>" -- this is the main metric we care about
-  rewrite_secs=$(echo "$raw_output" | sed -n 's/.*rewrite time (s): \([0-9.]*\).*/\1/p')
-  create_secs=$(echo "$raw_output" | sed -n 's/.*create time (s): \([0-9.]*\).*/\1/p')
+  for ((i = 1; i <= ITERATIONS; i++)); do
+    raw_output=$(lake exe run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || {
+      echo "  FAILED: $bench (iteration $i)" >&2
+      echo "  Output: $raw_output" >&2
+      continue
+    }
 
-  if [ -z "$rewrite_secs" ] && [ -z "$create_secs" ]; then
-    echo "  Could not parse timing for $bench, skipping" >&2
-    echo "  Raw output: $raw_output" >&2
-    continue
-  fi
+    rs=$(echo "$raw_output" | sed -n 's/.*rewrite time (s): \([0-9.]*\).*/\1/p')
+    cs=$(echo "$raw_output" | sed -n 's/.*create time (s): \([0-9.]*\).*/\1/p')
 
-  # Emit separate entries for create and rewrite phases
+    [ -n "$cs" ] && create_times+=("$cs")
+    [ -n "$rs" ] && rewrite_times+=("$rs")
+  done
+
   for phase_name in create rewrite; do
     if [ "$phase_name" = "create" ]; then
-      secs="$create_secs"
+      times=("${create_times[@]+"${create_times[@]}"}")
     else
-      secs="$rewrite_secs"
+      times=("${rewrite_times[@]+"${rewrite_times[@]}"}")
     fi
-    [ -z "$secs" ] && continue
+
+    [ ${#times[@]} -eq 0 ] && continue
+
+    secs=$(median "${times[@]}")
 
     # Convert seconds (float) to nanoseconds (integer) using awk
     value_ns=$(echo "$secs" | awk '{printf "%.0f", $1 * 1000000000}')
@@ -72,11 +89,11 @@ for bench in "${BENCHMARKS[@]}"; do
     "name": "${bench}/${phase_name}",
     "unit": "ns",
     "value": $value_ns,
-    "extra": "count=$COUNT pc=$PC ${phase_name}=${secs}s"
+    "extra": "count=$COUNT pc=$PC iterations=$ITERATIONS median_${phase_name}=${secs}s"
   }
 ENTRY
 
-    echo "  $bench/$phase_name: ${secs}s" >&2
+    echo "  $bench/$phase_name: ${secs}s (median of $ITERATIONS runs)" >&2
   done
 done
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.ref == 'refs/heads/main' }}
-          alert-threshold: "150%"
-          comment-on-alert: true
+          alert-threshold: "100000%" # effectively disabled, gathering baseline data
+          comment-on-alert: false
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           comment-always: ${{ github.event_name == 'pull_request' }}
           save-data-file: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run benchmarks
         run: |
           chmod +x .github/scripts/run_benchmarks.sh
-          .github/scripts/run_benchmarks.sh 1000 100
+          .github/scripts/run_benchmarks.sh 1000 100 5
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1
@@ -46,7 +46,7 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.ref == 'refs/heads/main' }}
-          alert-threshold: "400%"
+          alert-threshold: "150%"
           comment-on-alert: false
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           comment-always: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           benchmark-data-dir-path: dev/bench
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           alert-threshold: "150%"
-          comment-on-alert: false
+          comment-on-alert: true
           fail-on-alert: ${{ github.event_name == 'pull_request' }}
           comment-always: ${{ github.event_name == 'pull_request' }}
           save-data-file: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
 Each benchmark ran once which produced highly variable results.

  ## Fix 
  1. .github/scripts/run_benchmarks.sh — Run each benchmark 5 times and report the median
  2. .github/workflows/ci.yml: 
    - Pass 5 as the iterations argument: run_benchmarks.sh 1000 100 5
    - Increase threshold to a very large value, effectively disabling alerts. 