### PR TITLE
remove `LLVM.sdiv` redundant poison condition

### DIFF
--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -206,9 +206,6 @@ def sdiv {w : Nat} (x y : Int w) (exact : Bool := false) : Int w := Id.run do
   if exact ∧ x'.smod y' ≠ 0 then
     return poison
 
-  if y' == 0 then
-    return poison
-
   val (x'.sdiv y')
 
 /--


### PR DESCRIPTION
It feels like this condition is checked already in `y' == 0 || (w != 1 && x' == (BitVec.intMin w) && y' == -1)` (a couple lines above), so this should be redundant.  