### PR TITLE
Ensure unit-tests fail on io

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -17,11 +17,12 @@ jobs:
         uses: leanprover/lean-action@v1
         with:
           build-args: "--iofail"
+          test: false
 
       - name: Run unit tests
         uses: leanprover/lean-action@v1
         with:
-          build-args: "--iofail"
+          test-args: "--iofail"
           test: true
 
       - name: Install uv


### PR DESCRIPTION
In case unit tests print info or warnings, fail the build. This requires us to pass `--iofail` to `lake test`.

Additionally, this PR disables unit tests to be run while building the project, as they would otherwise be run twice. We prefer to have a separate build step for unit tests, such that failures there are apparent.