### PR TITLE
Parser linearity fix and optimization

### DIFF
--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -25,6 +25,7 @@ structure MlirParserState where
     (true), or has been forward declared (false).
   -/
   blocks : Std.HashMap ByteArray (BlockPtr × Bool)
+  deriving Inhabited
 
 def MlirParserState.fromContext (ctx : IRContext OpCode) : MlirParserState :=
   {ctx := ctx, values := Std.HashMap.emptyWithCapacity 128, blocks := Std.HashMap.emptyWithCapacity 1}
@@ -84,6 +85,35 @@ def registerValueDef (name : ByteArray) (value : ValuePtr) : MlirParserM Unit :=
 def setContext (ctx : IRContext OpCode) : MlirParserM Unit := do
   modify fun s => {s with ctx := ctx}
 
+/--
+  Modifies the current IR context.
+-/
+def modifyContext (f : IRContext OpCode → IRContext OpCode) : MlirParserM Unit := do
+  modify fun s => {s with ctx :=  f s.ctx}
+
+/--
+  Modifies the current IR context.
+
+  This function should be used instead of modifying the context with
+  `get`/`getContext` and `set`/`setContext` in order to preserve linearity.
+-/
+def modifyContextM' (f : IRContext OpCode → MlirParserM (α × IRContext OpCode)) : MlirParserM α := do
+  let ctx ← getContext
+  -- This `setContext` is required to preserve the linearity of the state
+  setContext default
+  let (r, ctx) ← f ctx
+  setContext ctx
+  pure r
+
+/--
+  Modifies the current IR context.
+
+  This function should be used instead of modifying the context with
+  `get`/`getContext` and `set`/`setContext` in order to preserve linearity.
+-/
+def modifyContextM (f : IRContext OpCode → MlirParserM (IRContext OpCode)) : MlirParserM Unit :=
+  modifyContextM' (fun ctx => do pure ((), ← f ctx))
+
 set_option warn.sorry false in
 /--
   Create a block at the given insert point and register its name in the parsing context.
@@ -97,10 +127,10 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
     throw s!"block %{String.fromUTF8! name} has already been defined"
   | some (block, false) => -- Block of this name was forward declared.
     /- Insert the block at the given location. -/
-    let ctx ← getContext
-    let some ctx := Rewriter.insertBlock? ctx block ip (by sorry) (by sorry) (by sorry)
-      | throw "internal error: failed to insert block"
-    setContext ctx
+    modifyContextM fun ctx => do
+      let some ctx := Rewriter.insertBlock? ctx block ip (by sorry) (by sorry) (by sorry)
+        | throw "internal error: failed to insert block"
+      pure ctx
     /- Notify the parsing context that the block is defined. -/
     modifyThe MlirParserState (fun state =>
     {state with
@@ -109,10 +139,10 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
     return block
   | none => -- Block has not yet been declared or referenced.
     /- Create the block. -/
-    let ctx ← getContext
-    let some (ctx, block) := Rewriter.createBlock ctx ip (by sorry) (by sorry)
-      | throw "internal error: failed to create block"
-    setContext ctx
+    let block ← modifyContextM' fun ctx => do
+      let some (ctx, block) := Rewriter.createBlock ctx ip (by sorry) (by sorry)
+        | throw "internal error: failed to create block"
+      pure (block, ctx)
     /- Notify the parsing context that the block is defined. -/
     modifyThe MlirParserState fun s =>
     {s with blocks := s.blocks.insert name (block, true)}
@@ -131,13 +161,13 @@ def defineBlockUse (name : ByteArray) : MlirParserM BlockPtr := do
     return block
   | none => -- Block not yet encountered
     /- Create the block. -/
-    let ctx ← getContext
-    let some (ctx, block) := Rewriter.createBlock ctx none (by sorry) (by sorry)
-      | throw "internal error: failed to create block"
-    setContext ctx
+    let block ← modifyContextM' fun ctx => do
+      let some (ctx, block) := Rewriter.createBlock ctx none (by sorry) (by sorry)
+        | throw "internal error: failed to create block"
+      pure (block, ctx)
     /- Notify the parsing context that the block is forward declared. -/
     modifyThe MlirParserState fun s =>
-    {s with blocks := s.blocks.insert name (block, false)}
+      {s with blocks := s.blocks.insert name (block, false)}
     return block
 
 /--
@@ -300,9 +330,7 @@ def parseOptionalBlockLabel (ip : BlockInsertPoint) : MlirParserM (Option BlockP
   let block ← defineBlock name ip
   /- Insert block arguments in the block. -/
   let blockArguments := arguments.mapIdx (fun index (_, type) => BlockArgument.mk (ValueImpl.mk type none) index () block)
-  let ctx ← getContext
-  let ctx := block.setArguments ctx blockArguments (by sorry)
-  setContext ctx
+  modifyContext fun ctx => block.setArguments ctx blockArguments (by sorry)
   /- Register the block argument names in the parser state. -/
   for ((argName, argType), index) in arguments.zipIdx do
     registerValueDef argName (ValuePtr.blockArgument {block := block, index := index})
@@ -391,10 +419,10 @@ partial def parseRegion : MlirParserM RegionPtr := do
 
   /- Create the region and parse the open delimiter. -/
   parsePunctuation "{"
-  let ctx := ← getContext
-  let some (ctx, region) := Rewriter.createRegion ctx
-      | throw "internal error: failed to create region"
-  setContext ctx
+  let region := ← modifyContextM' fun ctx => do
+    let some (ctx, region) := Rewriter.createRegion ctx
+        | throw "internal error: failed to create region"
+    pure (region, ctx)
 
   /- Case where there are no blocks inside the region. -/
   if (← parseOptionalPunctuation "}") then


### PR DESCRIPTION
Increases parser performance by 9.9x in benchmark and likely by a magnitude from time complexity perspective. Original code by @ineol. 

Required by #435.

Benchmarked against [`sqlite-3-stripped.mlir`](https://github.com/opencompl/veir/blob/math-fehr/sqlite-test/sqlite3-stripped.mlir) from `math-fehr` branch. Old commit is https://github.com/opencompl/veir/commit/da74b917befb9688e6f959ee222f947c3eca92f0 and new commit is current PR.

```
> hyperfine "./old-veir-opt sqlite3-stripped.mlir" "./new-veir-opt sqlite3-stripped.mlir"
Benchmark 1: ./old-veir-opt sqlite3-stripped.mlir
  Time (mean ± σ):     22.361 s ±  0.138 s    [User: 22.213 s, System: 0.062 s]
  Range (min … max):   22.059 s … 22.501 s    10 runs

Benchmark 2: ./new-veir-opt sqlite3-stripped.mlir
  Time (mean ± σ):      2.259 s ±  0.027 s    [User: 2.225 s, System: 0.028 s]
  Range (min … max):    2.222 s …  2.298 s    10 runs

Summary
  ./new-veir-opt sqlite3-stripped.mlir ran
    9.90 ± 0.13 times faster than ./old-veir-opt sqlite3-stripped.mlir
```