### PR TITLE
feat: PackedFloat.ofFloat/toFloat to coerce Lean's floats into FP model floats

### DIFF
--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -1,4 +1,5 @@
 module
 
 public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.OfFloat
 

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -4,8 +4,13 @@ import Veir.Data.FP.PackedFloat.Basic
 
 namespace Veir.Data.FP.PackedFloat
 
-/--  Convert a Lean double (`Float`) to a `PackedFloat`.
-This effectively reinterprets the bits of the `Float` as a `PackedFloat` with the same layout as the IEEE 754 double-precision format.
+/-- Convert a Lean double (`Float`) to a `PackedFloat`.
+Recall that a IEEE double has the following layout:
+  - 1 bit for the sign
+  - 11 bits for the exponent 
+  - 52 bits for the significand 
+This function reinterprets the bits of the `Float` as a `PackedFloat``
+with the corresponding sign, exponent, and significand fields.
 -/
 def ofFloat (f : Float) : PackedFloat 11 52 :=
   let bits : BitVec 64 := (Float.toBits f).toBitVec

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -1,0 +1,22 @@
+module
+
+import Veir.Data.FP.PackedFloat.Basic
+
+namespace Veir.Data.FP.PackedFloat
+
+/--  Convert a Lean double (`Float`) to a `PackedFloat`.
+This effectively reinterprets the bits of the `Float` as a `PackedFloat` with the same layout as the IEEE 754 double-precision format.
+-/
+def ofFloat (f : Float) : PackedFloat 11 52 :=
+  let bits : BitVec 64 := (Float.toBits f).toBitVec
+  let sign : Bool := (bits >>> 63) ≠ 0#_
+  let exponent := (bits >>> 52) &&& (1 <<< 11 - 1)
+  let significand := bits &&& (1 <<< 52 - 1)
+  PackedFloat.mk sign (exponent.setWidth 11) (significand.setWidth 52)
+
+/-- Convert a `PackedFloat` back to a Lean double (`Float`). -/
+def toFloat (pf : PackedFloat 11 52) : Float :=
+  let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
+  Float.ofBits (UInt64.ofBitVec bits)
+
+end Veir.Data.FP.PackedFloat


### PR DESCRIPTION
This PR adds suppport for coercing Lean's `Float` (double precision)
floating point type into a `FP.PackedFloat` (our model of floating point)
and back. 

This then allows us to develop a uniform API to perform floating point
operations on `FP.PackedFloat` values by converting to lean `Float`,
performing the operation, and then converting back to `FP.PackedFloat`
(with appropriate rounding), as long as the simulated float fits in the lean `Float`.

