### PR TITLE
Interpret `cf.cond_br`

### DIFF
--- a/Test/Interpreter/Cf/cond_br.mlir
+++ b/Test/Interpreter/Cf/cond_br.mlir
@@ -1,0 +1,20 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  ^1():
+    %x1 = "arith.constant"() <{"value" = 8 : i32}> : () -> i32
+    %x2 = "arith.constant"() <{"value" = 11 : i32}> : () -> i32
+    %cond = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
+    "cf.cond_br"(%cond, %x1, %x2) [^4,^3] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+  ^2(%y : i32):
+    "func.return"(%y) : (i32) -> ()
+  ^3(%z1 : i32):
+    %z2 = "arith.constant"() <{"value" = 2 : i32}> : () -> i32
+    %cond = "arith.constant"() <{"value" = -1 : i1}> : () -> i1
+    "cf.cond_br"(%cond, %z1, %z2) [^2,^4] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+  ^4(%a1 : i32):
+    %a2 = "arith.constant"() <{"value" = 5 : i32}> : () -> i32
+    "func.return"(%a2) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0000000b#32]

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -330,6 +330,15 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
   | .cf .br => do
     let #[dest] := blockOperands | none
     return (#[], some (.branch operands dest))
+  | .cf .cond_br => do
+    let #[destTrue, destFalse] := blockOperands | none
+    let some (RuntimeValue.int 1 (.val cond)) := operands[0]? | none
+    let some trueSize := properties.operandSegmentSizes.values[1]? | none
+    let trueSize := trueSize.toNat
+    if cond = 1#1 then
+      return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
+    else
+      return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
   /- Bitblastable semantics of RISC-V assembly instructions. -/
   | .riscv .li => do
     let imm := BitVec.ofInt 64 properties.value.value


### PR DESCRIPTION
This uses the `operandSegmentSizes` property to extract the relevant operands depending on the value of the condition.
