### PR TITLE
feat: add FP state inductive

### DIFF
--- a/Veir/Data/FP.lean
+++ b/Veir/Data/FP.lean
@@ -1,4 +1,6 @@
 module
 
 import Veir.Data.FP.PackedFloat
+import Veir.Data.FP.ScientificBV
+import Veir.Data.FP.State
 

--- a/Veir/Data/FP/PackedFloat/State.lean
+++ b/Veir/Data/FP/PackedFloat/State.lean
@@ -12,11 +12,11 @@ public section
 The state of the packed float, as defined by the exponent and significand bits,
 following the IEEE-754 interpretation (Section 3.4 of the IEEE-754 standard,
 https://standards.ieee.org/ieee/754/6210/):
-- biased exponent `allOnes` with non-zero significand → `NaN`
-- biased exponent `allOnes` with zero significand → `Infinity`
-- biased exponent `0` with zero significand → `Zero`
-- biased exponent `0` with non-zero significand → `Subnormal`
-- biased exponent between 1 and allOnes - 1 (inclusive) → `Normal`
+- biased exponent `allOnes` with non-zero significand → `.nan`
+- biased exponent `allOnes` with zero significand → `.infinite`
+- biased exponent `0` with zero significand → `.zero`
+- biased exponent `0` with non-zero significand → `.subnormal`
+- biased exponent between 1 and allOnes - 1 (inclusive) → `.normal`
 -/
 def state (pf : PackedFloat e s) : State :=
   if pf.ex = BitVec.allOnes e then

--- a/Veir/Data/FP/PackedFloat/State.lean
+++ b/Veir/Data/FP/PackedFloat/State.lean
@@ -2,7 +2,6 @@ module
 
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.State
-public import Veir.ForLean
 
 namespace Veir.Data.FP.PackedFloat
 

--- a/Veir/Data/FP/PackedFloat/State.lean
+++ b/Veir/Data/FP/PackedFloat/State.lean
@@ -1,0 +1,31 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.State
+public import Veir.ForLean
+
+namespace Veir.Data.FP.PackedFloat
+
+public section
+
+/--
+The state of the packed float, as defined by the exponent and significand bits,
+following the IEEE-754 interpretation (Section 3.4 of the IEEE-754 standard,
+https://standards.ieee.org/ieee/754/6210/):
+- biased exponent `allOnes` with non-zero significand → `NaN`
+- biased exponent `allOnes` with zero significand → `Infinity`
+- biased exponent `0` with zero significand → `Zero`
+- biased exponent `0` with non-zero significand → `Subnormal`
+- biased exponent between 1 and allOnes - 1 (inclusive) → `Normal`
+-/
+def state (pf : PackedFloat e s) : State :=
+  if pf.ex = BitVec.allOnes e then
+    if pf.sig = 0#s then .infinite
+    else .nan
+  else if pf.ex = 0#e then
+    if pf.sig = 0#s then .zero
+    else .subnormal
+  else .normal
+
+end
+

--- a/Veir/Data/FP/State.lean
+++ b/Veir/Data/FP/State.lean
@@ -1,0 +1,4 @@
+module
+
+public import Veir.Data.FP.State.Basic
+

--- a/Veir/Data/FP/State/Basic.lean
+++ b/Veir/Data/FP/State/Basic.lean
@@ -1,0 +1,49 @@
+module
+
+namespace Veir.Data.FP
+
+public section
+
+/--
+A plain enumeration of the possible states of a floating point value.
+We define this separately to enable bitblasting the state of a FP value,
+and to enable a shared representation of the FP state across
+packed/unpacked representations.
+-/
+inductive State
+/-- A zero floating point value. -/
+| zero
+/-- A finite subnormal value. -/
+| subnormal
+/-- A finite normal value. -/
+| normal
+/-- An infinite value. -/
+| infinite
+/-- A not a number (NaN) value. -/
+| nan
+deriving DecidableEq, Repr
+
+namespace State
+
+/-- A state is finite iff it is zero, subnormal, or normal. -/
+@[expose]
+def isFinite (s : State) : Prop :=
+  s = .zero ∨ s = .subnormal ∨ s = .normal
+
+instance {s : State} : Decidable (s.isFinite) := by
+  simp [State.isFinite]
+  infer_instance
+
+/-- A state is nonzero finite iff it is subnormal or normal. -/
+@[expose]
+def isNonzeroFinite (s : State) : Prop :=
+  s = .subnormal ∨ s = .normal
+
+instance {s : State} : Decidable (s.isNonzeroFinite) := by
+  simp [State.isNonzeroFinite]
+  infer_instance
+
+end State
+end -- public section
+end Veir.Data.FP
+


### PR DESCRIPTION
This PR adds a new C-style enum-inductive called 'state' which is
bitblastable, and enumerates the possible states a floating point number
can be in. This will be used to define unpacking, and to redefine the
rational interpretation of a packed number in a way that allows for
reasoning across abstraction layers (packed / escientific) of the status
of a given object.
