### PR TITLE
llvm:`getelementptr`

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -45,7 +45,7 @@
   %30 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 1 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
   %31 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
   %32 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-  "llvm.return"(%28, %29, %30, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> (), 
+  "llvm.return"(%28, %29, %30, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 }) : () -> ()
 
 // CHECK:       "builtin.module"() ({
@@ -90,7 +90,7 @@
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.ptr):
 // CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 2 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 1 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 1 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.pt
 // CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:     "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -39,6 +39,13 @@
   "llvm.br"(%arg6_0) [^8] : (i32) -> ()
 ^8(%arg7_0 : i32):
   "llvm.return"(%arg7_0) : (i32) -> ()
+^9(%ptr : !llvm.ptr):
+  %28 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 3 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+  %29 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 2 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+  %30 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 1 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+  %31 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+  %32 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+  "llvm.return"(%28, %29, %30, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> (), 
 }) : () -> ()
 
 // CHECK:       "builtin.module"() ({
@@ -80,4 +87,11 @@
 // CHECK-NEXT:     "llvm.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()
 // CHECK-NEXT:   ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:     "llvm.return"(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !llvm.ptr):
+// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 2 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 1 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+// CHECK-NEXT:     %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
+// CHECK-NEXT:     "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -28,6 +28,7 @@ match op with
 | .alloca => AllocaProperties
 | .load => LoadProperties
 | .store => StoreProperties
+| .getelementptr => GetelementptrProperties
 | _ => Unit
 
 instance : HasDialectOpInfo Llvm where

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -220,8 +220,16 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
     dict
   | .llvm .getelementptr => Id.run do
-    let dict := (Std.HashMap.emptyWithCapacity 2).insert "rawConstantIndices".toUTF8 (.denseArrayAttr props.rawConstantIndices)
-    dict.elem_type "elem_type".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
+    let mut dict := Std.HashMap.emptyWithCapacity 5
+    dict := dict.insert "rawConstantIndices".toUTF8 (Attribute.denseArrayAttr props.rawConstantIndices)
+    dict := dict.insert "elem_type".toUTF8 props.elem_type
+    if props.inbounds then
+      dict := dict.insert "inbounds".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.nusw then
+      dict := dict.insert "nusw".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.nuw then
+      dict := dict.insert "nuw".toUTF8 (.unitAttr UnitAttr.mk)
+    dict
   | .comb .extract =>
     (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
   | .comb .icmp =>

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -220,15 +220,10 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
     dict
   | .llvm .getelementptr => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 5
+    let mut dict := Std.HashMap.emptyWithCapacity 3
     dict := dict.insert "rawConstantIndices".toUTF8 (Attribute.denseArrayAttr props.rawConstantIndices)
     dict := dict.insert "elem_type".toUTF8 props.elem_type
-    if props.inbounds then
-      dict := dict.insert "inbounds".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.nusw then
-      dict := dict.insert "nusw".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.nuw then
-      dict := dict.insert "nuw".toUTF8 (.unitAttr UnitAttr.mk)
+    dict := dict.insert "noWrapFlags".toUTF8 (.integerAttr props.noWrapFlags)
     dict
   | .comb .extract =>
     (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -100,6 +100,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case alloca => exact (AllocaProperties.fromAttrDict attrDict)
     case load => exact (LoadProperties.fromAttrDict attrDict)
     case store => exact (StoreProperties.fromAttrDict attrDict)
+    case getelementptr => exact (GetelementptrProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case func =>
     all_goals exact (Except.ok ())
@@ -218,6 +219,9 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
     dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
     dict
+  | .llvm .getelementptr => Id.run do
+    let dict := (Std.HashMap.emptyWithCapacity 2).insert "rawConstantIndices".toUTF8 (.denseArrayAttr props.rawConstantIndices)
+    dict.elem_type "elem_type".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
   | .comb .extract =>
     (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
   | .comb .icmp =>

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -95,7 +95,7 @@ inductive Llvm where
 | alloca
 | load
 | store
-| getelementprt
+| getelementptr
 | return
 deriving Inhabited, Repr, Hashable, DecidableEq
 

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -95,6 +95,7 @@ inductive Llvm where
 | alloca
 | load
 | store
+| getelementprt
 | return
 deriving Inhabited, Repr, Hashable, DecidableEq
 

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -309,7 +309,7 @@ def GetelementptrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
     | none => .error "getelementptr: missing 'rawConstantIndices' property"
   let some typeAttr := attrDict["elem_type".toUTF8]?
     | throw "getelementptr: missing 'elem_type' property"
-  if h : typeAttr.isType = false then
+  if _ : typeAttr.isType = false then
     throw "getelementptr: expected 'elem_type' to be a type attribute"
   else
     return {
@@ -319,6 +319,7 @@ def GetelementptrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
       nusw,
       nuw
     }
+
 /--
   Properties of the `comb.extract` operation.
 -/

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -285,6 +285,41 @@ def StoreProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
   return { alignment := alignAttr, volatile_ := volatileAttr, nontemporal := nontemporalAttr, invariantGroup := invariantGroupAttr, syncscope := syncscopeAttr, access_groups := accessAttr, alias_scopes := aliasAttr, noalias_scopes := noaliasAttr, tbaa := tbaaAttr }
 
 /--
+  Properties of the `llvm.getelementptr` operation
+-/
+structure GetelementptrProperties where
+  rawConstantIndices : DenseArrayAttr
+  elem_type : TypeAttr
+  inbounds : Bool
+  nusw : Bool
+  nuw : Bool
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def GetelementptrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String GetelementptrProperties := do
+  let inbounds ← getUnitAttr "inbounds" attrDict
+  let nusw ← getUnitAttr "nusw" attrDict
+  let nuw ← getUnitAttr "nuw" attrDict
+  /- `inbounds` implies `nusw` -/
+  let nusw := nusw || inbounds
+  let rawConstantIndices ← match attrDict["rawConstantIndices".toUTF8]? with
+    | some (.denseArrayAttr arr) => .ok arr
+    | some attr => .error s!"getelementptr: expected 'rawConstantIndices' to be a dense array attribute, 
+        but got {attr}"
+    | none => .error "getelementptr: missing 'rawConstantIndices' property"
+  let some typeAttr := attrDict["elem_type".toUTF8]?
+    | throw "getelementptr: missing 'elem_type' property"
+  if h : typeAttr.isType = false then
+    throw "getelementptr: expected 'elem_type' to be a type attribute"
+  else
+    return {
+      rawConstantIndices,
+      elem_type := typeAttr.asType,
+      inbounds,
+      nusw,
+      nuw
+    }
+/--
   Properties of the `comb.extract` operation.
 -/
 structure CombExtractProperties where

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -290,18 +290,15 @@ def StoreProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
 structure GetelementptrProperties where
   rawConstantIndices : DenseArrayAttr
   elem_type : TypeAttr
-  inbounds : Bool
-  nusw : Bool
-  nuw : Bool
+  noWrapFlags : IntegerAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def GetelementptrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String GetelementptrProperties := do
-  let inbounds ← getUnitAttr "inbounds" attrDict
-  let nusw ← getUnitAttr "nusw" attrDict
-  let nuw ← getUnitAttr "nuw" attrDict
-  /- `inbounds` implies `nusw` -/
-  let nusw := nusw || inbounds
+  let noWrapFlags ← match attrDict["noWrapFlags".toUTF8]? with
+    | some (.integerAttr noWrapFlag) => .ok noWrapFlag
+    | some attr => .error s!"expected 'noWrapFlag' to be an optional integer attribute, but got {attr}"
+    | none => .ok { value := 0, type := { bitwidth := 32 } }
   let rawConstantIndices ← match attrDict["rawConstantIndices".toUTF8]? with
     | some (.denseArrayAttr arr) => .ok arr
     | some attr => .error s!"getelementptr: expected 'rawConstantIndices' to be a dense array attribute, 
@@ -309,16 +306,9 @@ def GetelementptrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
     | none => .error "getelementptr: missing 'rawConstantIndices' property"
   let some typeAttr := attrDict["elem_type".toUTF8]?
     | throw "getelementptr: missing 'elem_type' property"
-  if _ : typeAttr.isType = false then
-    throw "getelementptr: expected 'elem_type' to be a type attribute"
-  else
-    return {
-      rawConstantIndices,
-      elem_type := typeAttr.asType,
-      inbounds,
-      nusw,
-      nuw
-    }
+  if h : typeAttr.isType = false then
+    throw "getelementptr: expected 'elem_type' to be a type attribute" else
+  return {rawConstantIndices, elem_type := typeAttr.asType, noWrapFlags}
 
 /--
   Properties of the `comb.extract` operation.

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -666,7 +666,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
-  | .llvm .getelementptr =>
+  | .llvm .getelementptr => do
     if op.getNumOperands ctx opIn ≠ 2 then
       throw "Expected 2 operands"
     if op.getNumResults ctx opIn ≠ 0 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -669,8 +669,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
   | .llvm .getelementptr => do
     if op.getNumOperands ctx opIn ≠ 2 then
       throw "Expected 2 operands"
-    if op.getNumResults ctx opIn ≠ 0 then
-      throw "Expected 0 results"
+    if op.getNumResults ctx opIn ≠ 1 then
+      throw "Expected 1 results"
     if op.getNumRegions ctx opIn ≠ 0 then
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx opIn ≠ 0 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -666,6 +666,16 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : IRContext OpCo
     if op.getNumSuccessors ctx opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  | .llvm .getelementptr =>
+    if op.getNumOperands ctx opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumResults ctx opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
   /- MOD_ARITH -/
   | .mod_arith .add => do
     if op.getNumOperands ctx opIn ≠ 2 then


### PR DESCRIPTION
We add the syntax for the `llvm.getelementptr` operation