### PR TITLE
feat: add EDyadic for computable FP

### DIFF
--- a/Veir/Data/FP/EDyadic.lean
+++ b/Veir/Data/FP/EDyadic.lean
@@ -1,0 +1,3 @@
+module
+
+public import Veir.Data.FP.EDyadic.Basic

--- a/Veir/Data/FP/EDyadic/Basic.lean
+++ b/Veir/Data/FP/EDyadic/Basic.lean
@@ -1,6 +1,4 @@
 module
-public import Veir.Data.FP.Sign
-public import Veir.Data.FP.ExtRat
 public import Veir.Data.FP.ScientificBV
 
 namespace Veir.Data.FP
@@ -8,14 +6,20 @@ namespace Veir.Data.FP
 public section
 
 /--
-An extended dyadic number (EScientificBV)
+An extended dyadic number (EDyadic)
 is a representation of a floating-point number
 that includes the special values zero, infinity, and NaN.
 -/
 inductive EDyadic where
   /-- A zero with a sign bit. -/
   | zero (sign : Bool)
-  /-- A nonzero finite number in scientific notation. -/
+  /-- A nonzero finite number in dyadic notation.
+  While dyadics can be zero, we use the `zero` constructor to
+  represent zero values (so the sign is represent),
+  and we use `nonzeroFinite` to represent nonzero values.
+  Thus, there is an implicit invariant that the `nonzeroFinite`
+  constructor should only be used with nonzero dyadics
+  -/
   | nonzeroFinite (d : Dyadic)
   /-- An infinite number with a sign bit. -/
   | infinity (sign : Bool)

--- a/Veir/Data/FP/EDyadic/Basic.lean
+++ b/Veir/Data/FP/EDyadic/Basic.lean
@@ -18,7 +18,7 @@ inductive EDyadic where
   represent zero values (so the sign is represent),
   and we use `nonzeroFinite` to represent nonzero values.
   Thus, there is an implicit invariant that the `nonzeroFinite`
-  constructor should only be used with nonzero dyadics
+  constructor should only be used with nonzero dyadics.
   -/
   | nonzeroFinite (d : Dyadic)
   /-- An infinite number with a sign bit. -/

--- a/Veir/Data/FP/EDyadic/Basic.lean
+++ b/Veir/Data/FP/EDyadic/Basic.lean
@@ -1,0 +1,36 @@
+module
+public import Veir.Data.FP.Sign
+public import Veir.Data.FP.ExtRat
+public import Veir.Data.FP.ScientificBV
+
+namespace Veir.Data.FP
+
+public section
+
+/--
+An extended dyadic number (EScientificBV)
+is a representation of a floating-point number
+that includes the special values zero, infinity, and NaN.
+-/
+inductive EDyadic where
+  /-- A zero with a sign bit. -/
+  | zero (sign : Bool)
+  /-- A nonzero finite number in scientific notation. -/
+  | nonzeroFinite (d : Dyadic)
+  /-- An infinite number with a sign bit. -/
+  | infinity (sign : Bool)
+  /-- A NaN (not a number). -/
+  | nan
+  deriving Inhabited
+
+instance : Repr EDyadic where
+  reprPrec 
+    | .zero sign,  _ => s!"EDyadic.zero {sign}"
+    | .nonzeroFinite d,  _ => s!"EDyadic.finite {repr d.toRat}"
+    | .infinity sign, _ => s!"EDyadic.infinity {sign}"
+    | .nan, _ => "EDyadic.nan"
+
+end -- public section
+
+end Veir.Data.FP
+

--- a/Veir/Data/FP/EDyadic/ToExtRat.lean
+++ b/Veir/Data/FP/EDyadic/ToExtRat.lean
@@ -1,0 +1,26 @@
+module
+
+public import Veir.Data.FP.EDyadic
+public import Veir.Data.FP.ExtRat
+
+namespace Veir.Data.FP.EDyadic
+
+public section
+
+/--
+Compute the extended rational value of an `EDyadic`.
+The result is a rational number if the value is finite
+and is either infinity or NaN otherwise.
+
+There is one place where this function is not injective:
+When the input is ±0, the result is `0`, losing the sign bit.
+Everywhere else, the function is injective.
+-/
+def toExtRat : EDyadic → ExtRat
+  | .zero _ => .number 0
+  | .nonzeroFinite d => .number d.toRat
+  | .infinity sign => .infinity sign
+  | .nan => .nan
+
+  end -- public section
+

--- a/Veir/Data/FP/EDyadic/ToExtRat.lean
+++ b/Veir/Data/FP/EDyadic/ToExtRat.lean
@@ -22,5 +22,5 @@ def toExtRat : EDyadic → ExtRat
   | .infinity sign => .infinity sign
   | .nan => .nan
 
-  end -- public section
+  end
 

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -4,3 +4,4 @@ public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.ScientificBV.Basic
 public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.ToExtRat
+public import Veir.Data.FP.EDyadic


### PR DESCRIPTION
As discussed with @tobiasgrosser, for computable rounding,
it suffices to use the dyadics as a representation,
since it is a compressed, arbitrary-precision representation of numbers
of the form `k/2^n` where `k` is not divisible by `2`.

Therefore, we add an `EDyadic` type, and show how to convert it to a
rational. As the next step, we will show how to convert a `PackedFloat` into
an `EDyadic`.


Part of https://github.com/opencompl/veir/issues/504