### PR TITLE
Add `OperationPtr.getResultTypes`

### DIFF
--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -668,6 +668,23 @@ theorem getResults!.getElem_eq_getResult
   simp only [getResults!, getResult]
   grind
 
+def getResultTypes (op : OperationPtr) (ctx : IRContext OpInfo)
+    (inBounds : op.InBounds ctx := by grind) : Array TypeAttr :=
+  (op.get ctx).results.map (·.type)
+
+def getResultTypes! (op : OperationPtr) (ctx : IRContext OpInfo) : Array TypeAttr :=
+  (op.get! ctx).results.map (·.type)
+
+@[grind =_, eq_bang ←]
+theorem getResultTypes!_eq_getResultTypes {op : OperationPtr} (hin : op.InBounds ctx) :
+    op.getResultTypes! ctx = op.getResultTypes ctx (by grind) := by
+  grind [getResultTypes, getResultTypes!, get!_eq_get, getNumResults!_eq_getNumResults]
+
+@[grind =]
+theorem getResultTypes!.size_eq_getNumResults! {op : OperationPtr} :
+    (op.getResultTypes! ctx).size = op.getNumResults! ctx := by
+  grind [getResultTypes!, getNumResults!]
+
 def getNumRegions (op : OperationPtr) (ctx : IRContext OpInfo)
     (inBounds : op.InBounds ctx := by grind) : Nat :=
   (op.get ctx (by grind)).regions.size
@@ -1709,10 +1726,30 @@ def getType (arg : ValuePtr) (ctx : IRContext OpInfo) (argIn : arg.InBounds ctx 
   | opResult ptr => (ptr.get ctx (by grind)).type
   | blockArgument ptr => (ptr.get ctx (by grind)).type
 
+@[simp, grind =]
+theorem getType_opResult {ptr : OpResultPtr} {ctx : IRContext OpInfo} {h : (opResult ptr).InBounds ctx} :
+    (opResult ptr).getType ctx = (ptr.get ctx (by grind)).type := by
+  grind [getType]
+
+@[simp, grind =]
+theorem getType_blockArgument {ptr : BlockArgumentPtr} {ctx : IRContext OpInfo} {h : (blockArgument ptr).InBounds ctx} :
+    (blockArgument ptr).getType ctx = (ptr.get ctx (by grind)).type := by
+  grind [getType]
+
 def getType! (arg : ValuePtr) (ctx : IRContext OpInfo) : TypeAttr :=
   match arg with
   | opResult ptr => (ptr.get! ctx).type
   | blockArgument ptr => (ptr.get! ctx).type
+
+@[simp, grind =]
+theorem getType!_opResult {ptr : OpResultPtr} {ctx : IRContext OpInfo} :
+    (opResult ptr).getType! ctx = (ptr.get! ctx).type := by
+  grind [getType!]
+
+@[simp, grind =]
+theorem getType!_blockArgument {ptr : BlockArgumentPtr} {ctx : IRContext OpInfo} :
+    (blockArgument ptr).getType! ctx = (ptr.get! ctx).type := by
+  grind [getType!]
 
 @[grind =_, eq_bang ←]
 theorem getType!_eq_getType {ptr : ValuePtr} (hin : ptr.InBounds ctx) :
@@ -1879,6 +1916,25 @@ theorem setType_BlockArgumentPtr (ptr : BlockArgumentPtr) (ctx : IRContext OpInf
   unfold setType; rfl
 
 end ValuePtr
+
+theorem OperationPtr.getResultTypes!_def {op : OperationPtr} :
+    op.getResultTypes! ctx =
+    Array.map (fun v => v.getType! ctx) (op.getResults! ctx) := by
+  grind [OperationPtr.getResultTypes!, OperationPtr.getResult, ValuePtr.getType!, OpResultPtr.get!]
+
+@[simp, grind =]
+theorem OperationPtr.getResultTypes!.getElem!_eq {op : OperationPtr} :
+    index < op.getNumResults! ctx →
+    (op.getResultTypes! ctx)[index]! = ((op.getResult index).get! ctx).type := by
+  grind [getResultTypes!, getNumResults!, getResult, OpResultPtr.get!]
+
+@[simp, grind =]
+theorem OperationPtr.getResultTypes!.getElem_eq {op : OperationPtr}
+    {h : index < (op.getResultTypes! ctx).size} :
+    (op.getResultTypes! ctx)[index]'h = ((op.getResult index).get! ctx).type := by
+  simp only [getResultTypes!, getResult, OpResultPtr.get!]
+  grind
+
 
 /-!
   OpOperandPtrPtr accessors

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -685,7 +685,7 @@ def interpretOp (ctx : IRContext OpCode) (op : OperationPtr) (state : Interprete
     : Option (InterpreterState × Option ControlFlowAction) := do
   let operands ← state.getOperandValues ctx op
   let opType := op.getOpType! ctx
-  let (resultValues, action) ← interpretOp' opType (op.getProperties! ctx opType) ((op.get! ctx).results.map (·.type)) operands (op.getSuccessors! ctx)
+  let (resultValues, action) ← interpretOp' opType (op.getProperties! ctx opType) (op.getResultTypes! ctx) operands (op.getSuccessors! ctx)
   let newState := state.setResultValues ctx op resultValues
   return (newState, action)
 

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -60,8 +60,7 @@ theorem interpretOp_some_iff :
   ∃ operandValues resValues,
     (state.getOperandValues ctx op) = some operandValues ∧
     interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
-      ((op.get! ctx).results.map (·.type)) operandValues
-      (op.getSuccessors! ctx) = some (resValues, cf) ∧
+      (op.getResultTypes! ctx) operandValues (op.getSuccessors! ctx) = some (resValues, cf) ∧
     state' = state.setResultValues ctx op resValues := by
   simp only [interpretOp, bind, Option.bind]
   grind

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -35,6 +35,7 @@ The getters we consider are:
   * lastBlock
   * parent
 * ValuePtr.getType!
+* OperationPtr.getResultTypes!
 -/
 
 public section
@@ -293,6 +294,18 @@ theorem ValuePtr.getType!_WfRewriter_createOp :
       else value.getType! ctx.raw
     | .blockArgument _ => value.getType! ctx.raw := by
   grind (gen := 20)
+
+@[grind =>]
+theorem OperationPtr.getResultTypes!_WfRewriter_createOp :
+    WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
+      insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
+    operation.getResultTypes! ctx'.raw =
+    if operation = newOp then resultTypes else operation.getResultTypes! ctx.raw := by
+  intro h
+  ext i hi hi'
+  · grind
+  · have := ValuePtr.getType!_WfRewriter_createOp h (value := operation.getResult i)
+    grind
 
 end WfRewriter.createOp
 


### PR DESCRIPTION
This helper is useful in the interpreter, and makes it easier to write get-set lemmas for high-level rewriting operations.