### PR TITLE
rename llvm.constant to llvm.mlir.constant

### DIFF
--- a/Test/Builtin/unrealized_conversion_cast.mlir
+++ b/Test/Builtin/unrealized_conversion_cast.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
 ^bb0():
-  %0 = "llvm.constant"() <{"value" = 13 : i8}> : () -> i8
+  %0 = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
   %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> !reg
   %2 = "builtin.unrealized_conversion_cast"(%1) : (!reg) -> i32
-  // CHECK:          %{{.*}} = "llvm.constant"() <{"value" = 13 : i8}> : () -> i8
+  // CHECK:          %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
   // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !reg
   // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i32
 }) : () -> ()

--- a/Test/Interpreter/LLVM/add.mlir
+++ b/Test/Interpreter/LLVM/add.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
   %x = "llvm.add"(%lhs, %rhs) : (i32, i32) -> i32
   "func.return"(%x) : (i32) -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/add_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 100 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 100 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
   %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 150 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 150 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
   %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 255 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 3 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i8 }> : () -> i8
   %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/and.mlir
+++ b/Test/Interpreter/LLVM/and.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "llvm.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "llvm.constant"() <{ "value" = -7 : i32 }> : () -> i32
+  %three = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
+  %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
   %x = "llvm.and"(%three, %five) : (i32, i32) -> i32
   %y = "llvm.and"(%eight, %negseven) : (i32, i32) -> i32
   %z = "llvm.and"(%three, %eight) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/ashr.mlir
+++ b/Test/Interpreter/LLVM/ashr.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %seven = "llvm.constant"() <{ "value" = 127 : i8 }> : () -> i8
-  %negone = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
-  %four = "llvm.constant"() <{ "value" = 4 : i8 }> : () -> i8
-  %nine = "llvm.constant"() <{ "value" = 9 : i8 }> : () -> i8
+  %seven = "llvm.mlir.constant"() <{ "value" = 127 : i8 }> : () -> i8
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %four = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
+  %nine = "llvm.mlir.constant"() <{ "value" = 9 : i8 }> : () -> i8
   %x = "llvm.ashr"(%seven, %four) : (i8, i8) -> i8
   %y = "llvm.ashr"(%negone, %four) : (i8, i8) -> i8
   %z = "llvm.ashr"(%negone, %nine) : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/ashr_exact.mlir
+++ b/Test/Interpreter/LLVM/ashr_exact.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %seven = "llvm.constant"() <{ "value" = 64 : i8 }> : () -> i8
-  %negone = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
-  %four = "llvm.constant"() <{ "value" = 4 : i8 }> : () -> i8
-  %nine = "llvm.constant"() <{ "value" = 9 : i8 }> : () -> i8
+  %seven = "llvm.mlir.constant"() <{ "value" = 64 : i8 }> : () -> i8
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %four = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
+  %nine = "llvm.mlir.constant"() <{ "value" = 9 : i8 }> : () -> i8
   %x = "llvm.ashr"(%seven, %four) <{exact}> : (i8, i8) -> i8
   %y = "llvm.ashr"(%negone, %four) <{exact}> : (i8, i8) -> i8
   %z = "llvm.ashr"(%negone, %nine) <{exact}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/br.mlir
+++ b/Test/Interpreter/LLVM/br.mlir
@@ -2,8 +2,8 @@
 
 "builtin.module"() ({
   ^1():
-    %x1 = "llvm.constant"() <{"value" = 8 : i32}> : () -> i32
-    %x2 = "llvm.constant"() <{"value" = 11 : i32}> : () -> i32
+    %x1 = "llvm.mlir.constant"() <{"value" = 8 : i32}> : () -> i32
+    %x2 = "llvm.mlir.constant"() <{"value" = 11 : i32}> : () -> i32
     "llvm.br"(%x1, %x2) [^2] : (i32, i32) -> ()
   ^2(%y1 : i32, %y2 : i32):
     "llvm.return"(%y2) : (i32) -> ()

--- a/Test/Interpreter/LLVM/cond_br.mlir
+++ b/Test/Interpreter/LLVM/cond_br.mlir
@@ -2,18 +2,18 @@
 
 "builtin.module"() ({
   ^1():
-    %x1 = "llvm.constant"() <{"value" = 8 : i32}> : () -> i32
-    %x2 = "llvm.constant"() <{"value" = 11 : i32}> : () -> i32
-    %cond = "llvm.constant"() <{"value" = 0 : i1}> : () -> i1
+    %x1 = "llvm.mlir.constant"() <{"value" = 8 : i32}> : () -> i32
+    %x2 = "llvm.mlir.constant"() <{"value" = 11 : i32}> : () -> i32
+    %cond = "llvm.mlir.constant"() <{"value" = 0 : i1}> : () -> i1
     "llvm.cond_br"(%cond, %x1, %x2) [^4,^3] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
   ^2(%y : i32):
     "llvm.return"(%y) : (i32) -> ()
   ^3(%z1 : i32):
-    %z2 = "llvm.constant"() <{"value" = 2 : i32}> : () -> i32
-    %cond = "llvm.constant"() <{"value" = -1 : i1}> : () -> i1
+    %z2 = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+    %cond = "llvm.mlir.constant"() <{"value" = -1 : i1}> : () -> i1
     "llvm.cond_br"(%cond, %z1, %z2) [^2,^4] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
   ^4(%a1 : i32):
-    %a2 = "llvm.constant"() <{"value" = 5 : i32}> : () -> i32
+    %a2 = "llvm.mlir.constant"() <{"value" = 5 : i32}> : () -> i32
     "llvm.return"(%a2) : (i32) -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/LLVM/constant.mlir
+++ b/Test/Interpreter/LLVM/constant.mlir
@@ -1,9 +1,9 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %pos = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %neg = "llvm.constant"() <{ "value" = -4 : i32 }> : () -> i32
+  %pos = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %neg = "llvm.mlir.constant"() <{ "value" = -4 : i32 }> : () -> i32
   "func.return"(%pos, %zero, %neg) : (i32, i32, i32) -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/LLVM/icmp.mlir
+++ b/Test/Interpreter/LLVM/icmp.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %seven = "llvm.constant"() <{ value = 7 : i8 }> : () -> i8
-  %nine = "llvm.constant"() <{ value = 9 : i8 }> : () -> i8
+  %seven = "llvm.mlir.constant"() <{ value = 7 : i8 }> : () -> i8
+  %nine = "llvm.mlir.constant"() <{ value = 9 : i8 }> : () -> i8
   %x = "llvm.icmp"(%seven, %nine) <{ predicate = 0 : i64 }> : (i8, i8) -> i1
   %y = "llvm.icmp"(%seven, %nine) <{ predicate = 1 : i64 }> : (i8, i8) -> i1
   %z = "llvm.icmp"(%seven, %nine) <{ predicate = 2 : i64 }> : (i8, i8) -> i1

--- a/Test/Interpreter/LLVM/lshr.mlir
+++ b/Test/Interpreter/LLVM/lshr.mlir
@@ -1,12 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %zero = "llvm.constant"() <{ "value" = 0 : i8 }> : () -> i8
-  %seven = "llvm.constant"() <{ "value" = 127 : i8 }> : () -> i8
-  %negone = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
-  %four = "llvm.constant"() <{ "value" = 4 : i8 }> : () -> i8
-  %nine = "llvm.constant"() <{ "value" = 9 : i8 }> : () -> i8
-  %thirtytwo = "llvm.constant"() <{ "value" = 32 : i8 }> : () -> i8
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i8 }> : () -> i8
+  %seven = "llvm.mlir.constant"() <{ "value" = 127 : i8 }> : () -> i8
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %four = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
+  %nine = "llvm.mlir.constant"() <{ "value" = 9 : i8 }> : () -> i8
+  %thirtytwo = "llvm.mlir.constant"() <{ "value" = 32 : i8 }> : () -> i8
   %x = "llvm.lshr"(%seven, %four) : (i8, i8) -> i8
   %y = "llvm.lshr"(%negone, %four) : (i8, i8) -> i8
   %z = "llvm.lshr"(%negone, %nine) : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/lshr_exact.mlir
+++ b/Test/Interpreter/LLVM/lshr_exact.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %seven = "llvm.constant"() <{ "value" = 64 : i8 }> : () -> i8
-  %negone = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
-  %four = "llvm.constant"() <{ "value" = 4 : i8 }> : () -> i8
-  %nine = "llvm.constant"() <{ "value" = 9 : i8 }> : () -> i8
+  %seven = "llvm.mlir.constant"() <{ "value" = 64 : i8 }> : () -> i8
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %four = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
+  %nine = "llvm.mlir.constant"() <{ "value" = 9 : i8 }> : () -> i8
   %x = "llvm.lshr"(%seven, %four) <{exact}> : (i8, i8) -> i8
   %y = "llvm.lshr"(%negone, %four) <{exact}> : (i8, i8) -> i8
   %z = "llvm.lshr"(%negone, %nine) <{exact}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/mul.mlir
+++ b/Test/Interpreter/LLVM/mul.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
   %x = "llvm.mul"(%lhs, %rhs) : (i32, i32) -> i32
   "func.return"(%x) : (i32) -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 10 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 13 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 10 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 13 : i8 }> : () -> i8
   %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.mul"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 150 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 100 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
   %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.mul"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 2 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 255 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 2 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
   %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.mul"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/or.mlir
+++ b/Test/Interpreter/LLVM/or.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "llvm.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "llvm.constant"() <{ "value" = -7 : i32 }> : () -> i32
+  %three = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
+  %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
   %x = "llvm.or"(%three, %five) : (i32, i32) -> i32
   %y = "llvm.or"(%eight, %negseven) : (i32, i32) -> i32
   %z = "llvm.or"(%three, %eight) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/or_disjoint.mlir
+++ b/Test/Interpreter/LLVM/or_disjoint.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "llvm.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "llvm.constant"() <{ "value" = -7 : i32 }> : () -> i32
+  %three = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
+  %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
   %x = "llvm.or"(%three, %five) <{disjoint}> : (i32, i32) -> i32
   %y = "llvm.or"(%eight, %negseven) <{disjoint}> : (i32, i32) -> i32
   %z = "llvm.or"(%three, %eight) <{disjoint}> : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/sdiv.mlir
+++ b/Test/Interpreter/LLVM/sdiv.mlir
@@ -1,12 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 7 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %negone = "llvm.constant"() <{ "value" = -1 : i32 }> : () -> i32
-  %negthree = "llvm.constant"() <{ "value" = -3 : i32 }> : () -> i32
-  %negtwo = "llvm.constant"() <{ "value" = -2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
+  %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.sdiv"(%lhs, %rhs) : (i32, i32) -> i32
   %y = "llvm.sdiv"(%lhs, %zero) : (i32, i32) -> i32
   %z = "llvm.sdiv"(%lhs, %negone) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/sdiv_exact.mlir
+++ b/Test/Interpreter/LLVM/sdiv_exact.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 7 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
   %x = "llvm.sdiv"(%lhs, %rhs) <{exact}> : (i32, i32) -> i32
   "func.return"(%x) : (i32) -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/sext.mlir
+++ b/Test/Interpreter/LLVM/sext.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %c127 = "llvm.constant"() <{ "value" = 127 : i8 }> : () -> i8
-  %cneg = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %c127 = "llvm.mlir.constant"() <{ "value" = 127 : i8 }> : () -> i8
+  %cneg = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
   %a = "llvm.sext"(%c127) : (i8) -> i32
   %b = "llvm.sext"(%cneg) : (i8) -> i32
   "func.return"(%a, %b) : (i32, i32) -> ()

--- a/Test/Interpreter/LLVM/shl.mlir
+++ b/Test/Interpreter/LLVM/shl.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %lhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %thirtytwo = "llvm.constant"() <{ "value" = 32 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+  %thirtytwo = "llvm.mlir.constant"() <{ "value" = 32 : i32 }> : () -> i32
   %x = "llvm.shl"(%lhs, %rhs) : (i32, i32) -> i32
   %p = "llvm.shl"(%zero, %thirtytwo) : (i32, i32) -> i32
   "func.return"(%x, %p) : (i32, i32) -> ()

--- a/Test/Interpreter/LLVM/shl_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 10 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 4 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 10 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
   %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.shl"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 4 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 6 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 6 : i8 }> : () -> i8
   %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.shl"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 255 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 5 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 5 : i8 }> : () -> i8
   %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.shl"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/srem.mlir
+++ b/Test/Interpreter/LLVM/srem.mlir
@@ -1,12 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 7 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %negone = "llvm.constant"() <{ "value" = -1 : i32 }> : () -> i32
-  %negthree = "llvm.constant"() <{ "value" = -3 : i32 }> : () -> i32
-  %negtwo = "llvm.constant"() <{ "value" = -2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
+  %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.srem"(%lhs, %rhs) : (i32, i32) -> i32
   %y = "llvm.srem"(%lhs, %zero) : (i32, i32) -> i32
   %z = "llvm.srem"(%lhs, %negone) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/sub.mlir
+++ b/Test/Interpreter/LLVM/sub.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
   %x = "llvm.sub"(%lhs, %rhs) : (i32, i32) -> i32
   "func.return"(%x) : (i32) -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 200 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 80 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 80 : i8 }> : () -> i8
   %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.sub"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 100 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 220 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 220 : i8 }> : () -> i8
   %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.sub"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 200 : i8 }> : () -> i8
-  %rhs = "llvm.constant"() <{ "value" = 200 : i8 }> : () -> i8
+  %lhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
+  %rhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
   %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
   %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
   %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8

--- a/Test/Interpreter/LLVM/trunc.mlir
+++ b/Test/Interpreter/LLVM/trunc.mlir
@@ -1,9 +1,9 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %c255 = "llvm.constant"() <{ "value" = 255 : i32 }> : () -> i32
-  %c256 = "llvm.constant"() <{ "value" = 256 : i32 }> : () -> i32
-  %cneg = "llvm.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %c255 = "llvm.mlir.constant"() <{ "value" = 255 : i32 }> : () -> i32
+  %c256 = "llvm.mlir.constant"() <{ "value" = 256 : i32 }> : () -> i32
+  %cneg = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
   %a = "llvm.trunc"(%c255) : (i32) -> i8
   %b = "llvm.trunc"(%c256) : (i32) -> i8
   %c = "llvm.trunc"(%cneg) : (i32) -> i16

--- a/Test/Interpreter/LLVM/trunc_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_signed_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   // 127 fits in i8 signed: sext(trunc(127)) == 127, no poison
-  %c127 = "llvm.constant"() <{ "value" = 127 : i32 }> : () -> i32
+  %c127 = "llvm.mlir.constant"() <{ "value" = 127 : i32 }> : () -> i32
   // 128 does not fit in i8 signed: sext(trunc(128)) == -128 != 128, poison
-  %c128 = "llvm.constant"() <{ "value" = 128 : i32 }> : () -> i32
+  %c128 = "llvm.mlir.constant"() <{ "value" = 128 : i32 }> : () -> i32
   %a = "llvm.trunc"(%c127) <{nsw}> : (i32) -> i8
   %b = "llvm.trunc"(%c128) <{nsw}> : (i32) -> i8
   "func.return"(%a, %b) : (i8, i8) -> ()

--- a/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
@@ -4,7 +4,7 @@
 //   nsw: sext(0x80) = -128 != 384, poison
 //   nuw: zext(0x80) = 128 != 384, poison
 "builtin.module"() ({
-  %c384 = "llvm.constant"() <{ "value" = 384 : i32 }> : () -> i32
+  %c384 = "llvm.mlir.constant"() <{ "value" = 384 : i32 }> : () -> i32
   %none    = "llvm.trunc"(%c384) : (i32) -> i8
   %nsw     = "llvm.trunc"(%c384) <{nsw}> : (i32) -> i8
   %nuw     = "llvm.trunc"(%c384) <{nuw}> : (i32) -> i8

--- a/Test/Interpreter/LLVM/trunc_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_unsigned_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   // 255 fits in i8 unsigned: zext(trunc(255)) == 255, no poison
-  %c255 = "llvm.constant"() <{ "value" = 255 : i32 }> : () -> i32
+  %c255 = "llvm.mlir.constant"() <{ "value" = 255 : i32 }> : () -> i32
   // 256 does not fit in i8 unsigned: zext(trunc(256)) == 0 != 256, poison
-  %c256 = "llvm.constant"() <{ "value" = 256 : i32 }> : () -> i32
+  %c256 = "llvm.mlir.constant"() <{ "value" = 256 : i32 }> : () -> i32
   %a = "llvm.trunc"(%c255) <{nuw}> : (i32) -> i8
   %b = "llvm.trunc"(%c256) <{nuw}> : (i32) -> i8
   "func.return"(%a, %b) : (i8, i8) -> ()

--- a/Test/Interpreter/LLVM/udiv.mlir
+++ b/Test/Interpreter/LLVM/udiv.mlir
@@ -1,11 +1,11 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 130 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %negthree = "llvm.constant"() <{ "value" = -3 : i32 }> : () -> i32
-  %negtwo = "llvm.constant"() <{ "value" = -2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
+  %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.udiv"(%lhs, %rhs) : (i32, i32) -> i32
   %y = "llvm.udiv"(%lhs, %zero) : (i32, i32) -> i32
   %a = "llvm.udiv"(%negthree, %negtwo) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/udiv_exact.mlir
+++ b/Test/Interpreter/LLVM/udiv_exact.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 7 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
   %x = "llvm.udiv"(%lhs, %rhs) <{exact}> : (i32, i32) -> i32
   "func.return"(%x) : (i32) -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/urem.mlir
+++ b/Test/Interpreter/LLVM/urem.mlir
@@ -1,11 +1,11 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "llvm.constant"() <{ "value" = 130 : i32 }> : () -> i32
-  %rhs = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %negthree = "llvm.constant"() <{ "value" = -3 : i32 }> : () -> i32
-  %negtwo = "llvm.constant"() <{ "value" = -2 : i32 }> : () -> i32
+  %lhs = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
+  %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.urem"(%lhs, %rhs) : (i32, i32) -> i32
   %y = "llvm.urem"(%lhs, %zero) : (i32, i32) -> i32
   %a = "llvm.urem"(%negthree, %negtwo) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/xor.mlir
+++ b/Test/Interpreter/LLVM/xor.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "llvm.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "llvm.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "llvm.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "llvm.constant"() <{ "value" = -7 : i32 }> : () -> i32
+  %three = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
+  %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
   %x = "llvm.xor"(%three, %five) : (i32, i32) -> i32
   %y = "llvm.xor"(%eight, %negseven) : (i32, i32) -> i32
   %z = "llvm.xor"(%three, %eight) : (i32, i32) -> i32

--- a/Test/Interpreter/LLVM/zext.mlir
+++ b/Test/Interpreter/LLVM/zext.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %c255 = "llvm.constant"() <{ "value" = 255 : i8 }> : () -> i8
-  %cneg = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %c255 = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
+  %cneg = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
   %a = "llvm.zext"(%c255) : (i8) -> i32
   %b = "llvm.zext"(%cneg) : (i8) -> i32
   "func.return"(%a, %b) : (i32, i32) -> ()

--- a/Test/Interpreter/LLVM/zext_nneg.mlir
+++ b/Test/Interpreter/LLVM/zext_nneg.mlir
@@ -1,8 +1,8 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %cpos = "llvm.constant"() <{ "value" = 42 : i8 }> : () -> i8
-  %cneg = "llvm.constant"() <{ "value" = -1 : i8 }> : () -> i8
+  %cpos = "llvm.mlir.constant"() <{ "value" = 42 : i8 }> : () -> i8
+  %cneg = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
   %a = "llvm.zext"(%cpos) <{nneg}> : (i8) -> i32
   %b = "llvm.zext"(%cneg) <{nneg}> : (i8) -> i32
   "func.return"(%a, %b) : (i32, i32) -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -2,8 +2,8 @@
 
 "builtin.module"() ({
 ^bb0():
-  %5 = "llvm.constant"() <{"value" = 13 : i32}> : () -> i32
-  %6 = "llvm.constant"() <{"value" = 1 : i32}> : () -> i1
+  %5 = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
+  %6 = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i1
   %8 = "llvm.and"(%5, %5) : (i32, i32) -> i32
   %8 = "llvm.or"(%5, %5) : (i32, i32) -> i32
   %9 = "llvm.xor"(%5, %5) : (i32, i32) -> i32
@@ -50,8 +50,8 @@
 
 // CHECK:       "builtin.module"() ({
 // CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "llvm.constant"() <{"value" = 13 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "llvm.constant"() <{"value" = 1 : i32}> : () -> i1
+// CHECK-NEXT:     %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
+// CHECK-NEXT:     %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i1
 // CHECK-NEXT:     %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "llvm.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/li.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/li.mlir
@@ -2,8 +2,8 @@
 
 "builtin.module"() ({
     "func.func"() ({
-        %one = "llvm.constant"() <{ "value" = 1 : i64 }> : () -> i64
-        %two = "llvm.constant"() <{ "value" = 2 : i64 }> : () -> i64
+        %one = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
+        %two = "llvm.mlir.constant"() <{ "value" = 2 : i64 }> : () -> i64
         // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 1 : i64}> : () -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!reg) -> i64
         // CHECK-NEXT: [[B:%.*]] = "riscv.li"() <{"value" = 2 : i64}> : () -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/li_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/li_invalid.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
     "func.func"() ({
-        %one = "llvm.constant"() <{ "value" = 1 : i32 }> : () -> i32
-        %two = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
-        // CHECK:      %{{.*}} = "llvm.constant"() <{"value" = 1 : i32}> : () -> i32
-        // CHECK-NEXT: %{{.*}} = "llvm.constant"() <{"value" = 2 : i32}> : () -> i32
+        %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+        %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+        // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
+        // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/instcombine.mlir
+++ b/Test/Passes/instcombine.mlir
@@ -2,18 +2,18 @@
 
 "builtin.module"() ({
 ^bb0():
-    %zero = "llvm.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %two = "llvm.constant"() <{ "value" = 2 : i32 }> : () -> i32
+    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+    %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
     %a = "test.test"() : () -> i32
 
-    // CHECK:      %{{.*}} = "llvm.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.constant"() <{"value" = 2 : i32}> : () -> i32
+    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+    // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
     // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
 
     %mul_zero = "llvm.mul"(%a, %zero) : (i32, i32) -> i32
     %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
 
-    // CHECK-NEXT: %{{.*}} = "llvm.constant"() <{"value" = 0 : i32}> : () -> i32
+    // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
     // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 
     "test.test"(%mul_zero, %mul_two) : (i32, i32) -> ()
@@ -22,10 +22,10 @@
 
     // --- Identity and annihilation patterns ---
 
-    %one = "llvm.constant"() <{ "value" = 1 : i32 }> : () -> i32
+    %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
     %x = "test.test"() : () -> i32
 
-    // CHECK-NEXT: %[[ONE:.*]] = "llvm.constant"() <{"value" = 1 : i32}> : () -> i32
+    // CHECK-NEXT: %[[ONE:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
     // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
     // mul x * 1 => x
@@ -46,7 +46,7 @@
     // sub x - x => 0
     %sub_self = "llvm.sub"(%x, %x) : (i32, i32) -> i32
     "test.test"(%sub_self) : (i32) -> ()
-    // CHECK-NEXT: %[[SUB_ZERO:.*]] = "llvm.constant"() <{"value" = 0 : i32}> : () -> i32
+    // CHECK-NEXT: %[[SUB_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
     // CHECK-NEXT: "test.test"(%[[SUB_ZERO]]) : (i32) -> ()
 
     // and x & x => x
@@ -57,7 +57,7 @@
     // and x & 0 => 0
     %and_zero = "llvm.and"(%x, %zero) : (i32, i32) -> i32
     "test.test"(%and_zero) : (i32) -> ()
-    // CHECK-NEXT: %[[AND_ZERO:.*]] = "llvm.constant"() <{"value" = 0 : i32}> : () -> i32
+    // CHECK-NEXT: %[[AND_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
     // CHECK-NEXT: "test.test"(%[[AND_ZERO]]) : (i32) -> ()
 
     // or x | 0 => x
@@ -78,7 +78,7 @@
     // xor x ^ x => 0
     %xor_self = "llvm.xor"(%x, %x) : (i32, i32) -> i32
     "test.test"(%xor_self) : (i32) -> ()
-    // CHECK-NEXT: %[[XOR_ZERO:.*]] = "llvm.constant"() <{"value" = 0 : i32}> : () -> i32
+    // CHECK-NEXT: %[[XOR_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
     // CHECK-NEXT: "test.test"(%[[XOR_ZERO]]) : (i32) -> ()
 
 }) : () -> ()

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -11,7 +11,7 @@ public section
 @[expose, properties_of]
 def Llvm.propertiesOf (op : Llvm) : Type :=
 match op with
-| .constant => LLVMConstantProperties
+| .mlir.constant => LLVMConstantProperties
 | .add => NswNuwProperties
 | .sub => NswNuwProperties
 | .mul => NswNuwProperties

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -11,7 +11,7 @@ public section
 @[expose, properties_of]
 def Llvm.propertiesOf (op : Llvm) : Type :=
 match op with
-| .mlir.constant => LLVMConstantProperties
+| .mlir__constant => LLVMConstantProperties
 | .add => NswNuwProperties
 | .sub => NswNuwProperties
 | .mul => NswNuwProperties

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -85,7 +85,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     all_goals exact (Except.ok ())
   case llvm op =>
     cases op
-    case constant => exact (LLVMConstantProperties.fromAttrDict attrDict)
+    case mlir__constant => exact (LLVMConstantProperties.fromAttrDict attrDict)
     case add => exact (NswNuwProperties.fromAttrDict attrDict)
     case sub => exact (NswNuwProperties.fromAttrDict attrDict)
     case mul => exact (NswNuwProperties.fromAttrDict attrDict)
@@ -141,7 +141,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   match opCode with
   | .arith .constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
-  | .llvm .constant =>
+  | .llvm .mlir__constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
   | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci
   | .llvm .add | .llvm .sub | .llvm .mul | .llvm .shl | .llvm .trunc => Id.run do

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -229,7 +229,7 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
-  | .constant => do
+  | .mlir__constant => do
     let resType ← resultTypes[0]?
     let .integerType bw := resType.val
       | none

--- a/Veir/Meta/OpCode.lean
+++ b/Veir/Meta/OpCode.lean
@@ -47,7 +47,8 @@ meta def mkDialectCodeSimple (d : Dialect) : Name :=
 /--
 The name of an operation as a `String`. Used for `fromByteArray` and `fromName`.
 -/
-meta def mkOpName (d : Dialect) (op : String) : String := d.getName ++ "." ++ (op.replace "__" ".")
+meta def mkOpName (d : Dialect) (op : String) : String :=
+  d.getName ++ "." ++ (op.replace "__" ".") -- we replace "__" with "." to work around issues with '.' in constructor names.
 
 end Dialect
 
@@ -75,7 +76,7 @@ meta def emitFromName (ds : Array Dialect) : TermElabM Command := do
   let mut res : TSyntax `term ← `($builtin $unreg)
   for d in ds do
     for op in d.operations do
-      let op := op.replace "." "__"
+      let op := op.replace "." "__" -- we replace "." with "__" to avoid issues with '.' in constructor names
       if d.getName = "builtin" ∧ op = "unregistered" then continue
       res ← `(if name = $(Syntax.mkStrLit (d.mkOpName op)).toByteArray then ($(mkIdent d.mkDialectCode) $(mkIdent (.mkStr2 d.name op))) else $res)
   `(def $(mkIdent `OpCode.fromName) (name : $(mkIdent ``ByteArray)) : $(mkIdent `OpCode) := $res)

--- a/Veir/Meta/OpCode.lean
+++ b/Veir/Meta/OpCode.lean
@@ -47,7 +47,7 @@ meta def mkDialectCodeSimple (d : Dialect) : Name :=
 /--
 The name of an operation as a `String`. Used for `fromByteArray` and `fromName`.
 -/
-meta def mkOpName (d : Dialect) (op : String) : String := d.getName ++ "." ++ op
+meta def mkOpName (d : Dialect) (op : String) : String := d.getName ++ "." ++ (op.replace "__" ".")
 
 end Dialect
 
@@ -75,6 +75,7 @@ meta def emitFromName (ds : Array Dialect) : TermElabM Command := do
   let mut res : TSyntax `term ← `($builtin $unreg)
   for d in ds do
     for op in d.operations do
+      let op := op.replace "." "__"
       if d.getName = "builtin" ∧ op = "unregistered" then continue
       res ← `(if name = $(Syntax.mkStrLit (d.mkOpName op)).toByteArray then ($(mkIdent d.mkDialectCode) $(mkIdent (.mkStr2 d.name op))) else $res)
   `(def $(mkIdent `OpCode.fromName) (name : $(mkIdent ``ByteArray)) : $(mkIdent `OpCode) := $res)

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -71,7 +71,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
 inductive Llvm where
-| mlir.constant
+| mlir__constant
 | and
 | or
 | xor

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -71,7 +71,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
 inductive Llvm where
-| constant
+| mlir.constant
 | and
 | or
 | xor

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -40,7 +40,7 @@ def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
@@ -94,7 +94,7 @@ def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
@@ -122,7 +122,7 @@ def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
@@ -174,7 +174,7 @@ def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
-  let (rewriter, newOp) ← rewriter.createOp (.llvm .constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -51,8 +51,8 @@ def matchXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
   return (op[0]!, op[1]!)
 
 def matchConstantOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
-  let .llvm .constant := op.getOpType! ctx | none
-  let properties := op.getProperties! ctx (.llvm .constant)
+  let .llvm .mlir__constant := op.getOpType! ctx | none
+  let properties := op.getProperties! ctx (.llvm .mlir__constant)
   return properties.value
 
 def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
@@ -62,7 +62,7 @@ def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerA
 
 def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .builtin .unrealized_conversion_cast := op.getOpType! ctx | none
-  let properties := op.getProperties! ctx (.llvm .constant)
+  let properties := op.getProperties! ctx (.llvm .mlir__constant)
   return properties.value
 
 def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .ashr)) := do

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -403,7 +403,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .test .test => do
     pure ()
   /- LLVM -/
-  | .llvm .constant => do
+  | .llvm .mlir__constant => do
     if op.getNumOperands ctx.raw opIn ≠ 0 then
       throw "Expected 0 operands"
     if op.getNumResults ctx.raw opIn ≠ 1 then


### PR DESCRIPTION
MLIR uses the name `mlir.constant` for the constant operation in the `llvm` dialect to indicate that this is an MLIR-specific extension not present in LLVM. LLVM does not have constants as explicit operations in the IR but instead allows constant expressions as separate data structures as an alternative to SSA values.

As lean does not like `.` in names of inductive cases, we instead use `__` as a token for `.`.