### PR TITLE
add bitblasting test

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -2,3 +2,4 @@ import UnitTest.Lexer
 import UnitTest.Parser
 import UnitTest.AttrParser
 import UnitTest.MlirParser
+import UnitTest.Bitblasting.Bitblasting

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -14,458 +14,456 @@ import Veir.Data.Refinement
 macro "llvm_bv_decide" : tactic =>
   `(tactic| ((try simp [llvm_toBitVec]; try bv_decide); all_goals sorry))
 
-open Veir.Data.LLVM
-namespace Veir.Data.Int
 
 /-
   `LLVM.not` is not supported in
 
   theorem bv_AddSub_1043 :
-    ∀ (e e_1 e_2 : Int 64),
-      LLVM.Int.add (LLVM.Int.add (LLVM.Int.xor (LLVM.Int.and e_1 e) e) (LLVM.Int.constant 64 1)) e_2 ⊑ LLVM.Int.sub e_2 (LLVM.Int.or e_1 (LLVM.Int.not e)) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e_1 e) e) (Veir.Data.LLVM.Int.constant 64 1)) e_2 ⊑ Veir.Data.LLVM.Int.sub e_2 (Veir.Data.LLVM.Int.or e_1 (Veir.Data.LLVM.Int.not e)) := by
 -/
 
 theorem bv_AddSub_1152 :
-    ∀ (e e_1 : Int 1), LLVM.Int.add e_1 e ⊑ LLVM.Int.xor e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 1), Veir.Data.LLVM.Int.add e_1 e ⊑ Veir.Data.LLVM.Int.xor e_1 e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1156 :
-    ∀ (e : Int 64), (LLVM.Int.add e e) ⊑
-        (LLVM.Int.shl e (LLVM.Int.constant 64 1)) := by
+    ∀ (e : Veir.Data.LLVM.Int 64), (Veir.Data.LLVM.Int.add e e) ⊑
+        (Veir.Data.LLVM.Int.shl e (Veir.Data.LLVM.Int.constant 64 1)) := by
   llvm_bv_decide
 
 theorem bv_AddSub_1164 :
-    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.sub (LLVM.Int.constant 64 0) e) e_1 ⊑ LLVM.Int.sub e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) e_1 ⊑ Veir.Data.LLVM.Int.sub e_1 e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1165 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.add (LLVM.Int.sub (LLVM.Int.constant 64 0) e) (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) (LLVM.Int.add e e_1) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e_1) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) (Veir.Data.LLVM.Int.add e e_1) := by
   llvm_bv_decide
 
 theorem bv_AddSub_1176 :
-    ∀ (e e_1 : Int 64), LLVM.Int.add e (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) ⊑ LLVM.Int.sub e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e_1) ⊑ Veir.Data.LLVM.Int.sub e e_1 := by
   llvm_bv_decide
 
 theorem bv_AddSub_1202 :
-    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 ⊑ LLVM.Int.sub (LLVM.Int.sub e_1 (LLVM.Int.constant 64 1)) e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.constant 64 1)) e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1295 :
-    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.or e e_1 := by
   llvm_bv_decide
 
 theorem bv_AddSub_1309 :
-    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.and e e_1) (LLVM.Int.or e e_1) ⊑ LLVM.Int.add e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.or e e_1) ⊑ Veir.Data.LLVM.Int.add e e_1 := by
   llvm_bv_decide
 
 theorem bv_AddSub_1539 :
-    ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.sub (LLVM.Int.constant 64 0) e) ⊑ LLVM.Int.add e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) ⊑ Veir.Data.LLVM.Int.add e_1 e := by
   llvm_bv_decide
 
 /-
   `LLVM.neg` is not supported in
 
   theorem bv_AddSub_1539_2 :
-      ∀ (e e_1 : Int 64), LLVM.Int.sub e e_1 ⊑ LLVM.Int.add e (LLVM.Int.neg e_1) := by
+      ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e e_1 ⊑ Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.neg e_1) := by
 -/
 
 theorem bv_AddSub_1556 :
-    ∀ (e e_1 : Int 1), LLVM.Int.sub e_1 e ⊑ LLVM.Int.xor e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 1), Veir.Data.LLVM.Int.sub e_1 e ⊑ Veir.Data.LLVM.Int.xor e_1 e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1560 :
-    ∀ (e : Int 64), LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e ⊑ LLVM.Int.xor e (LLVM.Int.constant 64 (-1)) := by
+    ∀ (e : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 (-1)) e ⊑ Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1)) := by
   llvm_bv_decide
 
 theorem bv_AddSub_1564 :
-    ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.add e (LLVM.Int.add e_1 (LLVM.Int.constant 64 1)) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.add e_1 (Veir.Data.LLVM.Int.constant 64 1)) := by
   llvm_bv_decide
 
 theorem bv_AddSub_1574 :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e e_2) ⊑ LLVM.Int.sub (LLVM.Int.sub e_1 e_2) e := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.add e e_2) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub e_1 e_2) e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1614 :
-    ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e_1 e) ⊑
-      LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.add e_1 e) ⊑
+      Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1619 :
-    ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.sub e_1 e) e_1 ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub e_1 e) e_1 ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
   llvm_bv_decide
 
 theorem bv_AddSub_1624 :
-    ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.or e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.and e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.and e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_135 :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.and (LLVM.Int.xor e e_1) e_2 ⊑ LLVM.Int.xor (LLVM.Int.and e e_2) (LLVM.Int.and e_1 e_2) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_1) e_2 ⊑ Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_2) (Veir.Data.LLVM.Int.and e_1 e_2) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_144 :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) e_2 ⊑ LLVM.Int.and (LLVM.Int.or e (LLVM.Int.and e_1 e_2)) e_2 := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e e_1) e_2 ⊑ Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.and e_1 e_2)) e_2 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_698 :
-    ∀ (e e_1 e_2 : Int 64),
-      LLVM.Int.and (LLVM.Int.icmp
-            (LLVM.Int.and e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
-          (LLVM.Int.icmp (LLVM.Int.and e e_2) (LLVM.Int.constant 64 0) LLVM.IntPred.eq) ⊑
-        LLVM.Int.icmp  (LLVM.Int.and e (LLVM.Int.or e_1 e_2)) (LLVM.Int.constant 64 0) LLVM.IntPred.eq := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp
+            (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
+          (Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e e_2) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq) ⊑
+        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.or e_1 e_2)) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_709 :
-    ∀ (e e_1 e_2 : Int 64),
-      LLVM.Int.and (LLVM.Int.icmp  (LLVM.Int.and e e_1) e_1 LLVM.IntPred.eq) (LLVM.Int.icmp (LLVM.Int.and e e_2) e_2 LLVM.IntPred.eq) ⊑
-        LLVM.Int.icmp (LLVM.Int.and e (LLVM.Int.or e_1 e_2)) (LLVM.Int.or e_1 e_2) LLVM.IntPred.eq := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.and e e_1) e_1 Veir.Data.LLVM.IntPred.eq) (Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e e_2) e_2 Veir.Data.LLVM.IntPred.eq) ⊑
+        Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.or e_1 e_2)) (Veir.Data.LLVM.Int.or e_1 e_2) Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_716 :
-    ∀ (e e_1 e_2 : Int 64),
-      LLVM.Int.and (LLVM.Int.icmp (LLVM.Int.and e e_1) e LLVM.IntPred.eq) (LLVM.Int.icmp  (LLVM.Int.and e e_2) e LLVM.IntPred.eq) ⊑
-        LLVM.Int.icmp (LLVM.Int.and e (LLVM.Int.and e_1 e_2)) e LLVM.IntPred.eq := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e e_1) e Veir.Data.LLVM.IntPred.eq) (Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.and e e_2) e Veir.Data.LLVM.IntPred.eq) ⊑
+        Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.and e_1 e_2)) e Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_794 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.and (LLVM.Int.icmp e e_1 LLVM.IntPred.sgt)
-        (LLVM.Int.icmp e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.icmp e e_1 LLVM.IntPred.sgt := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.sgt)
+        (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.sgt := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_827 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.and (LLVM.Int.icmp  e (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
-            (LLVM.Int.icmp e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq) ⊑
-        LLVM.Int.icmp (LLVM.Int.or e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.eq := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp  e (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
+            (Veir.Data.LLVM.Int.icmp e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq) ⊑
+        Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_887_2 :
-    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.icmp e e_1 LLVM.IntPred.eq) (LLVM.Int.icmp e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.constant 1 0 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.eq) (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ Veir.Data.LLVM.Int.constant 1 0 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1230__A__B___A__B :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) ⊑
-        LLVM.Int.xor (LLVM.Int.or e e_1) (LLVM.Int.constant 64 (-1)) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑
+        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1241_AB__AB__AB :
-    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) (LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1247_AB__AB__AB :
-    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1))) (LLVM.Int.or e e_1) ⊑ LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.or e e_1) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1253_A__AB___A__B :
-    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.xor e e_1) e ⊑ LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_1) e ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1280_ABA___AB :
-    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) e ⊑ LLVM.Int.and e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) e ⊑ Veir.Data.LLVM.Int.and e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
-    ∀ (e e_1 e_2 : Int 64),
-      LLVM.Int.and (LLVM.Int.xor e e_2) (LLVM.Int.xor (LLVM.Int.xor e_2 e_1) e) ⊑
-        LLVM.Int.and (LLVM.Int.xor e e_2) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_2) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e_2 e_1) e) ⊑
+        Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_2) (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1294_A__B__A__B___A__B :
-    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑ LLVM.Int.and e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑ Veir.Data.LLVM.Int.and e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1683_1 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.icmp e e_1 LLVM.IntPred.ugt ) (LLVM.Int.icmp e e_1 LLVM.IntPred.eq ) ⊑ LLVM.Int.icmp e e_1 LLVM.IntPred.uge := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ugt ) (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.eq ) ⊑ Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.uge := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1683_2 :
-    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.icmp e e_1 LLVM.IntPred.uge)
-    (LLVM.Int.icmp e e_1 LLVM.IntPred.ne ) ⊑ LLVM.Int.constant 1 1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.uge)
+    (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ne ) ⊑ Veir.Data.LLVM.Int.constant 1 1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1704 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
-        (LLVM.Int.icmp  e e_1 LLVM.IntPred.ult) ⊑
-        LLVM.Int.icmp  (LLVM.Int.add e_1 (LLVM.Int.constant 64 (-1))) e LLVM.IntPred.uge := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp  e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
+        (Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.ult) ⊑
+        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.add e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) e Veir.Data.LLVM.IntPred.uge := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1705 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
-      (LLVM.Int.icmp  e_1 e LLVM.IntPred.ugt) ⊑
-        LLVM.Int.icmp  (LLVM.Int.add e_1 (LLVM.Int.constant 64 (-1))) e LLVM.IntPred.uge := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp  e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
+      (Veir.Data.LLVM.Int.icmp  e_1 e Veir.Data.LLVM.IntPred.ugt) ⊑
+        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.add e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) e Veir.Data.LLVM.IntPred.uge := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_1733 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.icmp  e (LLVM.Int.constant 64 0) LLVM.IntPred.ne)
-        (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.ne) ⊑
-        LLVM.Int.icmp  (LLVM.Int.or e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.ne := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp  e (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.ne)
+        (Veir.Data.LLVM.Int.icmp  e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.ne) ⊑
+        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.ne := by
   llvm_bv_decide
 
 /-
   `LLVM.not` is not supported in
 
   theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
-      ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.xor e e_1) e_2 ⊑
-      LLVM.Int.xor (LLVM.Int.or e e_2) (LLVM.Int.and e_1 (LLVM.Int.not e_2)) := by
+      ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e e_1) e_2 ⊑
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_2) (Veir.Data.LLVM.Int.and e_1 (Veir.Data.LLVM.Int.not e_2)) := by
 -/
 
 theorem bv_AndOrXor_2113___A__B__A___A__B :
-    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) e ⊑ LLVM.Int.or e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) e ⊑ Veir.Data.LLVM.Int.or e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2118___A__B__A___A__B :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2123___A__B__A__B___A__B :
-    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2188 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
-        LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
+        Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.xor e e_2) (LLVM.Int.xor (LLVM.Int.xor e_2 e_1) e) ⊑ LLVM.Int.or (LLVM.Int.xor e e_2) e_1 := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e e_2) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e_2 e_1) e) ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e e_2) e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.and (LLVM.Int.or e_2 e_1) e) e_2 ⊑ LLVM.Int.or e_2 (LLVM.Int.and e e_1) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e_2 e_1) e) e_2 ⊑ Veir.Data.LLVM.Int.or e_2 (Veir.Data.LLVM.Int.and e e_1) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2247__A__B__A__B :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) ⊑
-        LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1)) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑
+        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2263 :
-    ∀ (e e_1 : Int 64), LLVM.Int.or e_1 (LLVM.Int.xor e_1 e) ⊑ LLVM.Int.or e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or e_1 (Veir.Data.LLVM.Int.xor e_1 e) ⊑ Veir.Data.LLVM.Int.or e_1 e := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2264 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑ Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2265 :
-    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.or e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2284 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.or e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2285 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.xor e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2297 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
-        LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
+        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2367 :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.or e e_1) e_2 ⊑ LLVM.Int.or (LLVM.Int.or e e_2) e_1 := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.or e e_1) e_2 ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.or e e_2) e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2416 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) (LLVM.Int.constant 64 (-1)) ⊑
-        LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
+        Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2417 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) (LLVM.Int.constant 64 (-1)) ⊑
-        LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
+        Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2429 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.and e_1 e) (LLVM.Int.constant 64 (-1)) ⊑
-        LLVM.Int.or (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e_1 e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
+        Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2430 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.or e_1 e) (LLVM.Int.constant 64 (-1)) ⊑
-        LLVM.Int.and (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e_1 e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
+        Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2443 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.ashr (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) e) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.ashr e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.ashr (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.ashr e_1 e := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2453 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.icmp  e_1 e LLVM.IntPred.slt) (LLVM.Int.constant 1 (-1)) ⊑ LLVM.Int.icmp  e_1 e LLVM.IntPred.sge := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.icmp  e_1 e Veir.Data.LLVM.IntPred.slt) (Veir.Data.LLVM.Int.constant 1 (-1)) ⊑ Veir.Data.LLVM.Int.icmp  e_1 e Veir.Data.LLVM.IntPred.sge := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2475 :
-    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.sub e_1 e) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.add e (LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e_1) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.sub e_1 e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2486 :
-    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.add e e_1) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e_1) e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.add e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) e := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2581__BAB___A__B :
-    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.or e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2587__BAA___B__A :
-    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) e_1 ⊑ LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2595 :
-    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.or e e_1) ⊑ LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.or e e_1) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2607 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
-        LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
+        Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2617 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
-        LLVM.Int.xor e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
+        Veir.Data.LLVM.Int.xor e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2627 :
-    ∀ (e e_1 e_2 : Int 64),
-      LLVM.Int.xor (LLVM.Int.xor e e_1) (LLVM.Int.or e e_2) ⊑ LLVM.Int.xor (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_2) e_1 := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e e_1) (Veir.Data.LLVM.Int.or e e_2) ⊑ Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_2) e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2647 :
-    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.or e e_1 := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2658 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑
-        LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1)) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑
+        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) := by
   llvm_bv_decide
 
 theorem bv_AndOrXor_2663 :
-    ∀ (e e_1 : Int 64),
-      LLVM.Int.xor (LLVM.Int.icmp  e e_1 LLVM.IntPred.ule) (LLVM.Int.icmp  e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.icmp  e e_1 LLVM.IntPred.uge:= by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.ule) (Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.uge:= by
   llvm_bv_decide
 
 theorem bv_152 :
-    ∀ (e : Int 64), LLVM.Int.mul e (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+    ∀ (e : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul e (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
   llvm_bv_decide
 
 /--
   expected error: The SAT solver timed out while solving the problem.
 
   theorem bv_229 :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.mul (LLVM.Int.add e e_1) e_2 ⊑ LLVM.Int.add (LLVM.Int.mul e e_2) (LLVM.Int.mul e_1 e_2) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.add e e_1) e_2 ⊑ Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.mul e e_2) (Veir.Data.LLVM.Int.mul e_1 e_2) := by
   llvm_bv_decide
 -/
 
 
 theorem bv_239 :
-    ∀ (e e_1 : Int 64), LLVM.Int.mul (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) (LLVM.Int.sub (LLVM.Int.constant 64 0) e) ⊑ LLVM.Int.mul e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e_1) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) ⊑ Veir.Data.LLVM.Int.mul e_1 e := by
   llvm_bv_decide
 
 theorem bv_275 :
-    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.udiv e_1 e) e ⊑ LLVM.Int.sub e_1 (LLVM.Int.urem e_1 e) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.udiv e_1 e) e ⊑ Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.urem e_1 e) := by
   llvm_bv_decide
 
 theorem bv_275_2 :
-    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.sdiv e_1 e) e ⊑ LLVM.Int.sub e_1 (LLVM.Int.srem e_1 e) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.sdiv e_1 e) e ⊑ Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.srem e_1 e) := by
   llvm_bv_decide
 
 theorem bv_276 :
-    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.sdiv e_1 e) (LLVM.Int.sub (LLVM.Int.constant 5 0) e) ⊑ LLVM.Int.sub (LLVM.Int.srem e_1 e) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.sdiv e_1 e) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 5 0) e) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.srem e_1 e) e_1 := by
   llvm_bv_decide
 
 theorem bv_276_2 :
-    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.udiv e_1 e) (LLVM.Int.sub (LLVM.Int.constant 5 0) e) ⊑ LLVM.Int.sub (LLVM.Int.urem e_1 e) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.udiv e_1 e) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 5 0) e) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.urem e_1 e) e_1 := by
   llvm_bv_decide
 
 theorem bv_283 :
-    ∀ (e e_1 : Int 1), LLVM.Int.mul e_1 e ⊑ LLVM.Int.and e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 1), Veir.Data.LLVM.Int.mul e_1 e ⊑ Veir.Data.LLVM.Int.and e_1 e := by
   llvm_bv_decide
 
 theorem bv_290__292 :
-    ∀ (e e_1 : Int 64), LLVM.Int.mul (LLVM.Int.shl (LLVM.Int.constant 64 1) e) e_1 ⊑ LLVM.Int.shl e_1 e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.constant 64 1) e) e_1 ⊑ Veir.Data.LLVM.Int.shl e_1 e := by
   llvm_bv_decide
 
 theorem bv_820 :
-    ∀ (e e_1 : Int 9), LLVM.Int.sdiv (LLVM.Int.sub e (LLVM.Int.srem e e_1)) e_1 ⊑ LLVM.Int.sdiv e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 9), Veir.Data.LLVM.Int.sdiv (Veir.Data.LLVM.Int.sub e (Veir.Data.LLVM.Int.srem e e_1)) e_1 ⊑ Veir.Data.LLVM.Int.sdiv e e_1 := by
   llvm_bv_decide
 
 theorem bv_820' :
-    ∀ (e e_1 : Int 9), LLVM.Int.udiv (LLVM.Int.sub e (LLVM.Int.urem e e_1)) e_1 ⊑ LLVM.Int.udiv e e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 9), Veir.Data.LLVM.Int.udiv (Veir.Data.LLVM.Int.sub e (Veir.Data.LLVM.Int.urem e e_1)) e_1 ⊑ Veir.Data.LLVM.Int.udiv e e_1 := by
   llvm_bv_decide
 
 theorem bv_1030 :
-    ∀ (e : Int 64), LLVM.Int.sdiv e (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+    ∀ (e : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sdiv e (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
   llvm_bv_decide
 
 theorem bv_Select_858 :
-    ∀ (e e_1 : Int 1),
-      LLVM.Int.select e (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 ⊑ LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 1),
+      Veir.Data.LLVM.Int.select e (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) e_1 ⊑ Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) e_1 := by
   llvm_bv_decide
 
 theorem bv_Select_859' :
-    ∀ (e e_1 : Int 1),
-      LLVM.Int.select e e_1 (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) ⊑ LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 1),
+      Veir.Data.LLVM.Int.select e e_1 (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) e_1 := by
   llvm_bv_decide
 
 theorem bv_select_1100 :
-    ∀ (e e_1 : Int 64), LLVM.Int.select (LLVM.Int.constant 1 1) e_1 e ⊑ e_1 := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.select (Veir.Data.LLVM.Int.constant 1 1) e_1 e ⊑ e_1 := by
   llvm_bv_decide
 
 theorem bv_Select_1105 :
-    ∀ (e e_1 : Int 64), LLVM.Int.select (LLVM.Int.constant 1 0) e_1 e ⊑ e := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.select (Veir.Data.LLVM.Int.constant 1 0) e_1 e ⊑ e := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__239 :
-    ∀ (e e_1 : Int 64), LLVM.Int.lshr (LLVM.Int.shl e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.lshr (LLVM.Int.constant 64 (-1)) e_1) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.shl e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__279 :
-    ∀ (e e_1 : Int 64), LLVM.Int.shl (LLVM.Int.lshr e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.shl (LLVM.Int.constant 64 (-1)) e_1) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.lshr e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__440 :
-    ∀ (e e_1 e_2 e_3 : Int 64),
-      LLVM.Int.shl (LLVM.Int.xor e (LLVM.Int.and (LLVM.Int.lshr e_1 e_2) e_3)) e_2 ⊑
-        LLVM.Int.xor (LLVM.Int.and e_1 (LLVM.Int.shl e_3 e_2)) (LLVM.Int.shl e e_2) := by
+    ∀ (e e_1 e_2 e_3 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.lshr e_1 e_2) e_3)) e_2 ⊑
+        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e_1 (Veir.Data.LLVM.Int.shl e_3 e_2)) (Veir.Data.LLVM.Int.shl e e_2) := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__476 :
-    ∀ (e e_1 e_2 e_3 : Int 64),
-      LLVM.Int.shl (LLVM.Int.or (LLVM.Int.and (LLVM.Int.lshr e_1 e_2) e_3) e) e_2 ⊑
-        LLVM.Int.or (LLVM.Int.and e_1 (LLVM.Int.shl e_3 e_2)) (LLVM.Int.shl e e_2) := by
+    ∀ (e e_1 e_2 e_3 : Veir.Data.LLVM.Int 64),
+      Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.lshr e_1 e_2) e_3) e) e_2 ⊑
+        Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e_1 (Veir.Data.LLVM.Int.shl e_3 e_2)) (Veir.Data.LLVM.Int.shl e e_2) := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__497 :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.lshr (LLVM.Int.xor e e_2) e_1 ⊑ LLVM.Int.xor (LLVM.Int.lshr e e_1) (LLVM.Int.lshr e_2 e_1) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.xor e e_2) e_1 ⊑ Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.lshr e e_1) (Veir.Data.LLVM.Int.lshr e_2 e_1) := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__497''' :
-    ∀ (e e_1 e_2 : Int 64), LLVM.Int.shl (LLVM.Int.add e e_2) e_1 ⊑ LLVM.Int.add (LLVM.Int.shl e e_1) (LLVM.Int.shl e_2 e_1) := by
+    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.add e e_2) e_1 ⊑ Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.shl e e_1) (Veir.Data.LLVM.Int.shl e_2 e_1) := by
   llvm_bv_decide
 
 theorem bv_InstCombineShift__582 :
-    ∀ (e e_1 : Int 64), LLVM.Int.lshr (LLVM.Int.shl e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.lshr (LLVM.Int.constant 64 (-1)) e_1) := by
+    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.shl e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
   llvm_bv_decide

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -10,6 +10,10 @@ import Veir.Data.Refinement
   We exclude the tests comprising unsupported operations, such as `neg` and `not`.
 -/
 
+/-- We introduce a tactic to automatically prove all the lemmas. -/
+macro "llvm_bv_decide" : tactic =>
+  `(tactic| (simp [llvm_toBitVec]; try bv_decide; sorry))
+
 open Veir.Data.LLVM
 namespace Veir.Data.Int
 
@@ -23,50 +27,41 @@ namespace Veir.Data.Int
 
 theorem bv_AddSub_1152 :
     ∀ (e e_1 : Int 1), LLVM.Int.add e_1 e ⊑ LLVM.Int.xor e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1156 :
     ∀ (e : Int 64), (LLVM.Int.add e e) ⊑
         (LLVM.Int.shl e (LLVM.Int.constant 64 1)) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1164 :
     ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.sub (LLVM.Int.constant 64 0) e) e_1 ⊑ LLVM.Int.sub e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1165 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.add (LLVM.Int.sub (LLVM.Int.constant 64 0) e) (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) (LLVM.Int.add e e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1176 :
     ∀ (e e_1 : Int 64), LLVM.Int.add e (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) ⊑ LLVM.Int.sub e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1202 :
     ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 ⊑ LLVM.Int.sub (LLVM.Int.sub e_1 (LLVM.Int.constant 64 1)) e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1295 :
     ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1309 :
     ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.and e e_1) (LLVM.Int.or e e_1) ⊑ LLVM.Int.add e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1539 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.sub (LLVM.Int.constant 64 0) e) ⊑ LLVM.Int.add e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 /-
   `LLVM.neg` is not supported in
@@ -77,23 +72,19 @@ theorem bv_AddSub_1539 :
 
 theorem bv_AddSub_1556 :
     ∀ (e e_1 : Int 1), LLVM.Int.sub e_1 e ⊑ LLVM.Int.xor e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1560 :
     ∀ (e : Int 64), LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e ⊑ LLVM.Int.xor e (LLVM.Int.constant 64 (-1)) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1564 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.add e (LLVM.Int.add e_1 (LLVM.Int.constant 64 1)) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1574 :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e e_2) ⊑ LLVM.Int.sub (LLVM.Int.sub e_1 e_2) e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1614 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e_1 e) ⊑
@@ -104,23 +95,19 @@ theorem bv_AddSub_1614 :
 
 theorem bv_AddSub_1619 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.sub e_1 e) e_1 ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1624 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.or e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.and e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_135 :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.and (LLVM.Int.xor e e_1) e_2 ⊑ LLVM.Int.xor (LLVM.Int.and e e_2) (LLVM.Int.and e_1 e_2) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_144 :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) e_2 ⊑ LLVM.Int.and (LLVM.Int.or e (LLVM.Int.and e_1 e_2)) e_2 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_698 :
     ∀ (e e_1 e_2 : Int 64),
@@ -128,117 +115,99 @@ theorem bv_AndOrXor_698 :
             (LLVM.Int.and e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
           (LLVM.Int.icmp (LLVM.Int.and e e_2) (LLVM.Int.constant 64 0) LLVM.IntPred.eq) ⊑
         LLVM.Int.icmp  (LLVM.Int.and e (LLVM.Int.or e_1 e_2)) (LLVM.Int.constant 64 0) LLVM.IntPred.eq := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_709 :
     ∀ (e e_1 e_2 : Int 64),
       LLVM.Int.and (LLVM.Int.icmp  (LLVM.Int.and e e_1) e_1 LLVM.IntPred.eq) (LLVM.Int.icmp (LLVM.Int.and e e_2) e_2 LLVM.IntPred.eq) ⊑
         LLVM.Int.icmp (LLVM.Int.and e (LLVM.Int.or e_1 e_2)) (LLVM.Int.or e_1 e_2) LLVM.IntPred.eq := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_716 :
     ∀ (e e_1 e_2 : Int 64),
       LLVM.Int.and (LLVM.Int.icmp (LLVM.Int.and e e_1) e LLVM.IntPred.eq) (LLVM.Int.icmp  (LLVM.Int.and e e_2) e LLVM.IntPred.eq) ⊑
         LLVM.Int.icmp (LLVM.Int.and e (LLVM.Int.and e_1 e_2)) e LLVM.IntPred.eq := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_794 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.and (LLVM.Int.icmp e e_1 LLVM.IntPred.sgt)
         (LLVM.Int.icmp e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.icmp e e_1 LLVM.IntPred.sgt := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_827 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.and (LLVM.Int.icmp  e (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
             (LLVM.Int.icmp e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq) ⊑
         LLVM.Int.icmp (LLVM.Int.or e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.eq := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_887_2 :
     ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.icmp e e_1 LLVM.IntPred.eq) (LLVM.Int.icmp e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.constant 1 0 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1230__A__B___A__B :
     ∀ (e e_1 : Int 64),
       LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) ⊑
         LLVM.Int.xor (LLVM.Int.or e e_1) (LLVM.Int.constant 64 (-1)) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1241_AB__AB__AB :
     ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) (LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1247_AB__AB__AB :
     ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1))) (LLVM.Int.or e e_1) ⊑ LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1253_A__AB___A__B :
     ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.xor e e_1) e ⊑ LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1280_ABA___AB :
     ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) e ⊑ LLVM.Int.and e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : Int 64),
       LLVM.Int.and (LLVM.Int.xor e e_2) (LLVM.Int.xor (LLVM.Int.xor e_2 e_1) e) ⊑
         LLVM.Int.and (LLVM.Int.xor e e_2) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1294_A__B__A__B___A__B :
     ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑ LLVM.Int.and e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1683_1 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.icmp e e_1 LLVM.IntPred.ugt ) (LLVM.Int.icmp e e_1 LLVM.IntPred.eq ) ⊑ LLVM.Int.icmp e e_1 LLVM.IntPred.uge := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1683_2 :
     ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.icmp e e_1 LLVM.IntPred.uge)
     (LLVM.Int.icmp e e_1 LLVM.IntPred.ne ) ⊑ LLVM.Int.constant 1 1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1704 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
         (LLVM.Int.icmp  e e_1 LLVM.IntPred.ult) ⊑
         LLVM.Int.icmp  (LLVM.Int.add e_1 (LLVM.Int.constant 64 (-1))) e LLVM.IntPred.uge := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1705 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
       (LLVM.Int.icmp  e_1 e LLVM.IntPred.ugt) ⊑
         LLVM.Int.icmp  (LLVM.Int.add e_1 (LLVM.Int.constant 64 (-1))) e LLVM.IntPred.uge := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_1733 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.icmp  e (LLVM.Int.constant 64 0) LLVM.IntPred.ne)
         (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.ne) ⊑
         LLVM.Int.icmp  (LLVM.Int.or e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.ne := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 /-
   `LLVM.not` is not supported in
@@ -250,309 +219,255 @@ theorem bv_AndOrXor_1733 :
 
 theorem bv_AndOrXor_2113___A__B__A___A__B :
     ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) e ⊑ LLVM.Int.or e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2118___A__B__A___A__B :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2123___A__B__A__B___A__B :
     ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2188 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
         LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.xor e e_2) (LLVM.Int.xor (LLVM.Int.xor e_2 e_1) e) ⊑ LLVM.Int.or (LLVM.Int.xor e e_2) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.and (LLVM.Int.or e_2 e_1) e) e_2 ⊑ LLVM.Int.or e_2 (LLVM.Int.and e e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2247__A__B__A__B :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) ⊑
         LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1)) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2263 :
     ∀ (e e_1 : Int 64), LLVM.Int.or e_1 (LLVM.Int.xor e_1 e) ⊑ LLVM.Int.or e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2264 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2265 :
     ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2284 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.or e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2285 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.xor e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2297 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
         LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2367 :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.or e e_1) e_2 ⊑ LLVM.Int.or (LLVM.Int.or e e_2) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2416 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) (LLVM.Int.constant 64 (-1)) ⊑
         LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2417 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) (LLVM.Int.constant 64 (-1)) ⊑
         LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2429 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.and e_1 e) (LLVM.Int.constant 64 (-1)) ⊑
         LLVM.Int.or (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2430 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.or e_1 e) (LLVM.Int.constant 64 (-1)) ⊑
         LLVM.Int.and (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2443 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.ashr (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) e) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.ashr e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2453 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.icmp  e_1 e LLVM.IntPred.slt) (LLVM.Int.constant 1 (-1)) ⊑ LLVM.Int.icmp  e_1 e LLVM.IntPred.sge := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2475 :
     ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.sub e_1 e) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.add e (LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2486 :
     ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.add e e_1) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e_1) e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2581__BAB___A__B :
     ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.or e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2587__BAA___B__A :
     ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) e_1 ⊑ LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2595 :
     ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.or e e_1) ⊑ LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2607 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
         LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2617 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
         LLVM.Int.xor e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2627 :
     ∀ (e e_1 e_2 : Int 64),
       LLVM.Int.xor (LLVM.Int.xor e e_1) (LLVM.Int.or e e_2) ⊑ LLVM.Int.xor (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_2) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2647 :
     ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2658 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑
         LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1)) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AndOrXor_2663 :
     ∀ (e e_1 : Int 64),
       LLVM.Int.xor (LLVM.Int.icmp  e e_1 LLVM.IntPred.ule) (LLVM.Int.icmp  e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.icmp  e e_1 LLVM.IntPred.uge:= by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_152 :
     ∀ (e : Int 64), LLVM.Int.mul e (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 /--
   expected error: The SAT solver timed out while solving the problem.
 
   theorem bv_229 :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.mul (LLVM.Int.add e e_1) e_2 ⊑ LLVM.Int.add (LLVM.Int.mul e e_2) (LLVM.Int.mul e_1 e_2) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 -/
 
 
 theorem bv_239 :
     ∀ (e e_1 : Int 64), LLVM.Int.mul (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) (LLVM.Int.sub (LLVM.Int.constant 64 0) e) ⊑ LLVM.Int.mul e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_275 :
     ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.udiv e_1 e) e ⊑ LLVM.Int.sub e_1 (LLVM.Int.urem e_1 e) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_275_2 :
     ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.sdiv e_1 e) e ⊑ LLVM.Int.sub e_1 (LLVM.Int.srem e_1 e) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_276 :
     ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.sdiv e_1 e) (LLVM.Int.sub (LLVM.Int.constant 5 0) e) ⊑ LLVM.Int.sub (LLVM.Int.srem e_1 e) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_276_2 :
     ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.udiv e_1 e) (LLVM.Int.sub (LLVM.Int.constant 5 0) e) ⊑ LLVM.Int.sub (LLVM.Int.urem e_1 e) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_283 :
     ∀ (e e_1 : Int 1), LLVM.Int.mul e_1 e ⊑ LLVM.Int.and e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_290__292 :
     ∀ (e e_1 : Int 64), LLVM.Int.mul (LLVM.Int.shl (LLVM.Int.constant 64 1) e) e_1 ⊑ LLVM.Int.shl e_1 e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_820 :
     ∀ (e e_1 : Int 9), LLVM.Int.sdiv (LLVM.Int.sub e (LLVM.Int.srem e e_1)) e_1 ⊑ LLVM.Int.sdiv e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_820' :
     ∀ (e e_1 : Int 9), LLVM.Int.udiv (LLVM.Int.sub e (LLVM.Int.urem e e_1)) e_1 ⊑ LLVM.Int.udiv e e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_1030 :
     ∀ (e : Int 64), LLVM.Int.sdiv e (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_Select_858 :
     ∀ (e e_1 : Int 1),
       LLVM.Int.select e (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 ⊑ LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_Select_859' :
     ∀ (e e_1 : Int 1),
       LLVM.Int.select e e_1 (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) ⊑ LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_select_1100 :
     ∀ (e e_1 : Int 64), LLVM.Int.select (LLVM.Int.constant 1 1) e_1 e ⊑ e_1 := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_Select_1105 :
     ∀ (e e_1 : Int 64), LLVM.Int.select (LLVM.Int.constant 1 0) e_1 e ⊑ e := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__239 :
     ∀ (e e_1 : Int 64), LLVM.Int.lshr (LLVM.Int.shl e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.lshr (LLVM.Int.constant 64 (-1)) e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__279 :
     ∀ (e e_1 : Int 64), LLVM.Int.shl (LLVM.Int.lshr e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.shl (LLVM.Int.constant 64 (-1)) e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__440 :
     ∀ (e e_1 e_2 e_3 : Int 64),
       LLVM.Int.shl (LLVM.Int.xor e (LLVM.Int.and (LLVM.Int.lshr e_1 e_2) e_3)) e_2 ⊑
         LLVM.Int.xor (LLVM.Int.and e_1 (LLVM.Int.shl e_3 e_2)) (LLVM.Int.shl e e_2) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__476 :
     ∀ (e e_1 e_2 e_3 : Int 64),
       LLVM.Int.shl (LLVM.Int.or (LLVM.Int.and (LLVM.Int.lshr e_1 e_2) e_3) e) e_2 ⊑
         LLVM.Int.or (LLVM.Int.and e_1 (LLVM.Int.shl e_3 e_2)) (LLVM.Int.shl e e_2) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__497 :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.lshr (LLVM.Int.xor e e_2) e_1 ⊑ LLVM.Int.xor (LLVM.Int.lshr e e_1) (LLVM.Int.lshr e_2 e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__497''' :
     ∀ (e e_1 e_2 : Int 64), LLVM.Int.shl (LLVM.Int.add e e_2) e_1 ⊑ LLVM.Int.add (LLVM.Int.shl e e_1) (LLVM.Int.shl e_2 e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_InstCombineShift__582 :
     ∀ (e e_1 : Int 64), LLVM.Int.lshr (LLVM.Int.shl e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.lshr (LLVM.Int.constant 64 (-1)) e_1) := by
-  simp [llvm_toBitVec]
-  bv_decide
+  llvm_bv_decide

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -1,0 +1,558 @@
+import Veir.Data.LLVM.Int.Bitblast
+import Veir.Data.LLVM.Int.Basic
+import Veir.Data.Refinement
+
+/-!
+  This file contains some of the `InstCombine` tests retrieved from Lean-MLIR,
+  instantiated for integers with width `64`:
+  https://github.com/opencompl/lean-mlir/blob/main/SSA/Projects/InstCombine/AliveStatements.lean
+
+  We exclude the tests comprising unsupported operations, such as `neg` and `not`.
+-/
+
+open Veir.Data.LLVM
+namespace Veir.Data.Int
+
+/-
+  `LLVM.not` is not supported in
+
+  theorem bv_AddSub_1043 :
+    ∀ (e e_1 e_2 : Int 64),
+      LLVM.Int.add (LLVM.Int.add (LLVM.Int.xor (LLVM.Int.and e_1 e) e) (LLVM.Int.constant 64 1)) e_2 ⊑ LLVM.Int.sub e_2 (LLVM.Int.or e_1 (LLVM.Int.not e)) := by
+-/
+
+theorem bv_AddSub_1152 :
+    ∀ (e e_1 : Int 1), LLVM.Int.add e_1 e ⊑ LLVM.Int.xor e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1156 :
+    ∀ (e : Int 64), (LLVM.Int.add e e) ⊑
+        (LLVM.Int.shl e (LLVM.Int.constant 64 1)) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1164 :
+    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.sub (LLVM.Int.constant 64 0) e) e_1 ⊑ LLVM.Int.sub e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1165 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.add (LLVM.Int.sub (LLVM.Int.constant 64 0) e) (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) (LLVM.Int.add e e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1176 :
+    ∀ (e e_1 : Int 64), LLVM.Int.add e (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) ⊑ LLVM.Int.sub e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1202 :
+    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 ⊑ LLVM.Int.sub (LLVM.Int.sub e_1 (LLVM.Int.constant 64 1)) e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1295 :
+    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1309 :
+    ∀ (e e_1 : Int 64), LLVM.Int.add (LLVM.Int.and e e_1) (LLVM.Int.or e e_1) ⊑ LLVM.Int.add e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1539 :
+    ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.sub (LLVM.Int.constant 64 0) e) ⊑ LLVM.Int.add e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+/-
+  `LLVM.neg` is not supported in
+
+  theorem bv_AddSub_1539_2 :
+      ∀ (e e_1 : Int 64), LLVM.Int.sub e e_1 ⊑ LLVM.Int.add e (LLVM.Int.neg e_1) := by
+-/
+
+theorem bv_AddSub_1556 :
+    ∀ (e e_1 : Int 1), LLVM.Int.sub e_1 e ⊑ LLVM.Int.xor e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1560 :
+    ∀ (e : Int 64), LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e ⊑ LLVM.Int.xor e (LLVM.Int.constant 64 (-1)) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1564 :
+    ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.add e (LLVM.Int.add e_1 (LLVM.Int.constant 64 1)) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1574 :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e e_2) ⊑ LLVM.Int.sub (LLVM.Int.sub e_1 e_2) e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1614 :
+    ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e_1 e) ⊑
+      LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+  simp [llvm_toBitVec]
+
+  bv_decide
+
+theorem bv_AddSub_1619 :
+    ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.sub e_1 e) e_1 ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AddSub_1624 :
+    ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.or e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.and e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_135 :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.and (LLVM.Int.xor e e_1) e_2 ⊑ LLVM.Int.xor (LLVM.Int.and e e_2) (LLVM.Int.and e_1 e_2) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_144 :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) e_2 ⊑ LLVM.Int.and (LLVM.Int.or e (LLVM.Int.and e_1 e_2)) e_2 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_698 :
+    ∀ (e e_1 e_2 : Int 64),
+      LLVM.Int.and (LLVM.Int.icmp
+            (LLVM.Int.and e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
+          (LLVM.Int.icmp (LLVM.Int.and e e_2) (LLVM.Int.constant 64 0) LLVM.IntPred.eq) ⊑
+        LLVM.Int.icmp  (LLVM.Int.and e (LLVM.Int.or e_1 e_2)) (LLVM.Int.constant 64 0) LLVM.IntPred.eq := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_709 :
+    ∀ (e e_1 e_2 : Int 64),
+      LLVM.Int.and (LLVM.Int.icmp  (LLVM.Int.and e e_1) e_1 LLVM.IntPred.eq) (LLVM.Int.icmp (LLVM.Int.and e e_2) e_2 LLVM.IntPred.eq) ⊑
+        LLVM.Int.icmp (LLVM.Int.and e (LLVM.Int.or e_1 e_2)) (LLVM.Int.or e_1 e_2) LLVM.IntPred.eq := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_716 :
+    ∀ (e e_1 e_2 : Int 64),
+      LLVM.Int.and (LLVM.Int.icmp (LLVM.Int.and e e_1) e LLVM.IntPred.eq) (LLVM.Int.icmp  (LLVM.Int.and e e_2) e LLVM.IntPred.eq) ⊑
+        LLVM.Int.icmp (LLVM.Int.and e (LLVM.Int.and e_1 e_2)) e LLVM.IntPred.eq := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_794 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.and (LLVM.Int.icmp e e_1 LLVM.IntPred.sgt)
+        (LLVM.Int.icmp e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.icmp e e_1 LLVM.IntPred.sgt := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_827 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.and (LLVM.Int.icmp  e (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
+            (LLVM.Int.icmp e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq) ⊑
+        LLVM.Int.icmp (LLVM.Int.or e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.eq := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_887_2 :
+    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.icmp e e_1 LLVM.IntPred.eq) (LLVM.Int.icmp e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.constant 1 0 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1230__A__B___A__B :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) ⊑
+        LLVM.Int.xor (LLVM.Int.or e e_1) (LLVM.Int.constant 64 (-1)) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1241_AB__AB__AB :
+    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) (LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1247_AB__AB__AB :
+    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1))) (LLVM.Int.or e e_1) ⊑ LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1253_A__AB___A__B :
+    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.xor e e_1) e ⊑ LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1280_ABA___AB :
+    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) e ⊑ LLVM.Int.and e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
+    ∀ (e e_1 e_2 : Int 64),
+      LLVM.Int.and (LLVM.Int.xor e e_2) (LLVM.Int.xor (LLVM.Int.xor e_2 e_1) e) ⊑
+        LLVM.Int.and (LLVM.Int.xor e e_2) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1294_A__B__A__B___A__B :
+    ∀ (e e_1 : Int 64), LLVM.Int.and (LLVM.Int.or e e_1) (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑ LLVM.Int.and e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1683_1 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.icmp e e_1 LLVM.IntPred.ugt ) (LLVM.Int.icmp e e_1 LLVM.IntPred.eq ) ⊑ LLVM.Int.icmp e e_1 LLVM.IntPred.uge := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1683_2 :
+    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.icmp e e_1 LLVM.IntPred.uge)
+    (LLVM.Int.icmp e e_1 LLVM.IntPred.ne ) ⊑ LLVM.Int.constant 1 1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1704 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
+        (LLVM.Int.icmp  e e_1 LLVM.IntPred.ult) ⊑
+        LLVM.Int.icmp  (LLVM.Int.add e_1 (LLVM.Int.constant 64 (-1))) e LLVM.IntPred.uge := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1705 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.eq)
+      (LLVM.Int.icmp  e_1 e LLVM.IntPred.ugt) ⊑
+        LLVM.Int.icmp  (LLVM.Int.add e_1 (LLVM.Int.constant 64 (-1))) e LLVM.IntPred.uge := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_1733 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.icmp  e (LLVM.Int.constant 64 0) LLVM.IntPred.ne)
+        (LLVM.Int.icmp  e_1 (LLVM.Int.constant 64 0) LLVM.IntPred.ne) ⊑
+        LLVM.Int.icmp  (LLVM.Int.or e e_1) (LLVM.Int.constant 64 0) LLVM.IntPred.ne := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+/-
+  `LLVM.not` is not supported in
+
+  theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
+      ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.xor e e_1) e_2 ⊑
+      LLVM.Int.xor (LLVM.Int.or e e_2) (LLVM.Int.and e_1 (LLVM.Int.not e_2)) := by
+-/
+
+theorem bv_AndOrXor_2113___A__B__A___A__B :
+    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) e ⊑ LLVM.Int.or e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2118___A__B__A___A__B :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2123___A__B__A__B___A__B :
+    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2188 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
+        LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.xor e e_2) (LLVM.Int.xor (LLVM.Int.xor e_2 e_1) e) ⊑ LLVM.Int.or (LLVM.Int.xor e e_2) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.and (LLVM.Int.or e_2 e_1) e) e_2 ⊑ LLVM.Int.or e_2 (LLVM.Int.and e e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2247__A__B__A__B :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) ⊑
+        LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1)) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2263 :
+    ∀ (e e_1 : Int 64), LLVM.Int.or e_1 (LLVM.Int.xor e_1 e) ⊑ LLVM.Int.or e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2264 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2265 :
+    ∀ (e e_1 : Int 64), LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2284 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.or e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2285 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or e (LLVM.Int.xor (LLVM.Int.xor e e_1) (LLVM.Int.constant 64 (-1))) ⊑ LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2297 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.or (LLVM.Int.and e e_1) (LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
+        LLVM.Int.xor (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2367 :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.or (LLVM.Int.or e e_1) e_2 ⊑ LLVM.Int.or (LLVM.Int.or e e_2) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2416 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) (LLVM.Int.constant 64 (-1)) ⊑
+        LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2417 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) (LLVM.Int.constant 64 (-1)) ⊑
+        LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2429 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.and e_1 e) (LLVM.Int.constant 64 (-1)) ⊑
+        LLVM.Int.or (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2430 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.or e_1 e) (LLVM.Int.constant 64 (-1)) ⊑
+        LLVM.Int.and (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2443 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.ashr (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) e) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.ashr e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2453 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.icmp  e_1 e LLVM.IntPred.slt) (LLVM.Int.constant 1 (-1)) ⊑ LLVM.Int.icmp  e_1 e LLVM.IntPred.sge := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2475 :
+    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.sub e_1 e) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.add e (LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2486 :
+    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.add e e_1) (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.sub (LLVM.Int.constant 64 (-1)) e_1) e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2581__BAB___A__B :
+    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.or e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1))) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2587__BAA___B__A :
+    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) e_1 ⊑ LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2595 :
+    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.or e e_1) ⊑ LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2607 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.or e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
+        LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2617 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_1) ⊑
+        LLVM.Int.xor e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2627 :
+    ∀ (e e_1 e_2 : Int 64),
+      LLVM.Int.xor (LLVM.Int.xor e e_1) (LLVM.Int.or e e_2) ⊑ LLVM.Int.xor (LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) e_2) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2647 :
+    ∀ (e e_1 : Int 64), LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.xor e e_1) ⊑ LLVM.Int.or e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2658 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.and e (LLVM.Int.xor e_1 (LLVM.Int.constant 64 (-1)))) (LLVM.Int.xor e (LLVM.Int.constant 64 (-1))) ⊑
+        LLVM.Int.xor (LLVM.Int.and e e_1) (LLVM.Int.constant 64 (-1)) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_AndOrXor_2663 :
+    ∀ (e e_1 : Int 64),
+      LLVM.Int.xor (LLVM.Int.icmp  e e_1 LLVM.IntPred.ule) (LLVM.Int.icmp  e e_1 LLVM.IntPred.ne) ⊑ LLVM.Int.icmp  e e_1 LLVM.IntPred.uge:= by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_152 :
+    ∀ (e : Int 64), LLVM.Int.mul e (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+/--
+  expected error: The SAT solver timed out while solving the problem.
+
+  theorem bv_229 :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.mul (LLVM.Int.add e e_1) e_2 ⊑ LLVM.Int.add (LLVM.Int.mul e e_2) (LLVM.Int.mul e_1 e_2) := by
+  simp [llvm_toBitVec]
+  bv_decide
+-/
+
+
+theorem bv_239 :
+    ∀ (e e_1 : Int 64), LLVM.Int.mul (LLVM.Int.sub (LLVM.Int.constant 64 0) e_1) (LLVM.Int.sub (LLVM.Int.constant 64 0) e) ⊑ LLVM.Int.mul e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_275 :
+    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.udiv e_1 e) e ⊑ LLVM.Int.sub e_1 (LLVM.Int.urem e_1 e) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_275_2 :
+    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.sdiv e_1 e) e ⊑ LLVM.Int.sub e_1 (LLVM.Int.srem e_1 e) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_276 :
+    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.sdiv e_1 e) (LLVM.Int.sub (LLVM.Int.constant 5 0) e) ⊑ LLVM.Int.sub (LLVM.Int.srem e_1 e) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_276_2 :
+    ∀ (e e_1 : Int 5), LLVM.Int.mul (LLVM.Int.udiv e_1 e) (LLVM.Int.sub (LLVM.Int.constant 5 0) e) ⊑ LLVM.Int.sub (LLVM.Int.urem e_1 e) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_283 :
+    ∀ (e e_1 : Int 1), LLVM.Int.mul e_1 e ⊑ LLVM.Int.and e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_290__292 :
+    ∀ (e e_1 : Int 64), LLVM.Int.mul (LLVM.Int.shl (LLVM.Int.constant 64 1) e) e_1 ⊑ LLVM.Int.shl e_1 e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_820 :
+    ∀ (e e_1 : Int 9), LLVM.Int.sdiv (LLVM.Int.sub e (LLVM.Int.srem e e_1)) e_1 ⊑ LLVM.Int.sdiv e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_820' :
+    ∀ (e e_1 : Int 9), LLVM.Int.udiv (LLVM.Int.sub e (LLVM.Int.urem e e_1)) e_1 ⊑ LLVM.Int.udiv e e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_1030 :
+    ∀ (e : Int 64), LLVM.Int.sdiv e (LLVM.Int.constant 64 (-1)) ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_Select_858 :
+    ∀ (e e_1 : Int 1),
+      LLVM.Int.select e (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 ⊑ LLVM.Int.and (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_Select_859' :
+    ∀ (e e_1 : Int 1),
+      LLVM.Int.select e e_1 (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) ⊑ LLVM.Int.or (LLVM.Int.xor e (LLVM.Int.constant 1 (-1))) e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_select_1100 :
+    ∀ (e e_1 : Int 64), LLVM.Int.select (LLVM.Int.constant 1 1) e_1 e ⊑ e_1 := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_Select_1105 :
+    ∀ (e e_1 : Int 64), LLVM.Int.select (LLVM.Int.constant 1 0) e_1 e ⊑ e := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__239 :
+    ∀ (e e_1 : Int 64), LLVM.Int.lshr (LLVM.Int.shl e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.lshr (LLVM.Int.constant 64 (-1)) e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__279 :
+    ∀ (e e_1 : Int 64), LLVM.Int.shl (LLVM.Int.lshr e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.shl (LLVM.Int.constant 64 (-1)) e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__440 :
+    ∀ (e e_1 e_2 e_3 : Int 64),
+      LLVM.Int.shl (LLVM.Int.xor e (LLVM.Int.and (LLVM.Int.lshr e_1 e_2) e_3)) e_2 ⊑
+        LLVM.Int.xor (LLVM.Int.and e_1 (LLVM.Int.shl e_3 e_2)) (LLVM.Int.shl e e_2) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__476 :
+    ∀ (e e_1 e_2 e_3 : Int 64),
+      LLVM.Int.shl (LLVM.Int.or (LLVM.Int.and (LLVM.Int.lshr e_1 e_2) e_3) e) e_2 ⊑
+        LLVM.Int.or (LLVM.Int.and e_1 (LLVM.Int.shl e_3 e_2)) (LLVM.Int.shl e e_2) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__497 :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.lshr (LLVM.Int.xor e e_2) e_1 ⊑ LLVM.Int.xor (LLVM.Int.lshr e e_1) (LLVM.Int.lshr e_2 e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__497''' :
+    ∀ (e e_1 e_2 : Int 64), LLVM.Int.shl (LLVM.Int.add e e_2) e_1 ⊑ LLVM.Int.add (LLVM.Int.shl e e_1) (LLVM.Int.shl e_2 e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide
+
+theorem bv_InstCombineShift__582 :
+    ∀ (e e_1 : Int 64), LLVM.Int.lshr (LLVM.Int.shl e e_1) e_1 ⊑ LLVM.Int.and e (LLVM.Int.lshr (LLVM.Int.constant 64 (-1)) e_1) := by
+  simp [llvm_toBitVec]
+  bv_decide

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -1,5 +1,5 @@
-import Veir.Data.LLVM.Int.Bitblast
 import Veir.Data.LLVM.Int.Basic
+import Veir.Data.LLVM.Int.Simp
 import Veir.Data.Refinement
 
 /-!
@@ -12,7 +12,7 @@ import Veir.Data.Refinement
 
 /-- We introduce a tactic to automatically prove all the lemmas. -/
 macro "llvm_bv_decide" : tactic =>
-  `(tactic| (simp [llvm_toBitVec]; try bv_decide; sorry))
+  `(tactic| (try simp [llvm_toBitVec]; try bv_decide; <;> sorry))
 
 open Veir.Data.LLVM
 namespace Veir.Data.Int

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -2,10 +2,12 @@ import Veir.Data.LLVM.Int.Basic
 import Veir.Data.LLVM.Int.Simp
 import Veir.Data.Refinement
 
+open Veir.Data.LLVM.Int
+
 /-!
   This file contains some of the `InstCombine` tests retrieved from Lean-MLIR,
   instantiated for integers with width `64`:
-  https://github.com/opencompl/lean-mlir/blob/main/SSA/Projects/InstCombine/AliveStatements.lean
+  https://github.com/opencompl/lean-mlir/blob/77fa1c1507a61369f6d9a8ab3de54b9bbe5e1393/SSA/Projects/InstCombine/AliveStatements.lean#L1
 
   We exclude the tests comprising unsupported operations, such as `neg` and `not`.
 -/
@@ -14,456 +16,402 @@ import Veir.Data.Refinement
 macro "llvm_bv_decide" : tactic =>
   `(tactic| ((try simp [llvm_toBitVec]; try bv_decide); all_goals sorry))
 
+set_option warn.sorry false
 
 /-
   `LLVM.not` is not supported in
-
-  theorem bv_AddSub_1043 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e_1 e) e) (Veir.Data.LLVM.Int.constant 64 1)) e_2 ⊑ Veir.Data.LLVM.Int.sub e_2 (Veir.Data.LLVM.Int.or e_1 (Veir.Data.LLVM.Int.not e)) := by
+  example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+      add (add (xor (and e_1 e) e) (constant 64 1)) e_2 ⊑ sub e_2 (or e_1 (not e)) := by sorry
 -/
 
-theorem bv_AddSub_1152 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 1), Veir.Data.LLVM.Int.add e_1 e ⊑ Veir.Data.LLVM.Int.xor e_1 e := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 1) : add e_1 e ⊑ xor e_1 e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1156 :
-    ∀ (e : Veir.Data.LLVM.Int 64), (Veir.Data.LLVM.Int.add e e) ⊑
-        (Veir.Data.LLVM.Int.shl e (Veir.Data.LLVM.Int.constant 64 1)) := by
+example
+    (e : Veir.Data.LLVM.Int 64) : (add e e) ⊑
+        (shl e (constant 64 1)) := by
   llvm_bv_decide
 
-theorem bv_AddSub_1164 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) e_1 ⊑ Veir.Data.LLVM.Int.sub e_1 e := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) : add (sub (constant 64 0) e) e_1 ⊑ sub e_1 e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1165 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e_1) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) (Veir.Data.LLVM.Int.add e e_1) := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) :
+      add (sub (constant 64 0) e) (sub (constant 64 0) e_1) ⊑ sub (constant 64 0) (add e e_1) := by
   llvm_bv_decide
 
-theorem bv_AddSub_1176 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e_1) ⊑ Veir.Data.LLVM.Int.sub e e_1 := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) : add e (sub (constant 64 0) e_1) ⊑ sub e e_1 := by
   llvm_bv_decide
 
-theorem bv_AddSub_1202 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.constant 64 1)) e := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) : add (xor e (constant 64 (-1))) e_1 ⊑ sub (sub e_1 (constant 64 1)) e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1295 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.or e e_1 := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) : add (and e e_1) (xor e e_1) ⊑ or e e_1 := by
   llvm_bv_decide
 
-theorem bv_AddSub_1309 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.or e e_1) ⊑ Veir.Data.LLVM.Int.add e e_1 := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) : add (and e e_1) (or e e_1) ⊑ add e e_1 := by
   llvm_bv_decide
 
-theorem bv_AddSub_1539 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) ⊑ Veir.Data.LLVM.Int.add e_1 e := by
+example
+    (e e_1 : Veir.Data.LLVM.Int 64) : sub e_1 (sub (constant 64 0) e) ⊑ add e_1 e := by
   llvm_bv_decide
 
 /-
   `LLVM.neg` is not supported in
 
-  theorem bv_AddSub_1539_2 :
-      ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e e_1 ⊑ Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.neg e_1) := by
+  example
+      (e e_1 : Veir.Data.LLVM.Int 64) : sub e e_1 ⊑ add e (neg e_1) := by
 -/
 
-theorem bv_AddSub_1556 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 1), Veir.Data.LLVM.Int.sub e_1 e ⊑ Veir.Data.LLVM.Int.xor e_1 e := by
+example (e e_1 : Veir.Data.LLVM.Int 1) :
+    sub e_1 e ⊑ xor e_1 e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1560 :
-    ∀ (e : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 (-1)) e ⊑ Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1)) := by
+example (e : Veir.Data.LLVM.Int 64) :
+    sub (constant 64 (-1)) e ⊑ xor e (constant 64 (-1)) := by
   llvm_bv_decide
 
-theorem bv_AddSub_1564 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.add e_1 (Veir.Data.LLVM.Int.constant 64 1)) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    sub e_1 (xor e (constant 64 (-1))) ⊑ add e (add e_1 (constant 64 1)) := by
   llvm_bv_decide
 
-theorem bv_AddSub_1574 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.add e e_2) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub e_1 e_2) e := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    sub e_1 (add e e_2) ⊑ sub (sub e_1 e_2) e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1614 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.add e_1 e) ⊑
-      Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    sub e_1 (add e_1 e) ⊑ sub (constant 64 0) e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1619 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub e_1 e) e_1 ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    sub (sub e_1 e) e_1 ⊑ sub (constant 64 0) e := by
   llvm_bv_decide
 
-theorem bv_AddSub_1624 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.and e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    sub (or e e_1) (xor e e_1) ⊑ and e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_135 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_1) e_2 ⊑ Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_2) (Veir.Data.LLVM.Int.and e_1 e_2) := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    and (xor e e_1) e_2 ⊑ xor (and e e_2) (and e_1 e_2) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_144 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e e_1) e_2 ⊑ Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.and e_1 e_2)) e_2 := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    and (or e e_1) e_2 ⊑ and (or e (and e_1 e_2)) e_2 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_698 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp
-            (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
-          (Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e e_2) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq) ⊑
-        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.or e_1 e_2)) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    and (icmp (and e e_1) (constant 64 0) Veir.Data.LLVM.IntPred.eq)
+      (icmp (and e e_2) (constant 64 0) Veir.Data.LLVM.IntPred.eq) ⊑
+      icmp (and e (or e_1 e_2)) (constant 64 0) Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_709 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.and e e_1) e_1 Veir.Data.LLVM.IntPred.eq) (Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e e_2) e_2 Veir.Data.LLVM.IntPred.eq) ⊑
-        Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.or e_1 e_2)) (Veir.Data.LLVM.Int.or e_1 e_2) Veir.Data.LLVM.IntPred.eq := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    and (icmp (and e e_1) e_1 Veir.Data.LLVM.IntPred.eq)
+      (icmp (and e e_2) e_2 Veir.Data.LLVM.IntPred.eq) ⊑
+      icmp (and e (or e_1 e_2)) (or e_1 e_2) Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_716 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e e_1) e Veir.Data.LLVM.IntPred.eq) (Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.and e e_2) e Veir.Data.LLVM.IntPred.eq) ⊑
-        Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.and e_1 e_2)) e Veir.Data.LLVM.IntPred.eq := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    and (icmp (and e e_1) e Veir.Data.LLVM.IntPred.eq)
+      (icmp (and e e_2) e Veir.Data.LLVM.IntPred.eq) ⊑
+      icmp (and e (and e_1 e_2)) e Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_794 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.sgt)
-        (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.sgt := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (icmp e e_1 Veir.Data.LLVM.IntPred.sgt) (icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑
+      icmp e e_1 Veir.Data.LLVM.IntPred.sgt := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_827 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp  e (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
-            (Veir.Data.LLVM.Int.icmp e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq) ⊑
-        Veir.Data.LLVM.Int.icmp (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (icmp e (constant 64 0) Veir.Data.LLVM.IntPred.eq)
+      (icmp e_1 (constant 64 0) Veir.Data.LLVM.IntPred.eq) ⊑
+      icmp (or e e_1) (constant 64 0) Veir.Data.LLVM.IntPred.eq := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_887_2 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.eq) (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ Veir.Data.LLVM.Int.constant 1 0 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (icmp e e_1 Veir.Data.LLVM.IntPred.eq) (icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ constant 1 0 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1230__A__B___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑
-        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (xor e (constant 64 (-1))) (xor e_1 (constant 64 (-1))) ⊑
+      xor (or e e_1) (constant 64 (-1)) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1241_AB__AB__AB :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (or e e_1) (xor (and e e_1) (constant 64 (-1))) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1247_AB__AB__AB :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.or e e_1) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (xor (and e e_1) (constant 64 (-1))) (or e e_1) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1253_A__AB___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_1) e ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (xor e e_1) e ⊑ and e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1280_ABA___AB :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) e ⊑ Veir.Data.LLVM.Int.and e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (or (xor e (constant 64 (-1))) e_1) e ⊑ and e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1288_A__B__B__C__A___A__B__C :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_2) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e_2 e_1) e) ⊑
-        Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e e_2) (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    and (xor e e_2) (xor (xor e_2 e_1) e) ⊑ and (xor e e_2) (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1294_A__B__A__B___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑ Veir.Data.LLVM.Int.and e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    and (or e e_1) (xor (xor e (constant 64 (-1))) e_1) ⊑ and e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1683_1 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ugt ) (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.eq ) ⊑ Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.uge := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (icmp e e_1 Veir.Data.LLVM.IntPred.ugt) (icmp e e_1 Veir.Data.LLVM.IntPred.eq) ⊑
+      icmp e e_1 Veir.Data.LLVM.IntPred.uge := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1683_2 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.uge)
-    (Veir.Data.LLVM.Int.icmp e e_1 Veir.Data.LLVM.IntPred.ne ) ⊑ Veir.Data.LLVM.Int.constant 1 1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (icmp e e_1 Veir.Data.LLVM.IntPred.uge) (icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ constant 1 1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1704 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp  e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
-        (Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.ult) ⊑
-        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.add e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) e Veir.Data.LLVM.IntPred.uge := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (icmp e_1 (constant 64 0) Veir.Data.LLVM.IntPred.eq) (icmp e e_1 Veir.Data.LLVM.IntPred.ult) ⊑
+      icmp (add e_1 (constant 64 (-1))) e Veir.Data.LLVM.IntPred.uge := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1705 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp  e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.eq)
-      (Veir.Data.LLVM.Int.icmp  e_1 e Veir.Data.LLVM.IntPred.ugt) ⊑
-        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.add e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) e Veir.Data.LLVM.IntPred.uge := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (icmp e_1 (constant 64 0) Veir.Data.LLVM.IntPred.eq) (icmp e_1 e Veir.Data.LLVM.IntPred.ugt) ⊑
+      icmp (add e_1 (constant 64 (-1))) e Veir.Data.LLVM.IntPred.uge := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_1733 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.icmp  e (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.ne)
-        (Veir.Data.LLVM.Int.icmp  e_1 (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.ne) ⊑
-        Veir.Data.LLVM.Int.icmp  (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 0) Veir.Data.LLVM.IntPred.ne := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (icmp e (constant 64 0) Veir.Data.LLVM.IntPred.ne) (icmp e_1 (constant 64 0) Veir.Data.LLVM.IntPred.ne) ⊑
+      icmp (or e e_1) (constant 64 0) Veir.Data.LLVM.IntPred.ne := by
   llvm_bv_decide
 
 /-
   `LLVM.not` is not supported in
-
-  theorem bv_AndOrXor_2063__X__C1__C2____X__C2__C1__C2 :
-      ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e e_1) e_2 ⊑
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_2) (Veir.Data.LLVM.Int.and e_1 (Veir.Data.LLVM.Int.not e_2)) := by
+  example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    or (xor e e_1) e_2 ⊑ xor (or e e_2) (and e_1 (not e_2)) := by sorry
 -/
 
-theorem bv_AndOrXor_2113___A__B__A___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) e ⊑ Veir.Data.LLVM.Int.or e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (and (xor e (constant 64 (-1))) e_1) e ⊑ or e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2118___A__B__A___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (and e e_1) (xor e (constant 64 (-1))) ⊑ or (xor e (constant 64 (-1))) e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2123___A__B__A__B___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (and e (xor e_1 (constant 64 (-1)))) (xor e e_1) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2188 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
-        Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (and e (xor e_1 (constant 64 (-1)))) (and (xor e (constant 64 (-1))) e_1) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2231__A__B__B__C__A___A__B__C :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e e_2) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e_2 e_1) e) ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e e_2) e_1 := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    or (xor e e_2) (xor (xor e_2 e_1) e) ⊑ or (xor e e_2) e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2243__B__C__A__B___B__A__C :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.or e_2 e_1) e) e_2 ⊑ Veir.Data.LLVM.Int.or e_2 (Veir.Data.LLVM.Int.and e e_1) := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    or (and (or e_2 e_1) e) e_2 ⊑ or e_2 (and e e_1) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2247__A__B__A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑
-        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (xor e (constant 64 (-1))) (xor e_1 (constant 64 (-1))) ⊑ xor (and e e_1) (constant 64 (-1)) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2263 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or e_1 (Veir.Data.LLVM.Int.xor e_1 e) ⊑ Veir.Data.LLVM.Int.or e_1 e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or e_1 (xor e_1 e) ⊑ or e_1 e := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2264 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑ Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or e (xor (xor e (constant 64 (-1))) e_1) ⊑ or e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2265 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.or e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (and e e_1) (xor e e_1) ⊑ or e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2284 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or e (xor (or e e_1) (constant 64 (-1))) ⊑ or e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2285 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e e_1) (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑ Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or e (xor (xor e e_1) (constant 64 (-1))) ⊑ or e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2297 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
-        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    or (and e e_1) (xor (xor e (constant 64 (-1))) e_1) ⊑ xor (xor e (constant 64 (-1))) e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2367 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.or e e_1) e_2 ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.or e e_2) e_1 := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    or (or e e_1) e_2 ⊑ or (or e e_2) e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2416 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
-        Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and (xor e (constant 64 (-1))) e_1) (constant 64 (-1)) ⊑ or e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2417 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
-        Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (or (xor e (constant 64 (-1))) e_1) (constant 64 (-1)) ⊑ and e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2429 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e_1 e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
-        Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and e_1 e) (constant 64 (-1)) ⊑ or (xor e_1 (constant 64 (-1))) (xor e (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2430 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e_1 e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑
-        Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (or e_1 e) (constant 64 (-1)) ⊑ and (xor e_1 (constant 64 (-1))) (xor e (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2443 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.ashr (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.ashr e_1 e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (ashr (xor e_1 (constant 64 (-1))) e) (constant 64 (-1)) ⊑ ashr e_1 e := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2453 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.icmp  e_1 e Veir.Data.LLVM.IntPred.slt) (Veir.Data.LLVM.Int.constant 1 (-1)) ⊑ Veir.Data.LLVM.Int.icmp  e_1 e Veir.Data.LLVM.IntPred.sge := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (icmp e_1 e Veir.Data.LLVM.IntPred.slt) (constant 1 (-1)) ⊑ icmp e_1 e Veir.Data.LLVM.IntPred.sge := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2475 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.sub e_1 e) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.add e (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (sub e_1 e) (constant 64 (-1)) ⊑ add e (sub (constant 64 (-1)) e_1) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2486 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.add e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (add e e_1) (constant 64 (-1)) ⊑ sub (sub (constant 64 (-1)) e_1) e := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2581__BAB___A__B :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1))) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (or e e_1) e_1 ⊑ and e (xor e_1 (constant 64 (-1))) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2587__BAA___B__A :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and e e_1) e_1 ⊑ and (xor e (constant 64 (-1))) e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2595 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.or e e_1) ⊑ Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and e e_1) (or e e_1) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2607 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.or e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
-        Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (or e (xor e_1 (constant 64 (-1)))) (or (xor e (constant 64 (-1))) e_1) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2617 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_1) ⊑
-        Veir.Data.LLVM.Int.xor e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and e (xor e_1 (constant 64 (-1)))) (and (xor e (constant 64 (-1))) e_1) ⊑ xor e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2627 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.xor e e_1) (Veir.Data.LLVM.Int.or e e_2) ⊑ Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) e_2) e_1 := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    xor (xor e e_1) (or e e_2) ⊑ xor (and (xor e (constant 64 (-1))) e_2) e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2647 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.xor e e_1) ⊑ Veir.Data.LLVM.Int.or e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and e e_1) (xor e e_1) ⊑ or e e_1 := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2658 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.xor e_1 (Veir.Data.LLVM.Int.constant 64 (-1)))) (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 64 (-1))) ⊑
-        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e e_1) (Veir.Data.LLVM.Int.constant 64 (-1)) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (and e (xor e_1 (constant 64 (-1)))) (xor e (constant 64 (-1))) ⊑ xor (and e e_1) (constant 64 (-1)) := by
   llvm_bv_decide
 
-theorem bv_AndOrXor_2663 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.ule) (Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.ne) ⊑ Veir.Data.LLVM.Int.icmp  e e_1 Veir.Data.LLVM.IntPred.uge:= by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    xor (icmp e e_1 Veir.Data.LLVM.IntPred.ule) (icmp e e_1 Veir.Data.LLVM.IntPred.ne) ⊑
+      icmp e e_1 Veir.Data.LLVM.IntPred.uge:= by
   llvm_bv_decide
 
-theorem bv_152 :
-    ∀ (e : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul e (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
+example (e : Veir.Data.LLVM.Int 64) :
+    mul e (constant 64 (-1)) ⊑ sub (constant 64 0) e := by
   llvm_bv_decide
 
 /--
   expected error: The SAT solver timed out while solving the problem.
-
-  theorem bv_229 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.add e e_1) e_2 ⊑ Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.mul e e_2) (Veir.Data.LLVM.Int.mul e_1 e_2) := by
-  llvm_bv_decide
+  example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+      mul (add e e_1) e_2 ⊑ add (mul e e_2) (mul e_1 e_2) := by llvm_bv_decide
 -/
 
-
-theorem bv_239 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e_1) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e) ⊑ Veir.Data.LLVM.Int.mul e_1 e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    mul (sub (constant 64 0) e_1) (sub (constant 64 0) e) ⊑ mul e_1 e := by
   llvm_bv_decide
 
-theorem bv_275 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.udiv e_1 e) e ⊑ Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.urem e_1 e) := by
+example (e e_1 : Veir.Data.LLVM.Int 5) :
+    mul (udiv e_1 e) e ⊑ sub e_1 (urem e_1 e) := by
   llvm_bv_decide
 
-theorem bv_275_2 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.sdiv e_1 e) e ⊑ Veir.Data.LLVM.Int.sub e_1 (Veir.Data.LLVM.Int.srem e_1 e) := by
+example (e e_1 : Veir.Data.LLVM.Int 5) :
+    mul (sdiv e_1 e) e ⊑ sub e_1 (srem e_1 e) := by
   llvm_bv_decide
 
-theorem bv_276 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.sdiv e_1 e) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 5 0) e) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.srem e_1 e) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 5) :
+    mul (sdiv e_1 e) (sub (constant 5 0) e) ⊑ sub (srem e_1 e) e_1 := by
   llvm_bv_decide
 
-theorem bv_276_2 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 5), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.udiv e_1 e) (Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 5 0) e) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.urem e_1 e) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 5) :
+    mul (udiv e_1 e) (sub (constant 5 0) e) ⊑ sub (urem e_1 e) e_1 := by
   llvm_bv_decide
 
-theorem bv_283 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 1), Veir.Data.LLVM.Int.mul e_1 e ⊑ Veir.Data.LLVM.Int.and e_1 e := by
+example (e e_1 : Veir.Data.LLVM.Int 1) :
+    mul e_1 e ⊑ and e_1 e := by
   llvm_bv_decide
 
-theorem bv_290__292 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.mul (Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.constant 64 1) e) e_1 ⊑ Veir.Data.LLVM.Int.shl e_1 e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    mul (shl (constant 64 1) e) e_1 ⊑ shl e_1 e := by
   llvm_bv_decide
 
-theorem bv_820 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 9), Veir.Data.LLVM.Int.sdiv (Veir.Data.LLVM.Int.sub e (Veir.Data.LLVM.Int.srem e e_1)) e_1 ⊑ Veir.Data.LLVM.Int.sdiv e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 9) :
+    sdiv (sub e (srem e e_1)) e_1 ⊑ sdiv e e_1 := by
   llvm_bv_decide
 
-theorem bv_820' :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 9), Veir.Data.LLVM.Int.udiv (Veir.Data.LLVM.Int.sub e (Veir.Data.LLVM.Int.urem e e_1)) e_1 ⊑ Veir.Data.LLVM.Int.udiv e e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 9) :
+    udiv (sub e (urem e e_1)) e_1 ⊑ udiv e e_1 := by
   llvm_bv_decide
 
-theorem bv_1030 :
-    ∀ (e : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.sdiv e (Veir.Data.LLVM.Int.constant 64 (-1)) ⊑ Veir.Data.LLVM.Int.sub (Veir.Data.LLVM.Int.constant 64 0) e := by
+example (e : Veir.Data.LLVM.Int 64) :
+    sdiv e (constant 64 (-1)) ⊑ sub (constant 64 0) e := by
   llvm_bv_decide
 
-theorem bv_Select_858 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 1),
-      Veir.Data.LLVM.Int.select e (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) e_1 ⊑ Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 1) :
+    select e (xor e (constant 1 (-1))) e_1 ⊑ and (xor e (constant 1 (-1))) e_1 := by
   llvm_bv_decide
 
-theorem bv_Select_859' :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 1),
-      Veir.Data.LLVM.Int.select e e_1 (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) ⊑ Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.constant 1 (-1))) e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 1) :
+    select e e_1 (xor e (constant 1 (-1))) ⊑ or (xor e (constant 1 (-1))) e_1 := by
   llvm_bv_decide
 
-theorem bv_select_1100 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.select (Veir.Data.LLVM.Int.constant 1 1) e_1 e ⊑ e_1 := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    select (constant 1 1) e_1 e ⊑ e_1 := by
   llvm_bv_decide
 
-theorem bv_Select_1105 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.select (Veir.Data.LLVM.Int.constant 1 0) e_1 e ⊑ e := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    select (constant 1 0) e_1 e ⊑ e := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__239 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.shl e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    lshr (shl e e_1) e_1 ⊑ and e (lshr (constant 64 (-1)) e_1) := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__279 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.lshr e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    shl (lshr e e_1) e_1 ⊑ and e (shl (constant 64 (-1)) e_1) := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__440 :
-    ∀ (e e_1 e_2 e_3 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.xor e (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.lshr e_1 e_2) e_3)) e_2 ⊑
-        Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.and e_1 (Veir.Data.LLVM.Int.shl e_3 e_2)) (Veir.Data.LLVM.Int.shl e e_2) := by
+example (e e_1 e_2 e_3: Veir.Data.LLVM.Int 64) :
+    shl (xor e (and (lshr e_1 e_2) e_3)) e_2 ⊑ xor (and e_1 (shl e_3 e_2)) (shl e e_2) := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__476 :
-    ∀ (e e_1 e_2 e_3 : Veir.Data.LLVM.Int 64),
-      Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and (Veir.Data.LLVM.Int.lshr e_1 e_2) e_3) e) e_2 ⊑
-        Veir.Data.LLVM.Int.or (Veir.Data.LLVM.Int.and e_1 (Veir.Data.LLVM.Int.shl e_3 e_2)) (Veir.Data.LLVM.Int.shl e e_2) := by
+example (e e_1 e_2 e_3: Veir.Data.LLVM.Int 64) :
+    shl (or (and (lshr e_1 e_2) e_3) e) e_2 ⊑ or (and e_1 (shl e_3 e_2)) (shl e e_2) := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__497 :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.xor e e_2) e_1 ⊑ Veir.Data.LLVM.Int.xor (Veir.Data.LLVM.Int.lshr e e_1) (Veir.Data.LLVM.Int.lshr e_2 e_1) := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    lshr (xor e e_2) e_1 ⊑ xor (lshr e e_1) (lshr e_2 e_1) := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__497''' :
-    ∀ (e e_1 e_2 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.shl (Veir.Data.LLVM.Int.add e e_2) e_1 ⊑ Veir.Data.LLVM.Int.add (Veir.Data.LLVM.Int.shl e e_1) (Veir.Data.LLVM.Int.shl e_2 e_1) := by
+example (e e_1 e_2 : Veir.Data.LLVM.Int 64) :
+    shl (add e e_2) e_1 ⊑ add (shl e e_1) (shl e_2 e_1) := by
   llvm_bv_decide
 
-theorem bv_InstCombineShift__582 :
-    ∀ (e e_1 : Veir.Data.LLVM.Int 64), Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.shl e e_1) e_1 ⊑ Veir.Data.LLVM.Int.and e (Veir.Data.LLVM.Int.lshr (Veir.Data.LLVM.Int.constant 64 (-1)) e_1) := by
+example (e e_1 : Veir.Data.LLVM.Int 64) :
+    lshr (shl e e_1) e_1 ⊑ and e (lshr (constant 64 (-1)) e_1) := by
   llvm_bv_decide

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -12,7 +12,7 @@ import Veir.Data.Refinement
 
 /-- We introduce a tactic to automatically prove all the lemmas. -/
 macro "llvm_bv_decide" : tactic =>
-  `(tactic| (try simp [llvm_toBitVec]; try bv_decide; <;> sorry))
+  `(tactic| ((try simp [llvm_toBitVec]; try bv_decide); all_goals sorry))
 
 open Veir.Data.LLVM
 namespace Veir.Data.Int

--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -89,9 +89,7 @@ theorem bv_AddSub_1574 :
 theorem bv_AddSub_1614 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub e_1 (LLVM.Int.add e_1 e) ⊑
       LLVM.Int.sub (LLVM.Int.constant 64 0) e := by
-  simp [llvm_toBitVec]
-
-  bv_decide
+  llvm_bv_decide
 
 theorem bv_AddSub_1619 :
     ∀ (e e_1 : Int 64), LLVM.Int.sub (LLVM.Int.sub e_1 e) e_1 ⊑ LLVM.Int.sub (LLVM.Int.constant 64 0) e := by

--- a/Veir/Data/LLVM/Int/Simp.lean
+++ b/Veir/Data/LLVM/Int/Simp.lean
@@ -1,0 +1,5 @@
+module
+
+public import Lean
+
+register_simp_attr llvm_toBitVec


### PR DESCRIPTION
We add to unittest the tests for the bitblastability of the `LLVM.Int` type. 
The tests come from [lean-mlir](https://github.com/opencompl/lean-mlir/blob/main/SSA/Projects/InstCombine/AliveStatements.lean) and are instantiated for bitvectors of width 64.

We also introduce a simp set `llvm_toBitVec`, aimed at unfolding the semantics of `LLVM.Int` operations to bitblastable ones - a call to this simp set + a call to bv_decide should suffice to solve all lemmas on fixed-width `LLVM.Int` bitblastable operations.