### PR TITLE
continue CI on documentation errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Build docs
+        continue-on-error: true
         uses: leanprover/lean-action@v1
         with:
           lake-package-directory: "docbuild"
@@ -73,6 +74,7 @@ jobs:
 
       - name: Upload docs artifact
         if: github.ref == 'refs/heads/main'
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: docs


### PR DESCRIPTION
Documentation errors cause unnecessary noise on the CI and it seems the Lean documentation story is currently a bit unstable. Hence, let's hide these errors for now. We can re-evaluate this in the future when the documentation story got a bit stronger.