### PR TITLE
llvm: `constant` semantics

### DIFF
--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -66,6 +66,12 @@ instance {w : Nat} : ToString (Int w) where
     | .poison => "poison"
 
 /--
+  We define the semantics of a constant value
+-/
+def constant {w : Nat} (v : BitVec w) : Int w := Id.run do
+  val v
+
+/--
 The ‘add’ instruction returns the sum of its two operands.
 
 If the sum has unsigned overflow, the result returned is the mathematical result

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -69,8 +69,7 @@ instance {w : Nat} : ToString (Int w) where
   We define the semantics of a `constant` operation.
   The result of this operation is never poison.
 -/
-def constant (w : Nat) (v : _root_.Int) : Int w := Id.run do
-  val (BitVec.ofInt w v)
+def constant (w : Nat) (v : _root_.Int) : Int w := val (BitVec.ofInt w v)
 
 /--
 The ‘add’ instruction returns the sum of its two operands.

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -66,10 +66,10 @@ instance {w : Nat} : ToString (Int w) where
     | .poison => "poison"
 
 /--
-  We define the semantics of a constant value
+  We define the semantics of a `constant` operation.
 -/
-def constant {w : Nat} (v : BitVec w) : Int w := Id.run do
-  val v
+def constant (w : Nat) (v : _root_.Int) : Int w := Id.run do
+  val (BitVec.ofInt w v)
 
 /--
 The ‘add’ instruction returns the sum of its two operands.

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -67,6 +67,7 @@ instance {w : Nat} : ToString (Int w) where
 
 /--
   We define the semantics of a `constant` operation.
+  The result of this operation is never poison.
 -/
 def constant (w : Nat) (v : _root_.Int) : Int w := Id.run do
   val (BitVec.ofInt w v)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -212,8 +212,7 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
     let resType ← resultTypes[0]?
     let .integerType bw := resType.val
       | none
-    return (#[.int bw.bitwidth
-      (.val (BitVec.ofInt bw.bitwidth properties.value.value))], .continue)
+    return (#[.int bw.bitwidth (LLVM.Int.constant bw.bitwidth properties.value.value)], .continue)
   | .llvm .add => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else


### PR DESCRIPTION
We add explicit, declarative semantics of `llvm.constant` operation. This is useful to reason about the correctness of rewrites, e.g. in the context of instruction selection. The semantics are unchanged in practice, but wrapped in their own deifnition just like every other operation. 