### PR TITLE
comb: Add CIRCT's comb dialect

### DIFF
--- a/Test/Comb/identity.mlir
+++ b/Test/Comb/identity.mlir
@@ -1,0 +1,109 @@
+// RUN: veir-opt %s | filecheck %s
+
+"builtin.module"() ({
+^4():
+  %a = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
+  %b = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %c = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
+  %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
+  %add1 = "comb.add"(%a) : (i32) -> i32
+  %add2 = "comb.add"(%a, %b) : (i32, i32) -> i32
+  %add3 = "comb.add"(%a, %b, %c) : (i32, i32, i32) -> i32
+  %and1 = "comb.and"(%a) : (i32) -> i32
+  %and2 = "comb.and"(%a, %b) : (i32, i32) -> i32
+  %and3 = "comb.and"(%a, %b, %c) : (i32, i32, i32) -> i32
+  %concat0 = "comb.concat"() : () -> i0
+  %concat1 = "comb.concat"(%a) : (i32) -> i32
+  %concat2 = "comb.concat"(%a, %b) : (i32, i32) -> i64
+  %concat3 = "comb.concat"(%a, %b, %c) : (i32, i32, i32) -> i96
+  %divs = "comb.divs"(%a, %b) : (i32, i32) -> i32
+  %divu = "comb.divu"(%a, %b) : (i32, i32) -> i32
+  %extract = "comb.extract"(%a) <{ "lowBit" = 2 : i32 }> : (i32) -> i8
+  %icmp0 = "comb.icmp"(%a, %b) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
+  %icmp1 = "comb.icmp"(%a, %b) <{ "predicate" = 1 : i64 }> : (i32, i32) -> i1
+  %icmp2 = "comb.icmp"(%a, %b) <{ "predicate" = 2 : i64 }> : (i32, i32) -> i1
+  %icmp3 = "comb.icmp"(%a, %b) <{ "predicate" = 3 : i64 }> : (i32, i32) -> i1
+  %icmp4 = "comb.icmp"(%a, %b) <{ "predicate" = 4 : i64 }> : (i32, i32) -> i1
+  %icmp5 = "comb.icmp"(%a, %b) <{ "predicate" = 5 : i64 }> : (i32, i32) -> i1
+  %icmp6 = "comb.icmp"(%a, %b) <{ "predicate" = 6 : i64 }> : (i32, i32) -> i1
+  %icmp7 = "comb.icmp"(%a, %b) <{ "predicate" = 7 : i64 }> : (i32, i32) -> i1
+  %icmp8 = "comb.icmp"(%a, %b) <{ "predicate" = 8 : i64 }> : (i32, i32) -> i1
+  %icmp9 = "comb.icmp"(%a, %b) <{ "predicate" = 9 : i64 }> : (i32, i32) -> i1
+  %icmp10 = "comb.icmp"(%a, %b) <{ "predicate" = 10 : i64 }> : (i32, i32) -> i1
+  %icmp11 = "comb.icmp"(%a, %b) <{ "predicate" = 11 : i64 }> : (i32, i32) -> i1
+  %icmp12 = "comb.icmp"(%a, %b) <{ "predicate" = 12 : i64 }> : (i32, i32) -> i1
+  %icmp13 = "comb.icmp"(%a, %b) <{ "predicate" = 13 : i64 }> : (i32, i32) -> i1
+  %mods = "comb.mods"(%a, %b) : (i32, i32) -> i32
+  %modu = "comb.modu"(%a, %b) : (i32, i32) -> i32
+  %mul1 = "comb.mul"(%a) : (i32) -> i32
+  %mul2 = "comb.mul"(%a, %b) : (i32, i32) -> i32
+  %mul3 = "comb.mul"(%a, %b, %c) : (i32, i32, i32) -> i32
+  %mux = "comb.mux"(%true, %a, %b) : (i1, i32, i32) -> i32
+  %or1 = "comb.or"(%a) : (i32) -> i32
+  %or2 = "comb.or"(%a, %b) : (i32, i32) -> i32
+  %or3 = "comb.or"(%a, %b, %c) : (i32, i32, i32) -> i32
+  %parity = "comb.parity"(%a) : (i32) -> i1
+  %replicate = "comb.replicate"(%a) : (i32) -> i64
+  %reverse = "comb.reverse"(%a) : (i32) -> i32
+  %shl = "comb.shl"(%a, %b) : (i32, i32) -> i32
+  %shrs = "comb.shrs"(%a, %b) : (i32, i32) -> i32
+  %shru = "comb.shru"(%a, %b) : (i32, i32) -> i32
+  %sub = "comb.sub"(%a, %b) : (i32, i32) -> i32
+  %xor1 = "comb.xor"(%a) : (i32) -> i32
+  %xor2 = "comb.xor"(%a, %b) : (i32, i32) -> i32
+  %xor3 = "comb.xor"(%a, %b, %c) : (i32, i32, i32) -> i32
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^4():
+// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
+// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
+// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
+// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.concat"() : () -> i0
+// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}) : (i32, i32) -> i64
+// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i96
+// CHECK-NEXT:     %{{.*}} = "comb.divs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.divu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.extract"(%{{.*}}) <{"lowBit" = 2 : i32}> : (i32) -> i8
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 3 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 5 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 7 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 8 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 9 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 10 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 12 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 13 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.mods"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.modu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.mux"(%8, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.parity"(%{{.*}}) : (i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "comb.replicate"(%{{.*}}) : (i32) -> i64
+// CHECK-NEXT:     %{{.*}} = "comb.reverse"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.shrs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.shru"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -1,0 +1,23 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Comb.propertiesOf (op : Comb) : Type :=
+match op with
+| .extract => CombExtractProperties
+| .icmp => CombIcmpProperties
+| _ => Unit
+
+instance : HasDialectOpInfo Comb where
+  propertiesOf := Comb.propertiesOf
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -5,6 +5,7 @@ public import Veir.Dialects.LLVM.OpInfo
 public import Veir.Dialects.RISCV.OpInfo
 public import Veir.Dialects.ModArith.OpInfo
 public import Veir.Dialects.Cf.OpInfo
+public import Veir.Dialects.Comb.OpInfo
 
 namespace Veir
 
@@ -22,6 +23,7 @@ match opCode with
 | .riscv op => Riscv.propertiesOf op
 | .mod_arith op => Mod_Arith.propertiesOf op
 | .cf op => Cf.propertiesOf op
+| .comb op => Comb.propertiesOf op
 | _ => Unit
 
 instance : HasDialectOpInfo OpCode where
@@ -119,6 +121,11 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case trunci => exact (NswNuwProperties.fromAttrDict attrDict)
     case extui => exact (NnegProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
+  case comb op =>
+    cases op
+    case extract => exact (CombExtractProperties.fromAttrDict attrDict)
+    case icmp => exact (CombIcmpProperties.fromAttrDict attrDict)
+    all_goals exact (Except.ok ())
 
 /--
   Converts the properties of an operation into a dictionary of attributes.
@@ -167,5 +174,9 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .cf .cond_br =>
     let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
     dict.insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
+  | .comb .extract =>
+    (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
+  | .comb .icmp =>
+    (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr props.predicate)
   | _ =>
     Std.HashMap.emptyWithCapacity 0

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -212,6 +212,31 @@ inductive Datapath where
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
+inductive Comb where
+| add
+| and
+| concat
+| divs
+| divu
+| extract
+| icmp
+| mods
+| modu
+| mul
+| mux
+| or
+| parity
+| replicate
+| reverse
+| shl
+| shrs
+| shru
+| sub
+| truth_table
+| xor
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[opcodes]
 inductive Test where
 | test
 deriving Inhabited, Repr, Hashable, DecidableEq

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -232,7 +232,6 @@ inductive Comb where
 | shrs
 | shru
 | sub
-| truth_table
 | xor
 deriving Inhabited, Repr, Hashable, DecidableEq
 

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -187,5 +187,39 @@ def CondBrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     | throw s!"cf.cond_br: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
   return { branch_weights := weightsAttr, operandSegmentSizes := sizesAttr }
 
+/--
+  Properties of the `comb.extract` operation.
+-/
+structure CombExtractProperties where
+  lowBit : IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CombExtractProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CombExtractProperties := do
+  if attrDict.size > 1 then
+    throw s!"comb.extract: expected only one property, but got {attrDict.size} properties"
+  let some attr := attrDict["lowBit".toUTF8]?
+    | throw "comb.extract: missing 'lowBit' property"
+  let .integerAttr intAttr := attr
+    | throw s!"comb.extract: expected 'lowBit' to be an integer attribute, but got {attr}"
+  return { lowBit := intAttr }
+
+/--
+  Properties of `comb.icmp` operation, describing predicates for integer comparison.
+-/
+structure CombIcmpProperties where
+  predicate : IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CombIcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CombIcmpProperties := do
+  if attrDict.size > 1 then
+    throw s!"comb.icmp: expected only one property, but got {attrDict.size} properties"
+  let some attr := attrDict["predicate".toUTF8]?
+    | throw "comb.icmp: missing 'predicate' property"
+  let .integerAttr intAttr := attr
+    | throw s!"comb.icmp: expected 'predicate' to be an integer attribute, but got {attr}"
+  return { predicate := intAttr }
+
 end
 end Veir

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1667,7 +1667,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
-  | .comb .extract | .comb .parity | .comb .replicate | .comb .reverse | .comb .truth_table => do
+  | .comb .extract | .comb .parity | .comb .replicate | .comb .reverse => do
     if op.getNumOperands ctx opIn ≠ 1 then
       throw "Expected 1 operand"
     if op.getNumResults ctx opIn ≠ 1 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1638,6 +1638,55 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  | .comb .add | .comb .and | .comb .mul | .comb .or | .comb .xor => do
+    if op.getNumOperands ctx opIn < 1 then
+      throw "Expected 1 or more operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .comb .concat => do
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .comb .divs | .comb .divu | .comb .icmp | .comb .mods | .comb .modu | .comb .shl
+  | .comb .shrs | .comb .shru | .comb .sub => do
+    if op.getNumOperands ctx opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .comb .extract | .comb .parity | .comb .replicate | .comb .reverse | .comb .truth_table => do
+    if op.getNumOperands ctx opIn ≠ 1 then
+      throw "Expected 1 operand"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .comb .mux => do
+    if op.getNumOperands ctx opIn ≠ 3 then
+      throw "Expected 3 operands"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
 
 
 /--


### PR DESCRIPTION
This adds the basic definitions of operations from CIRCT's comb dialect, providing only the basic syntactic definitions/verifier, not semantic definitions. The `comb.truth_table` operation is currently missing as it requires `DenseBoolArrayAttr` which is not implemented in VEIR yet.

This also adds a basic filecheck test that just parses/prints each of the added ops. The variadic ops are repeated for varying numbers of arguments and `comb.icmp` instantiated for each valid `predicate` value.