### PR TITLE
Parse and verify `cf.cond_br`

### DIFF
--- a/Test/Cf/identity.mlir
+++ b/Test/Cf/identity.mlir
@@ -4,14 +4,20 @@
   ^4():
     "func.func"() ({
       ^6(%arg6_0 : i32):
-        "cf.br"(%arg6_0) [^6] : (i32) -> ()
-  }) : () -> ()
+        "cf.br"(%arg6_0) [^7] : (i32) -> ()
+      ^7(%arg7_0 : i32):
+        %9 = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
+        "cf.cond_br"(%9, %arg7_0, %arg7_0) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+    }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^4():
 // CHECK-NEXT:     "func.func"() ({
 // CHECK-NEXT:       ^6(%arg6_0 : i32):
-// CHECK-NEXT:         "cf.br"(%arg6_0) [^6] : (i32) -> ()
-// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT:         "cf.br"(%arg6_0) [^7] : (i32) -> ()
+// CHECK-NEXT:       ^7(%arg7_0 : i32):
+// CHECK-NEXT:         %9 = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
+// CHECK-NEXT:         "cf.cond_br"(%9, %arg7_0, %arg7_0) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -1,0 +1,22 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Cf.propertiesOf (op : Cf) : Type :=
+match op with
+| .cond_br => CondBrConstantProperties
+| _ => Unit
+
+instance : HasDialectOpInfo Cf where
+  propertiesOf := Cf.propertiesOf
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -4,6 +4,7 @@ public import Veir.Dialects.Arith.OpInfo
 public import Veir.Dialects.LLVM.OpInfo
 public import Veir.Dialects.RISCV.OpInfo
 public import Veir.Dialects.ModArith.OpInfo
+public import Veir.Dialects.Cf.OpInfo
 
 namespace Veir
 
@@ -20,6 +21,7 @@ match opCode with
 | .llvm op => Llvm.propertiesOf op
 | .riscv op => Riscv.propertiesOf op
 | .mod_arith op => Mod_Arith.propertiesOf op
+| .cf op => Cf.propertiesOf op
 | _ => Unit
 
 instance : HasDialectOpInfo OpCode where
@@ -95,7 +97,9 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     all_goals exact (Except.ok ())
   case func =>
     all_goals exact (Except.ok ())
-  case cf =>
+  case cf op =>
+    cases op
+    case cond_br => exact (CondBrConstantProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case builtin =>
     all_goals exact (Except.ok ())
@@ -156,5 +160,8 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .riscv .slliw | .riscv .srliw | .riscv .sraiw | .riscv .rori | .riscv .roriw | .riscv .slliuw
   | .riscv .bclri | .riscv .bexti | .riscv .binvi | .riscv .bseti | .mod_arith .constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
+  | .cf .cond_br =>
+    let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
+    dict.insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
   | _ =>
     Std.HashMap.emptyWithCapacity 0

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -66,6 +66,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 @[opcodes]
 inductive Cf where
 | br
+| cond_br
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -163,6 +163,29 @@ def ModArithConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray At
     | throw s!"mod_arith.constant: expected 'value' to be an integer attribute, but got {attr}"
   return { value := intAttr }
 
+/--
+  Properties of the `cond_br` operation.
+-/
+
+structure CondBrConstantProperties where
+  branch_weights : DenseArrayAttr
+  operandSegmentSizes : DenseArrayAttr
+
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CondBrConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CondBrConstantProperties := do
+  if attrDict.size > 2 then
+    throw s!"cf.cond_br: expected only 'branch_weights' and 'operandSegmentSizes' properties, but got {attrDict.size} properties"
+  let weightsAttr ← match attrDict["weightsAttr".toUTF8]? with
+    | some (.denseArrayAttr weightsAttr) => .ok weightsAttr
+    | some attr => .error s!"expected 'branch_weights' to be an optional dense array attribute, but got {attr}"
+    | none => .ok { elementType := { bitwidth := 32 }, values := #[] }
+  let some sizesAttr := attrDict["operandSegmentSizes".toUTF8]?
+    | throw "cf.cond_br: missing 'operandSegmentSizes' property"
+  let .denseArrayAttr sizesAttr := sizesAttr
+    | throw s!"cf.cond_br: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
+  return { branch_weights := weightsAttr, operandSegmentSizes := sizesAttr }
 
 end
 end Veir

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -382,6 +382,22 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 1 then
       throw "Expected 1 successor"
     pure ()
+  | .cf .cond_br => do
+    if op.getNumResults ctx opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 2 then
+      throw "Expected 1 successor"
+    let weights := (op.getProperties! ctx (OpCode.cf .cond_br)).branch_weights
+    if weights.values.size ≠ 2 && weights.values.size ≠ 0 then
+      throw "Expected 0 or 2 branch weights"
+    let sizes := (op.getProperties! ctx (OpCode.cf .cond_br)).operandSegmentSizes
+    if _ : sizes.values.size ≠ 3 then
+      throw "Expected 1 operand plus 2 variadic operands"
+    if sizes.values[0]! ≠ 1 then
+      throw "Expected 1 operand plus 2 variadic operands"
+    pure ()
   /- TEST -/
   | .test .test => do
     pure ()


### PR DESCRIPTION
This depends on #445.
Because `cf.cond_br` takes variadic operands there is some magic with the `operandSegmentSizes` property, I handle that in an ad-hoc way for now.
