### PR TITLE
fix definition of refinement

### DIFF
--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -20,5 +20,5 @@ def isRefinedBy (i i' : Veir.Data.LLVM.Int 64) : Prop :=
   | .val v =>
     match i' with
     | .val v' => v = v'
-    | .poison => true
+    | .poison => false
   | .poison => true


### PR DESCRIPTION
The previous definition of refinement was incorrect, a poison can never refine a concrete value. 