### PR TITLE
Add get-set lemmas for `getOpType`

### DIFF
--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -873,8 +873,9 @@ theorem setAttributes!_eq_setAttributes {op : OperationPtr} (inBounds : op.InBou
 @[inline]
 def getProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo)
     (inBounds : op.InBounds ctx := by grind)
-    (hprop : (op.get ctx inBounds).opType = opCode := by grind) : HasOpInfo.propertiesOf opCode :=
-  hprop ▸ (op.get ctx (by grind)).properties
+    (hprop : op.getOpType! ctx = opCode := by grind) : HasOpInfo.propertiesOf opCode :=
+  have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
+  h ▸ (op.get ctx (by grind)).properties
 
 @[inline]
 def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo) : HasOpInfo.propertiesOf opCode :=
@@ -885,7 +886,7 @@ def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo
 
 @[grind =_, eq_bang ←]
 theorem getProperties!_eq_getProperties {op : OperationPtr} (inBounds : op.InBounds ctx)
-    (hprop : (op.get! ctx).opType = opCode) :
+    (hprop : op.getOpType! ctx = opCode) :
     op.getProperties! ctx opCode = op.getProperties ctx opCode inBounds (by grind) := by
   grind [getProperties, getProperties!]
 
@@ -897,20 +898,22 @@ theorem getProperties!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
 def setProperties {opCode : OpInfo} (op : OperationPtr) (ctx : IRContext OpInfo)
     (newProperties : HasOpInfo.propertiesOf opCode)
     (inBounds : op.InBounds ctx := by grind)
-    (hprop : (op.get ctx inBounds).opType = opCode := by grind) : IRContext OpInfo :=
+    (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
+  have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
   let oldOp := op.get ctx (by grind)
-  op.set ctx { oldOp with properties := hprop ▸ newProperties }
+  op.set ctx { oldOp with properties := h ▸ newProperties }
 
 def setProperties! {opCode : OpInfo} (op : OperationPtr) (ctx : IRContext OpInfo)
   (newProperties : HasOpInfo.propertiesOf opCode)
-  (hprop : (op.get! ctx).opType = opCode := by grind) : IRContext OpInfo :=
+  (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
+  have h : (op.get! ctx).opType = opCode := by grind [getOpType!]
   let oldOp := op.get! ctx
-  op.set ctx { oldOp with properties := hprop ▸ newProperties }
+  op.set ctx { oldOp with properties := h ▸ newProperties }
 
 @[grind =_, eq_bang ←]
 theorem setProperties!_eq_setProperties {op : OperationPtr}
     (newProperties : HasOpInfo.propertiesOf opCode) (inBounds : op.InBounds ctx)
-    (hprop : (op.get ctx inBounds).opType = opCode) :
+    (hprop : op.getOpType! ctx = opCode) :
     op.setProperties! ctx newProperties =
     op.setProperties ctx newProperties inBounds := by
   grind [setProperties, setProperties!]
@@ -2289,7 +2292,7 @@ macro "setup_grind_with_get_set_definitions" : command => `(
   attribute [local grind] ValuePtr.getFirstUse! ValuePtr.getFirstUse ValuePtr.setFirstUse ValuePtr.setType ValuePtr.getType ValuePtr.getType!
   attribute [local grind] OpResultPtr.get! OpResultPtr.setFirstUse OpResultPtr.set OpResultPtr.setType
   attribute [local grind] BlockArgumentPtr.get! BlockArgumentPtr.setFirstUse BlockArgumentPtr.set BlockArgumentPtr.setType BlockArgumentPtr.setLoc
-  attribute [local grind] OperationPtr.setOperands OperationPtr.setBlockOperands OperationPtr.setResults OperationPtr.pushResult OperationPtr.setRegions OperationPtr.pushRegion OperationPtr.setProperties OperationPtr.setAttributes OperationPtr.pushOperand OperationPtr.pushBlockOperand OperationPtr.allocEmpty OperationPtr.dealloc OperationPtr.setNextOp OperationPtr.setPrevOp OperationPtr.setParent OperationPtr.getNumResults! OperationPtr.getNumOperands! OperationPtr.getNumRegions! OperationPtr.getRegion! OperationPtr.getNumSuccessors! OperationPtr.getProperties! OperationPtr.set OperationPtr.getOperands!
+  attribute [local grind] OperationPtr.setOperands OperationPtr.setBlockOperands OperationPtr.setResults OperationPtr.pushResult OperationPtr.setRegions OperationPtr.pushRegion OperationPtr.setProperties OperationPtr.setAttributes OperationPtr.pushOperand OperationPtr.pushBlockOperand OperationPtr.allocEmpty OperationPtr.dealloc OperationPtr.setNextOp OperationPtr.setPrevOp OperationPtr.setParent OperationPtr.getNumResults! OperationPtr.getNumOperands! OperationPtr.getNumRegions! OperationPtr.getRegion! OperationPtr.getNumSuccessors! OperationPtr.getProperties! OperationPtr.set OperationPtr.getOperands! OperationPtr.getOpType!
   attribute [local grind] Operation.empty
   attribute [local grind] BlockPtr.get! BlockPtr.setParent BlockPtr.setFirstUse BlockPtr.setFirstOp BlockPtr.setLastOp BlockPtr.setNextBlock BlockPtr.setPrevBlock BlockPtr.allocEmpty Block.empty BlockPtr.getNumArguments! BlockPtr.set BlockPtr.setArguments BlockPtr.pushArgument
   attribute [local grind =] Option.maybe_def

--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -408,6 +408,14 @@ theorem ValuePtr.getFirstUse!_inBounds :
 
 grind_pattern ValuePtr.getFirstUse!_inBounds => (value.getFirstUse! ctx), ctx.FieldsInBounds
 
+theorem ValuePtr.getDefiningOp!_inBounds :
+    ctx.FieldsInBounds →
+    value.InBounds ctx →
+    (value.getDefiningOp! ctx).maybe OperationPtr.InBounds ctx := by
+  cases value <;> grind
+
+grind_pattern ValuePtr.getDefiningOp!_inBounds => (value.getDefiningOp! ctx), ctx.FieldsInBounds
+
 end ValuePtr
 
 section OpOperandPtrPtr

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -25,9 +25,9 @@ setup_grind_with_get_set_definitions
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
  -   * Operation.attrs
- - * Operation.getProperties!
+ - * OperationPtr.getOpType!
+ - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
  - * OpResultPtr.get!
  - * OperationPtr.getNumOperands!
@@ -62,6 +62,13 @@ theorem OperationPtr.get!_OperationPtr_allocEmpty {operation : OperationPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
     operation.get! ctx' =
     if operation = op' then Operation.empty ty properties else operation.get! ctx := by
+  grind
+
+@[grind =>]
+theorem OperationPtr.getOpType!_OperationPtr_allocEmpty {operation : OperationPtr}
+    (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
+    operation.getOpType! ctx' =
+    if operation = op' then ty else operation.getOpType! ctx := by
   grind
 
 @[grind =>]
@@ -185,6 +192,13 @@ theorem OperationPtr.get!_OperationPtr_dealloc {operation : OperationPtr} :
     operation.InBounds (OperationPtr.dealloc operation' ctx hop') →
     operation.get! (OperationPtr.dealloc operation' ctx hop') =
     operation.get! ctx := by
+  grind [OperationPtr.InBounds]
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_OperationPtr_dealloc {operation : OperationPtr} :
+    operation.InBounds (OperationPtr.dealloc operation' ctx hop') →
+    operation.getOpType! (OperationPtr.dealloc operation' ctx hop') =
+    operation.getOpType! ctx := by
   grind [OperationPtr.InBounds]
 
 @[simp, grind =]
@@ -345,9 +359,9 @@ theorem OperationPtr.parent!_OperationPtr_setOperands {operation : OperationPtr}
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setOperands {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setOperands operation' ctx newOperands hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setOperands {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setOperands operation' ctx newOperands hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -510,9 +524,9 @@ theorem OperationPtr.parent!_OperationPtr_pushOperand {operation : OperationPtr}
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_pushOperand {operation : OperationPtr} :
-    (operation.get! (OperationPtr.pushOperand operation' ctx newOperand hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_pushOperand {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.pushOperand operation' ctx newOperand hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -675,9 +689,9 @@ theorem OperationPtr.parent!_OperationPtr_setBlockOperands {operation : Operatio
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setBlockOperands {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setBlockOperands operation' ctx newOperands hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setBlockOperands {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setBlockOperands operation' ctx newOperands hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -837,9 +851,9 @@ theorem OperationPtr.parent!_OperationPtr_pushBlockOperand {operation : Operatio
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_pushBlockOperand {operation : OperationPtr} :
-    (operation.get! (OperationPtr.pushBlockOperand operation' ctx newOperand hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_pushBlockOperand {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.pushBlockOperand operation' ctx newOperand hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -995,9 +1009,9 @@ theorem OperationPtr.parent!_OperationPtr_setResults {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setResults {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setResults operation' ctx newResults hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setResults {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setResults operation' ctx newResults hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -1171,9 +1185,9 @@ theorem OperationPtr.parent!_OperationPtr_pushResult {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_pushResult {operation : OperationPtr} :
-    (operation.get! (OperationPtr.pushResult operation' ctx newResult hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_pushResult {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.pushResult operation' ctx newResult hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -1305,7 +1319,7 @@ theorem BlockPtr.get!_OperationPtr_setProperties {block : BlockPtr} :
 theorem OperationPtr.get!_OperationPtr_setProperties {operation : OperationPtr} :
     operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
     if operation = operation' then
-      { operation.get! ctx with opType := (operation'.get! ctx).opType, properties := newProperties }
+      { operation.get! ctx with opType := operation'.getOpType! ctx, properties := newProperties }
     else
       operation.get! ctx := by
   grind
@@ -1353,9 +1367,9 @@ theorem OperationPtr.parent!_OperationPtr_setProperties {operation : OperationPt
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setProperties {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setProperties {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -1496,9 +1510,9 @@ theorem OperationPtr.parent!_OperationPtr_setAttributes {operation : OperationPt
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setAttributes {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setAttributes operation' ctx newAttrs opIn)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setAttributes {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setAttributes operation' ctx newAttrs opIn) =
+    operation.getOpType! ctx := by
   grind
 
 @[grind =]
@@ -1654,9 +1668,9 @@ theorem OperationPtr.parent!_OperationPtr_setRegions {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setRegions {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setRegions operation' ctx newRegions hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setRegions {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setRegions operation' ctx newRegions hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -1804,9 +1818,9 @@ theorem OperationPtr.parent!_OperationPtr_pushRegion {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_pushRegion {operation : OperationPtr} :
-    (operation.get! (OperationPtr.pushRegion operation' ctx newRegion hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_pushRegion {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.pushRegion operation' ctx newRegion hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -1978,6 +1992,12 @@ theorem OperationPtr.get!_BlockArgumentPtr_setType {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_BlockArgumentPtr_setType {operation : OperationPtr} :
+    operation.getOpType! (BlockArgumentPtr.setType arg' ctx newType harg') =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getProperties!_BlockArgumentPtr_setType {operation : OperationPtr} :
     operation.getProperties! (BlockArgumentPtr.setType arg' ctx newType harg') opCode =
     operation.getProperties! ctx opCode := by
@@ -2136,6 +2156,12 @@ theorem BlockPtr.lastOp!_BlockArgumentPtr_setFirstUse {block : BlockPtr} :
 theorem OperationPtr.get!_BlockArgumentPtr_setFirstUse {operation : OperationPtr} :
     operation.get! (BlockArgumentPtr.setFirstUse arg' ctx newFirstUse harg') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_BlockArgumentPtr_setFirstUse {operation : OperationPtr} :
+    operation.getOpType! (BlockArgumentPtr.setFirstUse arg' ctx newFirstUse harg') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -2303,6 +2329,12 @@ theorem OperationPtr.get!_BlockArgumentPtr_setLoc {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_BlockArgumentPtr_setLoc {operation : OperationPtr} :
+    operation.getOpType! (BlockArgumentPtr.setLoc arg' ctx newLoc harg') =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getProperties!_BlockArgumentPtr_setLoc {operation : OperationPtr} :
     operation.getProperties! (BlockArgumentPtr.setLoc arg' ctx newLoc harg') opCode =
     operation.getProperties! ctx opCode := by
@@ -2419,6 +2451,12 @@ theorem BlockPtr.get!_BlockPtr_allocEmpty {block : BlockPtr}
 theorem OperationPtr.get!_BlockPtr_allocEmpty {operation : OperationPtr}
     (heq : BlockPtr.allocEmpty ctx = some (ctx', bl)) :
     operation.get! ctx' = operation.get! ctx := by
+  grind
+
+@[simp, grind =>]
+theorem OperationPtr.getOpType!_BlockPtr_allocEmpty {operation : OperationPtr}
+    (heq : BlockPtr.allocEmpty ctx = some (ctx', bl)) :
+    operation.getOpType! ctx' = operation.getOpType! ctx := by
   grind
 
 @[simp, grind =>]
@@ -2572,6 +2610,12 @@ theorem BlockPtr.lastOp!_BlockPtr_setParent {block : BlockPtr} :
 theorem OperationPtr.get!_BlockPtr_setParent {operation : OperationPtr} :
     operation.get! (BlockPtr.setParent block' ctx newParent hblock') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setParent {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setParent block' ctx newParent hblock') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -2731,6 +2775,12 @@ theorem BlockPtr.lastOp!_BlockPtr_setFirstUse {block : BlockPtr} :
 theorem OperationPtr.get!_BlockPtr_setFirstUse {operation : OperationPtr} :
     operation.get! (BlockPtr.setFirstUse block' ctx newFirstUse hblock') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setFirstUse {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setFirstUse block' ctx newFirstUse hblock') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -2896,6 +2946,12 @@ theorem OperationPtr.get!_BlockPtr_setFirstOp {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setFirstOp {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setFirstOp block' ctx newFirstOp hblock') =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getProperties!_BlockPtr_setFirstOp {operation : OperationPtr} :
     operation.getProperties! (BlockPtr.setFirstOp block' ctx newFirstOp hblock') opCode =
     operation.getProperties! ctx opCode := by
@@ -3055,6 +3111,12 @@ theorem OperationPtr.get!_BlockPtr_setLastOp {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setLastOp {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setLastOp block' ctx newLastOp hblock') =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getProperties!_BlockPtr_setLastOp {operation : OperationPtr} :
     operation.getProperties! (BlockPtr.setLastOp block' ctx newLastOp hblock') opCode =
     operation.getProperties! ctx opCode := by
@@ -3210,6 +3272,12 @@ theorem BlockPtr.lastOp!_BlockPtr_setNextBlock {block : BlockPtr} :
 theorem OperationPtr.get!_BlockPtr_setNextBlock {operation : OperationPtr} :
     operation.get! (BlockPtr.setNextBlock block' ctx newNextBlock hblock') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setNextBlock {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setNextBlock block' ctx newNextBlock hblock') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -3372,6 +3440,12 @@ theorem OperationPtr.get!_BlockPtr_setPrevBlock {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setPrevBlock {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setPrevBlock block' ctx newPrevBlock hblock') =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getProperties!_BlockPtr_setPrevBlock {operation : OperationPtr} :
     operation.getProperties! (BlockPtr.setPrevBlock block' ctx newPrevBlock hblock') opCode =
     operation.getProperties! ctx opCode := by
@@ -3517,9 +3591,9 @@ theorem OperationPtr.parent!_OpOperandPtr_setNextUse {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtr_setNextUse {operation : OperationPtr} :
-    (operation.get! (OpOperandPtr.setNextUse operand' ctx newNextUse hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtr_setNextUse {operation : OperationPtr} :
+    operation.getOpType! (OpOperandPtr.setNextUse operand' ctx newNextUse hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -3673,9 +3747,9 @@ theorem OperationPtr.parent!_OpOperandPtr_setBack {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtr_setBack {operation : OperationPtr} :
-    (operation.get! (OpOperandPtr.setBack operand' ctx newBack hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtr_setBack {operation : OperationPtr} :
+    operation.getOpType! (OpOperandPtr.setBack operand' ctx newBack hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -3827,9 +3901,9 @@ theorem OperationPtr.parent!_OpOperandPtr_setOwner {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtr_setOwner {operation : OperationPtr} :
-    (operation.get! (OpOperandPtr.setOwner operand' ctx newOwner hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtr_setOwner {operation : OperationPtr} :
+    operation.getOpType! (OpOperandPtr.setOwner operand' ctx newOwner hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -3980,9 +4054,9 @@ theorem OperationPtr.parent!_OpOperandPtr_setValue {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtr_setValue {operation : OperationPtr} :
-    (operation.get! (OpOperandPtr.setValue operand' ctx newValue hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtr_setValue {operation : OperationPtr} :
+    operation.getOpType! (OpOperandPtr.setValue operand' ctx newValue hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -4136,9 +4210,9 @@ theorem OperationPtr.parent!_OpResultPtr_setType {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpResultPtr_setType {operation : OperationPtr} :
-    (operation.get! (OpResultPtr.setType result' ctx newType hresult')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpResultPtr_setType {operation : OperationPtr} :
+    operation.getOpType! (OpResultPtr.setType result' ctx newType hresult') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -4299,9 +4373,9 @@ theorem OperationPtr.parent!_OpResultPtr_setFirstUse {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpResultPtr_setFirstUse {operation : OperationPtr} :
-    (operation.get! (OpResultPtr.setFirstUse result' ctx newFirstUse hresult')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpResultPtr_setFirstUse {operation : OperationPtr} :
+    operation.getOpType! (OpResultPtr.setFirstUse result' ctx newFirstUse hresult') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -4435,6 +4509,12 @@ theorem OperationPtr.get!_RegionPtr_allocEmpty {operation : OperationPtr}
     operation.get! ctx' = operation.get! ctx := by
   grind
 
+@[simp, grind =>]
+theorem OperationPtr.getOpType!_RegionPtr_allocEmpty {operation : OperationPtr}
+    (heq : RegionPtr.allocEmpty ctx = some (ctx', rg')) :
+    operation.getOpType! ctx' = operation.getOpType! ctx := by
+  grind
+
 @[grind =>]
 theorem OperationPtr.getProperties!_RegionPtr_allocEmpty {operation : OperationPtr}
     (heq : RegionPtr.allocEmpty ctx = some (ctx', rg')) :
@@ -4549,6 +4629,12 @@ theorem BlockPtr.get!_RegionPtr_setParent {block : BlockPtr} :
 theorem OperationPtr.get!_RegionPtr_setParent {operation : OperationPtr} :
     operation.get! (RegionPtr.setParent region' ctx newParent hregion') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_RegionPtr_setParent {operation : OperationPtr} :
+    operation.getOpType! (RegionPtr.setParent region' ctx newParent hregion') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -4671,6 +4757,12 @@ theorem OperationPtr.get!_RegionPtr_setFirstBlock {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_RegionPtr_setFirstBlock {operation : OperationPtr} :
+    operation.getOpType! (RegionPtr.setFirstBlock region' ctx hregion' newFirstBlock) =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getProperties!_RegionPtr_setFirstBlock {operation : OperationPtr} :
     operation.getProperties! (RegionPtr.setFirstBlock region' ctx hregion' newFirstBlock) opCode =
     operation.getProperties! ctx opCode := by
@@ -4788,6 +4880,12 @@ theorem BlockPtr.get!_RegionPtr_setLastBlock {block : BlockPtr} :
 theorem OperationPtr.get!_RegionPtr_setLastBlock {operation : OperationPtr} :
     operation.get! (RegionPtr.setLastBlock region' ctx newLastBlock hregion') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_RegionPtr_setLastBlock {operation : OperationPtr} :
+    operation.getOpType! (RegionPtr.setLastBlock region' ctx newLastBlock hregion') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -4984,9 +5082,9 @@ theorem OperationPtr.parent!_ValuePtr_setType {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_ValuePtr_setType {operation : OperationPtr} :
-    (operation.get! (ValuePtr.setType value' ctx newType hvalue')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_ValuePtr_setType {operation : OperationPtr} :
+    operation.getOpType! (ValuePtr.setType value' ctx newType hvalue') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -5195,9 +5293,9 @@ theorem OperationPtr.parent!_ValuePtr_setFirstUse {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_ValuePtr_setFirstUse {operation : OperationPtr} :
-    (operation.get! (ValuePtr.setFirstUse value' ctx newFirstUse hvalue')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_ValuePtr_setFirstUse {operation : OperationPtr} :
+    operation.getOpType! (ValuePtr.setFirstUse value' ctx newFirstUse hvalue') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -5424,9 +5522,9 @@ theorem OperationPtr.parent!_OpOperandPtrPtr_set {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtrPtr_set {operation : OperationPtr} :
-    (operation.get! (OpOperandPtrPtr.set value' ctx newPtr hvalue')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtrPtr_set {operation : OperationPtr} :
+    operation.getOpType! (OpOperandPtrPtr.set value' ctx newPtr hvalue') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -5645,9 +5743,9 @@ theorem OperationPtr.parent!_BlockOperandPtrPtr_set {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtrPtr_set {operation : OperationPtr} :
-    (operation.get! (BlockOperandPtrPtr.set value' ctx newPtr hvalue')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtrPtr_set {operation : OperationPtr} :
+    operation.getOpType! (BlockOperandPtrPtr.set value' ctx newPtr hvalue') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -5809,9 +5907,9 @@ theorem OperationPtr.parent!_OperationPtr_setNextOp {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setNextOp {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setNextOp op' ctx newNextOp hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setNextOp {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setNextOp op' ctx newNextOp hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -5962,9 +6060,9 @@ theorem OperationPtr.parent!_OperationPtr_setPrevOp {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setPrevOp {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setPrevOp op' ctx newPrevOp hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setPrevOp {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setPrevOp op' ctx newPrevOp hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -6114,9 +6212,9 @@ theorem OperationPtr.parent!_OperationPtr_setParent {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_setParent {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setParent op' ctx newParent hop')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_setParent {operation : OperationPtr} :
+    operation.getOpType! (OperationPtr.setParent op' ctx newParent hop') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -6264,9 +6362,9 @@ theorem OperationPtr.parent!_BlockOperandPtr_setNextUse {operation : OperationPt
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtr_setNextUse {operation : OperationPtr} :
-    (operation.get! (BlockOperandPtr.setNextUse operand' ctx newNextUse hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtr_setNextUse {operation : OperationPtr} :
+    operation.getOpType! (BlockOperandPtr.setNextUse operand' ctx newNextUse hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -6420,9 +6518,9 @@ theorem OperationPtr.parent!_BlockOperandPtr_setBack {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtr_setBack {operation : OperationPtr} :
-    (operation.get! (BlockOperandPtr.setBack operand' ctx newBack hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtr_setBack {operation : OperationPtr} :
+    operation.getOpType! (BlockOperandPtr.setBack operand' ctx newBack hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -6574,9 +6672,9 @@ theorem OperationPtr.parent!_BlockOperandPtr_setOwner {operation : OperationPtr}
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtr_setOwner {operation : OperationPtr} :
-    (operation.get! (BlockOperandPtr.setOwner operand' ctx newOwner hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtr_setOwner {operation : OperationPtr} :
+    operation.getOpType! (BlockOperandPtr.setOwner operand' ctx newOwner hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -6728,9 +6826,9 @@ theorem OperationPtr.parent!_BlockOperandPtr_setValue {operation : OperationPtr}
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtr_setValue {operation : OperationPtr} :
-    (operation.get! (BlockOperandPtr.setValue operand' ctx newValue hoperand')).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtr_setValue {operation : OperationPtr} :
+    operation.getOpType! (BlockOperandPtr.setValue operand' ctx newValue hoperand') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -6880,6 +6978,12 @@ theorem BlockPtr.firstOp!_BlockPtr_setArguments {block : BlockPtr} :
 theorem OperationPtr.get!_BlockPtr_setArguments {operation : OperationPtr} :
     operation.get! (BlockPtr.setArguments block' ctx newArguments hblock') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_setArguments {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.setArguments block' ctx newArguments hblock') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -7047,6 +7151,12 @@ theorem BlockPtr.firstOp!_BlockPtr_pushArgument {block : BlockPtr} :
 theorem OperationPtr.get!_BlockPtr_pushArgument {operation : OperationPtr} :
     operation.get! (BlockPtr.pushArgument block' ctx newArgument hblock') =
     operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_pushArgument {operation : OperationPtr} :
+    operation.getOpType! (BlockPtr.pushArgument block' ctx newArgument hblock') =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/BlockOperands.lean
+++ b/Veir/Rewriter/GetSet/BlockOperands.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -118,9 +118,9 @@ theorem OperationPtr.parent!_pushBlockOperand {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_pushBlockOperand {operation : OperationPtr} :
-    (operation.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_pushBlockOperand {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -346,9 +346,9 @@ theorem OperationPtr.parent!_initBlockOperands {operation : OperationPtr} :
   fun_induction Rewriter.initBlockOperands <;> grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_initBlockOperands {operation : OperationPtr} :
-    (operation.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_initBlockOperands {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
+    operation.getOpType! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -29,7 +29,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -146,14 +146,14 @@ theorem OperationPtr.parent!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.parent!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (operation.get! ctx').parent
 
-theorem OperationPtr.opType!_createEmptyOp {operation : OperationPtr} :
+theorem OperationPtr.getOpType!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
-    (operation.get! ctx').opType =
-    if operation = op then opType else (operation.get! ctx).opType := by
+    operation.getOpType! ctx' =
+    if operation = op then opType else operation.getOpType! ctx := by
   grind [Operation.empty]
 
-grind_pattern OperationPtr.opType!_createEmptyOp =>
-  Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (operation.get! ctx').opType
+grind_pattern OperationPtr.getOpType!_createEmptyOp =>
+  Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getOpType! ctx'
 
 theorem OperationPtr.attrs!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
@@ -461,11 +461,11 @@ theorem OperationPtr.parent!_createOp {operation : OperationPtr} :
   grind (gen := 20) [cases InsertPoint, Operation.empty]
 
 @[grind =>]
-theorem OperationPtr.opType!_createOp {operation : OperationPtr} :
+theorem OperationPtr.getOpType!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
-    (operation.get! ctx').opType =
-    if operation = newOp then opType else (operation.get! ctx).opType := by
+    operation.getOpType! ctx' =
+    if operation = newOp then opType else operation.getOpType! ctx := by
   simp only [Rewriter.createOp]
   grind (gen := 20)
 

--- a/Veir/Rewriter/GetSet/CreateRegion.lean
+++ b/Veir/Rewriter/GetSet/CreateRegion.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -71,6 +71,12 @@ theorem BlockPtr.get!_createRegion {block : BlockPtr} :
 theorem OperationPtr.get!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.get! ctx' = operation.get! ctx := by
+  grind
+
+@[simp, grind =>]
+theorem OperationPtr.getOpType!_createRegion {operation : OperationPtr} :
+    Rewriter.createRegion ctx = some (ctx', reg) →
+    operation.getOpType! ctx' = operation.getOpType! ctx := by
   grind
 
 @[simp, grind =>]

--- a/Veir/Rewriter/GetSet/DetachBlockOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachBlockOperands.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -134,9 +134,9 @@ theorem OperationPtr.parent!_detachBlockOperands_loop {operation : OperationPtr}
     grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_detachBlockOperands_loop {operation : OperationPtr} :
-    (operation.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_detachBlockOperands_loop {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
+    operation.getOpType! ctx := by
   induction index generalizing ctx
   · grind [Rewriter.detachBlockOperands.loop]
   · simp only [Rewriter.detachBlockOperands.loop]
@@ -366,9 +366,9 @@ theorem OperationPtr.parent!_detachBlockOperands {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_detachBlockOperands {operation : OperationPtr} :
-    (operation.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_detachBlockOperands {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/DetachOp.lean
+++ b/Veir/Rewriter/GetSet/DetachOp.lean
@@ -26,7 +26,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -117,9 +117,9 @@ theorem OperationPtr.parent!_unsetParentAndNeighbors {operation : OperationPtr} 
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_unsetParentAndNeighbors {operation : OperationPtr} :
-    (operation.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_unsetParentAndNeighbors {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -313,9 +313,9 @@ theorem OperationPtr.parent!_detachOp {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_detachOp {operation : OperationPtr} :
-    (operation.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_detachOp {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -509,9 +509,9 @@ theorem OperationPtr.parent!_detachOpIfAttached {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_detachOpIfAttached {operation : OperationPtr} :
-    (operation.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_detachOpIfAttached {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -707,10 +707,10 @@ theorem OperationPtr.parent!_eraseOp {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_eraseOp {operation : OperationPtr} :
+theorem OperationPtr.getOpType!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
-    (operation.get! (Rewriter.eraseOp ctx op hCtx hOp)).opType =
-    (operation.get! ctx).opType := by
+    operation.getOpType! (Rewriter.eraseOp ctx op hCtx hOp) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/DetachOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachOperands.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -138,9 +138,9 @@ theorem OperationPtr.parent!_detachOperands_loop {operation : OperationPtr} :
     grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_detachOperands_loop {operation : OperationPtr} :
-    (operation.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_detachOperands_loop {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
+    operation.getOpType! ctx := by
   induction index generalizing ctx
   · grind [Rewriter.detachOperands.loop]
   · simp only [Rewriter.detachOperands.loop]
@@ -356,9 +356,9 @@ theorem OperationPtr.parent!_detachOperands {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_detachOperands {operation : OperationPtr} :
-    (operation.get! (Rewriter.detachOperands ctx op' hCtx hOp)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_detachOperands {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.detachOperands ctx op' hCtx hOp) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/InsertBlock.lean
+++ b/Veir/Rewriter/GetSet/InsertBlock.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -142,6 +142,16 @@ theorem OperationPtr.get!_insertBlock? {operation : OperationPtr} :
 
 grind_pattern OperationPtr.get!_insertBlock? =>
   Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.get! newCtx
+
+@[simp]
+theorem OperationPtr.getOpType!_insertBlock? {operation : OperationPtr} :
+    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+    operation.getOpType! newCtx = operation.getOpType! ctx := by
+  simp only [Rewriter.insertBlock?]
+  grind
+
+grind_pattern OperationPtr.getOpType!_insertBlock? =>
+  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
 
 @[simp]
 theorem OperationPtr.getNumResults!_insertBlock? {operation : OperationPtr} :

--- a/Veir/Rewriter/GetSet/InsertOp.lean
+++ b/Veir/Rewriter/GetSet/InsertOp.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -170,14 +170,14 @@ grind_pattern OperationPtr.parent!_insertOp? =>
   Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).parent
 
 @[simp]
-theorem OperationPtr.opType!_insertOp? {operation : OperationPtr} :
+theorem OperationPtr.getOpType!_insertOp? {operation : OperationPtr} :
     Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
-    (operation.get! newCtx).opType = (operation.get! ctx).opType := by
+    operation.getOpType! newCtx = operation.getOpType! ctx := by
   simp only [Rewriter.insertOp?]
   grind
 
-grind_pattern OperationPtr.opType!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).opType
+grind_pattern OperationPtr.getOpType!_insertOp? =>
+  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
 
 @[simp]
 theorem OperationPtr.attrs!_insertOp? {operation : OperationPtr} :

--- a/Veir/Rewriter/GetSet/Operands.lean
+++ b/Veir/Rewriter/GetSet/Operands.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -117,9 +117,9 @@ theorem OperationPtr.parent!_pushOperand {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_pushOperand {operation : OperationPtr} :
-    (operation.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_pushOperand {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -369,9 +369,9 @@ theorem OperationPtr.parent!_initOpOperands {operation : OperationPtr} :
   fun_induction Rewriter.initOpOperands <;> grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_initOpOperands {operation : OperationPtr} :
-    (operation.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_initOpOperands {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
+    operation.getOpType! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/Regions.lean
+++ b/Veir/Rewriter/GetSet/Regions.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -87,9 +87,9 @@ theorem OperationPtr.parent!_pushRegion {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_pushRegion {operation : OperationPtr} :
-    (operation.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_pushRegion {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -260,9 +260,9 @@ theorem OperationPtr.parent!_initOpRegions {operation : OperationPtr} {ctx' : IR
   fun_induction Rewriter.initOpRegions <;> grind
 
 @[simp, grind =>]
-theorem OperationPtr.opType!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
+theorem OperationPtr.getOpType!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
-    (operation.get! ctx').opType = (operation.get! ctx).opType := by
+    operation.getOpType! ctx' = operation.getOpType! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
 @[simp, grind =>]

--- a/Veir/Rewriter/GetSet/ReplaceUse.lean
+++ b/Veir/Rewriter/GetSet/ReplaceUse.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!

--- a/Veir/Rewriter/GetSet/Results.lean
+++ b/Veir/Rewriter/GetSet/Results.lean
@@ -24,7 +24,7 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
+ -   * OperationPtr.getOpType!
  -   * Operation.attrs
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
@@ -87,9 +87,9 @@ theorem OperationPtr.parent!_pushResult {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_pushResult {operation : OperationPtr} :
-    (operation.get! (Rewriter.pushResult ctx op type hop)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_pushResult {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.pushResult ctx op type hop) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -258,9 +258,9 @@ theorem OperationPtr.parent!_initOpResults {operation : OperationPtr} :
   fun_induction Rewriter.initOpResults <;> grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_initOpResults {operation : OperationPtr} :
-    (operation.get! (Rewriter.initOpResults ctx op types index hop hidx)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_initOpResults {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.initOpResults ctx op types index hop hidx) =
+    operation.getOpType! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/LinkedList/GetSet.lean
+++ b/Veir/Rewriter/LinkedList/GetSet.lean
@@ -19,9 +19,9 @@ public section
  -   * Operation.prev
  -   * Operation.next
  -   * Operation.parent
- -   * Operation.opType
  -   * Operation.attrs
  -   * Operation.properties
+ - * OperationPtr.getOpType!
  - * OperationPtr.getProperties!
  - * OperationPtr.getNumResults!
  - * OpResultPtr.get!
@@ -113,9 +113,9 @@ theorem OperationPtr.parent!_OpOperandPtr_removeFromCurrent {operation : Operati
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtr_removeFromCurrent {operation : OperationPtr} :
-    (operation.get! (opOperand'.removeFromCurrent ctx hopOperand' ctxInBounds)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtr_removeFromCurrent {operation : OperationPtr} :
+    (operation.getOpType! (opOperand'.removeFromCurrent ctx hopOperand' ctxInBounds)) =
+    (operation.getOpType! ctx) := by
   grind
 
 @[simp, grind =]
@@ -325,9 +325,9 @@ theorem OperationPtr.parent!_OpOperandPtr_insertIntoCurrent {operation : Operati
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OpOperandPtr_insertIntoCurrent {operation : OperationPtr} :
-    (operation.get! (opOperand'.insertIntoCurrent ctx hopOperand' ctxInBounds)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OpOperandPtr_insertIntoCurrent {operation : OperationPtr} :
+    operation.getOpType! (opOperand'.insertIntoCurrent ctx hopOperand' ctxInBounds) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -550,9 +550,9 @@ theorem OperationPtr.parent!_BlockOperandPtr_removeFromCurrent {operation : Oper
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtr_removeFromCurrent {operation : OperationPtr} :
-    (operation.get! (blockOperand'.removeFromCurrent ctx hOperand' ctxInBounds)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtr_removeFromCurrent {operation : OperationPtr} :
+    operation.getOpType! (blockOperand'.removeFromCurrent ctx hOperand' ctxInBounds) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -759,9 +759,9 @@ theorem OperationPtr.parent!_BlockOperandPtr_insertIntoCurrent {operation : Oper
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_BlockOperandPtr_insertIntoCurrent {operation : OperationPtr} :
-    (operation.get! (blockOperand'.insertIntoCurrent ctx hblockOperand' ctxInBounds)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_BlockOperandPtr_insertIntoCurrent {operation : OperationPtr} :
+    operation.getOpType! (blockOperand'.insertIntoCurrent ctx hblockOperand' ctxInBounds) =
+    operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
@@ -958,9 +958,9 @@ theorem OperationPtr.parent!_OperationPtr_linkBetween {operation : OperationPtr}
   grind
 
 @[simp, grind =]
-theorem OperationPtr.opType!_OperationPtr_linkBetween {operation : OperationPtr} :
-    (operation.get! (op'.linkBetween ctx prev next selfIn prevIn nextIn)).opType =
-    (operation.get! ctx).opType := by
+theorem OperationPtr.getOpType!_OperationPtr_linkBetween {operation : OperationPtr} :
+    (operation.getOpType! (op'.linkBetween ctx prev next selfIn prevIn nextIn)) =
+    (operation.getOpType! ctx) := by
   simp only [OperationPtr.linkBetween]
   grind
 
@@ -1144,13 +1144,13 @@ grind_pattern OperationPtr.parent!_OperationPtr_setParentWithCheck =>
   op'.setParentWithCheck ctx newParent selfIn, some newCtx, (operation.get! newCtx).parent
 
 @[simp]
-theorem OperationPtr.opType!_OperationPtr_setParentWithCheck {operation : OperationPtr} :
+theorem OperationPtr.getOpType!_OperationPtr_setParentWithCheck {operation : OperationPtr} :
     op'.setParentWithCheck ctx newParent selfIn = some newCtx →
-    (operation.get! newCtx).opType = (operation.get! ctx).opType := by
+    operation.getOpType! newCtx = operation.getOpType! ctx := by
   grind
 
-grind_pattern OperationPtr.opType!_OperationPtr_setParentWithCheck =>
-  op'.setParentWithCheck ctx newParent selfIn, some newCtx, (operation.get! newCtx).opType
+grind_pattern OperationPtr.getOpType!_OperationPtr_setParentWithCheck =>
+  op'.setParentWithCheck ctx newParent selfIn, some newCtx, (operation.getOpType! newCtx)
 
 @[simp]
 theorem OperationPtr.attrs!_OperationPtr_setParentWithCheck {operation : OperationPtr} :
@@ -1433,13 +1433,13 @@ grind_pattern OperationPtr.parent!_OperationPtr_linkBetweenWithParent =>
   op'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn, some newCtx, (operation.get! newCtx).parent
 
 @[simp]
-theorem OperationPtr.opType!_OperationPtr_linkBetweenWithParent {operation : OperationPtr} :
+theorem OperationPtr.getOpType!_OperationPtr_linkBetweenWithParent {operation : OperationPtr} :
     op'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn = some newCtx →
-    (operation.get! newCtx).opType = (operation.get! ctx).opType := by
+    (operation.getOpType! newCtx) = (operation.getOpType! ctx) := by
   grind
 
-grind_pattern OperationPtr.opType!_OperationPtr_linkBetweenWithParent =>
-  op'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn, some newCtx, (operation.get! newCtx).opType
+grind_pattern OperationPtr.getOpType!_OperationPtr_linkBetweenWithParent =>
+  op'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn, some newCtx, (operation.getOpType! newCtx)
 
 @[simp]
 theorem OperationPtr.attrs!_OperationPtr_linkBetweenWithParent {operation : OperationPtr} :
@@ -1679,6 +1679,13 @@ theorem OperationPtr.get!_BlockPtr_linkBetween {operation : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getOpType!_BlockPtr_linkBetween {operation : OperationPtr} :
+    operation.getOpType! (block'.linkBetween ctx prev next selfIn prevIn nextIn) =
+    operation.getOpType! ctx := by
+  simp only [BlockPtr.linkBetween]
+  grind
+
+@[simp, grind =]
 theorem OperationPtr.getNumResults!_BlockPtr_linkBetween {operation : OperationPtr} :
     operation.getNumResults! (block'.linkBetween ctx prev next selfIn prevIn nextIn) = operation.getNumResults! ctx := by
   simp only [BlockPtr.linkBetween]
@@ -1863,6 +1870,15 @@ theorem OperationPtr.get!_BlockPtr_setParentWithCheck {operation : OperationPtr}
 
 grind_pattern OperationPtr.get!_BlockPtr_setParentWithCheck =>
   block'.setParentWithCheck ctx newParent selfIn, some newCtx, operation.get! newCtx
+
+@[simp]
+theorem OperationPtr.getOpType!_BlockPtr_setParentWithCheck {operation : OperationPtr} :
+    block'.setParentWithCheck ctx newParent selfIn = some newCtx →
+    operation.getOpType! newCtx = operation.getOpType! ctx := by
+  grind
+
+grind_pattern OperationPtr.getOpType!_BlockPtr_setParentWithCheck =>
+  block'.setParentWithCheck ctx newParent selfIn, some newCtx, operation.getOpType! newCtx
 
 @[simp]
 theorem OperationPtr.getNumResults!_BlockPtr_setParentWithCheck {operation : OperationPtr} :
@@ -2098,6 +2114,14 @@ theorem OperationPtr.get!_BlockPtr_linkBetweenWithParent {operation : OperationP
 
 grind_pattern OperationPtr.get!_BlockPtr_linkBetweenWithParent =>
   block'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn, some newCtx, operation.get! newCtx
+
+theorem OperationPtr.getOpType!_BlockPtr_linkBetweenWithParent {operation : OperationPtr} :
+    block'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn = some newCtx →
+    operation.getOpType! newCtx = operation.getOpType! ctx := by
+  grind
+
+grind_pattern OperationPtr.getOpType!_BlockPtr_linkBetweenWithParent =>
+  block'.linkBetweenWithParent ctx prev next parent selfIn prevIn nextIn parentIn, some newCtx, operation.getOpType! newCtx
 
 @[simp]
 theorem OperationPtr.getNumResults!_BlockPtr_linkBetweenWithParent {operation : OperationPtr} :

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -17,8 +17,8 @@ The getters we consider are:
   * Operation.prev
   * Operation.next
   * Operation.parent
-  * Operation.opType
   * Operation.attrs
+* OperationPtr.getOpType!
 * OperationPtr.getProperties!
 * OperationPtr.getNumResults!
 * OperationPtr.getNumOperands!
@@ -146,11 +146,11 @@ theorem OperationPtr.parent!_WfRewriter_createOp :
   grind (gen := 20) [cases InsertPoint, Operation.empty]
 
 @[grind =>]
-theorem OperationPtr.opType!_WfRewriter_createOp :
+theorem OperationPtr.getOpType!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
-    (operation.get! ctx'.raw).opType =
-    if operation = newOp then opType else (operation.get! ctx.raw).opType := by
+    operation.getOpType! ctx'.raw =
+    if operation = newOp then opType else operation.getOpType! ctx.raw := by
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 


### PR DESCRIPTION
We should favor the use of `op.getOpType! ctx` instead of `(op.get! ctx).opType`. This PR changes the get-set lemmas to use `getOpType!`.