### PR TITLE
Use the WfIRContext API for PatternRewriter

### DIFF
--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -18,119 +18,119 @@ namespace Pattern
 
 def addIConstantFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option (PatternRewriter OpCode) := do
   -- Check that the operation is an arith.addi operation
-  if op.getOpType rewriter.ctx sorry ≠ .arith .addi then
+  if op.getOpType rewriter.ctx.val sorry ≠ .arith .addi then
     return rewriter
 
   -- Get the lhs and check that it is a constant
-  let lhsValuePtr := op.getOperand rewriter.ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand rewriter.ctx.val 0 (by sorry) (by sorry)
   let lhsOp ← match lhsValuePtr with
   | ValuePtr.opResult lhsOpResultPtr => some lhsOpResultPtr.op
   | _ => none
-  let lhsOpStruct := lhsOp.get rewriter.ctx (by sorry)
+  let lhsOpStruct := lhsOp.get rewriter.ctx.val (by sorry)
   if lhsOpStruct.opType ≠ .arith .constant then
     return rewriter
 
   -- Get the rhs and check that it is a constant
-  let rhsValuePtr := op.getOperand rewriter.ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand rewriter.ctx.val 1 (by sorry) (by sorry)
   let rhsOp ← match rhsValuePtr with
   | ValuePtr.opResult rhsOpResultPtr => some rhsOpResultPtr.op
   | _ => none
-  let rhsOpStruct := rhsOp.get rewriter.ctx (by sorry)
+  let rhsOpStruct := rhsOp.get rewriter.ctx.val (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! rewriter.ctx.val (.arith .constant)).value.value
+  let rhsVal := (rhsOp.getProperties! rewriter.ctx.val (.arith .constant)).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (rewriter, newOp) ← rewriter.createOp (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
-  let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry
+  let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
-  if (lhsValuePtr.getFirstUse rewriter.ctx (by sorry)).isNone then
-    rewriter ← rewriter.eraseOp lhsOp sorry
-  if (rhsValuePtr.getFirstUse rewriter.ctx (by sorry)).isNone then
-    rewriter ← rewriter.eraseOp rhsOp sorry
+  if (lhsValuePtr.getFirstUse rewriter.ctx.val (by sorry)).isNone then
+    rewriter ← rewriter.eraseOp lhsOp sorry sorry sorry
+  if (rhsValuePtr.getFirstUse rewriter.ctx.val (by sorry)).isNone then
+    rewriter ← rewriter.eraseOp rhsOp sorry sorry sorry
   return rewriter
 
-def addIConstantFoldingLocal (ctx: IRContext OpCode) (op: OperationPtr) :
-    Option (IRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+def addIConstantFoldingLocal (ctx: WfIRContext OpCode) (op: OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   -- Check that the operation is an `arith.addi` operation
-  let .arith .addi := op.getOpType ctx sorry
+  let .arith .addi := op.getOpType ctx.val sorry
     | some (ctx, none)
   -- Get the lhs and check that it is a constant
-  let lhsValuePtr := op.getOperand ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand ctx.val 0 (by sorry) (by sorry)
   let .opResult lhsOpResultPtr := lhsValuePtr
     | some (ctx, none)
   let lhsOp := lhsOpResultPtr.op
-  let lhsOpStruct := lhsOp.get ctx (by sorry)
+  let lhsOpStruct := lhsOp.get ctx.val (by sorry)
   let .arith .constant := lhsOpStruct.opType
     | some (ctx, none)
 
   -- Get the rhs and check that it is a constant
-  let rhsValuePtr := op.getOperand ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand ctx.val 1 (by sorry) (by sorry)
   let .opResult rhsOpResultPtr := rhsValuePtr
     | some (ctx, none)
   let rhsOp := rhsOpResultPtr.op
-  let rhsOpStruct := rhsOp.get ctx (by sorry)
+  let rhsOpStruct := rhsOp.get ctx.val (by sorry)
   let .arith .constant := rhsOpStruct.opType
     | some (ctx, none)
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! ctx (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! ctx (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! ctx.val (.arith .constant)).value.value
+  let rhsVal := (rhsOp.getProperties! ctx.val (.arith .constant)).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
-  let (ctx, newOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry
   return (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option (PatternRewriter OpCode)   := do
-  if op.getOpType rewriter.ctx sorry ≠ .arith .addi then
+  if op.getOpType rewriter.ctx.val sorry ≠ .arith .addi then
     return rewriter
 
   -- Get the rhs and check that it is the constant 0
-  let rhsValuePtr := op.getOperand rewriter.ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand rewriter.ctx.val 1 (by sorry) (by sorry)
   let rhsOp ← match rhsValuePtr with
   | ValuePtr.opResult rhsOpResultPtr => some rhsOpResultPtr.op
   | _ => none
-  let rhsOpStruct := rhsOp.get rewriter.ctx (by sorry)
+  let rhsOpStruct := rhsOp.get rewriter.ctx.val (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
-  if (rhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value ≠ 0 then
+  if (rhsOp.getProperties! rewriter.ctx.val (.arith .constant)).value.value ≠ 0 then
     return rewriter
 
   -- Get the lhs value
-  let lhsValuePtr := op.getOperand rewriter.ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand rewriter.ctx.val 0 (by sorry) (by sorry)
 
   let opValuePtr := op.getResult 0
   let mut rewriter ← rewriter.replaceValue opValuePtr lhsValuePtr sorry sorry
-  rewriter ← rewriter.eraseOp op sorry
+  rewriter ← rewriter.eraseOp op sorry sorry sorry
 
-  if (rhsValuePtr.getFirstUse rewriter.ctx (by sorry)).isNone then
-    rewriter ← rewriter.eraseOp rhsOp sorry
+  if (rhsValuePtr.getFirstUse rewriter.ctx.val (by sorry)).isNone then
+    rewriter ← rewriter.eraseOp rhsOp sorry sorry sorry
   return rewriter
 
 def mulITwoReduce (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option (PatternRewriter OpCode) := do
-  if op.getOpType rewriter.ctx sorry ≠ .arith .muli then
+  if op.getOpType rewriter.ctx.val sorry ≠ .arith .muli then
     return rewriter
 
   -- Get the rhs and check that it is the constant 2
-  let rhsValuePtr := op.getOperand rewriter.ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand rewriter.ctx.val 1 (by sorry) (by sorry)
   let rhsOp ← match rhsValuePtr with
   | ValuePtr.opResult rhsOpResultPtr => some rhsOpResultPtr.op
   | _ => none
-  let rhsOpStruct := rhsOp.get rewriter.ctx (by sorry)
+  let rhsOpStruct := rhsOp.get rewriter.ctx.val (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
-  if (rhsOp.getProperties! rewriter.ctx (.arith .constant)).value.value ≠ 2 then
+  if (rhsOp.getProperties! rewriter.ctx.val (.arith .constant)).value.value ≠ 2 then
     return rewriter
 
   -- Get the lhs value
-  let lhsValuePtr := op.getOperand rewriter.ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand rewriter.ctx.val 0 (by sorry) (by sorry)
 
   let (rewriter, newOp) ← rewriter.createOp (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (NswNuwProperties.mk false false) (some $ .before op) sorry sorry sorry sorry
-  let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry
+  let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
-  if (rhsValuePtr.getFirstUse rewriter.ctx (by sorry)).isNone then
-    rewriter ← rewriter.eraseOp rhsOp sorry
+  if (rhsValuePtr.getFirstUse rewriter.ctx.val (by sorry)).isNone then
+    rewriter ← rewriter.eraseOp rhsOp sorry sorry sorry
   return rewriter
 
 end Pattern
@@ -139,119 +139,120 @@ end Pattern
 -- applying the rewrites in custom locations
 namespace Custom
 
-abbrev Pattern := (IRContext OpCode) → OperationPtr → Option (IRContext OpCode)
+abbrev Pattern := (WfIRContext OpCode) → OperationPtr → Option (WfIRContext OpCode)
 
-def addIConstantFolding (ctx: IRContext OpCode) (op: OperationPtr) : Option (IRContext OpCode) := do
+def addIConstantFolding (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRContext OpCode) := do
   -- Check that the operation is an arith.addi operation
-  if op.getOpType ctx sorry ≠ .arith .addi then
+  if op.getOpType ctx.val sorry ≠ .arith .addi then
     return ctx
 
   -- Get the lhs and check that it is a constant
-  let lhsValuePtr := op.getOperand ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand ctx.val 0 (by sorry) (by sorry)
   let lhsOp ← match lhsValuePtr with
   | ValuePtr.opResult lhsOpResultPtr => some lhsOpResultPtr.op
   | _ => none
-  let lhsOpStruct := lhsOp.get ctx (by sorry)
+  let lhsOpStruct := lhsOp.get ctx.val (by sorry)
   if lhsOpStruct.opType ≠ .arith .constant then
     return ctx
 
   -- Get the rhs and check that it is a constant
-  let rhsValuePtr := op.getOperand ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand ctx.val 1 (by sorry) (by sorry)
   let rhsOp ← match rhsValuePtr with
   | ValuePtr.opResult rhsOpResultPtr => some rhsOpResultPtr.op
   | _ => none
-  let rhsOpStruct := rhsOp.get ctx (by sorry)
+  let rhsOpStruct := rhsOp.get ctx.val (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! ctx (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! ctx (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! ctx.val (.arith .constant)).value.value
+  let rhsVal := (rhsOp.getProperties! ctx.val (.arith .constant)).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
-  let (ctx, newOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry sorry
-  let mut ctx ← Rewriter.replaceOp? ctx op newOp sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
+  let mut ctx ← WfRewriter.replaceOp? ctx op newOp sorry sorry sorry sorry sorry
 
-  if (lhsValuePtr.getFirstUse ctx (by sorry)).isNone then
-    ctx ← Rewriter.eraseOp ctx lhsOp sorry sorry
-  if (rhsValuePtr.getFirstUse ctx (by sorry)).isNone then
-    ctx ← Rewriter.eraseOp ctx rhsOp sorry sorry
+  if (lhsValuePtr.getFirstUse ctx.val (by sorry)).isNone then
+    ctx ← WfRewriter.eraseOp ctx lhsOp sorry sorry sorry
+  if (rhsValuePtr.getFirstUse ctx.val (by sorry)).isNone then
+    ctx ← WfRewriter.eraseOp ctx rhsOp sorry sorry sorry
   return ctx
 
-def addIZeroFolding (ctx: IRContext OpCode) (op: OperationPtr) : Option (IRContext OpCode) := do
-  if op.getOpType ctx sorry ≠ .arith .addi then
+def addIZeroFolding (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRContext OpCode) := do
+  if op.getOpType ctx.val sorry ≠ .arith .addi then
     return ctx
 
   -- Get the rhs and check that it is the constant 0
-  let rhsValuePtr := op.getOperand ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand ctx.val 1 (by sorry) (by sorry)
   let rhsOp ← match rhsValuePtr with
   | ValuePtr.opResult rhsOpResultPtr => some rhsOpResultPtr.op
   | _ => none
-  let rhsOpStruct := rhsOp.get ctx (by sorry)
+  let rhsOpStruct := rhsOp.get ctx.val (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
-  if (rhsOp.getProperties! ctx (.arith .constant)).value.value ≠ 0 then
+  if (rhsOp.getProperties! ctx.val (.arith .constant)).value.value ≠ 0 then
     return ctx
 
   -- Get the lhs value
-  let lhsValuePtr := op.getOperand ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand ctx.val 0 (by sorry) (by sorry)
 
   let oldVal := op.getResult 0
-  let mut ctx ← Rewriter.replaceValue? ctx oldVal lhsValuePtr sorry sorry sorry
-  ctx ← Rewriter.eraseOp ctx op sorry sorry
+  let mut ctx ← WfRewriter.replaceValue ctx oldVal lhsValuePtr sorry sorry
+  ctx ← WfRewriter.eraseOp ctx op sorry sorry sorry
 
-  if (rhsValuePtr.getFirstUse ctx (by sorry)).isNone then
-    ctx ← Rewriter.eraseOp ctx rhsOp sorry sorry
+  if (rhsValuePtr.getFirstUse ctx.val (by sorry)).isNone then
+    ctx ← WfRewriter.eraseOp ctx rhsOp sorry sorry sorry
   return ctx
 
-def mulITwoReduce (ctx: IRContext OpCode) (op: OperationPtr) : Option (IRContext OpCode) := do
-  if op.getOpType ctx sorry ≠ .arith .muli then
+def mulITwoReduce (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRContext OpCode) := do
+  if op.getOpType ctx.val sorry ≠ .arith .muli then
     return ctx
 
   -- Get the rhs and check that it is the constant 2
-  let rhsValuePtr := op.getOperand ctx 1 (by sorry) (by sorry)
+  let rhsValuePtr := op.getOperand ctx.val 1 (by sorry) (by sorry)
   let rhsOp ← match rhsValuePtr with
   | ValuePtr.opResult rhsOpResultPtr => some rhsOpResultPtr.op
   | _ => none
-  let rhsOpStruct := rhsOp.get ctx (by sorry)
+  let rhsOpStruct := rhsOp.get ctx.val (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
-  if (rhsOp.getProperties! ctx (.arith .constant)).value.value ≠ 2 then
+  if (rhsOp.getProperties! ctx.val (.arith .constant)).value.value ≠ 2 then
     return ctx
 
   -- Get the lhs value
-  let lhsValuePtr := op.getOperand ctx 0 (by sorry) (by sorry)
+  let lhsValuePtr := op.getOperand ctx.val 0 (by sorry) (by sorry)
 
-  let (ctx, newOp) ← Rewriter.createOp ctx (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (NswNuwProperties.mk false false) (some $ .before op) sorry sorry sorry sorry sorry
-  let mut ctx ← Rewriter.replaceOp? ctx op newOp sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (NswNuwProperties.mk false false) (some $ .before op) sorry sorry sorry sorry
+  let mut ctx ← WfRewriter.replaceOp? ctx op newOp sorry sorry sorry sorry sorry
 
-  if (rhsValuePtr.getFirstUse ctx (by sorry)).isNone then
-    ctx ← Rewriter.eraseOp ctx rhsOp sorry sorry
+  if (rhsValuePtr.getFirstUse ctx.val (by sorry)).isNone then
+    ctx ← WfRewriter.eraseOp ctx rhsOp sorry sorry sorry
   return ctx
 
 -- Rewrites the first instance of an opcode in the program with the given pattern,
 -- within a program consisting of one region/block
-def rewriteFirst (ctx: IRContext OpCode) (topOp : OperationPtr) (opcode: OpCode) (rewrite: Pattern) : Option (IRContext OpCode) := do
-  let region := topOp.getRegion! ctx 0
-  let block := (region.get ctx (by sorry)).firstBlock.get!
-  let mut op ← (block.get! ctx).firstOp
+def rewriteFirst (ctx: WfIRContext OpCode) (topOp : OperationPtr) (opcode: OpCode) (rewrite: Pattern)
+    : Option (WfIRContext OpCode) := do
+  let region := topOp.getRegion! ctx.val 0
+  let block := (region.get ctx.val (by sorry)).firstBlock.get!
+  let mut op ← (block.get! ctx.val).firstOp
 
   while op.getOpType ctx sorry ≠ opcode do
-    op ← (op.get! ctx).next
+    op ← (op.get! ctx.val).next
 
   rewrite ctx op
 
-def rewriteFirstAddI (ctx: IRContext OpCode) (topOp : OperationPtr) (rewrite: Pattern) : Option (IRContext OpCode) :=
+def rewriteFirstAddI (ctx: WfIRContext OpCode) (topOp : OperationPtr) (rewrite: Pattern) : Option (WfIRContext OpCode) :=
   rewriteFirst ctx topOp (.arith .addi) rewrite
 
-def rewriteForwards (ctx: IRContext OpCode) (topOp : OperationPtr) (rewrite: Pattern) : Option (IRContext OpCode) := do
-  let region := topOp.getRegion! ctx 0
-  let block := (region.get ctx (by sorry)).firstBlock.get!
+def rewriteForwards (ctx: WfIRContext OpCode) (topOp : OperationPtr) (rewrite: Pattern) : Option (WfIRContext OpCode) := do
+  let region := topOp.getRegion! ctx.val 0
+  let block := (region.get ctx.val (by sorry)).firstBlock.get!
 
-  let mut maybeOp := (block.get! ctx).firstOp
+  let mut maybeOp := (block.get! ctx.val).firstOp
   let mut ctx := ctx
   while h : maybeOp.isSome do
     let op := maybeOp.get h
-    let next := (op.get! ctx).next
+    let next := (op.get! ctx.val).next
     -- TODO: This should be work but for some reason is not unique
     -- ctx := dbgTraceIfShared "rewriteForwards" ctx
     -- ctx ← rewrite ctx op
@@ -263,10 +264,10 @@ end Custom
 
 namespace Program
 
-def empty : Option (IRContext OpCode × OperationPtr × InsertPoint) := do
-  let (ctx, topLevelOp) ← IRContext.create OpCode
-  let region := topLevelOp.getRegion! ctx 0
-  let block := (region.get ctx (by sorry)).firstBlock.get!
+def empty : Option (WfIRContext OpCode × OperationPtr × InsertPoint) := do
+  let (ctx, topLevelOp) ← WfIRContext.create OpCode
+  let region := topLevelOp.getRegion! ctx.val 0
+  let block := (region.get ctx.val (by sorry)).firstBlock.get!
   let insertPoint := InsertPoint.atEnd block
   (ctx, topLevelOp, insertPoint)
 
@@ -279,31 +280,31 @@ def empty : Option (IRContext OpCode × OperationPtr × InsertPoint) := do
 --   %3 = arith.constant [inc] : u64
 --   %4 = [opcode] %2, %3 : u64
 --   ...
-def constFoldTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (root inc: Int) : Option (IRContext OpCode × OperationPtr) := do
+def constFoldTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (root inc: Int) : Option (WfIRContext OpCode × OperationPtr) := do
   let root := ArithConstantProperties.mk (IntegerAttr.mk root (IntegerType.mk 32))
   let inc := ArithConstantProperties.mk (IntegerAttr.mk inc (IntegerType.mk 32))
   let (gctx, topOp, insertPoint) ← empty
-  let mut (gctx, gacc) ← Rewriter.createOp gctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry sorry
+  let mut (gctx, gacc) ← WfRewriter.createOp gctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry
   for i in [0:size] do
     let ⟨thisOp, prop⟩ : (op : OpCode) × propertiesOf op := if (i % 100 < pc) then ⟨opcode, prop⟩ else ⟨.arith .andi, ()⟩
     let (ctx, acc) := (gctx, gacc)
-    let (ctx, rhsOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry sorry
+    let (ctx, rhsOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry
     let lhsVal := acc.getResult 0
     let rhsVal := rhsOp.getResult 0
-    let (ctx, acc) ← Rewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry sorry
+    let (ctx, acc) ← WfRewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry
     (gctx, gacc) := (ctx, acc)
 
   let accRes := gacc.getResult 0
-  let (ctx, op) ← Rewriter.createOp gctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry sorry
+  let (ctx, op) ← WfRewriter.createOp gctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
   (ctx, topOp)
 
-def addZeroTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) :=
+def addZeroTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
   constFoldTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 0
 
-def addOneTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) :=
+def addOneTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
   constFoldTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 1
 
-def mulTwoTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) :=
+def mulTwoTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
   constFoldTree (.arith .muli) (NswNuwProperties.mk false false) size pc 42 2
 
 
@@ -314,12 +315,12 @@ def mulTwoTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) :=
 --   %2 = [opcode] %0, %reuse : u64
 --   %3 = [opcode] %2, %reuse : u64
 --   ...
-def constReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (root inc: Int) : Option (IRContext OpCode × OperationPtr) := do
+def constReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (root inc: Int) : Option (WfIRContext OpCode × OperationPtr) := do
   let root := ArithConstantProperties.mk (IntegerAttr.mk root (IntegerType.mk 32))
   let inc := ArithConstantProperties.mk (IntegerAttr.mk inc (IntegerType.mk 32))
   let (ctx, topOp, insertPoint) ← empty
-  let (ctx, acc) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry sorry
-  let (ctx, reuse) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry sorry
+  let (ctx, acc) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry
+  let (ctx, reuse) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry
 
   let mut (gctx, gacc) := (ctx, acc)
   for i in [0:size] do
@@ -328,15 +329,15 @@ def constReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) 
     let (ctx, acc) := (gctx, gacc)
     let lhsVal := acc.getResult 0
     let rhsVal := reuse.getResult 0
-    let (ctx, acc) ← Rewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry sorry
+    let (ctx, acc) ← WfRewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry
     (gctx, gacc) := (ctx, acc)
   let (ctx, acc) := (gctx, gacc)
 
   let accRes := acc.getResult 0
-  let (ctx, op) ← Rewriter.createOp ctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry sorry
+  let (ctx, op) ← WfRewriter.createOp ctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
   (ctx, topOp)
 
-def addZeroReuseTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) :=
+def addZeroReuseTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
   constReuseTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 0
 
 -- Create a program that looks like:
@@ -348,15 +349,15 @@ def addZeroReuseTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) 
 --   %4 = [opcode] %3, %reuse : u64
 --   %5 = [opcode] %4, %reuse : u64
 --   ...
-def constLotsOfReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (lhs rhs: Int) : Option (IRContext OpCode × OperationPtr) := do
+def constLotsOfReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (lhs rhs: Int) : Option (WfIRContext OpCode × OperationPtr) := do
   let lhs := ArithConstantProperties.mk (IntegerAttr.mk lhs (IntegerType.mk 32))
   let rhs := ArithConstantProperties.mk (IntegerAttr.mk rhs (IntegerType.mk 32))
   let (ctx, topOp, insertPoint) ← empty
-  let (ctx, lhsOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] lhs insertPoint sorry sorry sorry sorry sorry
-  let (ctx, rhsOp) ← Rewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] rhs insertPoint sorry sorry sorry sorry sorry
+  let (ctx, lhsOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] lhs insertPoint sorry sorry sorry sorry
+  let (ctx, rhsOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] rhs insertPoint sorry sorry sorry sorry
   let lhsVal := lhsOp.getResult 0
   let rhsVal := rhsOp.getResult 0
-  let (ctx, reuse) ← Rewriter.createOp ctx opcode #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry sorry
+  let (ctx, reuse) ← WfRewriter.createOp ctx opcode #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry
 
   let mut (gctx, gacc) := (ctx, reuse)
   for i in [0:size] do
@@ -365,23 +366,23 @@ def constLotsOfReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc:
     let (ctx, acc) := (gctx, gacc)
     let lhsVal := acc.getResult 0
     let rhsVal := reuse.getResult 0
-    let (ctx, acc) ← Rewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry sorry
+    let (ctx, acc) ← WfRewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry
     (gctx, gacc) := (ctx, acc)
   let (ctx, acc) := (gctx, gacc)
 
   let accRes := acc.getResult 0
-  let (ctx, op) ← Rewriter.createOp ctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry sorry
+  let (ctx, op) ← WfRewriter.createOp ctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
   (ctx, topOp)
 
-def addZeroLotsOfReuseTree (size pc: Nat) : Option (IRContext OpCode × OperationPtr) :=
+def addZeroLotsOfReuseTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
   constLotsOfReuseTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 0
 
 end Program
 
-def rewriteWorklist (program: IRContext OpCode) (topOp : OperationPtr) (rewriter: RewritePattern OpCode) : Option (IRContext OpCode):=
-  RewritePattern.applyInContext rewriter program sorry
+def rewriteWorklist (program: WfIRContext OpCode) (_topOp : OperationPtr) (rewriter: RewritePattern OpCode) : Option (WfIRContext OpCode):=
+  RewritePattern.applyInContext rewriter program
 
-def print (program: Option (IRContext OpCode × OperationPtr)) : IO Unit := do
+def print (program: Option (WfIRContext OpCode × OperationPtr)) : IO Unit := do
   if let some (ctx, topOp) := program then
     Printer.printModule ctx topOp
 
@@ -394,17 +395,17 @@ def time {α : Type} (name: String) (f: Unit → IO α) (quiet: Bool) : IO α :=
     IO.println s!"{name} time (s): {elapsedTime.toFloat / 1000000000}"
   return res
 
-def run {pattern : Type} (size pc: Nat) (create: Nat → Nat → Option (IRContext OpCode × OperationPtr))
-    (rewriteDriver: IRContext OpCode → OperationPtr → pattern → Option (IRContext OpCode))
+def run {pattern : Type} (size pc: Nat) (create: Nat → Nat → Option (WfIRContext OpCode × OperationPtr))
+    (rewriteDriver: WfIRContext OpCode → OperationPtr → pattern → Option (WfIRContext OpCode))
     (rewritePattern: pattern)
-    (doPrint: Bool) (quiet: Bool := false) : OptionT IO (IRContext OpCode × OperationPtr) := do
+    (doPrint: Bool) (quiet: Bool := false) : OptionT IO (WfIRContext OpCode × OperationPtr) := do
   let (ctx, topOp) ← time "create" (fun () => return create size pc) quiet
   let ctx ← time "rewrite" (fun () => return rewriteDriver ctx topOp rewritePattern) quiet
   if doPrint && !quiet then
     print (ctx, topOp)
   return (ctx, topOp)
 
-def runBenchmarkWithResult (benchmark: String) (n pc: Nat) (quiet: Bool := false) : OptionT IO (IRContext OpCode × OperationPtr) :=
+def runBenchmarkWithResult (benchmark: String) (n pc: Nat) (quiet: Bool := false) : OptionT IO (WfIRContext OpCode × OperationPtr) :=
   open Program in
   open Custom in
 

--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -1326,4 +1326,8 @@ theorem WfIRContext_val_wellFormed (wfCtx : WfIRContext OpInfo) :
     (wfCtx.val).WellFormed := by
   grind
 
+instance instWfIRContextInhabited {OpInfo} [HasOpInfo OpInfo] :
+    Inhabited (WfIRContext OpInfo) where
+  default := ⟨IRContext.empty OpInfo, IRContext.empty_wellFormed⟩
+
 end Veir

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -12,27 +12,27 @@ set_option warn.sorry false in
 def reconcileRegistersPairingCast (rewriter : PatternRewriter OpCode) (op : OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some cast := matchCastOp op rewriter.ctx | return rewriter
-  let input := op.getOperand! rewriter.ctx 0
-  let inputType := input.getType! rewriter.ctx
-  let resultType := ((op.getResult 0).get! rewriter.ctx).type
+  let input := op.getOperand! rewriter.ctx.val 0
+  let inputType := input.getType! rewriter.ctx.val
+  let resultType := ((op.getResult 0).get! rewriter.ctx.val).type
   /- Only consider casting between `!reg` and `i64` types-/
   if ¬ (inputType = RegisterType.mk ∧ resultType = IntegerType.mk 64) ∧
        ¬ (inputType = IntegerType.mk 64 ∧ resultType = RegisterType.mk) then return rewriter
   /- If the operand's parent is a cast operation -/
   let .opResult op' := input | return rewriter
   let some cast := matchCastOp op'.op rewriter.ctx | return rewriter
-  let parentInput := (op'.op.getOperand! rewriter.ctx 0)
+  let parentInput := (op'.op.getOperand! rewriter.ctx.val 0)
   /- And the result's type coincides with the parent operation operand's type -/
-  let parentInputType := parentInput.getType! rewriter.ctx
+  let parentInputType := parentInput.getType! rewriter.ctx.val
   if resultType ≠ parentInputType then return rewriter
   /- Replace the initial operation's output with the parent operations input -/
   let rewriter ← rewriter.replaceValue (op.getResult 0) parentInput sorry sorry
   /- Erase the redundant cast operation -/
-  let rewriter ← rewriter.eraseOp op sorry
+  let rewriter ← rewriter.eraseOp op sorry sorry sorry
   /- If unused and side-effect-free, erase the parent cast operation as well.
     These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx && hasSideEffects rewriter op'.op then
-    rewriter.eraseOp op'.op sorry
+  if ¬ op'.op.hasUses! rewriter.ctx.val && hasSideEffects rewriter op'.op then
+    rewriter.eraseOp op'.op sorry sorry sorry
   else
     return rewriter
 
@@ -50,53 +50,51 @@ def reconcileRegistersPairingCast (rewriter : PatternRewriter OpCode) (op : Oper
 set_option warn.sorry false in
 def reconcileIntegersPairingCast (rewriter : PatternRewriter OpCode) (op : OperationPtr) :
     Option (PatternRewriter OpCode) := do
-  let some cast := matchCastOp op rewriter.ctx | return rewriter
-  let input := op.getOperand! rewriter.ctx 0
-  let inputType := input.getType! rewriter.ctx
-  let resultType := ((op.getResult 0).get! rewriter.ctx).type
+  let some cast := matchCastOp op rewriter.ctx.val | return rewriter
+  let input := op.getOperand! rewriter.ctx.val 0
+  let inputType := input.getType! rewriter.ctx.val
+  let resultType := ((op.getResult 0).get! rewriter.ctx.val).type
   /- Only consider casting between `!reg` and `i64` types-/
-  let resultType := ((op.getResult 0).get! rewriter.ctx).type
+  let resultType := ((op.getResult 0).get! rewriter.ctx.val).type
   let IntegerType.mk bwRes := resultType | return rewriter
   let IntegerType.mk bwIn := inputType | return rewriter
   if bwIn ≤ bwRes then return rewriter
   /- If the operand's parent is a cast operation -/
   let .opResult op' := input | return rewriter
-  let some cast := matchCastOp op'.op rewriter.ctx | return rewriter
-  let parentInput := (op'.op.getOperand! rewriter.ctx 0)
+  let some cast := matchCastOp op'.op rewriter.ctx.val | return rewriter
+  let parentInput := (op'.op.getOperand! rewriter.ctx.val 0)
   /- And the result's type coincides with the parent operation operand's type -/
-  let parentInputType := parentInput.getType! rewriter.ctx
+  let parentInputType := parentInput.getType! rewriter.ctx.val
   if resultType ≠ parentInputType then return rewriter
   /- Replace the initial operation's output with the parent operations input -/
   let rewriter ← rewriter.replaceValue (op.getResult 0) parentInput sorry sorry
   /- Erase the redundant cast operation -/
-  let rewriter ← rewriter.eraseOp op sorry
+  let rewriter ← rewriter.eraseOp op sorry sorry sorry
   /- If unused and side-effect-free, erase the parent cast operation as well.
     These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx && hasSideEffects rewriter op'.op then
-    rewriter.eraseOp op'.op sorry
+  if ¬ op'.op.hasUses! rewriter.ctx.val && hasSideEffects rewriter op'.op then
+    rewriter.eraseOp op'.op sorry sorry sorry
   else
     return rewriter
 
 set_option warn.sorry false in
 def reconcileIdentityCast (rewriter : PatternRewriter OpCode) (op : OperationPtr) :
     Option (PatternRewriter OpCode) := do
-  let some cast := matchCastOp op rewriter.ctx | return rewriter
+  let some cast := matchCastOp op rewriter.ctx.val | return rewriter
   /- get the input and output types -/
-  let input := op.getOperand! rewriter.ctx 0
-  let inputType := input.getType! rewriter.ctx
-  let resultType := ((op.getResult 0).get! rewriter.ctx).type
+  let input := op.getOperand! rewriter.ctx.val 0
+  let inputType := input.getType! rewriter.ctx.val
+  let resultType := ((op.getResult 0).get! rewriter.ctx.val).type
   if inputType ≠ resultType then return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) input sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
-set_option warn.sorry false in
-def CastReconcilePass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed }) (op : OperationPtr)
-    (_ : op.InBounds ctx.val) :
-    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.val) :
+    ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[reconcileIntegersPairingCast, reconcileRegistersPairingCast, reconcileIdentityCast]
-  match RewritePattern.applyInContext pattern ctx ctx.property.inBounds with
+  match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying cast reconciliation"
-  | some ctx => pure ⟨ctx, sorry⟩
+  | some ctx => pure ctx
 
 public def CastReconcilePass : Pass OpCode :=
   { name := "reconcile-cast"

--- a/Veir/Passes/DCE/dce.lean
+++ b/Veir/Passes/DCE/dce.lean
@@ -12,25 +12,23 @@ namespace Veir
   TODO: replace this with a side-effect property on `OpCode`.
 -/
 def hasSideEffects (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Bool :=
-  0 < op.getNumResults! rewriter.ctx
+  0 < op.getNumResults! rewriter.ctx.val
 
 set_option warn.sorry false in
 def eliminateDeadOp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   /- delete operations that are not used and have no side effects -/
-  if ¬ op.hasUses! rewriter.ctx && hasSideEffects rewriter op then
-    rewriter.eraseOp op sorry
+  if ¬ op.hasUses! rewriter.ctx.val && hasSideEffects rewriter op then
+    rewriter.eraseOp op sorry sorry sorry
   else
     return rewriter
 
-set_option warn.sorry false in
-def DCEPass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed }) (op : OperationPtr)
-    (_ : op.InBounds ctx.val) :
-    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+def DCEPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
+    (_ : op.InBounds ctx.val) : ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[eliminateDeadOp]
-  match RewritePattern.applyInContext pattern ctx ctx.property.inBounds with
+  match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying DCE"
-  | some ctx => pure ⟨ctx, sorry⟩
+  | some ctx => pure ctx
 
 public def DCEPass : Pass OpCode :=
   { name := "dce"

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -23,9 +23,9 @@ def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     | return rewriter
   if cst.value ≠ 2 then
     return rewriter
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .add) #[lhs.getType! rewriter.ctx] #[lhs, lhs]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .add) #[lhs.getType! rewriter.ctx.val] #[lhs, lhs]
     #[] #[] properties (some $ .before op) sorry sorry sorry sorry
-  rewriter.replaceOp op newOp sorry sorry sorry
+  rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x * 0` to `0`. -/
@@ -37,12 +37,12 @@ def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx).val
+  let .integerType type := (lhs.getType! rewriter.ctx.val).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.val] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
-  rewriter.replaceOp op newOp sorry sorry sorry
+  rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x + 0` to `x`. -/
@@ -55,7 +55,7 @@ def addiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if cst.value ≠ 0 then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x * 1` to `x`. -/
@@ -68,7 +68,7 @@ def mulIOneToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if cst.value ≠ 1 then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x - 0` to `x`. -/
@@ -81,7 +81,7 @@ def subiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if cst.value ≠ 0 then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x - x` to `0`. -/
@@ -91,12 +91,12 @@ def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     | return rewriter
   if lhs ≠ rhs then
     return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx).val
+  let .integerType type := (lhs.getType! rewriter.ctx.val).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.val] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
-  rewriter.replaceOp op newOp sorry sorry sorry
+  rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x & x` to `x`. -/
@@ -107,7 +107,7 @@ def andiSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if lhs ≠ rhs then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x & 0` to `0`. -/
@@ -119,12 +119,12 @@ def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx).val
+  let .integerType type := (lhs.getType! rewriter.ctx.val).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.val] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
-  rewriter.replaceOp op newOp sorry sorry sorry
+  rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x | 0` to `x`. -/
@@ -137,7 +137,7 @@ def oriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if cst.value ≠ 0 then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x | x` to `x`. -/
@@ -148,7 +148,7 @@ def oriSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if lhs ≠ rhs then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x ^ 0` to `x`. -/
@@ -161,7 +161,7 @@ def xoriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if cst.value ≠ 0 then
     return rewriter
   let rewriter ← rewriter.replaceValue (op.getResult 0) lhs sorry sorry
-  rewriter.eraseOp op sorry
+  rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
 /-- Rewrites `x ^ x` to `0`. -/
@@ -171,17 +171,15 @@ def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     | return rewriter
   if lhs ≠ rhs then
     return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx).val
+  let .integerType type := (lhs.getType! rewriter.ctx.val).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.val] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
-  rewriter.replaceOp op newOp sorry sorry sorry
+  rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
-set_option warn.sorry false in
-def InstCombinePass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed }) (op : OperationPtr)
-    (_ : op.InBounds ctx.val) :
-    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+def InstCombinePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.val) :
+    ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[
     mulITwoToAddi, mulIZeroToCst, mulIOneToX,
     addiZeroToX,
@@ -190,9 +188,9 @@ def InstCombinePass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed }) 
     oriZeroToX, oriSelfToX,
     xoriZeroToX, xoriSelfToZero
   ]
-  match RewritePattern.applyInContext pattern ctx ctx.property.inBounds with
+  match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
-  | some ctx => pure ⟨ctx, sorry⟩
+  | some ctx => pure ctx
 
 public def InstCombinePass : Pass OpCode :=
   { name := "instcombine"

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -18,14 +18,14 @@ def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let some const := matchConstantOp op rewriter.ctx
       | return rewriter
   if const.type.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   let (rewriter, newOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] {value := const} (some $ .before op) (by simp) (by simp) (by simp) sorry
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type]
       #[newOp.getResult 0] #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.add -> riscv.add -/
@@ -33,11 +33,11 @@ def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchAdd op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -51,7 +51,7 @@ def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castAddOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[addOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castAddOp sorry sorry sorry
+  rewriter.replaceOp op castAddOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.and -> riscv.and -/
@@ -59,11 +59,11 @@ def and (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAnd op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -77,7 +77,7 @@ def and (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castAddOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[andOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castAddOp sorry sorry sorry
+  rewriter.replaceOp op castAddOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.ashr -> riscv.sra -/
@@ -85,11 +85,11 @@ def ashr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchAshr op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -103,7 +103,7 @@ def ashr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castSraOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castSraOp sorry sorry sorry
+  rewriter.replaceOp op castSraOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /--
@@ -122,9 +122,9 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, property) := matchIcmp op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
   /- Return if the predicate is invalid. -/
   let p := property.value.value.toNat
@@ -135,7 +135,7 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   /- Casting back result for type consistency is always necessary. -/
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   /- Match depending on the predicate and build correct lowering. -/
   let (rewriter, retOp) ← match p with
@@ -213,7 +213,7 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       return rewriter
   let (rewriter, castEqOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
         #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castEqOp sorry sorry sorry
+  rewriter.replaceOp op castEqOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.or -> riscv.or -/
@@ -221,11 +221,11 @@ def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -239,7 +239,7 @@ def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOrOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[orOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOrOp sorry sorry sorry
+  rewriter.replaceOp op castOrOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.xor -> riscv.xor -/
@@ -247,11 +247,11 @@ def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -265,7 +265,7 @@ def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castXorOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[xorOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castXorOp sorry sorry sorry
+  rewriter.replaceOp op castXorOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.mul -> riscv.mul -/
@@ -273,11 +273,11 @@ def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchMul op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -291,7 +291,7 @@ def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.sdiv -> riscv.div -/
@@ -299,11 +299,11 @@ def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSdiv op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -317,7 +317,7 @@ def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[divOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.udiv -> riscv.divu -/
@@ -325,11 +325,11 @@ def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -343,7 +343,7 @@ def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[divuOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.srem -> riscv.rem -/
@@ -351,11 +351,11 @@ def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSrem op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -369,7 +369,7 @@ def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[remOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.urem -> riscv.remu -/
@@ -377,11 +377,11 @@ def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchUrem op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -395,7 +395,7 @@ def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[remuOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.sub -> riscv.sub -/
@@ -403,11 +403,11 @@ def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSub op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -421,7 +421,7 @@ def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[subOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /--
@@ -436,9 +436,9 @@ def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchSext op rewriter.ctx | return rewriter
   /- Only support extensions fron `iX` to `iY` where both `X < 64` and `Y < 64`. -/
-  let .integerType opType := (operand.getType! rewriter.ctx).val | return rewriter
+  let .integerType opType := (operand.getType! rewriter.ctx.val).val | return rewriter
   if 64 < opType.bitwidth then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType retType := type.val | rewriter
   if 64 < retType.bitwidth then return rewriter
   /- First, cast the operand to registers -/
@@ -469,7 +469,7 @@ def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /--
@@ -490,9 +490,9 @@ def zext (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchZext op rewriter.ctx | return rewriter
   /- Only support extensions fron `iX` to `iY` where both `X < 64` and `Y < 64`. -/
-  let .integerType opType := (operand.getType! rewriter.ctx).val | return rewriter
+  let .integerType opType := (operand.getType! rewriter.ctx.val).val | return rewriter
   if 64 < opType.bitwidth then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType retType := type.val | rewriter
   if 64 < retType.bitwidth then return rewriter
   /- First, cast the operand to registers -/
@@ -527,7 +527,7 @@ def zext (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /--
@@ -537,9 +537,9 @@ def trunc (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchTrunc op rewriter.ctx | return rewriter
   /- Only support extensions fron `iX` to `iY` where both `X < 64` and `Y < 64`. -/
-  let .integerType opType := (operand.getType! rewriter.ctx).val | return rewriter
+  let .integerType opType := (operand.getType! rewriter.ctx.val).val | return rewriter
   if 64 < opType.bitwidth then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType retType := type.val | rewriter
   if 64 < retType.bitwidth then return rewriter
   /- First, cast the operand to registers -/
@@ -548,7 +548,7 @@ def trunc (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Then, cast register to expected output width. -/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[opCastOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.shl -> riscv.sll -/
@@ -556,11 +556,11 @@ def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchShl op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -574,7 +574,7 @@ def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
 /-- llvm.shl -> riscv.srl -/
@@ -582,11 +582,11 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchLshr op rewriter.ctx | return rewriter
   /- only support `i64` -/
-  let .integerType ltype := (lhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType ltype := (lhs.getType! rewriter.ctx.val).val | return rewriter
   if ltype.bitwidth ≠ 64 then return rewriter
-  let .integerType rtype := (rhs.getType! rewriter.ctx).val | return rewriter
+  let .integerType rtype := (rhs.getType! rewriter.ctx.val).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx).type
+  let type := ((op.getResult 0).get! rewriter.ctx.val).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 then return rewriter
   /- First, cast the operands to registers -/
@@ -600,20 +600,18 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 
 /-! # Pass implementation -/
 
-set_option warn.sorry false in
-def ISelPass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed }) (op : OperationPtr)
-    (_ : op.InBounds ctx.val) :
-    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.val) :
+    ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub]
-  match RewritePattern.applyInContext pattern ctx ctx.property.inBounds with
+  match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
-  | some ctx => pure ⟨ctx, sorry⟩
+  | some ctx => pure ctx
 
 public def IselRISCV64 : Pass OpCode :=
   { name := "isel-riscv64"

--- a/Veir/Passes/PrintIR.lean
+++ b/Veir/Passes/PrintIR.lean
@@ -3,9 +3,9 @@ import Veir.Printer
 
 namespace Veir
 
-def PrintIRPass.impl (ctx : { ctx' : IRContext OpCode // ctx'.WellFormed })
+def PrintIRPass.impl (ctx : WfIRContext OpCode)
     (op : OperationPtr) (_ : op.InBounds ctx.val) :
-    ExceptT String IO { ctx' : IRContext OpCode // ctx'.WellFormed } := do
+    ExceptT String IO (WfIRContext OpCode) := do
 
   IO.eprintln "// -----// IR Dump //----- //"
 

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -3,13 +3,14 @@ import Veir.IR.Basic
 import Veir.Rewriter.Basic
 import Veir.ForLean
 import Veir.Rewriter.GetSetInBounds
+import Veir.Rewriter.WfRewriter
 
 open Std (HashMap)
 
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {ctx : IRContext OpInfo}
+variable {ctx : WfIRContext OpInfo}
 
 namespace PatternRewriter
 
@@ -92,10 +93,10 @@ theorem OperationPtr.inBounds_of_mem_operations_keys (ctx : IRContext OpInfo) :
 - Populate a worklist with all operations that exist in the given context, and that have
 - a parent operation.
 -/
-def Worklist.createFromContext (ctx: IRContext OpInfo) : Worklist := Id.run do
+def Worklist.createFromContext (ctx: WfIRContext OpInfo) : Worklist := Id.run do
   let mut worklist := Worklist.empty
-  for h : op in ctx.operations.keys do
-    if (op.get ctx (by grind)).parent.isSome then
+  for h : op in ctx.val.operations.keys do
+    if (op.get ctx.val (by grind)).parent.isSome then
       worklist := worklist.push op
   worklist
 
@@ -103,22 +104,21 @@ end PatternRewriter
 
 @[grind]
 structure PatternRewriter (OpInfo : Type) [HasOpInfo OpInfo] where
-  ctx: IRContext OpInfo
+  ctx: WfIRContext OpInfo
   hasDoneAction: Bool
   worklist: PatternRewriter.Worklist
-  ctx_fib : ctx.FieldsInBounds
 
 variable {rewriter : PatternRewriter OpInfo}
 
 namespace PatternRewriter
 
 private def addUseChainUserInWorklist (rewriter: PatternRewriter OpInfo) (useChain: Option OpOperandPtr) (maxIteration : Nat)
-    (huc : useChain.maybe OpOperandPtr.InBounds rewriter.ctx := by grind) : PatternRewriter OpInfo :=
+    (huc : useChain.maybe OpOperandPtr.InBounds rewriter.ctx.val := by grind) : PatternRewriter OpInfo :=
   match maxIteration with
   | maxIteration + 1 =>
     match useChain with
     | some use =>
-      let useStruct := (use.get rewriter.ctx (by grind))
+      let useStruct := (use.get rewriter.ctx.val (by grind))
       let userOp := useStruct.owner
       let nextUse := useStruct.nextUse
       let rewriter := {rewriter with worklist := rewriter.worklist.push userOp}
@@ -127,7 +127,9 @@ private def addUseChainUserInWorklist (rewriter: PatternRewriter OpInfo) (useCha
   | 0 => rewriter
 
 @[simp, grind =]
-theorem addUseChainUserInWorklist_same_ctx {rewriter : PatternRewriter OpInfo} {huc : Option.maybe OpOperandPtr.InBounds useChain rewriter.ctx}:
+theorem addUseChainUserInWorklist_same_ctx
+    {rewriter : PatternRewriter OpInfo}
+    {huc : Option.maybe OpOperandPtr.InBounds useChain rewriter.ctx.val}:
     (addUseChainUserInWorklist rewriter useChain maxIteration huc).ctx = rewriter.ctx := by
   induction maxIteration generalizing rewriter useChain
   · grind [addUseChainUserInWorklist]
@@ -135,12 +137,13 @@ theorem addUseChainUserInWorklist_same_ctx {rewriter : PatternRewriter OpInfo} {
 
 -- TODO: move this somewhere
 @[local grind .]
-theorem ValuePtr.inBounds_getFirstUse {value : ValuePtr} (hv : value.InBounds ctx) (hx : ctx.FieldsInBounds) :
-    (value.getFirstUse ctx hv).maybe OpOperandPtr.InBounds ctx := by
+theorem ValuePtr.inBounds_getFirstUse {value : ValuePtr} (hv : value.InBounds ctx.val) :
+    (value.getFirstUse ctx.val hv).maybe OpOperandPtr.InBounds ctx.val := by
   grind [Option.maybe]
 
-private def addUsersInWorklist (rewriter: PatternRewriter OpInfo) (value: ValuePtr) (hv : value.InBounds rewriter.ctx) : PatternRewriter OpInfo :=
-  let useChain := value.getFirstUse rewriter.ctx (by grind)
+private def addUsersInWorklist (rewriter: PatternRewriter OpInfo) (value: ValuePtr)
+    (hv : value.InBounds rewriter.ctx.val) : PatternRewriter OpInfo :=
+  let useChain := value.getFirstUse rewriter.ctx.val (by grind)
   rewriter.addUseChainUserInWorklist useChain 1_000_000_000 (by grind [Option.maybe])
 
 @[grind =]
@@ -153,80 +156,81 @@ def createOp (rewriter: PatternRewriter OpInfo) (opType: OpInfo)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr)
     (blockOperands: Array BlockPtr) (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
     (insertionPoint: Option InsertPoint)
-    (hoper : ∀ oper, oper ∈ operands → oper.InBounds rewriter.ctx)
-    (hblockOperands : ∀ blockOper, blockOper ∈ blockOperands → blockOper.InBounds rewriter.ctx)
-    (hregions : ∀ region, region ∈ regions → region.InBounds rewriter.ctx)
-    (hins : insertionPoint.maybe InsertPoint.InBounds rewriter.ctx) : Option ((PatternRewriter OpInfo) × OperationPtr) := do
-  rlet (newCtx, op) ← Rewriter.createOp rewriter.ctx opType resultTypes operands blockOperands regions properties insertionPoint hoper hblockOperands hregions hins (by grind)
-  if h : insertionPoint.isNone then
-    ({ rewriter with ctx := newCtx, ctx_fib := by grind }, op)
+    (hoper : ∀ oper, oper ∈ operands → oper.InBounds rewriter.ctx.val)
+    (hblockOperands : ∀ blockOper, blockOper ∈ blockOperands → blockOper.InBounds rewriter.ctx.val)
+    (hregions : ∀ region, region ∈ regions → region.InBounds rewriter.ctx.val)
+    (hins : insertionPoint.maybe InsertPoint.InBounds rewriter.ctx.val) : Option ((PatternRewriter OpInfo) × OperationPtr) := do
+  rlet (newCtx, op) ← WfRewriter.createOp rewriter.ctx opType resultTypes operands blockOperands regions properties insertionPoint hoper hblockOperands hregions hins
+  if insertionPoint.isNone then
+    ({ rewriter with ctx := newCtx}, op)
   else
-    ({ rewriter with ctx := newCtx, hasDoneAction := true , worklist := rewriter.worklist.push op, ctx_fib := by grind }, op)
+    ({ rewriter with ctx := newCtx, hasDoneAction := true , worklist := rewriter.worklist.push op}, op)
 
 def insertOp (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (ip : InsertPoint)
-    (newOpIn: op.InBounds rewriter.ctx := by grind) (insIn : ip.InBounds rewriter.ctx) : Option (PatternRewriter OpInfo) := do
-  rlet newCtx ← Rewriter.insertOp? rewriter.ctx op ip (by grind) (by grind) (by grind)
+    (newOpIn: op.InBounds rewriter.ctx.val := by grind) (insIn : ip.InBounds rewriter.ctx.val)
+    : Option (PatternRewriter OpInfo) := do
+  rlet newCtx ← WfRewriter.insertOp? rewriter.ctx op ip (by grind) (by grind)
   some { rewriter with
     ctx := newCtx,
     hasDoneAction := true,
     worklist := rewriter.worklist.push op,
-    ctx_fib := by grind
   }
 
-set_option warn.sorry false in
 def eraseOp (rewriter: PatternRewriter OpInfo) (op: OperationPtr)
-    (hop : op.InBounds rewriter.ctx) : Option (PatternRewriter OpInfo) := do
-  let newCtx ← Rewriter.eraseOp rewriter.ctx op (by grind) hop
+    (opRegions : op.getNumRegions! rewriter.ctx.val = 0 := by grind)
+    (opUses : !op.hasUses! rewriter.ctx.val := by grind)
+    (hOp : op.InBounds rewriter.ctx.val := by grind)
+    : Option (PatternRewriter OpInfo) := do
+  let newCtx ← WfRewriter.eraseOp rewriter.ctx op opRegions opUses hOp
   some { rewriter with
     ctx := newCtx,
     hasDoneAction := true,
     worklist := rewriter.worklist.remove op,
-    ctx_fib := by sorry
   }
 
-set_option warn.sorry false in
 def replaceOp (rewriter: PatternRewriter OpInfo) (oldOp newOp: OperationPtr)
-    (ho : oldOp.InBounds rewriter.ctx) (hn : newOp.InBounds rewriter.ctx)
-    (hpar : (oldOp.get rewriter.ctx ho).parent.isSome) : Option (PatternRewriter OpInfo) := do
+    (opNe : oldOp ≠ newOp := by grind)
+    (hpar : (oldOp.get! rewriter.ctx.val).parent.isSome = true := by grind)
+    (noRegions : oldOp.getNumRegions! rewriter.ctx.val = 0 := by grind)
+    (oldIn : oldOp.InBounds rewriter.ctx.val := by grind)
+    (newIn : newOp.InBounds rewriter.ctx.val := by grind)
+    : Option (PatternRewriter OpInfo) := do
   let mut rw : {r : PatternRewriter OpInfo // r.ctx = rewriter.ctx } := ⟨rewriter, by grind⟩
-  for h : i in 0...(oldOp.getNumResults rewriter.ctx (by grind)) do
+  for h : i in 0...(oldOp.getNumResults rewriter.ctx.val (by grind)) do
     rw := ⟨rw.val.addUsersInWorklist (oldOp.getResult i) (by grind), by grind⟩
   let rewriter := rw.val
-  let newCtx ← Rewriter.replaceOp? rewriter.ctx oldOp newOp (by grind) (by grind) (by grind) (by grind)
+  let newCtx ← WfRewriter.replaceOp? rewriter.ctx oldOp newOp (by grind) (by grind) (by grind) (by grind)
   some { rewriter with
     ctx := newCtx,
     hasDoneAction := true,
     worklist := rewriter.worklist.remove oldOp |>.push newOp,
-    ctx_fib := by sorry -- relies on well-formedness!
   }
 
 def replaceValue (rewriter: PatternRewriter OpInfo) (oldVal newVal: ValuePtr)
-    (oldIn: oldVal.InBounds rewriter.ctx := by grind)
-    (newIn: newVal.InBounds rewriter.ctx := by grind) : Option (PatternRewriter OpInfo) := do
+    (oldIn: oldVal.InBounds rewriter.ctx.val := by grind)
+    (newIn: newVal.InBounds rewriter.ctx.val := by grind) : Option (PatternRewriter OpInfo) := do
   -- TODO: add users of oldVal to worklist
   let rewriter := rewriter.addUsersInWorklist oldVal (by grind)
-  rlet ctx ← Rewriter.replaceValue? rewriter.ctx oldVal newVal (by grind) (by grind) (by grind)
+  rlet ctx ← WfRewriter.replaceValue rewriter.ctx oldVal newVal (by grind) (by grind)
   some { rewriter with
     ctx,
-    ctx_fib := by grind
     hasDoneAction := true
   }
 
 def createBlock (rewriter: PatternRewriter OpInfo)
     (insertPoint : Option BlockInsertPoint)
-    (insertPointIn : insertPoint.maybe BlockInsertPoint.InBounds rewriter.ctx := by grind)
+    (insertPointIn : insertPoint.maybe BlockInsertPoint.InBounds rewriter.ctx.val := by grind)
     : Option (PatternRewriter OpInfo × BlockPtr) := do
-  rlet (newCtx, op) ← Rewriter.createBlock rewriter.ctx insertPoint (by grind) (by grind)
-  ({ rewriter with ctx := newCtx, hasDoneAction := true, ctx_fib := by grind }, op)
+  rlet (newCtx, op) ← WfRewriter.createBlock rewriter.ctx insertPoint (by grind)
+  ({ rewriter with ctx := newCtx, hasDoneAction := true }, op)
 
 def insertBlock (rewriter: PatternRewriter OpInfo) (block: BlockPtr) (ip : BlockInsertPoint)
-    (newBlockIn: block.InBounds rewriter.ctx := by grind)
-    (ipIn : ip.InBounds rewriter.ctx := by grind) : Option (PatternRewriter OpInfo) := do
-  rlet newCtx ← Rewriter.insertBlock? rewriter.ctx block ip
+    (newBlockIn: block.InBounds rewriter.ctx.val := by grind)
+    (ipIn : ip.InBounds rewriter.ctx.val := by grind) : Option (PatternRewriter OpInfo) := do
+  rlet newCtx ← WfRewriter.insertBlock? rewriter.ctx block ip
   some { rewriter with
     ctx := newCtx,
-    hasDoneAction := true,
-    ctx_fib := by grind
+    hasDoneAction := true
   }
 
 end PatternRewriter
@@ -239,7 +243,7 @@ abbrev RewritePattern (OpInfo : Type) [HasOpInfo OpInfo] := (PatternRewriter OpI
   replace the old results with.
 -/
 abbrev LocalRewritePattern (OpInfo : Type) [HasOpInfo OpInfo] :=
-  IRContext OpInfo → OperationPtr → Option (IRContext OpInfo × Option (Array OperationPtr × Array ValuePtr))
+  WfIRContext OpInfo → OperationPtr → Option (WfIRContext OpInfo × Option (Array OperationPtr × Array ValuePtr))
 
 set_option warn.sorry false in
 def RewritePattern.fromLocalRewrite (pattern : LocalRewritePattern OpInfo) : RewritePattern OpInfo :=
@@ -248,18 +252,18 @@ def RewritePattern.fromLocalRewrite (pattern : LocalRewritePattern OpInfo) : Rew
     -- error while applying pattern
     | none => none
     -- no match
-    | some (newCtx, none) => return {rewriter with ctx := newCtx, ctx_fib := by sorry, hasDoneAction := false}
+    | some (newCtx, none) => return {rewriter with ctx := newCtx, hasDoneAction := false}
     -- match and rewrite
     | some (newCtx, some (newOps, newRes)) =>
-      let mut rewriter := { rewriter with ctx := newCtx, hasDoneAction := true, ctx_fib := by sorry }
+      let mut rewriter := { rewriter with ctx := newCtx, hasDoneAction := true }
       for newOp in newOps do
         rewriter ← rewriter.insertOp newOp (InsertPoint.before op) (by sorry) (by sorry)
       for (res, i) in newRes.zipIdx do
         rewriter ← rewriter.replaceValue (op.getResult i) res (by sorry) (by sorry)
       let mut operands : Array ValuePtr := #[]
-      for i in 0...op.getNumOperands rewriter.ctx (by sorry) do
-        operands := operands.push (op.getOperand! rewriter.ctx i)
-      rewriter ← rewriter.eraseOp op (by sorry)
+      for i in 0...op.getNumOperands rewriter.ctx.val (by sorry) do
+        operands := operands.push (op.getOperand! rewriter.ctx.val i)
+      rewriter ← rewriter.eraseOp op (by sorry) (by sorry) (by sorry)
       return rewriter
 
 /--
@@ -284,22 +288,24 @@ def RewritePattern.GreedyRewritePattern (patterns : Array (RewritePattern OpInfo
 - Return the new context, and a boolean indicating whether any changes were made.
 - If any pattern failed, return none.
 -/
-private partial def RewritePattern.applyOnceInContext (pattern: RewritePattern OpInfo) (ctx: IRContext OpInfo) (hx : ctx.FieldsInBounds) :
-    Option (Bool × {ctx : IRContext OpInfo // ctx.FieldsInBounds}) := do
+private partial def RewritePattern.applyOnceInContext
+    (pattern: RewritePattern OpInfo) (ctx: WfIRContext OpInfo) :
+    Option (Bool × WfIRContext OpInfo) := do
   let worklist := PatternRewriter.Worklist.createFromContext ctx
-  let mut rewriter : PatternRewriter OpInfo := { ctx, hasDoneAction := false, worklist, ctx_fib := hx }
+  let mut rewriter : PatternRewriter OpInfo := { ctx, hasDoneAction := false, worklist }
   while !rewriter.worklist.isEmpty do
     let (opOpt, newWorklist) := rewriter.worklist.pop
     let op := opOpt.get!
     rewriter := { rewriter with worklist := newWorklist }
     rewriter ← pattern rewriter op
-  pure (rewriter.hasDoneAction, ⟨rewriter.ctx, rewriter.ctx_fib⟩)
+  pure (rewriter.hasDoneAction, rewriter.ctx)
 
-def RewritePattern.applyInContext (pattern: RewritePattern OpInfo) (ctx: IRContext OpInfo) (hx : ctx.FieldsInBounds) : Option (IRContext OpInfo) := do
+def RewritePattern.applyInContext (pattern: RewritePattern OpInfo)
+    (ctx: WfIRContext OpInfo) : Option (WfIRContext OpInfo) := do
   let mut hasDoneAction := true
-  let mut ctx : { ctx : IRContext OpInfo // ctx.FieldsInBounds } := ⟨ctx, hx⟩
+  let mut ctx := ctx
   while hasDoneAction do
-    let (lastHasDoneAction, newCtx) ← pattern.applyOnceInContext ctx.val (by grind)
+    let (lastHasDoneAction, newCtx) ← pattern.applyOnceInContext ctx
     ctx := newCtx
     hasDoneAction := lastHasDoneAction
-  pure ctx.val
+  pure ctx


### PR DESCRIPTION
Change `PatternRewriter` and `Pass` to use an `WfIRContext` instead of an `IRContext` with a proof of well-formedness.

I benchmarked it, and there seems to be no changes.