### PR TITLE
Parse pretty dialect types

### DIFF
--- a/Test/Parsing/unregistered_ops.mlir
+++ b/Test/Parsing/unregistered_ops.mlir
@@ -2,5 +2,9 @@
 
 "builtin.module"() ({
     "unregistered.op"() : () -> ()
+    %1 = "unregistered.op"() : () -> !foo.bar
+    %2 = "unregistered.op"() : () -> !foo.bar<baz>
     // CHECK:     "builtin.unregistered"() : () -> ()
+    // CHECK-NEXT: %{{.*}} = "builtin.unregistered"() : () -> !foo.bar
+    // CHECK-NEXT: %{{.*}} = "builtin.unregistered"() : () -> !foo.bar<baz>
 }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -147,6 +147,7 @@ macro "#assert " e:term : command =>
 
 /-! ## Dialect type -/
 
+#assert expectSuccessType "!foo.bar" ⟨UnregisteredAttr.mk "!foo.bar" true, by grind⟩
 #assert expectSuccessType "!foo<bar>" ⟨UnregisteredAttr.mk "!foo<bar>" true, by grind⟩
 #assert expectSuccessType "!test.test<bar>" ⟨UnregisteredAttr.mk "!test.test<bar>" true, by grind⟩
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -208,18 +208,20 @@ private def parseUnregisteredAttrBody (startPos : Option Nat := none) : AttrPars
 
 /--
   Parse a dialect type, if present.
-  A dialect attribute has the form `!dialect.name<body>`.
+  A dialect attribute has the form `!dialect.name` or `!dialect.name<body>`.
 -/
 partial def parseOptionalDialectType : AttrParserM (Option TypeAttr) := do
   let startPos ← getPos
   let dialectName ← parseOptionalPrefixedKeyword .exclamationIdent
   let some dialectName := dialectName | return none
-  parsePunctuation "<"
-  let _ ← parseUnregisteredAttrBody
-  let endPos := (← peekToken).slice.stop
-  parsePunctuation ">"
-  let value := (Slice.mk startPos endPos).of (← getThe ParserState).input
-  return some (⟨UnregisteredAttr.mk (String.fromUTF8! value) true, by grind⟩)
+  if let true ← parseOptionalPunctuation "<" then
+    let _ ← parseUnregisteredAttrBody
+    let endPos := (← peekToken).slice.stop
+    parsePunctuation ">"
+    let value := (Slice.mk startPos endPos).of (← getThe ParserState).input
+    return some (⟨UnregisteredAttr.mk (String.fromUTF8! value) true, by grind⟩)
+  else
+    return some (⟨UnregisteredAttr.mk ("!" ++ String.fromUTF8! dialectName) true, by grind⟩)
 
 /--
   Parse a dialect attribute, if present.


### PR DESCRIPTION
Currently only dialect types of the form `!a.b<c>` are supported.

This adds supports for dialect types of the form `!a.b`.
