### PR TITLE
instruction selection: `constant`, `add` refinement proof

### DIFF
--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -9,23 +9,13 @@ public section
   This file defines the refinement relation from the `LLVM.Int` to `RISCV.Reg` type.
 -/
 
-open Classical in
-
-/--
-  `LLVM.Int` is refined by `RISCV.Reg`.
--/
-def IntIsRefinedByReg [DecidableEq Prop] (i : Veir.Data.LLVM.Int 64) (r : Veir.Data.RISCV.Reg) : Prop :=
-  match i with
-  | .val v => r.val = v
-  | .poison => true
-
 /--
   `LLVM.Int` is refined by `LLVM.Int`.
   `i'` refines `i` if its behaviour are a subset of the behaviours allowed by `i`.
   In particular, any concrete `i'` refines a poison `i`, but a poison `i'` does *not* refine
   any `i`.
 -/
-def IntIsRefinedByInt [DecidableEq Prop] (i i' : Veir.Data.LLVM.Int 64) : Prop :=
+def isRefinedBy (i i' : Veir.Data.LLVM.Int 64) : Prop :=
   match i with
   | .val v =>
     match i' with

--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -18,3 +18,17 @@ def IntIsRefinedByReg [DecidableEq Prop] (i : Veir.Data.LLVM.Int 64) (r : Veir.D
   match i with
   | .val v => r.val = v
   | .poison => true
+
+/--
+  `LLVM.Int` is refined by `LLVM.Int`.
+  `i'` refines `i` if its behaviour are a subset of the behaviours allowed by `i`.
+  In particular, any concrete `i'` refines a poison `i`, but a poison `i'` does *not* refine
+  any `i`.
+-/
+def isRefinedBy [DecidableEq Prop] (i i' : Veir.Data.LLVM.Int 64)  : Prop :=
+  match i with
+  | .val v =>
+    match i' with
+    | .val v' => v = v'
+    | .poison => true
+  | .poison => true

--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -25,7 +25,7 @@ def IntIsRefinedByReg [DecidableEq Prop] (i : Veir.Data.LLVM.Int 64) (r : Veir.D
   In particular, any concrete `i'` refines a poison `i`, but a poison `i'` does *not* refine
   any `i`.
 -/
-def isRefinedBy [DecidableEq Prop] (i i' : Veir.Data.LLVM.Int 64)  : Prop :=
+def IntIsRefinedByInt [DecidableEq Prop] (i i' : Veir.Data.LLVM.Int 64) : Prop :=
   match i with
   | .val v =>
     match i' with

--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -9,6 +9,7 @@ public section
   This file defines the refinement relation from the `LLVM.Int` to `RISCV.Reg` type.
 -/
 
+open Classical in
 
 /--
   `LLVM.Int` is refined by `RISCV.Reg`.

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -10,7 +10,7 @@ import Std.Tactic.BVDecide
 -/
 
 open Veir
-open Classical
+namespace RISCV64
 
 /--
   Prove the correctness of the `constant` lowering pattern.
@@ -19,33 +19,15 @@ open Classical
   are always concrete in the interpreter.
 -/
 theorem constant:
-    IntIsRefinedByReg (Data.LLVM.Int.constant 64 v) (Data.RISCV.li (BitVec.ofInt 64 v)) := by
-  simp [IntIsRefinedByReg, Data.LLVM.Int.constant, Data.RISCV.li]
-
-theorem constant':
-    IntIsRefinedByInt (Data.LLVM.Int.constant 64 v) (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
-  simp [IntIsRefinedByInt, Data.LLVM.Int.constant, Data.RISCV.li, RISCV.Reg.toInt]
+    isRefinedBy (Data.LLVM.Int.constant 64 v) (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
+  simp [isRefinedBy, Data.LLVM.Int.constant, Data.RISCV.li, RISCV.Reg.toInt]
 
 /--
   Prove the correctness of the `add` lowering pattern.
 -/
 theorem add:
-    IntIsRefinedByReg (Data.LLVM.Int.add x y) (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) := by
-  simp only [IntIsRefinedByReg, Data.LLVM.Int.add, Bool.false_eq_true, false_and, reduceIte,
-    pure_bind, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth, BitVec.setWidth_eq]
-  split
-  · split
-    · split
-      <;> bv_decide
-    · split
-      · bv_decide
-      · simp only [Id.run, Data.LLVM.Int.val.injEq] at *
-        bv_decide
-  · bv_decide
-
-theorem add':
-    IntIsRefinedByInt (Data.LLVM.Int.add x y) (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
-  simp only [IntIsRefinedByInt, Data.LLVM.Int.add, Bool.false_eq_true, false_and, ↓reduceIte,
+    isRefinedBy (Data.LLVM.Int.add x y) (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
+  simp only [isRefinedBy, Data.LLVM.Int.add, Bool.false_eq_true, false_and, ↓reduceIte,
     pure_bind, RISCV.Reg.toInt, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth,
     BitVec.setWidth_eq]
   split

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -22,6 +22,10 @@ theorem constant:
     IntIsRefinedByReg (Data.LLVM.Int.constant 64 v) (Data.RISCV.li (BitVec.ofInt 64 v)) := by
   simp [IntIsRefinedByReg, Data.LLVM.Int.constant, Data.RISCV.li]
 
+theorem constant':
+    IntIsRefinedByInt (Data.LLVM.Int.constant 64 v) (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
+  simp [IntIsRefinedByInt, Data.LLVM.Int.constant, Data.RISCV.li, RISCV.Reg.toInt]
+
 /--
   Prove the correctness of the `add` lowering pattern.
 -/
@@ -32,6 +36,21 @@ theorem add:
   split
   · split
     · split
+      <;> bv_decide
+    · split
+      · bv_decide
+      · simp only [Id.run, Data.LLVM.Int.val.injEq] at *
+        bv_decide
+  · bv_decide
+
+theorem add':
+    IntIsRefinedByInt (Data.LLVM.Int.add x y) (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
+  simp only [IntIsRefinedByInt, Data.LLVM.Int.add, Bool.false_eq_true, false_and, ↓reduceIte,
+    pure_bind, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth, BitVec.setWidth_eq]xw
+  split
+  · split
+    · bv_decide
+      split
       <;> bv_decide
     · split
       · bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -21,3 +21,20 @@ open Classical
 theorem constant:
     IntIsRefinedByReg (Data.LLVM.Int.constant 64 v) (Data.RISCV.li (BitVec.ofInt 64 v)) := by
   simp [IntIsRefinedByReg, Data.LLVM.Int.constant, Data.RISCV.li]
+
+/--
+  Prove the correctness of the `add` lowering pattern.
+-/
+theorem add:
+    IntIsRefinedByReg (Data.LLVM.Int.add x y) (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) := by
+  simp only [IntIsRefinedByReg, Data.LLVM.Int.add, Bool.false_eq_true, false_and, reduceIte,
+    pure_bind, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth, BitVec.setWidth_eq]
+  split
+  · split
+    · split
+      <;> bv_decide
+    · split
+      · bv_decide
+      · simp only [Id.run, Data.LLVM.Int.val.injEq] at *
+        bv_decide
+  · bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -46,11 +46,11 @@ theorem add:
 theorem add':
     IntIsRefinedByInt (Data.LLVM.Int.add x y) (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
   simp only [IntIsRefinedByInt, Data.LLVM.Int.add, Bool.false_eq_true, false_and, ↓reduceIte,
-    pure_bind, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth, BitVec.setWidth_eq]xw
+    pure_bind, RISCV.Reg.toInt, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth,
+    BitVec.setWidth_eq]
   split
   · split
-    · bv_decide
-      split
+    · split
       <;> bv_decide
     · split
       · bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -9,8 +9,7 @@ import Std.Tactic.BVDecide
   instruction selection rewrites.
 -/
 
-open Veir
-namespace RISCV64
+namespace Veir.Data.RISCV
 
 /--
   Prove the correctness of the `constant` lowering pattern.
@@ -18,14 +17,14 @@ namespace RISCV64
   We do not need to consider the poison case, as the semantics of `llvm_constant`
   are always concrete in the interpreter.
 -/
-theorem constant:
-    isRefinedBy (Data.LLVM.Int.constant 64 v) (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
+theorem constant_refinement:
+    isRefinedBy (LLVM.Int.constant 64 v) (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
   simp [isRefinedBy, Data.LLVM.Int.constant, Data.RISCV.li, RISCV.Reg.toInt]
 
 /--
   Prove the correctness of the `add` lowering pattern.
 -/
-theorem add:
+theorem add_refinement:
     isRefinedBy (Data.LLVM.Int.add x y) (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
   simp only [isRefinedBy, Data.LLVM.Int.add, Bool.false_eq_true, false_and, ↓reduceIte,
     pure_bind, RISCV.Reg.toInt, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth,

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -1,6 +1,7 @@
 import Veir.Data.RISCV.Reg.Basic
 import Veir.Data.LLVM.Int.Basic
 import Veir.Data.Casting
+import Veir.Data.Refinement
 import Std.Tactic.BVDecide
 
 /-!
@@ -9,6 +10,7 @@ import Std.Tactic.BVDecide
 -/
 
 open Veir
+open Classical
 
 /--
   Prove the correctness of the `constant` lowering pattern.
@@ -16,6 +18,6 @@ open Veir
   We do not need to consider the poison case, as the semantics of `llvm_constant`
   are always concrete in the interpreter.
 -/
-theorem constant_val (v : BitVec 64) :
-    (Data.LLVM.Int.val v) = RISCV.Reg.toInt (Data.RISCV.li v) 64 := by
-  simp [Data.RISCV.li, RISCV.Reg.toInt]
+theorem constant:
+    IntIsRefinedByReg (Data.LLVM.Int.constant 64 v) (Data.RISCV.li (BitVec.ofInt 64 v)) := by
+  simp [IntIsRefinedByReg, Data.LLVM.Int.constant, Data.RISCV.li]


### PR DESCRIPTION
We prove the correctness of the lowering pattern for `constant` and `add`. If we agree on this format and organization I will write more proofs and push them. Note that the proof for `constant` does not deal with `.poison`, as `llvm.constant` is never poison. 

I think we have two options to consider wrt. lemmas' formulation: 
* wrapping the semantics of the `unrealized_conversion_cast` (i.e.,`toReg : i64 -> !reg`) directly in the lemma and proving the refinement `i64` to `!reg`. 
* wrapping the semantics of the `unrealized_conversion_cast` *in both directions* (i.e.,`toReg : i64 -> !reg` and `toInt : !reg -> i64`). This would be more consistent with what the rewriter actually does, and the refinement goes from `i64` to `i64`. 

I am pushing both option and look forward to gathering opinions :)

Also, the tactic is the usual:
* unwrap semantics
* split + get rid of monad
* `bv_decide`

If we agree on these steps we can wrap it into an actual tactic, as we did in `lean-MLIR` (for a subsequent PR). 