### PR TITLE
Tentative implementation of `HasIRContext`.

### DIFF
--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -40,8 +40,8 @@ def addIConstantFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : 
     return rewriter
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! rewriter.ctx (OpCode.arith .constant)).value.value
+  let rhsVal := (rhsOp.getProperties! rewriter.ctx (OpCode.arith .constant)).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (rewriter, newOp) ← rewriter.createOp (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
   let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry
@@ -76,8 +76,8 @@ def addIConstantFoldingLocal (ctx: IRContext OpCode) (op: OperationPtr) :
     | some (ctx, none)
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! ctx (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! ctx (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! ctx (OpCode.arith .constant)).value.value
+  let rhsVal := (rhsOp.getProperties! ctx (OpCode.arith .constant)).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (ctx, newOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry sorry
   return (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -94,7 +94,7 @@ def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Opti
   let rhsOpStruct := rhsOp.get rewriter.ctx (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
-  if (rhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value ≠ 0 then
+  if (rhsOp.getProperties! rewriter.ctx (OpCode.arith .constant)).value.value ≠ 0 then
     return rewriter
 
   -- Get the lhs value
@@ -120,7 +120,7 @@ def mulITwoReduce (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option
   let rhsOpStruct := rhsOp.get rewriter.ctx (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
-  if (rhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value ≠ 2 then
+  if (rhsOp.getProperties! rewriter.ctx (OpCode.arith .constant)).value.value ≠ 2 then
     return rewriter
 
   -- Get the lhs value
@@ -165,8 +165,8 @@ def addIConstantFolding (ctx: IRContext OpCode) (op: OperationPtr) : Option (IRC
     return ctx
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! ctx (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! ctx (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! ctx (OpCode.arith .constant)).value.value
+  let rhsVal := (rhsOp.getProperties! ctx (OpCode.arith .constant)).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (ctx, newOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry sorry
   let mut ctx ← Rewriter.replaceOp? ctx op newOp sorry sorry sorry sorry
@@ -189,7 +189,7 @@ def addIZeroFolding (ctx: IRContext OpCode) (op: OperationPtr) : Option (IRConte
   let rhsOpStruct := rhsOp.get ctx (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
-  if (rhsOp.getProperties! ctx (.arith .constant)).value.value ≠ 0 then
+  if (rhsOp.getProperties! ctx (OpCode.arith .constant)).value.value ≠ 0 then
     return ctx
 
   -- Get the lhs value
@@ -215,7 +215,7 @@ def mulITwoReduce (ctx: IRContext OpCode) (op: OperationPtr) : Option (IRContext
   let rhsOpStruct := rhsOp.get ctx (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
-  if (rhsOp.getProperties! ctx (.arith .constant)).value.value ≠ 2 then
+  if (rhsOp.getProperties! ctx (OpCode.arith .constant)).value.value ≠ 2 then
     return ctx
 
   -- Get the lhs value

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -182,7 +182,7 @@ structure Operation (OpInfo : Type) [HasOpInfo OpInfo] where
   operands : Array OpOperand
 deriving Inhabited, Repr, Hashable
 
-variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {OpInfo : outParam Type} [HasOpInfo OpInfo]
 
 namespace Operation
 
@@ -273,7 +273,21 @@ deriving Inhabited, Repr
 
 theorem IRContext.default_def : (default : IRContext OpInfo) = IRContext.mk ∅ ∅ ∅ 0 := by rfl
 
+/--
+A typeclass for types that stores an IRContext.
+As we have types that extends IRContext, using this typeclass allows us to write functions
+that are generic over all those types.
+-/
+class HasIRContext (Ctx : Type) (OpInfo : outParam Type) [HasOpInfo OpInfo] where
+  getCtx : Ctx → IRContext OpInfo
+
+instance instIRContextHasIRContext : HasIRContext (IRContext OpInfo) OpInfo where
+  getCtx := fun x => x
+
+attribute [grind] instIRContextHasIRContext HasIRContext.getCtx
+
 variable {ctx ctx' : IRContext OpInfo}
+variable {Ctx : Type} [HasIRContext Ctx OpInfo]
 
 /-! Empty objects. -/
 
@@ -318,30 +332,31 @@ OperationPtr accessors
 namespace OperationPtr
 
 @[local grind]
-def InBounds (op : OperationPtr) (ctx : IRContext OpInfo) : Prop :=
-  op ∈ ctx.operations
+def InBounds (op : OperationPtr) (ctx : Ctx) : Prop :=
+  op ∈ IRContext.operations (HasIRContext.getCtx ctx)
 
-def inBounds_def : InBounds op ctx ↔ op ∈ ctx.operations := by rfl
+theorem inBounds_def {ctx : Ctx} :
+  InBounds op ctx = (op ∈ (HasIRContext.getCtx ctx).operations) := by rfl
 
 @[no_expose]
 instance : Decidable (InBounds op ctx) := by
   unfold InBounds; infer_instance
 
-def get (ptr : OperationPtr) (ctx : IRContext OpInfo) (inBounds : ptr.InBounds ctx := by grind) : Operation OpInfo :=
-  ctx.operations[ptr]'(by unfold InBounds at inBounds; grind)
+def get (ptr : OperationPtr) (ctx : Ctx) (inBounds : ptr.InBounds ctx := by grind) : Operation OpInfo :=
+  (HasIRContext.getCtx ctx).operations[ptr]'(by grind [inBounds_def])
 
-def get! (ptr : OperationPtr) (ctx : IRContext OpInfo) : Operation OpInfo :=
-  ctx.operations[ptr]!
+def get! (ptr : OperationPtr) (ctx : Ctx) : Operation OpInfo :=
+  (HasIRContext.getCtx ctx).operations[ptr]!
 
 @[grind =_, eq_bang ←]
 theorem get!_eq_get {ptr : OperationPtr} (hin : ptr.InBounds ctx) :
     ptr.get! ctx = (ptr.get ctx hin) := by
   grind [get, get!, InBounds]
 
-def getOpType (op : OperationPtr) (ctx : IRContext OpInfo) (inBounds : op.InBounds ctx) : OpInfo :=
+def getOpType (op : OperationPtr) (ctx : Ctx) (inBounds : op.InBounds ctx) : OpInfo :=
   (op.get ctx (by grind)).opType
 
-def getOpType! (op : OperationPtr) (ctx : IRContext OpInfo) : OpInfo :=
+def getOpType! (op : OperationPtr) (ctx : Ctx) : OpInfo :=
   (op.get! ctx).opType
 
 @[grind =_, eq_bang ←]
@@ -349,10 +364,10 @@ theorem getOpType!_eq_getOpType {op : OperationPtr} (hin : op.InBounds ctx) :
     op.getOpType! ctx = op.getOpType ctx hin := by
   grind [getOpType, getOpType!]
 
-def getNumOperands (op : OperationPtr) (ctx : IRContext OpInfo) (inBounds : op.InBounds ctx := by grind) : Nat :=
+def getNumOperands (op : OperationPtr) (ctx : Ctx) (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).operands.size
 
-def getNumOperands! (op : OperationPtr) (ctx : IRContext OpInfo) : Nat :=
+def getNumOperands! (op : OperationPtr) (ctx : Ctx) : Nat :=
   (op.get! ctx).operands.size
 
 @[grind =_, eq_bang ←]
@@ -381,11 +396,11 @@ theorem getOpOperand_op {op : OperationPtr} {index : Nat} :
     (getOpOperand op index).op = op := by
   grind [getOpOperand]
 
-def getOperand (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat)
+def getOperand (op : OperationPtr) (ctx : Ctx) (index : Nat)
     (inBounds : op.InBounds ctx := by grind) (h : index < getNumOperands op ctx inBounds := by grind) : ValuePtr :=
   ((op.get ctx (by grind)).operands[index]'(by grind [getNumOperands])).value
 
-def getOperand! (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat) : ValuePtr :=
+def getOperand! (op : OperationPtr) (ctx : Ctx) (index : Nat) : ValuePtr :=
   ((op.get! ctx).operands[index]!).value
 
 @[grind =_, eq_bang ←]
@@ -394,10 +409,10 @@ theorem getOperand!_eq_getOperand {op : OperationPtr} {index : Nat}
     op.getOperand! ctx index = op.getOperand ctx index hin' h := by
   grind [getOperand, getOperand!]
 
-def getOperands (op : OperationPtr) (ctx : IRContext OpInfo) (inBounds : op.InBounds ctx := by grind) : Array ValuePtr :=
+def getOperands (op : OperationPtr) (ctx : Ctx) (inBounds : op.InBounds ctx := by grind) : Array ValuePtr :=
   (op.get ctx (by grind)).operands.map (·.value)
 
-def getOperands! (op : OperationPtr) (ctx : IRContext OpInfo) : Array ValuePtr :=
+def getOperands! (op : OperationPtr) (ctx : Ctx) : Array ValuePtr :=
   (op.get! ctx).operands.map (·.value)
 
 @[grind =_, eq_bang ←]
@@ -436,10 +451,10 @@ theorem getOperands!.getElem_eq_getOperand! {op : OperationPtr} {h} :
     (op.getOperands! ctx)[index]'h = op.getOperand! ctx index := by
   grind [getOperands!, getOperand!]
 
-def getNumSuccessors (op : OperationPtr) (ctx : IRContext OpInfo) (inBounds : op.InBounds ctx := by grind) : Nat :=
+def getNumSuccessors (op : OperationPtr) (ctx : Ctx) (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).blockOperands.size
 
-def getNumSuccessors! (op : OperationPtr) (ctx : IRContext OpInfo) : Nat :=
+def getNumSuccessors! (op : OperationPtr) (ctx : Ctx) : Nat :=
   (op.get! ctx).blockOperands.size
 
 @[grind =_, eq_bang ←]
@@ -468,11 +483,11 @@ theorem getBlockOperand_op {op : OperationPtr} {index : Nat} :
     (getBlockOperand op index).op = op := by
   grind [getBlockOperand]
 
-def getSuccessor (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat)
+def getSuccessor (op : OperationPtr) (ctx : Ctx) (index : Nat)
     (inBounds : op.InBounds ctx := by grind) (h : index < getNumSuccessors op ctx inBounds := by grind) : BlockPtr :=
   ((op.get ctx (by grind)).blockOperands[index]'(by grind [getNumSuccessors])).value
 
-def getSuccessor! (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat) : BlockPtr :=
+def getSuccessor! (op : OperationPtr) (ctx : Ctx) (index : Nat) : BlockPtr :=
   ((op.get! ctx).blockOperands[index]!).value
 
 @[grind =_, eq_bang ←]
@@ -481,10 +496,10 @@ theorem getSuccessor!_eq_getSuccessor {op : OperationPtr} {index : Nat}
     op.getSuccessor! ctx index = op.getSuccessor ctx index hin' h := by
   grind [getSuccessor, getSuccessor!]
 
-def getNumResults (op : OperationPtr) (ctx : IRContext OpInfo) (inBounds : op.InBounds ctx := by grind) : Nat :=
+def getNumResults (op : OperationPtr) (ctx : Ctx) (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).results.size
 
-def getNumResults! (op : OperationPtr) (ctx : IRContext OpInfo) : Nat :=
+def getNumResults! (op : OperationPtr) (ctx : Ctx) : Nat :=
   (op.get! ctx).results.size
 
 @[grind =_, eq_bang ←]
@@ -517,11 +532,11 @@ theorem eq_getResult_of_OpResultPtr_op_eq {res : OpResultPtr} :
     res.op = op → res = op.getResult res.index := by
   grind [getResult, cases OpResultPtr]
 
-def getNumRegions (op : OperationPtr) (ctx : IRContext OpInfo)
+def getNumRegions (op : OperationPtr) (ctx : Ctx)
     (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).regions.size
 
-def getNumRegions! (op : OperationPtr) (ctx : IRContext OpInfo) : Nat :=
+def getNumRegions! (op : OperationPtr) (ctx : Ctx) : Nat :=
   (op.get! ctx).regions.size
 
 @[grind =_, eq_bang ←]
@@ -534,12 +549,12 @@ theorem getNumRegions!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getNumRegions! ctx = op.getNumRegions! ctx' := by
   grind [getNumRegions!]
 
-def getRegion (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat)
+def getRegion (op : OperationPtr) (ctx : Ctx) (index : Nat)
   (inBounds : op.InBounds ctx := by grind) (iInBounds : index < op.getNumRegions ctx inBounds := by grind) : RegionPtr :=
   (op.get ctx (by grind)).regions[index]'(by grind [getNumRegions])
 
 @[grind funCC]
-def getRegion! (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat) : RegionPtr :=
+def getRegion! (op : OperationPtr) (ctx : Ctx) (index : Nat) : RegionPtr :=
   (op.get! ctx).regions[index]!
 
 @[grind =_, eq_bang ←]
@@ -720,13 +735,13 @@ theorem setAttributes!_eq_setAttributes {op : OperationPtr} (inBounds : op.InBou
   grind [setAttributes, setAttributes!]
 
 @[inline]
-def getProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo)
+def getProperties (op : OperationPtr) (ctx : Ctx) (opCode : OpInfo)
     (inBounds : op.InBounds ctx := by grind)
     (hprop : (op.get ctx inBounds).opType = opCode := by grind) : HasOpInfo.propertiesOf opCode :=
   hprop ▸ (op.get ctx (by grind)).properties
 
 @[inline]
-def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo) : HasOpInfo.propertiesOf opCode :=
+def getProperties! (op : OperationPtr) (ctx : Ctx) (opCode : OpInfo) : HasOpInfo.propertiesOf opCode :=
   if h : (op.get! ctx).opType = opCode then
     h ▸ (op.get! ctx).properties
   else
@@ -764,11 +779,11 @@ theorem setProperties!_eq_setProperties {op : OperationPtr}
     op.setProperties ctx newProperties inBounds := by
   grind [setProperties, setProperties!]
 
-def nextOperand (op : OperationPtr) (ctx : IRContext OpInfo)
+def nextOperand (op : OperationPtr) (ctx : Ctx)
     (inBounds : op.InBounds ctx := by grind) : OpOperandPtr :=
   .mk op (op.getNumOperands ctx (by grind))
 
-def nextOperand! (op : OperationPtr) (ctx : IRContext OpInfo) : OpOperandPtr :=
+def nextOperand! (op : OperationPtr) (ctx : Ctx) : OpOperandPtr :=
   .mk op (op.getNumOperands! ctx)
 
 @[grind =_, eq_bang ←]
@@ -781,11 +796,11 @@ theorem nextOperand!_eq_getOpOperand {op : OperationPtr} :
     op.nextOperand! ctx = op.getOpOperand (op.getNumOperands! ctx) := by
   rfl
 
-def nextBlockOperand (op : OperationPtr) (ctx : IRContext OpInfo)
+def nextBlockOperand (op : OperationPtr) (ctx : Ctx)
     (inBounds : op.InBounds ctx := by grind) : BlockOperandPtr :=
   .mk op (op.getNumSuccessors ctx (by grind))
 
-def nextBlockOperand! (op : OperationPtr) (ctx : IRContext OpInfo) : BlockOperandPtr :=
+def nextBlockOperand! (op : OperationPtr) (ctx : Ctx) : BlockOperandPtr :=
   .mk op (op.getNumSuccessors! ctx)
 
 @[grind =_, eq_bang ←]
@@ -798,11 +813,11 @@ theorem nextBlockOperand!_eq_getBlockOperand {op : OperationPtr} :
     op.nextBlockOperand! ctx = op.getBlockOperand (op.getNumSuccessors! ctx) := by
   rfl
 
-def nextResult (op : OperationPtr) (ctx : IRContext OpInfo)
+def nextResult (op : OperationPtr) (ctx : Ctx)
     (inBounds : op.InBounds ctx := by grind) : OpResultPtr :=
   .mk op (op.getNumResults ctx (by grind))
 
-def nextResult! (op : OperationPtr) (ctx : IRContext OpInfo) : OpResultPtr :=
+def nextResult! (op : OperationPtr) (ctx : Ctx) : OpResultPtr :=
   .mk op (op.getNumResults! ctx)
 
 @[grind =_, eq_bang ←]
@@ -840,10 +855,10 @@ end OperationPtr
 namespace OpOperandPtr
 
 @[local grind]
-def InBounds (operand : OpOperandPtr) (ctx : IRContext OpInfo) : Prop :=
+def InBounds (operand : OpOperandPtr) (ctx : Ctx) : Prop :=
   ∃ h, operand.index < (operand.op.get ctx h).operands.size
 
-theorem inBounds_def : InBounds opr ctx ↔ ∃ h, opr.index < opr.op.getNumOperands ctx h := by
+theorem inBounds_def {ctx : Ctx} : InBounds opr ctx ↔ ∃ h, opr.index < opr.op.getNumOperands ctx h := by
   rfl
 
 @[no_expose]
@@ -857,10 +872,10 @@ theorem InBounds_iff (operand : OpOperandPtr) (ctx : IRContext OpInfo) :
     operand.InBounds ctx :=
   by grind [inBounds_def]
 
-def get (operand : OpOperandPtr) (ctx : IRContext OpInfo) (operandIn : operand.InBounds ctx := by grind) : OpOperand :=
+def get (operand : OpOperandPtr) (ctx : Ctx) (operandIn : operand.InBounds ctx := by grind) : OpOperand :=
   (operand.op.get ctx (by grind [InBounds])).operands[operand.index]'(by grind [InBounds, OperationPtr.getNumOperands])
 
-def get! (operand : OpOperandPtr) (ctx : IRContext OpInfo) : OpOperand :=
+def get! (operand : OpOperandPtr) (ctx : Ctx) : OpOperand :=
   (operand.op.get! ctx).operands[operand.index]!
 
 @[grind =_, eq_bang ←]
@@ -973,10 +988,10 @@ theorem OperationPtr.getOperand_eq_OpOperandPtr_get :
 namespace BlockOperandPtr
 
 @[local grind]
-def InBounds (operand : BlockOperandPtr) (ctx : IRContext OpInfo) : Prop :=
+def InBounds (operand : BlockOperandPtr) (ctx : Ctx) : Prop :=
   ∃ h, operand.index < (operand.op.get ctx h).blockOperands.size
 
-theorem inBounds_def :
+theorem inBounds_def {ctx : Ctx} :
     InBounds opr ctx ↔ ∃ h, opr.index < opr.op.getNumSuccessors ctx h := by
   rfl
 
@@ -991,9 +1006,9 @@ theorem inBounds_of_OperationPtr_inBounds {operand : BlockOperandPtr} {ctx : IRC
     operand.InBounds ctx :=
   by grind [inBounds_def]
 
-def get (operand : BlockOperandPtr) (ctx : IRContext OpInfo) (operandIn : operand.InBounds ctx := by grind) : BlockOperand :=
+def get (operand : BlockOperandPtr) (ctx : Ctx) (operandIn : operand.InBounds ctx := by grind) : BlockOperand :=
   (operand.op.get ctx (by grind [InBounds])).blockOperands[operand.index]'(by grind [InBounds])
-def get! (operand : BlockOperandPtr) (ctx : IRContext OpInfo) : BlockOperand :=
+def get! (operand : BlockOperandPtr) (ctx : Ctx) : BlockOperand :=
   operand.op.get! ctx |>.blockOperands[operand.index]!
 @[grind =_, eq_bang ←]
 theorem get!_eq_get {ptr : BlockOperandPtr} (hin : ptr.InBounds ctx) :
@@ -1090,10 +1105,10 @@ end BlockOperandPtr
 namespace OpResultPtr
 
 @[local grind]
-def InBounds (result : OpResultPtr) (ctx : IRContext OpInfo) : Prop :=
+def InBounds (result : OpResultPtr) (ctx : Ctx) : Prop :=
   ∃ h, result.index < (result.op.get ctx h).results.size
 
-theorem inBounds_def : InBounds res ctx ↔ ∃ h, res.index < res.op.getNumResults ctx h := by
+theorem inBounds_def {ctx : Ctx} : InBounds res ctx ↔ ∃ h, res.index < res.op.getNumResults ctx h := by
   rfl
 
 @[no_expose]
@@ -1113,10 +1128,10 @@ theorem inBounds_of {result : OpResultPtr} :
     result.InBounds ctx :=
   by grind [InBounds, OperationPtr.getNumResults!]
 
-def get (result : OpResultPtr) (ctx : IRContext OpInfo) (resultIn : result.InBounds ctx := by grind) : OpResult :=
+def get (result : OpResultPtr) (ctx : Ctx) (resultIn : result.InBounds ctx := by grind) : OpResult :=
   (result.op.get ctx (by grind [InBounds])).results[result.index]'(by grind [InBounds])
 
-def get! (result : OpResultPtr) (ctx : IRContext OpInfo) : OpResult :=
+def get! (result : OpResultPtr) (ctx : Ctx) : OpResult :=
   (result.op.get! ctx).results[result.index]!
 
 @[grind =_, eq_bang ←]
@@ -1196,19 +1211,19 @@ end OpResultPtr
 
 namespace BlockPtr
 
-def InBounds (block : BlockPtr) (ctx : IRContext OpInfo) : Prop :=
-  block ∈ ctx.blocks
+def InBounds (block : BlockPtr) (ctx : Ctx) : Prop :=
+  block ∈ (HasIRContext.getCtx ctx).blocks
 
-def inBounds_def : InBounds block ctx ↔ block ∈ ctx.blocks := by rfl
+theorem inBounds_def {ctx : Ctx} : InBounds block ctx ↔ block ∈ (HasIRContext.getCtx ctx).blocks := by rfl
 
 @[no_expose]
 instance : Decidable (InBounds block ctx) := by
   unfold InBounds; infer_instance
 
-def get (ptr : BlockPtr) (ctx : IRContext OpInfo) (inBounds : ptr.InBounds ctx := by grind) : Block :=
-  ctx.blocks[ptr]'(by unfold InBounds at inBounds; grind)
+def get (ptr : BlockPtr) (ctx : Ctx) (inBounds : ptr.InBounds ctx := by grind) : Block :=
+  (HasIRContext.getCtx ctx).blocks[ptr]'(by grind [inBounds_def])
 
-def get! (ptr : BlockPtr) (ctx : IRContext OpInfo) : Block := ctx.blocks[ptr]!
+def get! (ptr : BlockPtr) (ctx : Ctx) : Block := (HasIRContext.getCtx ctx).blocks[ptr]!
 
 @[grind =_, eq_bang ←]
 theorem get!_eq_get {ptr : BlockPtr} (hin : ptr.InBounds ctx) :
@@ -1313,10 +1328,10 @@ theorem allocEmpty_def (heq : allocEmpty ctx = some (ctx', ptr')) :
     ctx' = set ⟨ctx.nextID⟩ {ctx with nextID := ctx.nextID + 1} Block.empty := by
   grind [allocEmpty]
 
-def getNumArguments (block : BlockPtr) (ctx : IRContext OpInfo) (inBounds : block.InBounds ctx := by grind) : Nat :=
+def getNumArguments (block : BlockPtr) (ctx : Ctx) (inBounds : block.InBounds ctx := by grind) : Nat :=
   (block.get ctx (by grind)).arguments.size
 
-def getNumArguments! (block : BlockPtr) (ctx : IRContext OpInfo) : Nat :=
+def getNumArguments! (block : BlockPtr) (ctx : Ctx) : Nat :=
   (block.get! ctx).arguments.size
 
 @[grind =_, eq_bang ←]
@@ -1342,11 +1357,11 @@ theorem getArgument_block {block : BlockPtr} {index : Nat} :
     (getArgument block index).block = block := by
   grind [getArgument]
 
-def nextArgument (block : BlockPtr) (ctx : IRContext OpInfo)
+def nextArgument (block : BlockPtr) (ctx : Ctx)
     (inBounds: block.InBounds ctx := by grind) : BlockArgumentPtr :=
   getArgument block (block.getNumArguments ctx (by grind))
 
-def nextArgument! (block : BlockPtr) (ctx : IRContext OpInfo) : BlockArgumentPtr :=
+def nextArgument! (block : BlockPtr) (ctx : Ctx) : BlockArgumentPtr :=
   getArgument block (block.getNumArguments! ctx)
 
 @[grind =_, eq_bang ←]
@@ -1395,10 +1410,10 @@ end BlockPtr
 namespace BlockArgumentPtr
 
 @[local grind]
-def InBounds (arg : BlockArgumentPtr) (ctx : IRContext OpInfo) : Prop :=
+def InBounds (arg : BlockArgumentPtr) (ctx : Ctx) : Prop :=
   ∃ h, arg.index < (arg.block.get ctx h).arguments.size
 
-theorem inBounds_def : InBounds arg ctx ↔ ∃ h, arg.index < arg.block.getNumArguments ctx h := by
+theorem inBounds_def {ctx : Ctx} : InBounds arg ctx ↔ ∃ h, arg.index < arg.block.getNumArguments ctx h := by
   rfl
 
 @[no_expose]
@@ -1412,10 +1427,10 @@ theorem InBounds_iff (arg : BlockArgumentPtr) (ctx : IRContext OpInfo) :
     arg.InBounds ctx :=
   by grind [inBounds_def]
 
-def get (arg : BlockArgumentPtr) (ctx : IRContext OpInfo) (argIn : arg.InBounds ctx := by grind) : BlockArgument :=
+def get (arg : BlockArgumentPtr) (ctx : Ctx) (argIn : arg.InBounds ctx := by grind) : BlockArgument :=
   (arg.block.get ctx (by grind [InBounds])).arguments[arg.index]'(by grind [InBounds])
 
-def get! (arg : BlockArgumentPtr) (ctx : IRContext OpInfo) : BlockArgument :=
+def get! (arg : BlockArgumentPtr) (ctx : Ctx) : BlockArgument :=
   (arg.block.get! ctx).arguments[arg.index]!
 
 @[grind =_, eq_bang ←]
@@ -1519,17 +1534,17 @@ end BlockArgumentPtr
 
 namespace ValuePtr
 
-inductive InBounds : ValuePtr → IRContext OpInfo → Prop
+inductive InBounds : ValuePtr → Ctx → Prop
 | op_result ptr ctx : ptr.InBounds ctx → (opResult ptr).InBounds ctx
 | block_argument ptr ctx : ptr.InBounds ctx → (blockArgument ptr).InBounds ctx
 
 @[simp, grind=]
-theorem inBounds_opResult (ptr : OpResultPtr) (ctx : IRContext OpInfo) :
+theorem inBounds_opResult (ptr : OpResultPtr) {ctx : Ctx} :
     (opResult ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
 @[simp, grind=]
-theorem inBounds_blockArg (ptr : BlockArgumentPtr) (ctx : IRContext OpInfo) :
+theorem inBounds_blockArg (ptr : BlockArgumentPtr) {ctx : Ctx} :
     (blockArgument ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
@@ -1541,12 +1556,12 @@ instance : Decidable (InBounds value ctx) := by
   · rw [inBounds_blockArg]
     infer_instance
 
-def getType (arg : ValuePtr) (ctx : IRContext OpInfo) (argIn : arg.InBounds ctx := by grind) : TypeAttr :=
+def getType (arg : ValuePtr) (ctx : Ctx) (argIn : arg.InBounds ctx := by grind) : TypeAttr :=
   match arg with
-  | opResult ptr => (ptr.get ctx (by grind)).type
-  | blockArgument ptr => (ptr.get ctx (by grind)).type
+  | opResult ptr => (ptr.get ctx).type
+  | blockArgument ptr => (ptr.get ctx).type
 
-def getType! (arg : ValuePtr) (ctx : IRContext OpInfo) : TypeAttr :=
+def getType! (arg : ValuePtr) (ctx : Ctx) : TypeAttr :=
   match arg with
   | opResult ptr => (ptr.get! ctx).type
   | blockArgument ptr => (ptr.get! ctx).type
@@ -1556,12 +1571,12 @@ theorem getType!_eq_getType {ptr : ValuePtr} (hin : ptr.InBounds ctx) :
     ptr.getType! ctx = ptr.getType ctx hin := by
   unfold getType getType!; grind
 
-def getFirstUse (arg : ValuePtr) (ctx : IRContext OpInfo) (argIn : arg.InBounds ctx := by grind) : Option OpOperandPtr :=
+def getFirstUse (arg : ValuePtr) (ctx : Ctx) (argIn : arg.InBounds ctx := by grind) : Option OpOperandPtr :=
   match arg with
   | opResult ptr => (ptr.get ctx).firstUse
   | blockArgument ptr => (ptr.get ctx).firstUse
 
-def getFirstUse! (arg : ValuePtr) (ctx : IRContext OpInfo) : Option OpOperandPtr :=
+def getFirstUse! (arg : ValuePtr) (ctx : Ctx) : Option OpOperandPtr :=
   match arg with
   | opResult ptr => (ptr.get! ctx).firstUse
   | blockArgument ptr => (ptr.get! ctx).firstUse
@@ -1594,7 +1609,7 @@ theorem getFirstUse!_blockArgument_eq {ba : BlockArgumentPtr} {ctx : IRContext O
 /--
 Returns true if the value has any uses.
 -/
-def hasUses (value : ValuePtr) (ctx : IRContext OpInfo) (valueIn : value.InBounds ctx := by grind) : Bool :=
+def hasUses (value : ValuePtr) (ctx : Ctx) (valueIn : value.InBounds ctx := by grind) : Bool :=
   (value.getFirstUse ctx (by grind)).isSome
 
 theorem hasUses_def {value : ValuePtr} (valueIn : value.InBounds ctx) :
@@ -1604,7 +1619,7 @@ theorem hasUses_def {value : ValuePtr} (valueIn : value.InBounds ctx) :
 /--
 Returns true if the value has any uses.
 -/
-def hasUses! (value : ValuePtr) (ctx : IRContext OpInfo) : Bool :=
+def hasUses! (value : ValuePtr) (ctx : Ctx) : Bool :=
   (value.getFirstUse! ctx).isSome
 
 @[grind =_, eq_bang ←]
@@ -1678,17 +1693,17 @@ end ValuePtr
 
 namespace OpOperandPtrPtr
 
-inductive InBounds (ctx : IRContext OpInfo) : OpOperandPtrPtr → Prop
+inductive InBounds (ctx : Ctx) : OpOperandPtrPtr → Prop
   | operandNextUseInBounds ptr : ptr.InBounds ctx → (operandNextUse ptr).InBounds ctx
   | valueFirstUseInBounds ptr : ptr.InBounds ctx → (valueFirstUse ptr).InBounds ctx
 
 @[simp, grind=]
-theorem inBounds_operandNextUse (ptr : OpOperandPtr) (ctx : IRContext OpInfo) :
+theorem inBounds_operandNextUse (ptr : OpOperandPtr) {ctx : Ctx} :
     (operandNextUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
 @[simp, grind=]
-theorem inBounds_valueFirstUse (ptr : ValuePtr) (ctx : IRContext OpInfo) :
+theorem inBounds_valueFirstUse (ptr : ValuePtr) {ctx : Ctx} :
     (valueFirstUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind [InBounds]
 
@@ -1700,12 +1715,12 @@ instance : Decidable (InBounds ctx value) := by
   · rw [inBounds_valueFirstUse]
     infer_instance
 
-def get (ptrPtr : OpOperandPtrPtr) (ctx : IRContext OpInfo) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : Option OpOperandPtr :=
+def get (ptrPtr : OpOperandPtrPtr) (ctx : Ctx) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : Option OpOperandPtr :=
   match ptrPtr with
   | operandNextUse ptr => (ptr.get ctx).nextUse
-  | valueFirstUse val => val.getFirstUse ctx (by grind)
+  | valueFirstUse val => val.getFirstUse ctx
 
-def get! (ptrPtr : OpOperandPtrPtr) (ctx : IRContext OpInfo) : Option OpOperandPtr :=
+def get! (ptrPtr : OpOperandPtrPtr) (ctx : Ctx) : Option OpOperandPtr :=
   match ptrPtr with
   | operandNextUse ptr => (ptr.get! ctx).nextUse
   | valueFirstUse val => val.getFirstUse! ctx
@@ -1772,19 +1787,19 @@ end OpOperandPtrPtr
 
 namespace RegionPtr
 
-def InBounds (region : RegionPtr) (ctx : IRContext OpInfo) : Prop :=
-  region ∈ ctx.regions
+def InBounds (region : RegionPtr) (ctx : Ctx) : Prop :=
+  region ∈ (HasIRContext.getCtx ctx).regions
 
-def inBounds_def : region.InBounds ctx ↔ region ∈ ctx.regions := by rfl
+theorem inBounds_def {ctx : Ctx} : region.InBounds ctx ↔ region ∈ (HasIRContext.getCtx ctx).regions := by rfl
 
 @[no_expose]
 instance : Decidable (InBounds region ctx) := by
   unfold InBounds; infer_instance
 
-def get (ptr : RegionPtr) (ctx : IRContext OpInfo) (inBounds : ptr.InBounds ctx := by grind) : Region :=
-  ctx.regions[ptr]'(by unfold InBounds at inBounds; grind)
+def get (ptr : RegionPtr) (ctx : Ctx) (inBounds : ptr.InBounds ctx := by grind) : Region :=
+  (HasIRContext.getCtx ctx).regions[ptr]'(by grind [InBounds])
 
-def get! (ptr : RegionPtr) (ctx : IRContext OpInfo) : Region := ctx.regions[ptr]!
+def get! (ptr : RegionPtr) (ctx : Ctx) : Region := (HasIRContext.getCtx ctx).regions[ptr]!
 
 @[grind =_, eq_bang ←]
 theorem get!_eq_get {ptr : RegionPtr} (hin : ptr.InBounds ctx) :
@@ -1853,17 +1868,17 @@ end RegionPtr
 namespace BlockOperandPtrPtr
 
 @[local grind]
-inductive InBounds (ctx : IRContext OpInfo) : BlockOperandPtrPtr → Prop
+inductive InBounds (ctx : Ctx) : BlockOperandPtrPtr → Prop
   | blockOperandNextUseInBounds ptr : ptr.InBounds ctx → (blockOperandNextUse ptr).InBounds ctx
   | blockFirstUseInBounds ptr : ptr.InBounds ctx → (blockFirstUse ptr).InBounds ctx
 
 @[simp, grind=]
-theorem inBounds_operandNextUse (ptr : BlockOperandPtr) (ctx : IRContext OpInfo) :
+theorem inBounds_operandNextUse (ptr : BlockOperandPtr) {ctx : Ctx} :
     (blockOperandNextUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind
 
 @[simp, grind=]
-theorem inBounds_valueFirstUse (ptr : BlockPtr) (ctx : IRContext OpInfo) :
+theorem inBounds_valueFirstUse (ptr : BlockPtr) {ctx : Ctx} :
     (blockFirstUse ptr).InBounds ctx ↔ ptr.InBounds ctx := by
   grind
 
@@ -1875,12 +1890,12 @@ instance : Decidable (InBounds ctx ptr) := by
   · rw [inBounds_valueFirstUse]
     infer_instance
 
-def get (ptrPtr : BlockOperandPtrPtr) (ctx : IRContext OpInfo) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : Option BlockOperandPtr :=
+def get (ptrPtr : BlockOperandPtrPtr) (ctx : Ctx) (ptrPtrIn : ptrPtr.InBounds ctx := by grind) : Option BlockOperandPtr :=
   match ptrPtr with
-  | blockOperandNextUse ptr => (ptr.get ctx).nextUse
-  | blockFirstUse val => (val.get ctx (by grind)).firstUse
+  | blockOperandNextUse ptr => (ptr.get ctx (by cases ptrPtrIn; assumption)).nextUse
+  | blockFirstUse val => (val.get ctx (by cases ptrPtrIn; assumption)).firstUse
 
-def get! (ptrPtr : BlockOperandPtrPtr) (ctx : IRContext OpInfo) : Option BlockOperandPtr :=
+def get! (ptrPtr : BlockOperandPtrPtr) (ctx : Ctx) : Option BlockOperandPtr :=
   match ptrPtr with
   | blockOperandNextUse ptr => (ptr.get! ctx).nextUse
   | blockFirstUse val => (val.get! ctx).firstUse
@@ -1930,24 +1945,24 @@ end BlockOperandPtrPtr
 
 namespace OperationPtr
 
-def hasUses.loop (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat)
+def hasUses.loop (op : OperationPtr) (ctx : Ctx) (index : Nat)
     (opIn : op.InBounds ctx := by grind)
     (hresult : index < op.getNumResults ctx := by grind) : Bool :=
-  if ((op.getResult index).get ctx).firstUse.isSome then
+  if ((op.getResult index).get ctx (by grind [OpResultPtr.inBounds_def])).firstUse.isSome then
     true
   else
     match index with
     | 0 => false
     | index' + 1 => hasUses.loop op ctx index'
 
-def hasUses (op : OperationPtr) (ctx : IRContext OpInfo) (opIn : op.InBounds ctx := by grind) : Bool :=
+def hasUses (op : OperationPtr) (ctx : Ctx) (opIn : op.InBounds ctx := by grind) : Bool :=
   let numResults := op.getNumResults ctx
   if h : numResults = 0 then
     false
   else
     hasUses.loop op ctx (numResults - 1)
 
-def hasUses!.loop (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat) : Bool :=
+def hasUses!.loop (op : OperationPtr) (ctx : Ctx) (index : Nat) : Bool :=
   if ((op.getResult index).get! ctx).firstUse.isSome then
     true
   else
@@ -1955,7 +1970,7 @@ def hasUses!.loop (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat) : B
     | 0 => false
     | index' + 1 => hasUses!.loop op ctx index'
 
-def hasUses! (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
+def hasUses! (op : OperationPtr) (ctx : Ctx) : Bool :=
   let numResults := op.getNumResults! ctx
   if numResults = 0 then
     false
@@ -2013,7 +2028,7 @@ def IRContext.empty (OpInfo : Type) [HasOpInfo OpInfo] : IRContext OpInfo := {
 -/
 def IRContext.forOpsDepM (ctx : IRContext OpInfo) {m : Type w → Type w'} [Monad m]
     (p : ∀ (op : OperationPtr), op.InBounds ctx → m PUnit) : m PUnit :=
-  ctx.operations.forKeysDepM (fun opPtr h => p opPtr (by grind [OperationPtr.InBounds]))
+  ctx.operations.forKeysDepM (fun opPtr h => p opPtr (by grind [OperationPtr.inBounds_def]))
 
 /-! Generic pointers -/
 
@@ -2031,34 +2046,34 @@ inductive GenericPtr where
 
 namespace GenericPtr
 
-def InBounds (ptr : GenericPtr) (ctx : IRContext OpInfo) : Prop :=
+def InBounds (ptr : GenericPtr) (c : Ctx) : Prop :=
   match ptr with
-  | block ptr => ptr.InBounds ctx
-  | operation ptr => ptr.InBounds ctx
-  | opResult ptr => ptr.InBounds ctx
-  | opOperand ptr => ptr.InBounds ctx
-  | blockOperand ptr => ptr.InBounds ctx
-  | blockOperandPtr ptr => ptr.InBounds ctx
-  | blockArgument ptr => ptr.InBounds ctx
-  | region ptr => ptr.InBounds ctx
-  | value ptr => ptr.InBounds ctx
-  | opOperandPtr ptr => ptr.InBounds ctx
+  | block ptr => ptr.InBounds c
+  | operation ptr => ptr.InBounds c
+  | opResult ptr => ptr.InBounds c
+  | opOperand ptr => ptr.InBounds c
+  | blockOperand ptr => ptr.InBounds c
+  | blockOperandPtr ptr => ptr.InBounds c
+  | blockArgument ptr => ptr.InBounds c
+  | region ptr => ptr.InBounds c
+  | value ptr => ptr.InBounds c
+  | opOperandPtr ptr => ptr.InBounds c
 
 section generic_ptr
 
-variable {ctx : IRContext OpInfo}
+variable {c : Ctx}
 
-@[simp, grind =, grind =_] theorem iff_block (ptr : BlockPtr) : (block ptr).InBounds ctx ↔ ptr.InBounds ctx := by
+@[simp, grind =, grind =_] theorem iff_block (ptr : BlockPtr) : (block ptr).InBounds c ↔ ptr.InBounds c := by
   grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_operation (ptr : OperationPtr) : (operation ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_result (ptr : OpResultPtr) : (opResult ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_opOperand (ptr : OpOperandPtr) : (opOperand ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_blockOperand (ptr : BlockOperandPtr) : (blockOperand ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_blockOperandPtr (ptr : BlockOperandPtrPtr) : (blockOperandPtr ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_blockArgument (ptr : BlockArgumentPtr) : (blockArgument ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_region (ptr : RegionPtr) : (region ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_value (ptr : ValuePtr) : (value ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
-@[simp, grind =, grind =_] theorem iff_opOperandPtr (ptr : OpOperandPtrPtr) : (opOperandPtr ptr).InBounds ctx ↔ ptr.InBounds ctx := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_operation (ptr : OperationPtr) : (operation ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_result (ptr : OpResultPtr) : (opResult ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_opOperand (ptr : OpOperandPtr) : (opOperand ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_blockOperand (ptr : BlockOperandPtr) : (blockOperand ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_blockOperandPtr (ptr : BlockOperandPtrPtr) : (blockOperandPtr ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_blockArgument (ptr : BlockArgumentPtr) : (blockArgument ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_region (ptr : RegionPtr) : (region ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_value (ptr : ValuePtr) : (value ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
+@[simp, grind =, grind =_] theorem iff_opOperandPtr (ptr : OpOperandPtrPtr) : (opOperandPtr ptr).InBounds c ↔ ptr.InBounds c := by grind [InBounds]
 
 @[no_expose]
 instance : Decidable (InBounds ptr ctx) := by

--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -7,6 +7,8 @@ import Veir.ForLean
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {Ctx : Type} [HasIRContext Ctx OpInfo]
+variable {c c' : Ctx}
 
 public section
 
@@ -56,21 +58,21 @@ theorem OperationPtr.pushRegion_genericPtr_mono (ptr : GenericPtr)  :
 
 @[grind .]
 theorem OperationPtr.getOpOperand_inBounds (op : OperationPtr)
-    (hop : op.InBounds ctx) i (h₂ : i < op.getNumOperands ctx hop) :
-    (op.getOpOperand i).InBounds ctx := by
-  grind
+    (hop : op.InBounds c) i (h₂ : i < op.getNumOperands c hop) :
+    (op.getOpOperand i).InBounds c := by
+  grind [OperationPtr.getNumOperands]
 
 @[grind .]
 theorem OperationPtr.getBlockOperand_inBounds (op : OperationPtr)
-    (hop : op.InBounds ctx) i (h₂ : i < op.getNumSuccessors ctx hop) :
-    (op.getBlockOperand i).InBounds ctx := by
-  grind
+    (hop : op.InBounds c) i (h₂ : i < op.getNumSuccessors c hop) :
+    (op.getBlockOperand i).InBounds c := by
+  grind [OperationPtr.getNumSuccessors]
 
 @[grind .]
 theorem OperationPtr.getResult_inBounds (op : OperationPtr)
-    (hop : op.InBounds ctx) i (h₂ : i < op.getNumResults ctx hop) :
-    (op.getResult i).InBounds ctx := by
-  grind
+    (hop : op.InBounds c) i (h₂ : i < op.getNumResults c hop) :
+    (op.getResult i).InBounds c := by
+  grind [OperationPtr.getNumResults]
 
 @[grind =]
 theorem OperationPtr.setResults_genericPtr_mono (ptr : GenericPtr)
@@ -262,16 +264,19 @@ theorem BlockOperandPtr.InBounds.op_ne_of_inBounds_OperationPtr_dealloc {blockOp
   grind
 
 @[grind .]
-theorem OperationPtr.nextOperand_not_inBounds (opPtr : OperationPtr) (h : opPtr.InBounds ctx) : ¬ (opPtr.nextOperand ctx).InBounds ctx := by
-  grind
+theorem OperationPtr.nextOperand_not_inBounds (opPtr : OperationPtr) (h : opPtr.InBounds c) :
+    ¬ (opPtr.nextOperand c).InBounds c := by
+  grind [OperationPtr.nextOperand, OperationPtr.getNumOperands]
 
 @[grind .]
-theorem OperationPtr.nextBlockOperand_not_inBounds (opPtr : OperationPtr) (h : opPtr.InBounds ctx) : ¬ (opPtr.nextBlockOperand ctx).InBounds ctx := by
-  grind
+theorem OperationPtr.nextBlockOperand_not_inBounds (opPtr : OperationPtr) (h : opPtr.InBounds c) :
+    ¬ (opPtr.nextBlockOperand c).InBounds c := by
+  grind [OperationPtr.nextBlockOperand, OperationPtr.getNumSuccessors]
 
 @[grind .]
-theorem OperationPtr.nextResult_not_inBounds (opPtr : OperationPtr) (h : opPtr.InBounds ctx) : ¬ (opPtr.nextResult ctx).InBounds ctx := by
-  grind
+theorem OperationPtr.nextResult_not_inBounds (opPtr : OperationPtr) (h : opPtr.InBounds c) :
+    ¬ (opPtr.nextResult c).InBounds c := by
+  grind [OperationPtr.nextResult, OperationPtr.getNumResults]
 
 end operation
 
@@ -292,8 +297,8 @@ theorem OpOperandPtr.get_set {op : OperationPtr} (hop : op.InBounds (opOperand.s
   grind
 
 @[grind .]
-theorem OpOperandPtr.operation_inBounds_of_inBounds (h : opOperand.InBounds ctx) :
-    opOperand.op.InBounds ctx := by
+theorem OpOperandPtr.operation_inBounds_of_inBounds (h : opOperand.InBounds c) :
+    opOperand.op.InBounds c := by
   grind [OpOperandPtr.InBounds]
 
 @[grind =]
@@ -317,15 +322,15 @@ theorem OpOperandPtr.setValue_genericPtr_mono (ptr : GenericPtr)  :
   grind
 
 theorem OpOperandPtr.inBounds_if_operand_size_eq :
-    (OperationPtr.getNumOperands opPtr ctx opIn = OperationPtr.getNumOperands opPtr' ctx' op'In) ↔
-    (∀ index, (OpOperandPtr.mk opPtr index).InBounds ctx ↔ (OpOperandPtr.mk opPtr' index).InBounds ctx') := by
+    (OperationPtr.getNumOperands opPtr c opIn = OperationPtr.getNumOperands opPtr' c' op'In) ↔
+    (∀ index, (OpOperandPtr.mk opPtr index).InBounds c ↔ (OpOperandPtr.mk opPtr' index).InBounds c') := by
   constructor
-  · grind
+  · grind [OperationPtr.getNumOperands]
   · intro hi
     apply Nat.eq_iff_forall_lessthan
     intros i
     have := hi i
-    grind
+    grind [OperationPtr.getNumOperands]
 
 end opoperand
 
@@ -333,11 +338,11 @@ section opresult
 
 attribute [local grind] OpResultPtr.setType OpResultPtr.setFirstUse OpResultPtr.setOwner
 
-variable {opRes : OpResultPtr} (h : opRes.InBounds ctx)
+variable {opRes : OpResultPtr}
 
 @[grind .]
-theorem OpResultPtr.operation_inBounds_of_inBounds (h : opRes.InBounds ctx) :
-    opRes.op.InBounds ctx := by
+theorem OpResultPtr.operation_inBounds_of_inBounds (h : opRes.InBounds c) :
+    opRes.op.InBounds c := by
   grind
 
 @[grind =]
@@ -362,8 +367,8 @@ section blockargument
 variable {ba : BlockArgumentPtr}
 
 @[grind .]
-theorem BlockArgumentPtr.operation_inBounds_of_inBounds (h : ba.InBounds ctx) :
-    ba.block.InBounds ctx := by
+theorem BlockArgumentPtr.operation_inBounds_of_inBounds (h : ba.InBounds c) :
+    ba.block.InBounds c := by
   grind
 
 @[grind =]
@@ -408,9 +413,9 @@ variable {block : BlockPtr} (h : block.InBounds ctx)
 
 @[grind .]
 theorem BlockPtr.getArgument_inBounds (block : BlockPtr)
-    (hblock : block.InBounds ctx) i (h₂ : i < block.getNumArguments ctx hblock) :
-    (block.getArgument i).InBounds ctx := by
-  grind
+    (hblock : block.InBounds c) i (h₂ : i < block.getNumArguments c hblock) :
+    (block.getArgument i).InBounds c := by
+  grind [BlockPtr.getNumArguments]
 
 @[grind =]
 theorem BlockPtr.setParent_genericPtr_mono (ptr : GenericPtr)  :
@@ -565,8 +570,8 @@ section blockoperand
 variable {blockOperand : BlockOperandPtr} (h : blockOperand.InBounds ctx)
 
 @[grind .]
-theorem BlockOperandPtr.operation_inBounds_of_inBounds (h : blockOperand.InBounds ctx) :
-    blockOperand.op.InBounds ctx := by
+theorem BlockOperandPtr.operation_inBounds_of_inBounds (h : blockOperand.InBounds c) :
+    blockOperand.op.InBounds c := by
   grind
 
 @[grind =]

--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -1326,4 +1326,8 @@ theorem WfIRContext_val_wellFormed (wfCtx : WfIRContext OpInfo) :
     (wfCtx.val).WellFormed := by
   grind
 
+public instance WfIRContext.hasIRContext (OpInfo : Type) [HasOpInfo OpInfo] :
+    HasIRContext (WfIRContext OpInfo) OpInfo where
+  getCtx wfCtx := wfCtx.val
+
 end Veir

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -52,7 +52,7 @@ def matchXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
 
 def matchConstantOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .llvm .constant := op.getOpType! ctx | none
-  let properties := op.getProperties! ctx (.llvm .constant)
+  let properties := op.getProperties! ctx (OpCode.llvm .constant)
   return properties.value
 
 def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
@@ -62,7 +62,7 @@ def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerA
 
 def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .builtin .unrealized_conversion_cast := op.getOpType! ctx | none
-  let properties := op.getProperties! ctx (.llvm .constant)
+  let properties := op.getProperties! ctx (OpCode.llvm .constant)
   return properties.value
 
 def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .ashr)) := do

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -108,21 +108,50 @@ structure PatternRewriter (OpInfo : Type) [HasOpInfo OpInfo] where
   worklist: PatternRewriter.Worklist
   ctx_fib : ctx.FieldsInBounds
 
+instance PatternRewriter.hasIRContext : HasIRContext (PatternRewriter OpInfo) OpInfo where
+  getCtx := PatternRewriter.ctx
+
 variable {rewriter : PatternRewriter OpInfo}
 
 namespace PatternRewriter
 
+def pushOpToWorklist (rewriter : PatternRewriter OpInfo) (op : OperationPtr) :=
+  {rewriter with worklist := rewriter.worklist.push op}
+
+@[grind _=_]
+theorem test {ptr : GenericPtr} :
+    ptr.InBounds rewriter ↔ ptr.InBounds rewriter.ctx := by
+  sorry
+
+@[grind _=_]
+theorem test2 (opopr : OpOperandPtr) :
+    opopr.get! rewriter = opopr.get! rewriter.ctx := by sorry
+
+@[grind =]
+theorem pushOpToWorkList_genericPtr_mono {ptr : GenericPtr} {rewriter : PatternRewriter OpInfo} :
+    ptr.InBounds (rewriter.pushOpToWorklist op) ↔ ptr.InBounds rewriter := by
+  simp only [PatternRewriter.pushOpToWorklist]
+  grind
+
 private def addUseChainUserInWorklist (rewriter: PatternRewriter OpInfo) (useChain: Option OpOperandPtr) (maxIteration : Nat)
-    (huc : useChain.maybe OpOperandPtr.InBounds rewriter.ctx := by grind) : PatternRewriter OpInfo :=
+    (huc : useChain.maybe OpOperandPtr.InBounds rewriter := by grind) : PatternRewriter OpInfo :=
   match maxIteration with
   | maxIteration + 1 =>
     match useChain with
     | some use =>
-      let useStruct := (use.get rewriter.ctx (by grind))
+      let useStruct := (use.get rewriter (by grind))
       let userOp := useStruct.owner
       let nextUse := useStruct.nextUse
-      let rewriter := {rewriter with worklist := rewriter.worklist.push userOp}
-      rewriter.addUseChainUserInWorklist nextUse maxIteration
+      let rewriter := rewriter.pushOpToWorklist userOp
+      rewriter.addUseChainUserInWorklist nextUse maxIteration (by
+        intro opOperand _
+        subst nextUse
+        simp only [←GenericPtr.iff_opOperand]
+        simp only [rewriter, pushOpToWorkList_genericPtr_mono]
+        simp only [GenericPtr.iff_opOperand]
+        subst useStruct
+        grind
+      )
     | none => rewriter
   | 0 => rewriter
 


### PR DESCRIPTION
Currently, we have `IRContext`, `WfIRContext`, `Rewriter`, and `WfRewriter` that all "contains" an `IRContext`.
What we would like to have is a coercion from all of these to `IRContext`. However, as `IRContext` has a parameter that we always implicitely deduce, the coercion almost never works.

One of the solution would be to reimplement all getters so that they can use these different classes, but I wanted to try if there was another solution before trying this.

The implementation here uses a new typeclass `HasIRContext`, which is essentially just the coercion from the types to `IRContext`.

Please let me know what you think of the design