### PR TITLE
feat: add unpacked floats

### DIFF
--- a/Veir/Data/FP/ScientificBV.lean
+++ b/Veir/Data/FP/ScientificBV.lean
@@ -1,4 +1,3 @@
 module
 
-public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.ScientificBV.Basic

--- a/Veir/Data/FP/ScientificBV/Basic.lean
+++ b/Veir/Data/FP/ScientificBV/Basic.lean
@@ -3,28 +3,29 @@ public import Veir.Data.FP.Sign
 
 namespace Veir.Data.FP
 
-namespace UnpackedFloat
+namespace ScientificBV
 
 public section
 
 /--
-`UnpackedFloat e s` is the *working* (unpacked) representation of a floating-point
-number with `e` bits for the exponent and `s` bits for the significand.
+`ScientificBV e s` is the *working* (scientific notation) representation of a
+floating-point number with `e` bits for the exponent, and 
+`s` bits for the significand.
 
-The unpacked float `uf` is interpreted as the rational number
+The scientific bv `s` is interpreted as the rational number
 given by the formula:
 
 ```
-(-1)^uf.sign * 2^(uf.ex.toInt) * (1 + uf.sig.toNat / 2^s)
+(-1)^s.sign * 2^(s.ex.toInt) * (1 + s.sig.toNat / 2^s)
 ```
 
 Crucially, this means that we can only represent *non-zero*
-numbers in the unpacked format,
+numbers in the scientific format,
 since the  implicit leading bit of the significand is always 1,
 so the significand is interpreted as a number in [1, 2).
 -/
 @[ext]
-structure UnpackedFloat (e s : Nat) where
+structure ScientificBV (e s : Nat) where
   /-- Sign of the floating-point number. -/
   sign : Bool
   /-- Unbiased exponent, interpreted as an integer. -/
@@ -48,11 +49,11 @@ def exToRat (e : BitVec e) : Rat :=
   2 ^ e.toInt
 
 /--
-Convert an unpacked float to a rational number.
-This provides semantics to `UnpackedFloat e s` in terms of rational numbers.
+Convert a scientific bv to a rational number.
+This provides semantics to `ScientificBV e s` in terms of rational numbers.
 -/
-def toRat {e s : Nat} (uf : UnpackedFloat e s) : Rat :=
-  let sign := signToInt uf.sign
-  let exponent := exToRat uf.ex
-  let significand := sigToRat uf.sig
+def toRat {e s : Nat} (sbv : ScientificBV e s) : Rat :=
+  let sign := signToInt sbv.sign
+  let exponent := exToRat sbv.ex
+  let significand := sigToRat sbv.sig
   sign * exponent * significand

--- a/Veir/Data/FP/Sign.lean
+++ b/Veir/Data/FP/Sign.lean
@@ -4,7 +4,7 @@ namespace Veir.Data.FP
 
 /--
 Treat a boolean as a sign,
-where `true` corresponds to -1 and `false` corresponds to `1`.
+where `true` corresponds to `-1` and `false` corresponds to `1`.
 -/
 public def signToInt (s : Bool) : Rat :=
   if s then -1 else 1

--- a/Veir/Data/FP/Sign.lean
+++ b/Veir/Data/FP/Sign.lean
@@ -1,0 +1,10 @@
+module
+
+namespace Veir.Data.FP
+
+/--
+Treat a boolean as a sign,
+where `true` corresponds to -1 and `false` corresponds to `1`.
+-/
+public def signToInt (s : Bool) : Rat :=
+  if s then -1 else 1

--- a/Veir/Data/FP/UnpackedFloat.lean
+++ b/Veir/Data/FP/UnpackedFloat.lean
@@ -1,3 +1,0 @@
-module
-
-public import Veir.Data.FP.UnpackedFloat.Basic

--- a/Veir/Data/FP/UnpackedFloat.lean
+++ b/Veir/Data/FP/UnpackedFloat.lean
@@ -1,4 +1,3 @@
 module
 
-public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.UnpackedFloat.Basic

--- a/Veir/Data/FP/UnpackedFloat/Basic.lean
+++ b/Veir/Data/FP/UnpackedFloat/Basic.lean
@@ -42,7 +42,7 @@ def sigToRat (s : BitVec s) : Rat :=
 
 /--
 Treat an exponent bitvector as a rational number,
-where the exponent is interpreted as an integer.
+power of two where the exponent is the bitvector interpreted as an integer.
 -/
 def exToRat (e : BitVec e) : Rat :=
   2 ^ e.toInt

--- a/Veir/Data/FP/UnpackedFloat/Basic.lean
+++ b/Veir/Data/FP/UnpackedFloat/Basic.lean
@@ -1,0 +1,58 @@
+module
+public import Veir.Data.FP.Sign
+
+namespace Veir.Data.FP
+
+namespace UnpackedFloat
+
+public section
+
+/--
+`UnpackedFloat e s` is the *working* (unpacked) representation of a floating-point
+number with `e` bits for the exponent and `s` bits for the significand.
+
+The unpacked float `uf` is interpreted as the rational number
+given by the formula:
+
+```
+(-1)^uf.sign * 2^(uf.ex.toInt) * (1 + uf.sig.toNat / 2^s)
+```
+
+Crucially, this means that we can only represent *non-zero*
+numbers in the unpacked format,
+since the  implicit leading bit of the significand is always 1,
+so the significand is interpreted as a number in [1, 2).
+-/
+@[ext]
+structure UnpackedFloat (e s : Nat) where
+  /-- Sign of the floating-point number. -/
+  sign : Bool
+  /-- Unbiased exponent, interpreted as an integer. -/
+  ex : BitVec e
+  /-- Significand, interpreted as a number in [1, 2).-/
+  sig : BitVec s
+  deriving Inhabited, Repr
+
+/--
+Treat a significand bitvector as a rational number in [1, 2),
+where the leading bit is implicitly 1 and the trailing bits are interpreted as a fraction.
+-/
+def sigToRat (s : BitVec s) : Rat :=
+  1 + s.toNat / (2 ^ s.toNat)
+
+/--
+Treat an exponent bitvector as a rational number,
+where the exponent is interpreted as an integer.
+-/
+def exToRat (e : BitVec e) : Rat :=
+  2 ^ e.toInt
+
+/--
+Convert an unpacked float to a rational number.
+This provides semantics to `UnpackedFloat e s` in terms of rational numbers.
+-/
+def toRat {e s : Nat} (uf : UnpackedFloat e s) : Rat :=
+  let sign := signToInt uf.sign
+  let exponent := exToRat uf.ex
+  let significand := sigToRat uf.sig
+  sign * exponent * significand


### PR DESCRIPTION
This PR adds support for unpacked floating point numbers,
which represent a nonzero rational number as two bitvectors,
the exponent and the significand.
