### PR TITLE
Parse and verify basic LLVM memory operations

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -28,6 +28,12 @@
   %21 = "llvm.trunc"(%5) : (i32) -> i1
   %22 = "llvm.sext"(%6) : (i1) -> i32
   %23 = "llvm.zext"(%6) : (i1) -> i32
+  %24 = "llvm.alloca"(%5) <{elem_type = i32}> : (i32) -> !llvm.ptr
+  %25 = "llvm.alloca"(%5) <{elem_type = i32, alignment = 4 : i32, inalloca}> : (i32) -> !llvm.ptr
+  "llvm.store"(%24, %5) : (!llvm.ptr, i32) -> ()
+  "llvm.store"(%24, %5) <{alignment = 1 : i32, volatile_, nontemporal, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr, i32) -> ()
+  %26 = "llvm.load"(%24) : (!llvm.ptr) -> i32
+  %27 = "llvm.load"(%24) <{alignment = 1 : i32, volatile_, nontemporal, invariant, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr) -> i32
   "llvm.cond_br"(%6, %5, %5) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
 ^7(%arg6_0 : i32):
   "llvm.br"(%arg6_0) [^8] : (i32) -> ()
@@ -63,6 +69,12 @@
 // CHECK-NEXT:     %{{.*}} = "llvm.trunc"(%{{.*}}) : (i32) -> i1
 // CHECK-NEXT:     %{{.*}} = "llvm.sext"(%{{.*}}) : (i1) -> i32
 // CHECK-NEXT:     %{{.*}} = "llvm.zext"(%{{.*}}) : (i1) -> i32
+// CHECK-NEXT:     %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 0 : i64, "elem_type" = i32}> : (i32) -> !llvm.ptr
+// CHECK-NEXT:     %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 4 : i32, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
+// CHECK-NEXT:     "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr, i32) -> ()
+// CHECK-NEXT:     "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr, i32) -> ()
+// CHECK-NEXT:     %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
+// CHECK-NEXT:     %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariant, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr) -> i32
 // CHECK-NEXT:     "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:     "llvm.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -25,6 +25,9 @@ match op with
 | .zext => NnegProperties
 | .icmp => IcmpProperties
 | .cond_br => CondBrProperties
+| .alloca => AllocaProperties
+| .load => LoadProperties
+| .store => StoreProperties
 | _ => Unit
 
 instance : HasDialectOpInfo Llvm where

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -97,6 +97,9 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case zext => exact (NnegProperties.fromAttrDict attrDict)
     case icmp => exact (IcmpProperties.fromAttrDict attrDict)
     case cond_br => exact (CondBrProperties.fromAttrDict attrDict)
+    case alloca => exact (AllocaProperties.fromAttrDict attrDict)
+    case load => exact (LoadProperties.fromAttrDict attrDict)
+    case store => exact (StoreProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case func =>
     all_goals exact (Except.ok ())
@@ -172,8 +175,49 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .riscv .bclri | .riscv .bexti | .riscv .binvi | .riscv .bseti | .mod_arith .constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
   | .cf .cond_br =>
-    let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
+    let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
     dict.insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
+  | .llvm .alloca => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 3
+    dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
+    dict := dict.insert "elem_type".toUTF8 props.elem_type
+    if props.inalloca then
+      dict := dict.insert "inalloca".toUTF8 (.unitAttr UnitAttr.mk)
+    dict
+  | .llvm .load => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 10
+    dict := dict.insert "alignment".toUTF8 (.integerAttr props.alignment)
+    if props.volatile_ then
+      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.nontemporal then
+      dict := dict.insert "nontemporal".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.invariant then
+      dict := dict.insert "invariant".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.invariantGroup then
+      dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
+    if let some syncscope := props.syncscope then
+      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
+    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
+    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
+    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
+    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
+    dict
+  | .llvm .store => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 9
+    dict := dict.insert "alignment".toUTF8 (.integerAttr props.alignment)
+    if props.volatile_ then
+      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.nontemporal then
+      dict := dict.insert "nontemporal".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.invariantGroup then
+      dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
+    if let some syncscope := props.syncscope then
+      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
+    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
+    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
+    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
+    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
+    dict
   | .comb .extract =>
     (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
   | .comb .icmp =>

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -202,6 +202,8 @@ deriving Inhabited, Repr, Hashable
 
 end
 
+def ArrayAttr.empty : ArrayAttr := { value := #[] }
+
 /--
   Construct a `DictionaryAttr` from an array of key-value pairs.
   TODO: ensure that entries are unique.

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -92,6 +92,9 @@ inductive Llvm where
 | zext
 | br
 | cond_br
+| alloca
+| load
+| store
 | return
 deriving Inhabited, Repr, Hashable, DecidableEq
 

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -180,6 +180,111 @@ def CondBrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
   return { branch_weights := weightsAttr, operandSegmentSizes := sizesAttr }
 
 /--
+  Properties of LLVM memory operations.
+-/
+
+structure AllocaProperties where
+  alignment : IntegerAttr
+  elem_type : TypeAttr
+  inalloca : Bool
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def AllocaProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String AllocaProperties := do
+  let alignAttr ← match attrDict["alignment".toUTF8]? with
+    | some (.integerAttr alignAttr) => .ok alignAttr
+    | some attr => .error s!"expected 'alignment' to be an optional integer attribute, but got {attr}"
+    | none => .ok { value := 0, type := { bitwidth := 64 } }
+  let some typeAttr := attrDict["elem_type".toUTF8]?
+    | throw "alloca: missing 'elem_type' property"
+  if _ : typeAttr.isType = false then throw "alloca: expected 'elem_type' to be a type attribute" else
+  let inallocaAttr ← getUnitAttr "inalloca" attrDict
+  return { alignment := alignAttr, elem_type := typeAttr.asType, inalloca := inallocaAttr }
+
+structure LoadProperties where
+  alignment : IntegerAttr
+  volatile_ : Bool
+  nontemporal : Bool
+  invariant : Bool
+  invariantGroup : Bool
+  --ordering
+  syncscope : Option StringAttr
+  --dereferenceable
+  access_groups : ArrayAttr
+  alias_scopes : ArrayAttr
+  noalias_scopes : ArrayAttr
+  tbaa : ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LoadProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LoadProperties := do
+  let alignAttr ← match attrDict["alignment".toUTF8]? with
+  | some (.integerAttr alignAttr) => .ok alignAttr
+  | some attr => .error s!"expected 'alignment' to be an optional integer attribute, but got {attr}"
+  | none => .ok { value := 0, type := { bitwidth := 64 } }
+  let volatileAttr ← getUnitAttr "volatile_" attrDict
+  let nontemporalAttr ← getUnitAttr "nontemporal" attrDict
+  let invariantAttr ← getUnitAttr "invariant" attrDict
+  let invariantGroupAttr ← getUnitAttr "invariantGroup" attrDict
+  let syncscopeAttr ← match attrDict["syncscope".toUTF8]? with
+    | some (.stringAttr syncscopeAttr) => .ok (some syncscopeAttr)
+    | some attr => .error s!"expected 'syncscope' to be an optional string attribute, but got {attr}"
+    | none => .ok none
+  let accessAttr := attrDict["access_groups".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr accessAttr := accessAttr
+    | throw s!"store: expected 'access_groups' to be an array attribute, but got {accessAttr}"
+  let aliasAttr := attrDict["alias_scopes".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr aliasAttr := aliasAttr
+    | throw s!"store: expected 'alias_scopes' to be an array attribute, but got {aliasAttr}"
+  let noaliasAttr := attrDict["noalias_scopes".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr noaliasAttr := noaliasAttr
+    | throw s!"store: expected 'noalias_scopes' to be an array attribute, but got {noaliasAttr}"
+  let tbaaAttr := attrDict["tbaa".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr tbaaAttr := tbaaAttr
+    | throw s!"store: expected 'tbaa' to be an array attribute, but got {tbaaAttr}"
+  return { alignment := alignAttr, volatile_ := volatileAttr, nontemporal := nontemporalAttr, invariant := invariantAttr, invariantGroup := invariantGroupAttr, syncscope := syncscopeAttr, access_groups := accessAttr, alias_scopes := aliasAttr, noalias_scopes := noaliasAttr, tbaa := tbaaAttr }
+
+structure StoreProperties where
+  alignment : IntegerAttr
+  volatile_ : Bool
+  nontemporal : Bool
+  invariantGroup : Bool
+  --ordering
+  syncscope : Option StringAttr
+  access_groups : ArrayAttr
+  alias_scopes : ArrayAttr
+  noalias_scopes : ArrayAttr
+  tbaa : ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def StoreProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String StoreProperties := do
+  let alignAttr ← match attrDict["alignment".toUTF8]? with
+  | some (.integerAttr alignAttr) => .ok alignAttr
+  | some attr => .error s!"expected 'alignment' to be an optional integer attribute, but got {attr}"
+  | none => .ok { value := 0, type := { bitwidth := 64 } }
+  let volatileAttr ← getUnitAttr "volatile_" attrDict
+  let nontemporalAttr ← getUnitAttr "nontemporal" attrDict
+  let invariantGroupAttr ← getUnitAttr "invariantGroup" attrDict
+  let syncscopeAttr ← match attrDict["syncscope".toUTF8]? with
+    | some (.stringAttr syncscopeAttr) => .ok (some syncscopeAttr)
+    | some attr => .error s!"expected 'syncscope' to be an optional string attribute, but got {attr}"
+    | none => .ok none
+  let accessAttr := attrDict["access_groups".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr accessAttr := accessAttr
+    | throw s!"store: expected 'access_groups' to be an array attribute, but got {accessAttr}"
+  let aliasAttr := attrDict["alias_scopes".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr aliasAttr := aliasAttr
+    | throw s!"store: expected 'alias_scopes' to be an array attribute, but got {aliasAttr}"
+  let noaliasAttr := attrDict["noalias_scopes".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr noaliasAttr := noaliasAttr
+    | throw s!"store: expected 'noalias_scopes' to be an array attribute, but got {noaliasAttr}"
+  let tbaaAttr := attrDict["tbaa".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr tbaaAttr := tbaaAttr
+    | throw s!"store: expected 'tbaa' to be an array attribute, but got {tbaaAttr}"
+  return { alignment := alignAttr, volatile_ := volatileAttr, nontemporal := nontemporalAttr, invariantGroup := invariantGroupAttr, syncscope := syncscopeAttr, access_groups := accessAttr, alias_scopes := aliasAttr, noalias_scopes := noaliasAttr, tbaa := tbaaAttr }
+
+/--
   Properties of the `comb.extract` operation.
 -/
 structure CombExtractProperties where

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -636,6 +636,36 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if sizes.values[0]! ≠ 1 then
       throw "Expected 1 operand plus 2 variadic operands"
     pure ()
+  | .llvm .alloca => do
+    if op.getNumOperands ctx opIn ≠ 1 then
+      throw "Expected 1 operand"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .llvm .load => do
+    if op.getNumOperands ctx opIn ≠ 1 then
+      throw "Expected 1 operand"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .llvm .store => do
+    if op.getNumOperands ctx opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumResults ctx opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
   /- MOD_ARITH -/
   | .mod_arith .add => do
     if op.getNumOperands ctx opIn ≠ 2 then


### PR DESCRIPTION
Depends on #474.

I left out the few properties (notably the atomic memory orderings) that require enum support.
