### PR TITLE
hw: Parse `!hw.modty`, `hw.module` and `hw.output`

### DIFF
--- a/Test/HW/identity.mlir
+++ b/Test/HW/identity.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-opt %s | filecheck %s
+
+"builtin.module"() ({
+^4():
+  "hw.module"() <{module_type = !hw.modty<output a : i10, input b : i10>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "bar"}> ({
+  ^bb0(%b: i10):
+    "hw.output"(%b) : (i10) -> ()
+  }) {sym_visibility = "public"} : () -> ()
+  "hw.module"() <{module_type = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "foo"}> ({
+  ^bb0(%arg5: i3, %arg6: i1):
+    "hw.output"(%arg5, %arg6) : (i3, i1) -> ()
+  }) {sym_visibility = "private"} : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^4():
+// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<output a : i10, input b : i10>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "bar"}> ({
+// CHECK-NEXT:       ^6(%{{.*}}: i10):
+// CHECK-NEXT:         "hw.output"(%{{.*}}) : (i10) -> ()
+// CHECK-NEXT:     }) {"sym_visibility" = "public"} : () -> ()
+// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "foo"}> ({
+// CHECK-NEXT:       ^10(%{{.*}} : i3, %{{.*}}: i1):
+// CHECK-NEXT:         "hw.output"(%{{.*}}, %{{.*}}) : (i3, i1) -> ()
+// CHECK-NEXT:     }) {"sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -187,3 +187,14 @@ macro "#assert " e:term : command =>
 #assert expectSuccessAttr "@printf" (FlatSymbolRefAttr.mk "@printf")
 #assert expectSuccessAttr "@\"my.func\"" (FlatSymbolRefAttr.mk "@\"my.func\"")
 #assert expectMissingAttr "foo"
+
+/-! ## HW Module type -/
+#assert expectSuccessType "!hw.modty<>" (HW.ModuleType.mk #[])
+#assert expectSuccessType "!hw.modty<input a : i3, inout b : i6,  output c : i10>"
+  (HW.ModuleType.mk #[
+    {name := "a", type := IntegerType.mk 3, dir := .input},
+    {name := "b", type := IntegerType.mk 6, dir := .inout},
+    {name := "c", type := IntegerType.mk 10, dir := .output}])
+#assert expectErrorType "!hw.modty<foo>" "module port expected"
+#assert expectErrorType "!hw.modty<input : foo>" "identifier expected"
+#assert expectErrorType "!hw.modty<input a : foo>" "integer type expected"

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -1,0 +1,22 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def HW.propertiesOf (op : HW) : Type :=
+match op with
+| .module => HWModuleProperties
+| _ => Unit
+
+instance : HasDialectOpInfo HW where
+  propertiesOf := HW.propertiesOf
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -6,6 +6,7 @@ public import Veir.Dialects.RISCV.OpInfo
 public import Veir.Dialects.ModArith.OpInfo
 public import Veir.Dialects.Cf.OpInfo
 public import Veir.Dialects.Comb.OpInfo
+public import Veir.Dialects.HW.OpInfo
 
 namespace Veir
 
@@ -24,6 +25,7 @@ match opCode with
 | .mod_arith op => Mod_Arith.propertiesOf op
 | .cf op => Cf.propertiesOf op
 | .comb op => Comb.propertiesOf op
+| .hw op => HW.propertiesOf op
 | _ => Unit
 
 instance : HasDialectOpInfo OpCode where
@@ -132,6 +134,10 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case extract => exact (CombExtractProperties.fromAttrDict attrDict)
     case icmp => exact (CombIcmpProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
+  case hw op =>
+    cases op
+    case module => exact (HWModuleProperties.fromAttrDict attrDict)
+    all_goals exact (Except.ok ())
 
 /--
   Converts the properties of an operation into a dictionary of attributes.
@@ -231,5 +237,11 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
   | .comb .icmp =>
     (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr props.predicate)
+  | .hw .module => Id.run do
+    let dict := Std.HashMap.emptyWithCapacity 4
+    let dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    let dict := dict.insert "per_port_attrs".toUTF8 (.arrayAttr props.per_port_attrs)
+    let dict := dict.insert "parameters".toUTF8 (.arrayAttr props.parameters)
+    dict
   | _ =>
     Std.HashMap.emptyWithCapacity 0

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -239,6 +239,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr props.predicate)
   | .hw .module => Id.run do
     let dict := Std.HashMap.emptyWithCapacity 4
+    let dict := dict.insert "module_type".toUTF8 (.hwModuleType props.module_type)
     let dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
     let dict := dict.insert "per_port_attrs".toUTF8 (.arrayAttr props.per_port_attrs)
     let dict := dict.insert "parameters".toUTF8 (.arrayAttr props.parameters)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -172,7 +172,7 @@ deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
   The `!hw.modty` type from CIRCT's hw dialect.
-  This represents a list of ports to a module
+  This represents a list of ports to a module.
 -/
 structure ModuleType where
   ports : Array ModulePort

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -1,6 +1,7 @@
 module
 
 import Veir.ForLean
+public import Std.Data.Iterators.Producers.Array
 
 /-!
   # Attributes
@@ -147,6 +148,38 @@ deriving Inhabited, Repr, DecidableEq, Hashable
 
 end CudaTile
 
+namespace HW
+
+/--
+  The `ModulePort::Direction` type from CIRCT's hw dialect.
+  This represents the direction of a module port.
+-/
+inductive ModulePort.Direction
+| input
+| output
+| inout
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  The `ModulePort` type from CIRCT's hw dialect.
+  This represents a port to a module with a direction, type and name.
+-/
+structure ModulePort where
+  name : String
+  type : IntegerType
+  dir : ModulePort.Direction
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  The `!hw.modty` type from CIRCT's hw dialect.
+  This represents a list of ports to a module
+-/
+structure ModuleType where
+  ports : Array ModulePort
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+end HW
+
 mutual
 
 /--
@@ -218,6 +251,8 @@ inductive Attribute
 | llvmPointerType (type : LLVM.PointerType)
 /-- Cuda Tile pointer type -/
 | cudaTilePointerType (type : CudaTile.PointerType)
+/-- CIRCT hw module type -/
+| hwModuleType (type : HW.ModuleType)
 deriving Inhabited, Repr, Hashable
 
 end
@@ -363,6 +398,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case hwModuleType.hwModuleType type1 type2 =>
+    exact (match decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -434,6 +473,20 @@ instance : ToString LLVM.PointerType where
 instance : ToString CudaTile.PointerType where
   toString ptr := s!"!cuda_tile.ptr<{ptr.pointeeType}>"
 
+instance : ToString HW.ModulePort.Direction where
+  toString
+  | .input => "input"
+  | .output => "output"
+  | .inout => "inout"
+
+instance : ToString HW.ModulePort where
+  toString attr := s!"{attr.dir} {attr.name} : {attr.type}"
+
+instance : ToString HW.ModuleType where
+  toString attr :=
+    let values := attr.ports.iter.map ToString.toString |>.intercalateString ", "
+    s!"!hw.modty<{values}>"
+
 mutual
 
 def ArrayAttr.toString (attr : ArrayAttr) : String :=
@@ -504,6 +557,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .modArithType type => ToString.toString type
   | .llvmPointerType type => ToString.toString type
   | .cudaTilePointerType type => ToString.toString type
+  | .hwModuleType type => ToString.toString type
 termination_by sizeOf attr
 
 end
@@ -567,6 +621,9 @@ instance : Coe LLVM.PointerType Attribute where
 instance : Coe CudaTile.PointerType Attribute where
   coe type := .cudaTilePointerType type
 
+instance : Coe HW.ModuleType Attribute where
+  coe type := .hwModuleType type
+
 /-!
   ## TypeAttr definition
 
@@ -598,6 +655,7 @@ def isType (attr : Attribute) : Bool :=
   | .registerAttr _ => true
   | .llvmPointerType _ => true
   | .cudaTilePointerType _ => true
+  | .hwModuleType _ => true
 
 @[simp, grind =]
 theorem isType_integerType type : (integerType type).isType = true := by rfl
@@ -612,6 +670,8 @@ theorem isType_modArithType type : (modArithType type).isType = true := by rfl
 theorem isType_llvmPointerType type : (llvmPointerType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_cudaTilePointerType type : (cudaTilePointerType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_hwModuleType type : (hwModuleType type).isType = true := by rfl
 
 end Attribute
 
@@ -661,6 +721,9 @@ instance : Coe LLVM.PointerType TypeAttr where
 
 instance : Coe CudaTile.PointerType TypeAttr where
   coe type := ⟨.cudaTilePointerType type, by rfl⟩
+
+instance : Coe HW.ModuleType TypeAttr where
+  coe type := ⟨.hwModuleType type, by rfl⟩
 
 end
 end Veir

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -246,6 +246,12 @@ inductive Comb where
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
+inductive HW where
+| module
+| output
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[opcodes]
 inductive Test where
 | test
 deriving Inhabited, Repr, Hashable, DecidableEq

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -311,6 +311,49 @@ def parseOptionalModArithType : AttrParserM (Option TypeAttr) := do
   parsePunctuation ">"
   return some (ModArithType.mk modulus modulusType)
 
+/--
+  Parse CIRCT's HW dialect's `ModulePort::Direction` type.
+  Its syntax is `(input|output|inout)`.
+-/
+def parseOptionalHWModulePortDirection : AttrParserM (Option HW.ModulePort.Direction) := do
+  if (← parseOptionalKeyword "input".toByteArray) then
+    return some .input
+  if (← parseOptionalKeyword "output".toByteArray) then
+    return some .output
+  if (← parseOptionalKeyword "inout".toByteArray) then
+    return some .inout
+  return none
+
+/--
+  Parse CIRCT's HW dialect's `ModulePort` type.
+  Its syntax is `(input|output|inout) name : iN`.
+-/
+def parseOptionalHWModulePort : AttrParserM (Option HW.ModulePort) := do
+  let .some dir ← parseOptionalHWModulePortDirection | return none
+  let name := String.fromUTF8! (← parseIdentifier)
+  parsePunctuation ":"
+  let type ← parseIntegerType
+  return some { dir, name, type }
+
+def parseHWModulePort (errorMsg : String := "module port expected") : AttrParserM (HW.ModulePort) := do
+  match ← parseOptionalHWModulePort with
+  | some ty => return ty
+  | none => throw errorMsg
+
+/--
+  Parse CIRCT's HW dialect's `ModuleType` type.
+  Its syntax is `!hw.modty<ports>` where `ports` is a comma delimited list of `ModulePort`s.
+-/
+def parseOptionalHWModuleType : AttrParserM (Option HW.ModuleType) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "hw.modty".toByteArray then return none
+  let _ ← consumeToken
+  let ports ← parseDelimitedList .angle parseHWModulePort
+  return some { ports }
+
 mutual
 
 /--
@@ -352,6 +395,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some llvmPointerType
   if let some cudaTilePointerType := ← parseOptionalCudaTilePointerType then
     return some cudaTilePointerType
+  if let some hwModuleType ← parseOptionalHWModuleType then
+    return some hwModuleType
   if let some dialectType ← parseOptionalDialectType then
     return some dialectType
   else if let some functionType := ← parseOptionalFunctionType then

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -348,6 +348,7 @@ def CombIcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
   Properties of `hw.module`.
 -/
 structure HWModuleProperties where
+  module_type : HW.ModuleType
   sym_name : StringAttr
   per_port_attrs : ArrayAttr
   parameters : ArrayAttr
@@ -355,6 +356,9 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 def HWModuleProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String HWModuleProperties := do
+  let some module_type := attrDict["module_type".toUTF8]? | throw "hw.module: requires attribute 'module_type'"
+  let .hwModuleType module_type := module_type | throw s!"hw.module: expected 'module_type' to be `!hw.modty`, but got {module_type}"
+
   let some sym_name := attrDict["sym_name".toUTF8]? | throw "hw.module: requires attribute 'sym_name'"
   let .stringAttr sym_name := sym_name | throw s!"hw.module: expected 'sym_name' to be a string attribute, but got {sym_name}"
 
@@ -364,7 +368,7 @@ def HWModuleProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
   let parameters := attrDict["parameters".toUTF8]?.getD (.arrayAttr .empty)
   let .arrayAttr parameters := parameters | throw s!"hw.module: expected 'parameters' to be an array attribute, but got {parameters}"
 
-  return { sym_name, per_port_attrs, parameters }
+  return { module_type, sym_name, per_port_attrs, parameters }
 
 end
 end Veir

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -344,5 +344,27 @@ def CombIcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
     | throw s!"comb.icmp: expected 'predicate' to be an integer attribute, but got {attr}"
   return { predicate := intAttr }
 
+/--
+  Properties of `hw.module`.
+-/
+structure HWModuleProperties where
+  sym_name : StringAttr
+  per_port_attrs : ArrayAttr
+  parameters : ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def HWModuleProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String HWModuleProperties := do
+  let some sym_name := attrDict["sym_name".toUTF8]? | throw "hw.module: requires attribute 'sym_name'"
+  let .stringAttr sym_name := sym_name | throw s!"hw.module: expected 'sym_name' to be a string attribute, but got {sym_name}"
+
+  let per_port_attrs := attrDict["per_port_attrs".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr per_port_attrs := per_port_attrs | throw s!"hw.module: expected 'per_port_attrs' to be an array attribute, but got {per_port_attrs}"
+
+  let parameters := attrDict["parameters".toUTF8]?.getD (.arrayAttr .empty)
+  let .arrayAttr parameters := parameters | throw s!"hw.module: expected 'parameters' to be an array attribute, but got {parameters}"
+
+  return { sym_name, per_port_attrs, parameters }
+
 end
 end Veir

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1780,6 +1780,25 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  /- HW -/
+  | .hw .module => do
+    if op.getNumOperands ctx opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx opIn ≠ 1 then
+      throw "Expected 1 region"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .hw .output => do
+    if op.getNumResults ctx opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
 
 public section
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1782,21 +1782,21 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     pure ()
   /- HW -/
   | .hw .module => do
-    if op.getNumOperands ctx opIn ≠ 0 then
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
       throw "Expected 0 operands"
-    if op.getNumResults ctx opIn ≠ 0 then
+    if op.getNumResults ctx.raw opIn ≠ 0 then
       throw "Expected 0 results"
-    if op.getNumRegions ctx opIn ≠ 1 then
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
       throw "Expected 1 region"
-    if op.getNumSuccessors ctx opIn ≠ 0 then
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
   | .hw .output => do
-    if op.getNumResults ctx opIn ≠ 0 then
+    if op.getNumResults ctx.raw opIn ≠ 0 then
       throw "Expected 0 results"
-    if op.getNumRegions ctx opIn ≠ 0 then
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
       throw "Expected 0 regions"
-    if op.getNumSuccessors ctx opIn ≠ 0 then
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
 


### PR DESCRIPTION
This PR adds parsing logic to parse the `!hw.modty` type, a description of the ports of a hardware module, as well as `hw.module` and `hw.output`.

To parse `!hw.modty` we introduce `HW.ModuleType`, `HW.ModulePort` and `HW.ModulePort.Direction` with parsers for each.

This currently ignores the `result_locs` and `comment` fields of `hw.module`.

I'm happy to split out the `!hw.modty` parser from the usage in `hw.module` and `hw.output` into a separate PR if it makes it easier to review, but it was gonna end up with stacked PRs so I thought I would leave them for now.