### PR TITLE
Fix definition of `.WellFormed` to only take pointers instead of structures.

### DIFF
--- a/Veir/IR/DeallocLemmas.lean
+++ b/Veir/IR/DeallocLemmas.lean
@@ -228,8 +228,8 @@ theorem IRContext.fieldsInBounds_OperationPtr_dealloc {ctx : IRContext OpInfo} {
     · grind [Option.maybe_def]
     · grind [Option.maybe_def]
     · grind [Option.maybe_def]
-    · grind [Option.maybe_def, IRContext.WellFormed, Operation.WellFormed]
-    · grind [Option.maybe_def, IRContext.WellFormed, Operation.WellFormed]
+    · grind [Option.maybe_def, IRContext.WellFormed, OperationPtr.WellFormed]
+    · grind [Option.maybe_def, IRContext.WellFormed, OperationPtr.WellFormed]
     · intro arg harg hblock
       have ⟨array, harray⟩ := wf.valueDefUseChains arg (by grind)
       constructor <;> grind [ValuePtr.DefUse]
@@ -237,7 +237,7 @@ theorem IRContext.fieldsInBounds_OperationPtr_dealloc {ctx : IRContext OpInfo} {
     constructor
     · grind
     · grind
-    · grind [IRContext.WellFormed, Operation.WellFormed]
+    · grind [IRContext.WellFormed, OperationPtr.WellFormed]
 
 theorem Operation.wellFormed_OperationPtr_dealloc
     (wf : ctx.WellFormed (Std.ExtHashSet.fromOperands ctx op) (Std.ExtHashSet.fromSuccessors ctx op))
@@ -246,18 +246,18 @@ theorem Operation.wellFormed_OperationPtr_dealloc
     (hparent : (op.get! ctx).parent = none)
     (hregions : op.getNumRegions! ctx = 0)
     (inBoundsAfter' : opPtr'.InBounds (OperationPtr.dealloc op ctx inBounds)) :
-    Operation.WellFormed op' (OperationPtr.dealloc op ctx inBounds) opPtr' inBoundsAfter' := by
+    OperationPtr.WellFormed (OperationPtr.dealloc op ctx inBounds) opPtr' inBoundsAfter' := by
   have := wf.operations opPtr' inBounds'
   constructor
   · grind [IRContext.fieldsInBounds_OperationPtr_dealloc]
-  · grind [IRContext.WellFormed, Operation.WellFormed]
-  · grind [IRContext.WellFormed, Operation.WellFormed]
-  · grind [IRContext.WellFormed, Operation.WellFormed]
-  · grind [IRContext.WellFormed, Operation.WellFormed]
-  · grind [IRContext.WellFormed, Operation.WellFormed]
+  · grind [IRContext.WellFormed, OperationPtr.WellFormed]
+  · grind [IRContext.WellFormed, OperationPtr.WellFormed]
+  · grind [IRContext.WellFormed, OperationPtr.WellFormed]
+  · grind [IRContext.WellFormed, OperationPtr.WellFormed]
+  · grind [IRContext.WellFormed, OperationPtr.WellFormed]
   · intro region regionInBounds
-    apply Operation.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind [IRContext.WellFormed, Operation.WellFormed]
-  · grind [IRContext.WellFormed, Operation.WellFormed]
+    apply OperationPtr.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind [IRContext.WellFormed, OperationPtr.WellFormed]
+  · grind [IRContext.WellFormed, OperationPtr.WellFormed]
 
 theorem Block.wellFormed_OperationPtr_dealloc
     (wf : ctx.WellFormed (Std.ExtHashSet.fromOperands ctx op) (Std.ExtHashSet.fromSuccessors ctx op))
@@ -266,13 +266,13 @@ theorem Block.wellFormed_OperationPtr_dealloc
     (hparent : (op.get! ctx).parent = none)
     (hregions : op.getNumRegions! ctx = 0)
     (inBoundsAfter : blockPtr.InBounds (OperationPtr.dealloc op ctx inBounds)) :
-    Block.WellFormed block (OperationPtr.dealloc op ctx inBounds) blockPtr inBoundsAfter := by
+    BlockPtr.WellFormed (OperationPtr.dealloc op ctx inBounds) blockPtr inBoundsAfter := by
   constructor
   · grind [IRContext.fieldsInBounds_OperationPtr_dealloc]
-  · grind [IRContext.WellFormed, Block.WellFormed]
-  · grind [IRContext.WellFormed, Block.WellFormed]
-  · grind [IRContext.WellFormed, Block.WellFormed]
-  · grind [IRContext.WellFormed, Block.WellFormed]
+  · grind [IRContext.WellFormed, BlockPtr.WellFormed]
+  · grind [IRContext.WellFormed, BlockPtr.WellFormed]
+  · grind [IRContext.WellFormed, BlockPtr.WellFormed]
+  · grind [IRContext.WellFormed, BlockPtr.WellFormed]
 
 theorem Region.wellFormed_OperationPtr_dealloc
     (wf : ctx.WellFormed (Std.ExtHashSet.fromOperands ctx op) (Std.ExtHashSet.fromSuccessors ctx op))
@@ -281,7 +281,7 @@ theorem Region.wellFormed_OperationPtr_dealloc
     (hparent : (op.get! ctx).parent = none)
     (hregions : op.getNumRegions! ctx = 0)
     (inBoundsAfter : regionPtr.InBounds (OperationPtr.dealloc op ctx inBounds)) :
-    Region.WellFormed (regionPtr.get! (OperationPtr.dealloc op ctx inBounds)) (OperationPtr.dealloc op ctx inBounds) regionPtr := by
+    RegionPtr.WellFormed (OperationPtr.dealloc op ctx inBounds) regionPtr := by
   constructor
   · have := wf.regions regionPtr inBounds'
     have := this.inBounds
@@ -292,7 +292,7 @@ theorem Region.wellFormed_OperationPtr_dealloc
     simp only [RegionPtr.get!_OperationPtr_dealloc] at hparent
     have ⟨i, hi₁, hi₂⟩ := h₂ hparent
     exists i
-    grind [IRContext.fieldsInBounds_OperationPtr_dealloc, IRContext.WellFormed, Region.WellFormed]
+    grind [IRContext.fieldsInBounds_OperationPtr_dealloc, IRContext.WellFormed, RegionPtr.WellFormed]
 
 theorem ValuePtr.defUse_OperationPtr_dealloc
     (wf : ctx.WellFormed (Std.ExtHashSet.fromOperands ctx op) (Std.ExtHashSet.fromSuccessors ctx op))

--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -628,8 +628,7 @@ theorem RegionPtr.BlockChain_array_injective
       intros iInBounds jInBounds hNe
       grind [RegionPtr.BlockChain]
 
--- TODO: weird to have op and opPtr
-structure Operation.WellFormed (op : Operation OpInfo) (ctx : IRContext OpInfo) (opPtr : OperationPtr) hop : Prop where
+structure OperationPtr.WellFormed (ctx : IRContext OpInfo) (opPtr : OperationPtr) hop : Prop where
   inBounds : Operation.FieldsInBounds opPtr ctx hop
   result_index i (iInBounds : i < opPtr.getNumResults! ctx) : ((opPtr.getResult i).get! ctx).index = i
   result_owner i (iInBounds : i < opPtr.getNumResults! ctx) :
@@ -644,7 +643,7 @@ structure Operation.WellFormed (op : Operation OpInfo) (ctx : IRContext OpInfo) 
   opChain_of_parent_none : (opPtr.get! ctx).parent = none →
     (opPtr.get! ctx).prev = none ∧ (opPtr.get! ctx).next = none
 
-structure Block.WellFormed (block : Block) (ctx : IRContext OpInfo) (blockPtr : BlockPtr) hbl : Prop where
+structure BlockPtr.WellFormed (ctx : IRContext OpInfo) (blockPtr : BlockPtr) hbl : Prop where
   inBounds : Block.FieldsInBounds blockPtr ctx hbl
   argument i (iInBounds : i < blockPtr.getNumArguments! ctx) : ((blockPtr.getArgument i).get! ctx).index = i
   argument_owners i (iInBounds : i < blockPtr.getNumArguments! ctx) : ((blockPtr.getArgument i).get! ctx).owner = blockPtr
@@ -653,9 +652,9 @@ structure Block.WellFormed (block : Block) (ctx : IRContext OpInfo) (blockPtr : 
   next_eq_of_parent_eq_none : (blockPtr.get! ctx).parent = none →
     (blockPtr.get! ctx).next = none
 
-structure Region.WellFormed (region : Region) (ctx : IRContext OpInfo) (regionPtr : RegionPtr) where
-  inBounds : region.FieldsInBounds ctx
-  parent_op {op} (heq : region.parent = some op) : ∃ i, i < op.getNumRegions! ctx ∧ op.getRegion! ctx i = regionPtr
+structure RegionPtr.WellFormed (ctx : IRContext OpInfo) (regionPtr : RegionPtr) where
+  inBounds : (regionPtr.get! ctx).FieldsInBounds ctx
+  parent_op {op} (heq : (regionPtr.get! ctx).parent = some op) : ∃ i, i < op.getNumRegions! ctx ∧ op.getRegion! ctx i = regionPtr
 
 structure IRContext.WellFormed (ctx : IRContext OpInfo)
   (missingOperandUses : Std.ExtHashSet OpOperandPtr := ∅)
@@ -670,11 +669,11 @@ structure IRContext.WellFormed (ctx : IRContext OpInfo)
   blockChain (regionPtr : RegionPtr) (regionPtrInBounds : regionPtr.InBounds ctx) :
     ∃ array, RegionPtr.BlockChain regionPtr ctx array
   operations (opPtr : OperationPtr) (opPtrInBounds : opPtr.InBounds ctx) :
-    (opPtr.get! ctx).WellFormed ctx opPtr opPtrInBounds
+    opPtr.WellFormed ctx opPtrInBounds
   blocks (blockPtr : BlockPtr) (blockPtrInBounds : blockPtr.InBounds ctx) :
-    (blockPtr.get! ctx).WellFormed ctx blockPtr blockPtrInBounds
+    blockPtr.WellFormed ctx blockPtrInBounds
   regions (regionPtr : RegionPtr) (regionPtrInBounds : regionPtr.InBounds ctx) :
-    (regionPtr.get! ctx).WellFormed ctx regionPtr
+    regionPtr.WellFormed ctx
 
 attribute [grind →] IRContext.WellFormed.inBounds
 
@@ -767,8 +766,8 @@ theorem RegionPtr.blockChain_unchanged
     regionPtr.BlockChain ctx' array := by
   constructor <;> grind [RegionPtr.BlockChain]
 
-theorem Operation.WellFormed_unchanged
-    (hWf : (opPtr.get! ctx).WellFormed ctx opPtr opPtrInBounds)
+theorem OperationPtr.WellFormed_unchanged
+    (hWf : opPtr.WellFormed ctx opPtrInBounds)
     (hInBounds' : Operation.FieldsInBounds opPtr ctx' opPtrInBounds')
     (hSameNumOperands :
       opPtr.getNumOperands! ctx = opPtr.getNumOperands! ctx')
@@ -803,11 +802,11 @@ theorem Operation.WellFormed_unchanged
       opPtr.getNumRegions! ctx = opPtr.getNumRegions! ctx')
     (hSameRegions :
       ∀ i, i < opPtr.getNumRegions! ctx → opPtr.getRegion! ctx i = opPtr.getRegion! ctx' i) :
-    (opPtr.get! ctx').WellFormed ctx' opPtr opPtrInBounds' := by
-  constructor <;> grind [Operation.WellFormed, Operation.FieldsInBounds]
+    opPtr.WellFormed ctx' opPtrInBounds' := by
+  constructor <;> grind [OperationPtr.WellFormed, Operation.FieldsInBounds]
 
-theorem Block.WellFormed_unchanged
-    (hWf : (blockPtr.get! ctx).WellFormed ctx blockPtr blockPtrInBounds)
+theorem BlockPtr.WellFormed_unchanged
+    (hWf : blockPtr.WellFormed ctx blockPtrInBounds)
     (hInBounds' : Block.FieldsInBounds blockPtr ctx' blockPtrInBounds')
     (hSameParent : (blockPtr.get! ctx).parent = (blockPtr.get! ctx').parent)
     (hSamePrev : (blockPtr.get! ctx).prev = (blockPtr.get! ctx').prev)
@@ -819,11 +818,11 @@ theorem Block.WellFormed_unchanged
     (hSameArgumentIndex :
       ∀ i, i < blockPtr.getNumArguments ctx →
       ((blockPtr.getArgument i).get! ctx).index = ((blockPtr.getArgument i).get! ctx').index) :
-    (blockPtr.get! ctx').WellFormed ctx' blockPtr blockPtrInBounds' := by
-  constructor <;> grind [Block.WellFormed]
+    blockPtr.WellFormed ctx' blockPtrInBounds' := by
+  constructor <;> grind [BlockPtr.WellFormed]
 
-theorem Region.WellFormed_unchanged
-    (hWf : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr)
+theorem RegionPtr.WellFormed_unchanged {regionPtr : RegionPtr}
+    (hWf : regionPtr.WellFormed ctx)
     (hInBounds' : (regionPtr.get! ctx').FieldsInBounds ctx')
     (hSameParentOp : (regionPtr.get! ctx).parent = (regionPtr.get! ctx').parent)
     (hSameNumRegions :
@@ -833,8 +832,8 @@ theorem Region.WellFormed_unchanged
       ∀ parent, (regionPtr.get! ctx).parent = some parent →
       ∀ i, i < parent.getNumRegions! ctx →
       parent.getRegion! ctx i = parent.getRegion! ctx' i) :
-    (regionPtr.get! ctx').WellFormed ctx' regionPtr := by
-  constructor <;> grind [Region.WellFormed]
+    regionPtr.WellFormed ctx' := by
+  constructor <;> grind [RegionPtr.WellFormed]
 
 noncomputable def BlockPtr.operationList (block : BlockPtr) (ctx : IRContext OpInfo) (hctx : ctx.WellFormed) (hblock : block.InBounds ctx) : Array OperationPtr :=
   (hctx.opChain block hblock).choose
@@ -951,7 +950,7 @@ theorem IRContext.WellFormed.OperationPtr_next!_eq_some_of_prev!_eq_some
     (prevOp.get! ctx).next = some op := by
   cases hparent : (op.get! ctx).parent
   case none =>
-    grind [IRContext.WellFormed, BlockPtr.OpChain, Operation.WellFormed]
+    grind [IRContext.WellFormed, BlockPtr.OpChain, OperationPtr.WellFormed]
   case some parent =>
     intro hprev
     have ⟨array, harray⟩ := wf.opChain parent (by grind)
@@ -964,7 +963,7 @@ theorem IRContext.WellFormed.OperationPtr_prev!_eq_some_of_next!_eq_some
     (nextOp.get! ctx).prev = some op := by
   cases hparent : (op.get! ctx).parent
   case none =>
-    grind [IRContext.WellFormed, BlockPtr.OpChain, Operation.WellFormed]
+    grind [IRContext.WellFormed, BlockPtr.OpChain, OperationPtr.WellFormed]
   case some parent =>
     intro hprev
     have ⟨array, harray⟩ := wf.opChain parent (by grind)
@@ -975,7 +974,7 @@ theorem IRContext.WellFormed.OperationPtr_parent!_ne_none_of_next!_ne_none
     (wf : ctx.WellFormed missingUses missingSuccessorUses) :
     (op.get! ctx).next ≠ none →
     (op.get! ctx).parent ≠ none := by
-  grind [IRContext.WellFormed, Operation.WellFormed]
+  grind [IRContext.WellFormed, OperationPtr.WellFormed]
 
 grind_pattern IRContext.WellFormed.OperationPtr_parent!_ne_none_of_next!_ne_none =>
   ctx.WellFormed missingUses missingSuccessorUses, (op.get! ctx).next, (op.get! ctx).parent
@@ -985,7 +984,7 @@ theorem IRContext.WellFormed.OperationPtr_parent!_ne_none_of_prev!_ne_none
     (wf : ctx.WellFormed missingUses missingSuccessorUses) :
     (op.get! ctx).prev ≠ none →
     (op.get! ctx).parent ≠ none := by
-  grind [IRContext.WellFormed, Operation.WellFormed]
+  grind [IRContext.WellFormed, OperationPtr.WellFormed]
 
 grind_pattern IRContext.WellFormed.OperationPtr_parent!_ne_none_of_prev!_ne_none =>
   ctx.WellFormed missingUses missingSuccessorUses, (op.get! ctx).prev, (op.get! ctx).parent
@@ -1036,7 +1035,7 @@ theorem IRContext.WellFormed.BlockPtr_next!_eq_some_of_prev!_eq_some
     (prevBl.get! ctx).next = some bl := by
   cases hparent : (bl.get! ctx).parent
   case none =>
-    grind [IRContext.WellFormed, RegionPtr.BlockChain, Block.WellFormed]
+    grind [IRContext.WellFormed, RegionPtr.BlockChain, BlockPtr.WellFormed]
   case some parent =>
     intro hprev
     have ⟨array, harray⟩ := wf.blockChain parent (by grind)
@@ -1052,7 +1051,7 @@ theorem IRContext.WellFormed.BlockPtr_prev!_eq_some_of_next!_eq_some
     (nextBl.get! ctx).prev = some bl := by
   cases hparent : (bl.get! ctx).parent
   case none =>
-    grind [IRContext.WellFormed, RegionPtr.BlockChain, Block.WellFormed]
+    grind [IRContext.WellFormed, RegionPtr.BlockChain, BlockPtr.WellFormed]
   case some parent =>
     intro hnext
     have ⟨array, harray⟩ := wf.blockChain parent (by grind)
@@ -1066,7 +1065,7 @@ theorem IRContext.WellFormed.BlockPtr_parent!_ne_none_of_next!_ne_none
     (wf : ctx.WellFormed missingUses missingSuccessorUses) :
     (bl.get! ctx).next ≠ none →
     (bl.get! ctx).parent ≠ none := by
-  grind [IRContext.WellFormed, Block.WellFormed]
+  grind [IRContext.WellFormed, BlockPtr.WellFormed]
 
 grind_pattern IRContext.WellFormed.BlockPtr_parent!_ne_none_of_next!_ne_none =>
   ctx.WellFormed missingUses missingSuccessorUses, (bl.get! ctx).next, (bl.get! ctx).parent
@@ -1076,7 +1075,7 @@ theorem IRContext.WellFormed.BlockPtr_parent!_ne_none_of_prev!_ne_none
     (wf : ctx.WellFormed missingUses missingSuccessorUses) :
     (bl.get! ctx).prev ≠ none →
     (bl.get! ctx).parent ≠ none := by
-  grind [IRContext.WellFormed, Block.WellFormed]
+  grind [IRContext.WellFormed, BlockPtr.WellFormed]
 
 grind_pattern IRContext.WellFormed.BlockPtr_parent!_ne_none_of_prev!_ne_none =>
   ctx.WellFormed missingUses missingSuccessorUses, (bl.get! ctx).prev, (bl.get! ctx).parent
@@ -1292,11 +1291,11 @@ grind_pattern OperationPtr.idxInParentFromTail_next_eq =>
   nextOp.idxInParentFromTail ctx hnextOp hctx, (op.get! ctx).next, some nextOp, ctx.WellFormed, op.InBounds ctx
 
 /--
-  Prove preservation of the `region_parent` field of `Operation.WellFormed`, if
+  Prove preservation of the `region_parent` field of `OperationPtr.WellFormed`, if
   region parents, number of regions, and region pointers are unchanged in the
   new context.
 -/
-theorem Operation.WellFormed.region_parent.unchanged
+theorem OperationPtr.WellFormed.region_parent.unchanged
     {opPtr : OperationPtr} {ctx ctx' : IRContext OpInfo}
     (h_getRegion : opPtr.getRegion! ctx' = opPtr.getRegion! ctx)
     (h_numRegions : opPtr.getNumRegions! ctx' = opPtr.getNumRegions! ctx)

--- a/Veir/Rewriter/InsertPoint.lean
+++ b/Veir/Rewriter/InsertPoint.lean
@@ -488,10 +488,10 @@ theorem exists_parent_of_prev_eq_some {ip : BlockInsertPoint} (ctxWf : ctx.WellF
   cases ip
   case before block =>
     have := ctxWf.blocks block (by grind)
-    cases h : (block.get! ctx).parent <;> grind [Block.WellFormed]
+    cases h : (block.get! ctx).parent <;> grind [BlockPtr.WellFormed]
   case atEnd region =>
     have := ctxWf.regions region (by grind)
-    cases h : (region.get! ctx).lastBlock <;> grind [Region.WellFormed]
+    cases h : (region.get! ctx).lastBlock <;> grind [RegionPtr.WellFormed]
 
 grind_pattern exists_parent_of_prev_eq_some =>
   ctx.WellFormed, ip.InBounds ctx, ip.prev! ctx, some prevOp

--- a/Veir/Rewriter/LinkedList/WellFormed.lean
+++ b/Veir/Rewriter/LinkedList/WellFormed.lean
@@ -79,21 +79,21 @@ theorem RegionPtr.blockChain_OpOperandPtr_insertIntoCurrent
 
 theorem Operation.wellFormed_OpOperandPtr_insertIntoCurrent
     {opPtr : OperationPtr} {opInBounds} {use : OpOperandPtr} {useInBounds}
-    (hWF : (opPtr.get! ctx).WellFormed ctx opPtr opInBounds) :
-    (opPtr.get! (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) opPtr (by grind) := by
-  apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : opPtr.WellFormed ctx opInBounds) :
+    opPtr.WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Block.wellFormed_OpOperandPtr_insertIntoCurrent
     {blockPtr : BlockPtr} {blockInBounds} {use : OpOperandPtr} {useInBounds}
-    (hWF : (blockPtr.get! ctx).WellFormed ctx blockPtr blockInBounds) :
-    (blockPtr.get! (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) blockPtr (by grind) := by
-  apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : blockPtr.WellFormed ctx blockInBounds) :
+    blockPtr.WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Region.wellFormed_OpOperandPtr_insertIntoCurrent
     {regionPtr : RegionPtr} (regionInBounds : regionPtr.InBounds ctx) {use : OpOperandPtr} {useInBounds}
-    (hWF : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr) :
-    (RegionPtr.get! regionPtr (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) regionPtr := by
-  apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : regionPtr.WellFormed ctx) :
+    regionPtr.WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) := by
+  apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem IRContext.wellFormed_OpOperandPtr_insertIntoCurrent
     {ctx : IRContext OpInfo} {use : OpOperandPtr} {useInBounds} {ctxInBounds}
@@ -264,21 +264,21 @@ theorem RegionPtr.blockChain_OpOperandPtr_removeFromCurrent
 
 theorem Operation.wellFormed_OpOperandPtr_removeFromCurrent
     {opPtr : OperationPtr} {opInBounds} {use : OpOperandPtr} {useInBounds}
-    (hWF : (opPtr.get! ctx).WellFormed ctx opPtr opInBounds) :
-    (opPtr.get! (use.removeFromCurrent ctx useInBounds ctxInBounds)).WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) opPtr (by grind) := by
-  apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : opPtr.WellFormed ctx opInBounds) :
+    opPtr.WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Block.wellFormed_OpOperandPtr_removeFromCurrent
     {blockPtr : BlockPtr} {blockInBounds} {use : OpOperandPtr} {useInBounds}
-    (hWF : (blockPtr.get! ctx).WellFormed ctx blockPtr blockInBounds) :
-    (blockPtr.get! (use.removeFromCurrent ctx useInBounds ctxInBounds)).WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) blockPtr (by grind) := by
-  apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : blockPtr.WellFormed ctx blockInBounds) :
+    blockPtr.WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Region.wellFormed_OpOperandPtr_removeFromCurrent
     {regionPtr : RegionPtr} (regionInBounds : regionPtr.InBounds ctx) {use : OpOperandPtr} {useInBounds}
-    (hWF : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr) :
-    (RegionPtr.get! regionPtr (use.removeFromCurrent ctx useInBounds ctxInBounds)).WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) regionPtr := by
-  apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : regionPtr.WellFormed ctx) :
+    regionPtr.WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) := by
+  apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem IRContext.wellFormed_OpOperandPtr_removeFromCurrent
     {ctx : IRContext OpInfo} {use : OpOperandPtr} {useInBounds} {ctxInBounds}
@@ -401,21 +401,21 @@ theorem RegionPtr.blockChain_BlockOperandPtr_insertIntoCurrent
 
 theorem Operation.wellFormed_BlockOperandPtr_insertIntoCurrent
     {opPtr : OperationPtr} {opInBounds} {use : BlockOperandPtr} {useInBounds}
-    (hWF : (opPtr.get! ctx).WellFormed ctx opPtr opInBounds) :
-    (opPtr.get! (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) opPtr (by grind) := by
-  apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : opPtr.WellFormed ctx opInBounds) :
+    opPtr.WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Block.wellFormed_BlockOperandPtr_insertIntoCurrent
     {blockPtr : BlockPtr} {blockInBounds} {use : BlockOperandPtr} {useInBounds}
-    (hWF : (blockPtr.get! ctx).WellFormed ctx blockPtr blockInBounds) :
-    (blockPtr.get! (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) blockPtr (by grind) := by
-  apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : blockPtr.WellFormed ctx blockInBounds) :
+    BlockPtr.WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) blockPtr (by grind) := by
+  apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Region.wellFormed_BlockOperandPtr_insertIntoCurrent
     {regionPtr : RegionPtr} (regionInBounds : regionPtr.InBounds ctx) {use : BlockOperandPtr} {useInBounds}
-    (hWF : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr) :
-    (RegionPtr.get! regionPtr (use.insertIntoCurrent ctx useInBounds ctxInBounds)).WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) regionPtr := by
-  apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : regionPtr.WellFormed ctx) :
+    regionPtr.WellFormed (use.insertIntoCurrent ctx useInBounds ctxInBounds) := by
+  apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem IRContext.wellFormed_BlockOperandPtr_insertIntoCurrent
     {ctx : IRContext OpInfo} {use : BlockOperandPtr} {useInBounds} {ctxInBounds}
@@ -586,21 +586,21 @@ theorem RegionPtr.blockChain_BlockOperandPtr_removeFromCurrent
 
 theorem Operation.wellFormed_BlockOperandPtr_removeFromCurrent
     {opPtr : OperationPtr} {opInBounds} {use : BlockOperandPtr} {useInBounds}
-    (hWF : (opPtr.get! ctx).WellFormed ctx opPtr opInBounds) :
-    (opPtr.get! (use.removeFromCurrent ctx useInBounds ctxInBounds)).WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) opPtr (by grind) := by
-  apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : opPtr.WellFormed ctx opInBounds) :
+    opPtr.WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Block.wellFormed_BlockOperandPtr_removeFromCurrent
     {blockPtr : BlockPtr} {blockInBounds} {use : BlockOperandPtr} {useInBounds}
-    (hWF : (blockPtr.get! ctx).WellFormed ctx blockPtr blockInBounds) :
-    (blockPtr.get! (use.removeFromCurrent ctx useInBounds ctxInBounds)).WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) blockPtr (by grind) := by
-  apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : blockPtr.WellFormed ctx blockInBounds) :
+    blockPtr.WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) (by grind) := by
+  apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Region.wellFormed_BlockOperandPtr_removeFromCurrent
     {regionPtr : RegionPtr} (regionInBounds : regionPtr.InBounds ctx) {use : BlockOperandPtr} {useInBounds}
-    (hWF : (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr) :
-    (RegionPtr.get! regionPtr (use.removeFromCurrent ctx useInBounds ctxInBounds)).WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) regionPtr := by
-  apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+    (hWF : regionPtr.WellFormed ctx) :
+    regionPtr.WellFormed (use.removeFromCurrent ctx useInBounds ctxInBounds) := by
+  apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem IRContext.wellFormed_BlockOperandPtr_removeFromCurrent
     {ctx : IRContext OpInfo} {use : BlockOperandPtr} {useInBounds} {ctxInBounds}
@@ -749,30 +749,30 @@ theorem Operation.wellFormed_OperationPtr_linkBetweenWithParent
     (prevOpParent : prevOp.maybe₁ (fun prev => (prev.get! ctx).parent = some parentBlock))
     (nextOpParent : nextOp.maybe₁ (fun next => (next.get! ctx).parent = some parentBlock))
     (hctx : op.linkBetweenWithParent ctx prevOp nextOp parentBlock selfIn prevIn nextIn parentIn = some newCtx) :
-    (OperationPtr.get! opPtr ctx).WellFormed ctx opPtr opInBounds →
-    (OperationPtr.get! opPtr newCtx).WellFormed newCtx opPtr (by grind) := by
+    OperationPtr.WellFormed ctx opPtr opInBounds →
+    OperationPtr.WellFormed newCtx opPtr (by grind) := by
   intro wf
   constructor
   case region_parent =>
     intro region regionInBounds
-    apply Operation.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind [IRContext.WellFormed, Operation.WellFormed]
-  all_goals grind [Option.maybe₁_def, IRContext.WellFormed, Operation.WellFormed]
+    apply OperationPtr.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind [IRContext.WellFormed, OperationPtr.WellFormed]
+  all_goals grind [Option.maybe₁_def, IRContext.WellFormed, OperationPtr.WellFormed]
 
 theorem Block.wellFormed_OperationPtr_linkBetweenWithParent
     (ctxInBounds: IRContext.FieldsInBounds ctx)
     (hctx : op.linkBetweenWithParent ctx prevOp nextOp parentBlock selfIn prevIn nextIn parentIn = some newCtx) :
-    (BlockPtr.get! blockPtr ctx).WellFormed ctx blockPtr blockInBounds →
-    (BlockPtr.get! blockPtr newCtx).WellFormed newCtx blockPtr (by grind) := by
+    BlockPtr.WellFormed ctx blockPtr blockInBounds →
+    BlockPtr.WellFormed newCtx blockPtr (by grind) := by
   intros
-  apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+  apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Region.wellFormed_OperationPtr_linkBetweenWithParent
     (ctxInBounds: IRContext.FieldsInBounds ctx) (regionInBounds : regionPtr.InBounds ctx)
     (hctx : op.linkBetweenWithParent ctx prevOp nextOp parentBlock selfIn prevIn nextIn parentIn = some newCtx) :
-    (RegionPtr.get! regionPtr ctx).WellFormed ctx regionPtr →
-    (RegionPtr.get! regionPtr newCtx).WellFormed newCtx regionPtr := by
+    RegionPtr.WellFormed ctx regionPtr →
+    RegionPtr.WellFormed newCtx regionPtr := by
   intros
-  apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+  apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem IRContext.wellFormed_OperationPtr_linkBetweenWithParent
     (hWF : ctx.WellFormed)
@@ -920,31 +920,31 @@ theorem RegionPtr.blockChain_BlockPtr_linkBetweenWithParent_other
 theorem Operation.wellFormed_BlockPtr_linkBetweenWithParent
     (ctxInBounds: IRContext.FieldsInBounds ctx)
     (hctx : block.linkBetweenWithParent ctx prevBlock nextBlock parentRegion selfIn prevIn nextIn parentIn = some newCtx) :
-    (OperationPtr.get! opPtr ctx).WellFormed ctx opPtr opInBounds →
-    (OperationPtr.get! opPtr newCtx).WellFormed newCtx opPtr (by grind) := by
+    OperationPtr.WellFormed ctx opPtr opInBounds →
+    OperationPtr.WellFormed newCtx opPtr (by grind) := by
   intros
-  apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+  apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Block.wellFormed_BlockPtr_linkBetweenWithParent
     (ctxWf : IRContext.WellFormed ctx)
     (prevBlockParent : prevBlock.maybe₁ (fun prev => (prev.get! ctx).parent = some parentRegion))
     (nextBlockParent : nextBlock.maybe₁ (fun next => (next.get! ctx).parent = some parentRegion))
     (hctx : block.linkBetweenWithParent ctx prevBlock nextBlock parentRegion selfIn prevIn nextIn parentIn = some newCtx)
-    (hWF : (BlockPtr.get! block' ctx).WellFormed ctx block' blockInBounds) :
-    (BlockPtr.get! block' newCtx).WellFormed newCtx block' (by grind) := by
-  by_cases hBlock : block' = block <;> constructor <;> grind [Block.WellFormed, Option.maybe₁_def]
+    (hWF : BlockPtr.WellFormed ctx block' blockInBounds) :
+    BlockPtr.WellFormed newCtx block' (by grind) := by
+  by_cases hBlock : block' = block <;> constructor <;> grind [BlockPtr.WellFormed, Option.maybe₁_def]
 
 theorem Region.wellFormed_BlockPtr_linkBetweenWithParent
     (ctxWf : IRContext.WellFormed ctx)
     (hctx : block.linkBetweenWithParent ctx prevBlock nextBlock parentRegion selfIn prevIn nextIn parentIn = some newCtx)
     (regionInBounds : region.InBounds ctx)
-    (hWF : (RegionPtr.get! region ctx).WellFormed ctx region) :
-    (RegionPtr.get! region newCtx).WellFormed newCtx region := by
+    (hWF : RegionPtr.WellFormed ctx region) :
+    RegionPtr.WellFormed newCtx region := by
   by_cases hregion : region = parentRegion
-  · constructor <;> try grind [Region.WellFormed, Option.maybe₁_def]
+  · constructor <;> try grind [RegionPtr.WellFormed, Option.maybe₁_def]
     simp only [OperationPtr.getRegion!_BlockPtr_linkBetweenWithParent hctx]
-    grind [Region.WellFormed]
-  · apply Region.WellFormed_unchanged (ctx := ctx) <;> grind [Region.WellFormed]
+    grind [RegionPtr.WellFormed]
+  · apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind [RegionPtr.WellFormed]
 
 theorem IRContext.wellFormed_BlockPtr_linkBetweenWithParent
     (hWF : ctx.WellFormed)

--- a/Veir/Rewriter/WellFormed/Block.lean
+++ b/Veir/Rewriter/WellFormed/Block.lean
@@ -63,17 +63,17 @@ theorem BlockPtr.allocEmpty_wellFormed (hctx : ctx.WellFormed)
   case operations =>
     intro operation operationInBounds
     have := hctx.operations operation (by grind)
-    apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+    apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
   case blocks =>
     intro block blockInBounds
     by_cases bl = block
     · constructor <;> grind [Block.empty]
     · have := hctx.blocks block (by grind)
-      apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+      apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
   case regions =>
     intro region regionInBounds
     have := hctx.regions region (by grind)
-    apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+    apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Rewriter.createBlock_WellFormed (ctxWf : ctx.WellFormed) :
     Rewriter.createBlock ctx ip hctx hip = some (newCtx, newBlock) →

--- a/Veir/Rewriter/WellFormed/OpOperands.lean
+++ b/Veir/Rewriter/WellFormed/OpOperands.lean
@@ -120,7 +120,7 @@ theorem Rewriter.pushOperand_WellFormed  (valuePtr : ValuePtr) (valuePtrInBounds
       intros region regionInBounds
       simp only [OperationPtr.getRegion!_pushOperand]
       grind
-    all_goals grind [Operation.WellFormed]
+    all_goals grind [OperationPtr.WellFormed]
   case blocks =>
     intros bl blInBounds
     have ⟨h₁, h₂, h₃, h₄, h₅⟩ := hOpWf.blocks bl (by grind)

--- a/Veir/Rewriter/WellFormed/OpRegion.lean
+++ b/Veir/Rewriter/WellFormed/OpRegion.lean
@@ -57,7 +57,7 @@ theorem IRContext.wellFormed_Rewriter_pushRegion :
         · intro _
           exists op.getNumRegions! ctx
           grind
-    all_goals grind [Operation.WellFormed]
+    all_goals grind [OperationPtr.WellFormed]
   case blocks =>
     intros bl hbl
     have ⟨h₁, h₂, h₃, h₄, h₅⟩ := wf.blocks bl (by grind)

--- a/Veir/Rewriter/WellFormed/OpResults.lean
+++ b/Veir/Rewriter/WellFormed/OpResults.lean
@@ -80,14 +80,14 @@ theorem IRContext.wellFormed_Rewriter_pushResult :
     constructor
     case region_parent =>
       intro region regionInBounds
-      apply Operation.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind
+      apply OperationPtr.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind
     all_goals grind
   case blocks =>
     intros bl hbl
     have : bl.InBounds ctx := by grind
-    grind [Block.WellFormed_unchanged]
+    grind [BlockPtr.WellFormed_unchanged]
   case regions =>
-    grind [Region.WellFormed_unchanged]
+    grind [RegionPtr.WellFormed_unchanged]
 
 /-! ## Rewriter.initOpResults -/
 

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -132,7 +132,7 @@ theorem Rewriter.detachOp_WellFormed (ctx : IRContext OpInfo) (wf : ctx.WellForm
     constructor
     case region_parent =>
       intro region regionInBounds
-      apply Operation.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind
+      apply OperationPtr.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind
     case opChain_of_parent_none =>
       cases hParent: (op.get! ctx).parent
         <;> grind [BlockPtr.OpChain_next_ne, BlockPtr.OpChain_prev_ne]
@@ -140,9 +140,9 @@ theorem Rewriter.detachOp_WellFormed (ctx : IRContext OpInfo) (wf : ctx.WellForm
   case blocks =>
     intros bl hbl
     have : bl.InBounds ctx := by grind
-    grind [Block.WellFormed_unchanged]
+    grind [BlockPtr.WellFormed_unchanged]
   case regions =>
-    grind [Region.WellFormed_unchanged]
+    grind [RegionPtr.WellFormed_unchanged]
 
 end detachOp
 
@@ -403,16 +403,16 @@ theorem Rewriter.createEmptyOp_wellFormed  (hctx : IRContext.WellFormed ctx) :
       constructor
       case neg.region_parent =>
         intro region regionInBounds
-        apply Operation.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind
+        apply OperationPtr.WellFormed.region_parent.unchanged (ctx := ctx) <;> grind
       all_goals grind
   case blocks =>
     intro bl hbl
     have := hctx.blocks bl (by grind)
-    apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+    apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
   case regions =>
     intro reg hreg
     have := hctx.regions reg (by grind)
-    apply Region.WellFormed_unchanged (ctx := ctx) <;> try grind
+    apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> try grind
 
 theorem Rewriter.createOp_WellFormed
     (hctx : IRContext.WellFormed ctx) :

--- a/Veir/Rewriter/WellFormed/Region.lean
+++ b/Veir/Rewriter/WellFormed/Region.lean
@@ -40,12 +40,12 @@ theorem IRContext.wellFormed_Rewriter_createRegion (hctx : ctx.WellFormed) :
       apply RegionPtr.blockChain_unchanged (ctx := ctx) <;> grind
   · intro operation operationInBounds
     have := hctx.operations operation (by grind)
-    apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind
+    apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind
   · intro block blockInBounds
     have := hctx.blocks block (by grind)
-    apply Block.WellFormed_unchanged (ctx := ctx) <;> grind
+    apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind
   · intro region' region'InBounds
     by_cases region = region'
     · constructor <;> grind
     · have := hctx.regions region' (by grind)
-      apply Region.WellFormed_unchanged (ctx := ctx) <;> grind
+      apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind

--- a/Veir/Rewriter/WellFormed/Value.lean
+++ b/Veir/Rewriter/WellFormed/Value.lean
@@ -139,13 +139,13 @@ theorem Rewriter.replaceUse_WellFormed (ctx: IRContext OpInfo) (use : OpOperandP
       apply RegionPtr.blockChain_unchanged (ctx := ctx) <;> grind
     case operations =>
       intros opPtr opPtrInBounds
-      apply Operation.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
+      apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
     case blocks =>
       intros blockPtr blockPtrInBounds
-      apply Block.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
+      apply BlockPtr.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
     case regions =>
       intros regionPtr regionPtrInBounds
-      apply Region.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
+      apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
 
 theorem Rewriter.replaceValue?_WellFormed (ctx: IRContext OpInfo) (oldValue: ValuePtr) (newValue: ValuePtr)
     (oldIn: oldValue.InBounds ctx)


### PR DESCRIPTION
`Operation.WellFormed`, `Block.WellFormed`, `Region.WellFormed` were taking both the pointer and the structure as argument, despite the structure not being used in any of the fields.

This changes their names to `OperationPtr.WellFormed` (etc..), and remove the structure argument. This doesn't have any other changes.

Fixes #44 