### PR TITLE
Add grind pattern for `ValuePtr.getDefiningOp!` and `InBounds`

### DIFF
--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -408,6 +408,14 @@ theorem ValuePtr.getFirstUse!_inBounds :
 
 grind_pattern ValuePtr.getFirstUse!_inBounds => (value.getFirstUse! ctx), ctx.FieldsInBounds
 
+theorem ValuePtr.getDefiningOp!_inBounds :
+    ctx.FieldsInBounds →
+    value.InBounds ctx →
+    (value.getDefiningOp! ctx).maybe OperationPtr.InBounds ctx := by
+  cases value <;> grind
+
+grind_pattern ValuePtr.getDefiningOp!_inBounds => (value.getDefiningOp! ctx), ctx.FieldsInBounds
+
 end ValuePtr
 
 section OpOperandPtrPtr


### PR DESCRIPTION
This was needed in a future PR.