### PR TITLE
fix: generalized refinement for any width `w` 

### DIFF
--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -22,3 +22,5 @@ def isRefinedBy {w : Nat} (i i' : Veir.Data.LLVM.Int w) : Prop :=
     | .val v' => v = v'
     | .poison => false
   | .poison => true
+
+@[inherit_doc] infix:50 " ⊑ "  => isRefinedBy

--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -15,7 +15,7 @@ public section
   In particular, any concrete `i'` refines a poison `i`, but a poison `i'` does *not* refine
   any `i`.
 -/
-def isRefinedBy (i i' : Veir.Data.LLVM.Int 64) : Prop :=
+def isRefinedBy {w : Nat} (i i' : Veir.Data.LLVM.Int w) : Prop :=
   match i with
   | .val v =>
     match i' with


### PR DESCRIPTION
We generalize the definition of the refinement relation for every width, and add support for the notation `⊑`. 

This PR was originally part of #457, from where I am pulling out what is separately upstreamable.