### PR TITLE
Fix printing of operations that have both successors and properties

### DIFF
--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -186,8 +186,8 @@ partial def printOperation (ctx: IRContext OpCode) (op: OperationPtr) (indent: N
   printOpResults ctx op
   IO.print s!"\"{String.fromUTF8! opStruct.opType.name}\""
   printOpOperands ctx op
-  printOpProperties ctx op
   printBlockOperands ctx op
+  printOpProperties ctx op
   if op.getNumRegions! ctx > 0 then
     IO.print " "
     printRegions ctx op indent


### PR DESCRIPTION
As per https://mlir.llvm.org/docs/LangRef/#operations, successors should go first.
The parser is correct, but the printer inverts them.

As there is a bug with the current parsing of unregistered operations, the test will be added when we add `cf.cond_br`