### PR TITLE
fix: open namespace after structure has been defined [FP]

### DIFF
--- a/Veir/Data/FP/PackedFloat/Basic.lean
+++ b/Veir/Data/FP/PackedFloat/Basic.lean
@@ -2,8 +2,6 @@ module
 
 namespace Veir.Data.FP
 
-namespace PackedFloat
-
 public section
 
 /--

--- a/Veir/Data/FP/ScientificBV/Basic.lean
+++ b/Veir/Data/FP/ScientificBV/Basic.lean
@@ -3,8 +3,6 @@ public import Veir.Data.FP.Sign
 
 namespace Veir.Data.FP
 
-namespace ScientificBV
-
 public section
 
 /--
@@ -34,6 +32,8 @@ structure ScientificBV (e s : Nat) where
   sig : BitVec s
   deriving Inhabited, Repr
 
+namespace ScientificBV
+
 /--
 Treat a significand bitvector as a rational number in [1, 2),
 where the leading bit is implicitly 1 and the trailing bits are interpreted as a fraction.
@@ -57,3 +57,9 @@ def toRat {e s : Nat} (sbv : ScientificBV e s) : Rat :=
   let exponent := exToRat sbv.ex
   let significand := sigToRat sbv.sig
   sign * exponent * significand
+
+end ScientificBV
+
+end -- public section
+
+end Veir.Data.FP


### PR DESCRIPTION
This enables dot notation to work properly, and has the structure
be scoped as `Veir.Data.FP.X`, followed by a namespace of
`Veir.Data.FP.X` which allows `X` theory to be developed.
