### PR TITLE
refinement relation from `LLVM.Int` to `RISCV.Reg`

### DIFF
--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -1,0 +1,19 @@
+module
+
+public import Veir.Data.LLVM.Int.Basic
+public import Veir.Data.RISCV.Reg.Basic
+
+public section
+
+/-!
+  This file defines the refinement relation from the `LLVM.Int` to `RISCV.Reg` type.
+-/
+
+
+/--
+  `LLVM.Int` is refined by `RISCV.Reg`.
+-/
+def IntIsRefinedByReg [DecidableEq Prop] (i : Veir.Data.LLVM.Int 64) (r : Veir.Data.RISCV.Reg) : Prop :=
+  match i with
+  | .val v => r.val = v
+  | .poison => true


### PR DESCRIPTION
We add the definition of the refinement relation from `LLVM.Int` to `RISCV.Reg`. This is the core relation we want to reason about when proving the correctness of instruction selection patterns. We say an integer `i : LLVM.Int` is refined by a register `r : RISCV.Reg` if the behaviours allowed by the register are a subset smaller or equal to the integer's behaviour.

Formally, an integer `i : LLVM.Int` is refined by a register `r : RISCV.Reg` iff: 
* if `i` is a concrete value `.val v`, then the register `r` must contain `v` (i.e., `r.val = v`), and the two behave identically.
* if `i` is a `.poison`, any value can refine it and the relation always holds, as the register displays a specific behaviour among the different ones `poison` can have.