### PR TITLE
feat: new packed float datatype

### DIFF
--- a/Veir/Data.lean
+++ b/Veir/Data.lean
@@ -1,3 +1,4 @@
 module
 
 import Veir.Data.LLVM
+import Veir.Data.FP

--- a/Veir/Data/FP.lean
+++ b/Veir/Data/FP.lean
@@ -1,0 +1,4 @@
+module
+
+import Veir.Data.FP.PackedFloat
+

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -1,0 +1,3 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic

--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -1,0 +1,4 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic
+

--- a/Veir/Data/FP/PackedFloat/Basic.lean
+++ b/Veir/Data/FP/PackedFloat/Basic.lean
@@ -7,19 +7,21 @@ namespace PackedFloat
 public section
 
 /--
-A packed floating point number,
+A packed floating point number of radix 2,
 with exponent and significand widths encoded at the type level.
-This implements the IEEE-754 floating point specification [1] of the bit layout.
-[1] Muller, Jean-Michel, et al. Handbook of floating-point arithmetic.
+This definition implements Section 3.4, Figure 3.1 of the IEEE-754 standard [1].
+We recommend [2] for a comprehensive introduction.
+[1] IEEE 754-2019, https://standards.ieee.org/ieee/754/6210/
+[2] Muller, Jean-Michel, et al. Handbook of floating-point arithmetic.
     Vol. 1. Basel, Switzerland:: Birkhäuser, 2018.
-
 -/
 @[ext]
 structure PackedFloat (exWidth sigWidth : Nat) where
     /-- Sign bit. -/
     sign : Bool
-    /-- Exponent of the packed float. -/
+    /-- Biased exponent of the packed float. -/
     ex : BitVec exWidth
-    /-- Significand (mantissa) of the packed float. -/
+    /-- Trailing significand (mantissa) of the packed float.
+      Leading digit implicitly encoded by biased exponent. -/
     sig : BitVec sigWidth
 deriving DecidableEq, Repr, Inhabited

--- a/Veir/Data/FP/PackedFloat/Basic.lean
+++ b/Veir/Data/FP/PackedFloat/Basic.lean
@@ -1,0 +1,21 @@
+module
+
+namespace Veir.Data.FP
+
+namespace PackedFloat
+
+public section
+
+/--
+A packed floating point number,
+with exponent and significand widths encoded at the type level.
+-/
+@[ext]
+structure PackedFloat (exWidth sigWidth : Nat) where
+    /-- Sign bit. -/
+    sign : Bool
+    /-- Exponent of the packed float. -/
+    ex : BitVec exWidth
+    /-- Significand (mantissa) of the packed float. -/
+    sig : BitVec sigWidth
+deriving DecidableEq, Repr, Inhabited

--- a/Veir/Data/FP/PackedFloat/Basic.lean
+++ b/Veir/Data/FP/PackedFloat/Basic.lean
@@ -9,6 +9,10 @@ public section
 /--
 A packed floating point number,
 with exponent and significand widths encoded at the type level.
+This implements the IEEE-754 floating point specification [1] of the bit layout.
+[1] Muller, Jean-Michel, et al. Handbook of floating-point arithmetic.
+    Vol. 1. Basel, Switzerland:: Birkhäuser, 2018.
+
 -/
 @[ext]
 structure PackedFloat (exWidth sigWidth : Nat) where

--- a/Veir/Data/FP/PackedFloat/Basic.lean
+++ b/Veir/Data/FP/PackedFloat/Basic.lean
@@ -7,7 +7,7 @@ namespace PackedFloat
 public section
 
 /--
-A packed floating point number of radix 2,
+A packed floating point number of radix 2 following IEEE 754 [1],
 with exponent and significand widths encoded at the type level.
 This definition implements Section 3.4, Figure 3.1 of the IEEE-754 standard [1].
 We recommend [2] for a comprehensive introduction.
@@ -17,11 +17,11 @@ We recommend [2] for a comprehensive introduction.
 -/
 @[ext]
 structure PackedFloat (exWidth sigWidth : Nat) where
-    /-- Sign bit. -/
+    /-- Sign bit -/
     sign : Bool
-    /-- Biased exponent of the packed float. -/
+    /-- Biased exponent -/
     ex : BitVec exWidth
     /-- Trailing significand (mantissa) of the packed float.
-      Leading digit implicitly encoded by biased exponent. -/
+     The leading bit of the significand is implicitly encoded in the biased exponent. -/
     sig : BitVec sigWidth
 deriving DecidableEq, Repr, Inhabited


### PR DESCRIPTION
This PR adds a new `PackedFloat e s` datatype that represents an IEEE
formatted floating point number with `e` bits of exponent and `s` bits
of significand.
