### PR TITLE
Use ExtHashMap for the interpreter state

### DIFF
--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -63,14 +63,11 @@ def InterpreterState.getVar? (state : InterpreterState) (var : ValuePtr)
   state.variables[var]?
 
 @[ext]
-theorem InterpreterState.ext {state1 state2 : InterpreterState} :
-    (∀ var, state1.getVar? var = state2.getVar? var) →
-    state1 = state2 := by
-  intro h
-  have ⟨state1⟩ := state1; have ⟨state2⟩ := state2
-  simp only [mk.injEq]
-  ext key value
-  simp only [InterpreterState.getVar?] at h
+theorem InterpreterState.ext {s₁ s₂ : InterpreterState} :
+    (∀ var, s₁.getVar? var = s₂.getVar? var) →
+    s₁ = s₂ := by
+  rcases s₁; rcases s₂
+  simp only [getVar?, mk.injEq]
   grind
 
 /--

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -46,7 +46,7 @@ instance : ToString (RuntimeValue) where
   It includes a mapping from IR values to their runtime values.
 -/
 structure InterpreterState where
-  variables : Std.HashMap ValuePtr RuntimeValue
+  variables : Std.ExtHashMap ValuePtr RuntimeValue
 
 /--
   Set the value of a variable.
@@ -61,6 +61,17 @@ def InterpreterState.setVar (state : InterpreterState) (var : ValuePtr) (val : R
 def InterpreterState.getVar? (state : InterpreterState) (var : ValuePtr)
     : Option RuntimeValue :=
   state.variables[var]?
+
+@[ext]
+theorem InterpreterState.ext {state1 state2 : InterpreterState} :
+    (∀ var, state1.getVar? var = state2.getVar? var) →
+    state1 = state2 := by
+  intro h
+  have ⟨state1⟩ := state1; have ⟨state2⟩ := state2
+  simp only [mk.injEq]
+  ext key value
+  simp only [InterpreterState.getVar?] at h
+  grind
 
 /--
   Get the value of the operands of an operation.
@@ -91,7 +102,7 @@ def InterpreterState.setResultValues (state : InterpreterState) (ctx : IRContext
   Create an interpreter state with no variables defined.
 -/
 def InterpreterState.empty : InterpreterState :=
-  { variables := Std.HashMap.emptyWithCapacity 8 }
+  { variables := Std.ExtHashMap.emptyWithCapacity 8 }
 
 /--
   How the control flow should proceed after interpreting an operation.


### PR DESCRIPTION
This will allow us to more easily reason about the interpreter state, as we can then use equality between states instead of defining a property for it.