### PR TITLE
Parse Location attributes

### DIFF
--- a/Test/Parsing/attributes.mlir
+++ b/Test/Parsing/attributes.mlir
@@ -1,6 +1,6 @@
 // RUN: veir-opt %s | filecheck %s
 
 "builtin.module"() ({
-    "test.test"() { test = 23 : i32, "fo/no" = 1 : i32 } : () -> ()
-    // CHECK:     "test.test"() {"fo/no" = 1 : i32, "test" = 23 : i32} : () -> ()
+    "test.test"() { test = 23 : i32, "fo/no" = 1 : i32, "location" = loc("source":10:20) } : () -> ()
+    // CHECK:     "test.test"() {"fo/no" = 1 : i32, "location" = loc("source":10:20), "test" = 23 : i32} : () -> ()
 }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -156,6 +156,16 @@ macro "#assert " e:term : command =>
 #assert expectSuccessAttr "#foo<bar>" (UnregisteredAttr.mk "#foo<bar>" false)
 #assert expectSuccessAttr "#test.test<bar>" (UnregisteredAttr.mk "#test.test<bar>" false)
 
+/-! ## Location attribute -/
+
+#assert expectSuccessAttr "loc(mysource.cc:10:8)" (LocationAttr.mk "mysource.cc:10:8")
+#assert expectSuccessAttr r#"loc(callsite("foo" at "mysource.cc":10:8))"# (LocationAttr.mk r#"callsite("foo" at "mysource.cc":10:8)"#)
+#assert expectSuccessAttr r#"loc("mysource.cc":10:8 to 12:18)"# (LocationAttr.mk r#""mysource.cc":10:8 to 12:18"#)
+#assert expectSuccessAttr r#"loc(fused["mysource.cc":10:8, "mysource.cc":22:8])"# (LocationAttr.mk r#"fused["mysource.cc":10:8, "mysource.cc":22:8]"#)
+#assert expectSuccessAttr r#"loc(fused<CSE>["mysource.cc":10:8, "mysource.cc":22:8])"# (LocationAttr.mk r#"fused<CSE>["mysource.cc":10:8, "mysource.cc":22:8]"#)
+#assert expectSuccessAttr r#"loc("CSE"("mysource.cc":10:8))"# (LocationAttr.mk r#""CSE"("mysource.cc":10:8)"#)
+#assert expectSuccessAttr "loc(?)" (LocationAttr.mk "?")
+
 /-! ## Modarith type -/
 
 #assert expectSuccessType "!mod_arith.int<17>" (ModArithType.mk 17 none)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -80,6 +80,14 @@ structure UnitAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  A source location.
+  This currently stores the raw string of the MLIR location syntax body.
+-/
+structure LocationAttr where
+  value : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   An array of integer attributes.
   The values are stored as an array of integers, and an associated integer type.
   Note that the integers are not necessarily in the range of the integer type.
@@ -182,6 +190,8 @@ inductive Attribute
 | stringAttr (attr : StringAttr)
 /-- Unit attribute -/
 | unitAttr (attr : UnitAttr)
+/-- Location attribute -/
+| locationAttr (attr : LocationAttr)
 /-- Array attribute -/
 | arrayAttr (attr : ArrayAttr)
 /-- Dense array attribute -/
@@ -309,6 +319,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case locationAttr.locationAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case arrayAttr.arrayAttr attr1 attr2 =>
     exact (match ArrayAttr.decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -378,6 +392,9 @@ instance : ToString StringAttr where
 
 instance : ToString UnitAttr where
   toString _ := "unit"
+
+instance : ToString LocationAttr where
+  toString attr := s!"loc(" ++ attr.value ++ ")"
 
 instance : ToString DenseArrayAttr where
   toString attr :=
@@ -460,6 +477,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .registerAttr attr => ToString.toString attr
   | .stringAttr attr => ToString.toString attr
   | .unitAttr attr => ToString.toString attr
+  | .locationAttr attr => ToString.toString attr
   | .arrayAttr attr => attr.toString
   | .denseArrayAttr attr => ToString.toString attr
   | .dictionaryAttr attr => attr.toString
@@ -500,6 +518,9 @@ instance : Coe StringAttr Attribute where
 
 instance : Coe UnitAttr Attribute where
   coe attr := .unitAttr attr
+
+instance : Coe LocationAttr Attribute where
+  coe attr := .locationAttr attr
 
 instance : Coe UnregisteredAttr Attribute where
   coe attr := .unregisteredAttr attr
@@ -544,6 +565,7 @@ def isType (attr : Attribute) : Bool :=
   | .integerAttr _ => false
   | .stringAttr _ => false
   | .unitAttr _ => false
+  | .locationAttr _ => false
   | .arrayAttr _ => false
   | .denseArrayAttr _ => false
   | .dictionaryAttr _ => false

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -247,7 +247,6 @@ partial def parseOptionalLocationAttr : AttrParserM (Option Attribute) := do
     return none
   parsePunctuation "("
   let body ← parseUnregisteredAttrBody .rParen
-  let endPos := (← peekToken).slice.stop
   parsePunctuation ")"
   return some (LocationAttr.mk body)
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -155,10 +155,10 @@ def matchingBracket! (kind : TokenKind) : TokenKind :=
 /--
   Parse the body of an unregistered attribute, which is a balanced
   string for `<`, `(`, `[`, `{`, and may contain string literals.
-  The first `<` is expected to have already been consumed when this function is called.
-  The ending `>` is not consumed by this function.
+  The opening token is expected to have already been consumed when this function is called.
+  The ending token (by default `>`) is not consumed by this function.
 -/
-private def parseUnregisteredAttrBody (startPos : Option Nat := none) : AttrParserM String := do
+private def parseUnregisteredAttrBody (endToken : TokenKind := .greater) (startPos : Option Nat := none) : AttrParserM String := do
   let startPos := startPos.getD (← peekToken).slice.start
 
   /- This stack corresponds to the brackets that are still open. -/
@@ -182,7 +182,7 @@ private def parseUnregisteredAttrBody (startPos : Option Nat := none) : AttrPars
       /- If we don't have any open bracket, either we end the parsing if
          the bracket is the last `>`, or we raise an error. -/
       if bracketStack.isEmpty then
-        if token.kind == .greater then
+        if token.kind == endToken then
           endPos := token.slice.start
           break
         throw s!"unexpected closing bracket {closingName} in attribute body"
@@ -237,6 +237,19 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   parsePunctuation ">"
   let value := (Slice.mk startPos endPos).of (← getThe ParserState).input
   return some (UnregisteredAttr.mk (String.fromUTF8! value) false)
+
+/--
+  Parse a location attribute, if present.
+  A location attribute has the form `loc(body)`.
+-/
+partial def parseOptionalLocationAttr : AttrParserM (Option Attribute) := do
+  if !(← parseOptionalKeyword "loc".toByteArray) then
+    return none
+  parsePunctuation "("
+  let body ← parseUnregisteredAttrBody .rParen
+  let endPos := (← peekToken).slice.stop
+  parsePunctuation ")"
+  return some (LocationAttr.mk body)
 
 /--
   Parse an LLVM pointer type `!llvm.ptr`, if present.
@@ -399,6 +412,8 @@ partial def parseOptionalDictionaryAttr : AttrParserM (Option DictionaryAttr) :=
 partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
   if let some dialectAttr ← parseOptionalDialectAttr then
     return some dialectAttr
+  else if let some locationAttr ← parseOptionalLocationAttr then
+    return some locationAttr
   else if let some type ← parseOptionalType then
     return some type.val
   else if let some integerAttr ← parseOptionalIntegerAttr then


### PR DESCRIPTION
This parses MLIR's location attributes of the form `loc(body)` where body is a string with balanced delimiters inside into a LocationAttr.

LocationAttr just stores `body` as a string for now, without trying to parse it further.
