### PR TITLE
feat: Extended Rationals

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -2,3 +2,4 @@ import UnitTest.Lexer
 import UnitTest.Parser
 import UnitTest.AttrParser
 import UnitTest.MlirParser
+import UnitTest.FP

--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -1,5 +1,3 @@
 module 
 
 public import UnitTest.FP.PackedFloat
-
-

--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -1,0 +1,5 @@
+module 
+
+public import UnitTest.FP.PackedFloat
+
+

--- a/UnitTest/FP/PackedFloat.lean
+++ b/UnitTest/FP/PackedFloat.lean
@@ -1,0 +1,4 @@
+module
+
+public import UnitTest.FP.PackedFloat.ToExtRat
+

--- a/UnitTest/FP/PackedFloat/ToExtRat.lean
+++ b/UnitTest/FP/PackedFloat/ToExtRat.lean
@@ -16,36 +16,36 @@ These tests check `PackedFloat.toExtRat` against the values produced by
 reinterpreting Lean's native `Float` (an IEEE-754 double) via
 `PackedFloat.ofFloat`. -/
 
-#guard toExtRat (ofFloat 0.0) = ExtRat.Number 0
-#guard toExtRat (ofFloat (-0.0)) = ExtRat.Number 0
-#guard toExtRat (ofFloat 1.0) = ExtRat.Number 1
+#guard toExtRat (ofFloat 0.0) = .number 0
+#guard toExtRat (ofFloat (-0.0)) = .number 0
+#guard toExtRat (ofFloat 1.0) = .number 1
 #guard toFloat (ofFloat 1.0) == 1.0
 
-#guard toExtRat (ofFloat (-1.0)) = ExtRat.Number (-1)
+#guard toExtRat (ofFloat (-1.0)) = .number (-1)
 #guard toFloat (ofFloat (-1.0)) == -1.0
 
-#guard toExtRat (ofFloat 2.0) = ExtRat.Number 2
+#guard toExtRat (ofFloat 2.0) = .number 2
 #guard toFloat (ofFloat (2.0)) == 2.0
 
-#guard toExtRat (ofFloat 0.5) = ExtRat.Number (1 / 2)
+#guard toExtRat (ofFloat 0.5) = .number (1 / 2)
 #guard toFloat (ofFloat (0.5)) == 0.5
 
-#guard toExtRat (ofFloat 1.5) = ExtRat.Number (3 / 2)
+#guard toExtRat (ofFloat 1.5) = .number (3 / 2)
 #guard toFloat (ofFloat (1.5)) == 1.5
 
-#guard toExtRat (ofFloat (-1.5)) = ExtRat.Number (-3 / 2)
+#guard toExtRat (ofFloat (-1.5)) = .number (-3 / 2)
 #guard toFloat (ofFloat (-1.5)) == -1.5
 
-#guard toExtRat (ofFloat 1024.0) = ExtRat.Number 1024
+#guard toExtRat (ofFloat 1024.0) = .number 1024
 #guard toFloat (ofFloat (1024.0)) == 1024.0
 
-#guard toExtRat (ofFloat (1.0 / 0.0)) = ExtRat.Infinity false
+#guard toExtRat (ofFloat (1.0 / 0.0)) = .infinity false
 #guard toFloat (ofFloat (1.0 / 0.0)) == 1.0 / 0.0
 
-#guard toExtRat (ofFloat (-1.0 / 0.0)) = ExtRat.Infinity true
+#guard toExtRat (ofFloat (-1.0 / 0.0)) = .infinity true
 #guard toFloat (ofFloat (-1.0 / 0.0)) == -1.0 / 0.0
 
-#guard toExtRat (ofFloat (0.0 / 0.0)) = ExtRat.NaN
+#guard toExtRat (ofFloat (0.0 / 0.0)) = .nan
 #guard Float.isNaN <| toFloat (ofFloat (0.0 / 0.0))
 
 /-! ### Subnormals
@@ -67,4 +67,4 @@ test this precisely that it is the machine epsilon.
 #guard toFloat smallestPositiveSubnormal > 0.0
 
 #guard toExtRat smallestPositiveSubnormal =
-  ExtRat.Number (1 / ((2 ^ 1074 : Nat) : Rat))
+  .number (1 / ((2 ^ 1074 : Nat) : Rat))

--- a/UnitTest/FP/PackedFloat/ToExtRat.lean
+++ b/UnitTest/FP/PackedFloat/ToExtRat.lean
@@ -62,7 +62,7 @@ def smallestPositiveSubnormal : PackedFloat 11 52 :=
 Construct the float that 'smallestPositiveSubnormal'
 corresponds to as a Lean float.
 The subnormal is larger than zero, but I'm not sure how to
-test this precisely that it is the machine epsilon.
+test precisely that it is the machine epsilon.
 -/
 #guard toFloat smallestPositiveSubnormal > 0.0
 

--- a/UnitTest/FP/PackedFloat/ToExtRat.lean
+++ b/UnitTest/FP/PackedFloat/ToExtRat.lean
@@ -48,7 +48,7 @@ reinterpreting Lean's native `Float` (an IEEE-754 double) via
 #guard toExtRat (ofFloat (0.0 / 0.0)) = .nan
 #guard Float.isNaN <| toFloat (ofFloat (0.0 / 0.0))
 
-/-! ### Subnormals
+/-! ## Subnormals
 
 The smallest representable positive double is the subnormal whose biased
 exponent is `0` and whose trailing significand is `1`:

--- a/UnitTest/FP/PackedFloat/ToExtRat.lean
+++ b/UnitTest/FP/PackedFloat/ToExtRat.lean
@@ -1,0 +1,70 @@
+module
+
+public import Veir.Data.FP.ExtRat.Basic
+public import Veir.Data.FP.PackedFloat.ToExtRat
+
+public meta import Veir.Data.FP.ExtRat.Basic
+public meta import Veir.Data.FP.PackedFloat.OfFloat
+public meta import Veir.Data.FP.PackedFloat.ToExtRat
+
+namespace UnitTest.Fp.PackedFloat.ToExtRat
+
+open Veir.Data.FP
+open Veir.Data.FP.PackedFloat
+
+/-! ## Tests against Lean's native `Float` (IEEE-754 double)
+
+These tests check `PackedFloat.toExtRat` against the values produced by
+reinterpreting Lean's native `Float` (an IEEE-754 double) via
+`PackedFloat.ofFloat`. -/
+
+#guard toExtRat (ofFloat 0.0) = ExtRat.Number 0
+#guard toExtRat (ofFloat (-0.0)) = ExtRat.Number 0
+#guard toExtRat (ofFloat 1.0) = ExtRat.Number 1
+#guard toFloat (ofFloat 1.0) == 1.0
+
+#guard toExtRat (ofFloat (-1.0)) = ExtRat.Number (-1)
+#guard toFloat (ofFloat (-1.0)) == -1.0
+
+#guard toExtRat (ofFloat 2.0) = ExtRat.Number 2
+#guard toFloat (ofFloat (2.0)) == 2.0
+
+#guard toExtRat (ofFloat 0.5) = ExtRat.Number (1 / 2)
+#guard toFloat (ofFloat (0.5)) == 0.5
+
+#guard toExtRat (ofFloat 1.5) = ExtRat.Number (3 / 2)
+#guard toFloat (ofFloat (1.5)) == 1.5
+
+#guard toExtRat (ofFloat (-1.5)) = ExtRat.Number (-3 / 2)
+#guard toFloat (ofFloat (-1.5)) == -1.5
+
+#guard toExtRat (ofFloat 1024.0) = ExtRat.Number 1024
+#guard toFloat (ofFloat (1024.0)) == 1024.0
+
+#guard toExtRat (ofFloat (1.0 / 0.0)) = ExtRat.Infinity false
+#guard toFloat (ofFloat (1.0 / 0.0)) == 1.0 / 0.0
+
+#guard toExtRat (ofFloat (-1.0 / 0.0)) = ExtRat.Infinity true
+#guard toFloat (ofFloat (-1.0 / 0.0)) == -1.0 / 0.0
+
+#guard toExtRat (ofFloat (0.0 / 0.0)) = ExtRat.NaN
+#guard Float.isNaN <| toFloat (ofFloat (0.0 / 0.0)) 
+
+/-! ### Subnormals
+
+The smallest representable positive double is the subnormal whose biased
+exponent is `0` and whose trailing significand is `1`:
+`+0 * 2^(1 - 1023) * (1 / 2^52) = 2^(-1074) = 1 / 2^1074`. -/
+
+/-- Smallest positive representable double (subnormal). -/
+def smallestPositiveSubnormal : PackedFloat 11 52 :=
+  PackedFloat.mk (sign := false) (ex := 0#11) (sig := 1#52)
+
+/-
+construct the float that it corresponds to as a Lean float.
+The subnormal is larger than zero, but I'm not sure how to 
+-/
+#guard toFloat smallestPositiveSubnormal > 0.0
+
+#guard toExtRat smallestPositiveSubnormal =
+  ExtRat.Number (1 / ((2 ^ 1074 : Nat) : Rat))

--- a/UnitTest/FP/PackedFloat/ToExtRat.lean
+++ b/UnitTest/FP/PackedFloat/ToExtRat.lean
@@ -1,11 +1,9 @@
 module
 
-public import Veir.Data.FP.ExtRat.Basic
-public import Veir.Data.FP.PackedFloat.ToExtRat
+import Veir.Data.FP.PackedFloat.ToExtRat
 
-public meta import Veir.Data.FP.ExtRat.Basic
-public meta import Veir.Data.FP.PackedFloat.OfFloat
-public meta import Veir.Data.FP.PackedFloat.ToExtRat
+meta import Veir.Data.FP.PackedFloat.OfFloat
+meta import Veir.Data.FP.PackedFloat.ToExtRat
 
 namespace UnitTest.Fp.PackedFloat.ToExtRat
 

--- a/UnitTest/FP/PackedFloat/ToExtRat.lean
+++ b/UnitTest/FP/PackedFloat/ToExtRat.lean
@@ -48,7 +48,7 @@ reinterpreting Lean's native `Float` (an IEEE-754 double) via
 #guard toFloat (ofFloat (-1.0 / 0.0)) == -1.0 / 0.0
 
 #guard toExtRat (ofFloat (0.0 / 0.0)) = ExtRat.NaN
-#guard Float.isNaN <| toFloat (ofFloat (0.0 / 0.0)) 
+#guard Float.isNaN <| toFloat (ofFloat (0.0 / 0.0))
 
 /-! ### Subnormals
 
@@ -61,8 +61,10 @@ def smallestPositiveSubnormal : PackedFloat 11 52 :=
   PackedFloat.mk (sign := false) (ex := 0#11) (sig := 1#52)
 
 /-
-construct the float that it corresponds to as a Lean float.
-The subnormal is larger than zero, but I'm not sure how to 
+Construct the float that 'smallestPositiveSubnormal'
+corresponds to as a Lean float.
+The subnormal is larger than zero, but I'm not sure how to
+test this precisely that it is the machine epsilon.
 -/
 #guard toFloat smallestPositiveSubnormal > 0.0
 

--- a/Veir/Data/FP/.claude/settings.local.json
+++ b/Veir/Data/FP/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(lake build *)"
+    ]
+  }
+}

--- a/Veir/Data/FP/.claude/settings.local.json
+++ b/Veir/Data/FP/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(lake build *)"
-    ]
-  }
-}

--- a/Veir/Data/FP/EScientificBV.lean
+++ b/Veir/Data/FP/EScientificBV.lean
@@ -1,0 +1,3 @@
+module
+
+public import Veir.Data.FP.EScientificBV.Basic

--- a/Veir/Data/FP/ExtRat.lean
+++ b/Veir/Data/FP/ExtRat.lean
@@ -1,0 +1,3 @@
+module
+
+public import Veir.Data.FP.ExtRat.Basic

--- a/Veir/Data/FP/ExtRat/Basic.lean
+++ b/Veir/Data/FP/ExtRat/Basic.lean
@@ -1,0 +1,17 @@
+module
+
+namespace Veir.Data.FP
+
+public section
+
+/--
+Extended rational numbers: rationals augmented with `NaN` and signed infinities.
+This is the mathematical model that an IEEE-754 floating-point number is
+interpreted as: every bit pattern of a `PackedFloat` corresponds to either
+`NaN`, a signed infinity, or a precise rational number.
+-/
+inductive ExtRat where
+  | NaN : ExtRat
+  | Infinity : Bool → ExtRat
+  | Number : Rat → ExtRat
+deriving DecidableEq, Repr, Inhabited

--- a/Veir/Data/FP/ExtRat/Basic.lean
+++ b/Veir/Data/FP/ExtRat/Basic.lean
@@ -12,7 +12,7 @@ interpreted as: every bit pattern of a `PackedFloat` corresponds to either
 or a precise rational number.
 -/
 inductive ExtRat where
-  | NaN : ExtRat
-  | Infinity : (sign : Bool) → ExtRat
-  | Number : Rat → ExtRat
+  | nan : ExtRat
+  | infinity : (sign : Bool) → ExtRat
+  | number : Rat → ExtRat
 deriving DecidableEq, Repr, Inhabited

--- a/Veir/Data/FP/ExtRat/Basic.lean
+++ b/Veir/Data/FP/ExtRat/Basic.lean
@@ -8,10 +8,11 @@ public section
 Extended rational numbers: rationals augmented with `NaN` and signed infinities.
 This is the mathematical model that an IEEE-754 floating-point number is
 interpreted as: every bit pattern of a `PackedFloat` corresponds to either
-`NaN`, a signed infinity, or a precise rational number.
+`NaN`, a signed infinity (where sign=true indicates negative infinity),
+or a precise rational number.
 -/
 inductive ExtRat where
   | NaN : ExtRat
-  | Infinity : Bool → ExtRat
+  | Infinity : (sign : Bool) → ExtRat
   | Number : Rat → ExtRat
 deriving DecidableEq, Repr, Inhabited

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -2,3 +2,5 @@ module
 
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.ScientificBV.Basic
+public import Veir.Data.FP.ExtRat.Basic
+public import Veir.Data.FP.PackedFloat.ToExtRat

--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -2,4 +2,5 @@ module
 
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.PackedFloat.OfFloat
+public import Veir.Data.FP.PackedFloat.ToExtRat
 

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -9,8 +9,8 @@ public section
 /-- Convert a Lean double (`Float`) to a `PackedFloat`.
 Recall that a IEEE double has the following layout:
   - 1 bit for the sign
-  - 11 bits for the exponent 
-  - 52 bits for the significand 
+  - 11 bits for the exponent
+  - 52 bits for the significand
 This function reinterprets the bits of the `Float` as a `PackedFloat``
 with the corresponding sign, exponent, and significand fields.
 -/
@@ -26,3 +26,4 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
   Float.ofBits (UInt64.ofBitVec bits)
 
+end

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -1,8 +1,10 @@
 module
 
-import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.Basic
 
 namespace Veir.Data.FP.PackedFloat
+
+public section
 
 /-- Convert a Lean double (`Float`) to a `PackedFloat`.
 Recall that a IEEE double has the following layout:
@@ -24,4 +26,3 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
   Float.ofBits (UInt64.ofBitVec bits)
 
-end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -26,5 +26,5 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
   Float.ofBits (UInt64.ofBitVec bits)
 
-end
+end -- public section
 end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -27,3 +27,4 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   Float.ofBits (UInt64.ofBitVec bits)
 
 end
+end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -1,0 +1,73 @@
+module
+
+public import Veir.Data.FP.ExtRat.Basic
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.OfFloat
+public import Veir.Data.FP.Sign
+
+public meta import Veir.Data.FP.ExtRat.Basic
+public meta import Veir.Data.FP.PackedFloat.OfFloat
+public meta import Veir.Data.FP.Sign
+
+namespace Veir.Data.FP.PackedFloat
+
+public section
+
+/--
+The exponent bias for a packed float with `e` exponent bits.
+For a double (`e = 11`), this is `2^10 - 1 = 1023`.
+-/
+def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
+
+/-- `2` raised to a (possibly negative) integer power, as a `Rat`. -/
+def pow2 (k : Int) : Rat :=
+  if k ≥ 0 then ((2 ^ k.toNat : Nat) : Rat)
+  else 1 / ((2 ^ (-k).toNat : Nat) : Rat)
+
+/--
+The fractional contribution of the trailing significand: `sig.toNat / 2^s`.
+For a normal float this lies in `[0, 1)` and is added to the implicit leading
+`1`; for a subnormal float it is multiplied by the minimum exponent directly.
+-/
+def sigFrac {s : Nat} (sig : BitVec s) : Rat :=
+  (sig.toNat : Rat) / ((2 ^ s : Nat) : Rat)
+
+/--
+Convert a `PackedFloat e s` to its precise mathematical value as an `ExtRat`,
+following the IEEE-754 interpretation:
+- biased exponent `allOnes` with non-zero significand → `NaN`
+- biased exponent `allOnes` with zero significand → signed `Infinity`
+- biased exponent `0` with zero significand → `Number 0` (sign discarded)
+- biased exponent `0` with non-zero significand → subnormal:
+  `(-1)^sign * 2^(1 - bias) * (sig / 2^s)`
+- otherwise normal:
+  `(-1)^sign * 2^(ex - bias) * (1 + sig / 2^s)`
+-/
+def toExtRat {e s : Nat} (pf : PackedFloat e s) : ExtRat :=
+  if pf.ex = BitVec.allOnes e then
+    if pf.sig = 0#s then ExtRat.Infinity pf.sign
+    else ExtRat.NaN
+  else if pf.ex = 0#e then
+    if pf.sig = 0#s then ExtRat.Number 0
+    else
+      ExtRat.Number (signToInt pf.sign * pow2 (1 - (bias e : Int)) * sigFrac pf.sig)
+  else
+    ExtRat.Number (signToInt pf.sign *
+      pow2 ((pf.ex.toNat : Int) - (bias e : Int)) * (1 + sigFrac pf.sig))
+
+/-! ## Tests against Lean's native `Float` (IEEE-754 double) -/
+
+#guard toExtRat (ofFloat 0.0) = ExtRat.Number 0
+#guard toExtRat (ofFloat (-0.0)) = ExtRat.Number 0
+#guard toExtRat (ofFloat 1.0) = ExtRat.Number 1
+#guard toExtRat (ofFloat (-1.0)) = ExtRat.Number (-1)
+#guard toExtRat (ofFloat 2.0) = ExtRat.Number 2
+#guard toExtRat (ofFloat (-2.0)) = ExtRat.Number (-2)
+#guard toExtRat (ofFloat 0.5) = ExtRat.Number (1 / 2)
+#guard toExtRat (ofFloat 0.25) = ExtRat.Number (1 / 4)
+#guard toExtRat (ofFloat 1.5) = ExtRat.Number (3 / 2)
+#guard toExtRat (ofFloat (-1.5)) = ExtRat.Number (-3 / 2)
+#guard toExtRat (ofFloat 1024.0) = ExtRat.Number 1024
+#guard toExtRat (ofFloat (1.0 / 0.0)) = ExtRat.Infinity false
+#guard toExtRat (ofFloat (-1.0 / 0.0)) = ExtRat.Infinity true
+#guard toExtRat (ofFloat (0.0 / 0.0)) = ExtRat.NaN

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -15,9 +15,7 @@ For a double (`e = 11`), this is `2^10 - 1 = 1023`.
 def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
 
 /-- `2` raised to a (possibly negative) integer power, as a `Rat`. -/
-def pow2 (k : Int) : Rat :=
-  if k ≥ 0 then ((2 ^ k.toNat : Nat) : Rat)
-  else 1 / ((2 ^ (-k).toNat : Nat) : Rat)
+def pow2 (k : Int) : Rat := 2 ^ k
 
 /--
 The fractional contribution of the trailing significand: `sig.toNat / 2^s`.

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.Sign
+public import Veir.ForLean
 
 namespace Veir.Data.FP.PackedFloat
 
@@ -13,9 +14,6 @@ The exponent bias for a packed float with `e` exponent bits.
 For a double (`e = 11`), this is `2^10 - 1 = 1023`.
 -/
 def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
-
-/-- `2` raised to a (possibly negative) integer power, as a `Rat`. -/
-def pow2 (k : Int) : Rat := 2 ^ k
 
 /--
 The fractional contribution of the trailing significand: `sig.toNat / 2^s`.
@@ -44,7 +42,7 @@ def toExtRat {e s : Nat} (pf : PackedFloat e s) : ExtRat :=
   else if pf.ex = 0#e then
     if pf.sig = 0#s then ExtRat.Number 0
     else
-      ExtRat.Number (signToInt pf.sign * pow2 (1 - (bias e : Int)) * sigFrac pf.sig)
+      ExtRat.Number (signToInt pf.sign * Rat.twoPow (1 - (bias e : Int)) * sigFrac pf.sig)
   else
     ExtRat.Number (signToInt pf.sign *
-      pow2 ((pf.ex.toNat : Int) - (bias e : Int)) * (1 + sigFrac pf.sig))
+      Rat.twoPow ((pf.ex.toNat : Int) - (bias e : Int)) * (1 + sigFrac pf.sig))

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -37,12 +37,12 @@ https://standards.ieee.org/ieee/754/6210/):
 -/
 def toExtRat {e s : Nat} (pf : PackedFloat e s) : ExtRat :=
   if pf.ex = BitVec.allOnes e then
-    if pf.sig = 0#s then ExtRat.Infinity pf.sign
-    else ExtRat.NaN
+    if pf.sig = 0#s then .infinity pf.sign
+    else .nan
   else if pf.ex = 0#e then
-    if pf.sig = 0#s then ExtRat.Number 0
+    if pf.sig = 0#s then .number 0
     else
-      ExtRat.Number (signToInt pf.sign * Rat.twoPow (1 - (bias e : Int)) * sigFrac pf.sig)
+      .number (signToInt pf.sign * Rat.twoPow (1 - (bias e : Int)) * sigFrac pf.sig)
   else
-    ExtRat.Number (signToInt pf.sign *
+    .number (signToInt pf.sign *
       Rat.twoPow ((pf.ex.toNat : Int) - (bias e : Int)) * (1 + sigFrac pf.sig))

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -20,7 +20,7 @@ def pow2 (k : Int) : Rat := 2 ^ k
 /--
 The fractional contribution of the trailing significand: `sig.toNat / 2^s`.
 For a normal float this lies in `[0, 1)` and is added to the implicit leading
-`1`; for a subnormal float it is multiplied by the minimum exponent directly.
+`1`; for a subnormal float this is multiplied by the minimum exponent directly.
 -/
 def sigFrac {s : Nat} (sig : BitVec s) : Rat :=
   (sig.toNat : Rat) / ((2 ^ s : Nat) : Rat)

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -2,12 +2,7 @@ module
 
 public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.Basic
-public import Veir.Data.FP.PackedFloat.OfFloat
 public import Veir.Data.FP.Sign
-
-public meta import Veir.Data.FP.ExtRat.Basic
-public meta import Veir.Data.FP.PackedFloat.OfFloat
-public meta import Veir.Data.FP.Sign
 
 namespace Veir.Data.FP.PackedFloat
 
@@ -34,7 +29,8 @@ def sigFrac {s : Nat} (sig : BitVec s) : Rat :=
 
 /--
 Convert a `PackedFloat e s` to its precise mathematical value as an `ExtRat`,
-following the IEEE-754 interpretation:
+following the IEEE-754 interpretation (Section 3.4 of the IEEE-754 standard,
+https://standards.ieee.org/ieee/754/6210/):
 - biased exponent `allOnes` with non-zero significand → `NaN`
 - biased exponent `allOnes` with zero significand → signed `Infinity`
 - biased exponent `0` with zero significand → `Number 0` (sign discarded)
@@ -54,20 +50,3 @@ def toExtRat {e s : Nat} (pf : PackedFloat e s) : ExtRat :=
   else
     ExtRat.Number (signToInt pf.sign *
       pow2 ((pf.ex.toNat : Int) - (bias e : Int)) * (1 + sigFrac pf.sig))
-
-/-! ## Tests against Lean's native `Float` (IEEE-754 double) -/
-
-#guard toExtRat (ofFloat 0.0) = ExtRat.Number 0
-#guard toExtRat (ofFloat (-0.0)) = ExtRat.Number 0
-#guard toExtRat (ofFloat 1.0) = ExtRat.Number 1
-#guard toExtRat (ofFloat (-1.0)) = ExtRat.Number (-1)
-#guard toExtRat (ofFloat 2.0) = ExtRat.Number 2
-#guard toExtRat (ofFloat (-2.0)) = ExtRat.Number (-2)
-#guard toExtRat (ofFloat 0.5) = ExtRat.Number (1 / 2)
-#guard toExtRat (ofFloat 0.25) = ExtRat.Number (1 / 4)
-#guard toExtRat (ofFloat 1.5) = ExtRat.Number (3 / 2)
-#guard toExtRat (ofFloat (-1.5)) = ExtRat.Number (-3 / 2)
-#guard toExtRat (ofFloat 1024.0) = ExtRat.Number 1024
-#guard toExtRat (ofFloat (1.0 / 0.0)) = ExtRat.Infinity false
-#guard toExtRat (ofFloat (-1.0 / 0.0)) = ExtRat.Infinity true
-#guard toExtRat (ofFloat (0.0 / 0.0)) = ExtRat.NaN

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -291,3 +291,13 @@ theorem umulOverflow_comm {w : Nat} (x y : BitVec w) :
   grind [BitVec.umulOverflow]
 
 end BitVec
+
+
+namespace Rat
+
+/-- `2` raised to a (possibly negative) integer power as a `Rat`. -/
+def twoPow (k : Int) : Rat := 2 ^ k
+
+
+end Rat
+

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -292,12 +292,10 @@ theorem umulOverflow_comm {w : Nat} (x y : BitVec w) :
 
 end BitVec
 
-
 namespace Rat
 
 /-- `2` raised to a (possibly negative) integer power as a `Rat`. -/
 def twoPow (k : Int) : Rat := 2 ^ k
-
 
 end Rat
 


### PR DESCRIPTION
This PR adds the evaluation of packed floating point numbers as extended rationals.
This allows us to print the value of packed floating point numbers,
both to check that our translation from Float → PackedFloat is correct,
as well as (in a subsequent PR) that our translation from PackedFloat → ScientificBV is correct.
