### PR TITLE
Use `BlockPtr.nextArgument` in a lemma

### DIFF
--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -7237,14 +7237,11 @@ theorem BlockPtr.getNumArguments!_BlockPtr_pushArgument {block : BlockPtr} {hop}
 @[grind =]
 theorem BlockArgumentPtr.get!_BlockPtr_pushArgument {blockArg : BlockArgumentPtr} :
     blockArg.get! (BlockPtr.pushArgument block' ctx newArgument hblock') =
-    if blockArg.block = block' then
-      if blockArg.index = (block'.getNumArguments! ctx) then
-        newArgument
-      else
-        blockArg.get! ctx
+    if blockArg = block'.nextArgument! ctx then
+      newArgument
     else
       blockArg.get! ctx := by
-  grind
+  grind [BlockPtr.getArgument]
 
 @[simp, grind =]
 theorem RegionPtr.get!_BlockPtr_pushArgument {region : RegionPtr} :


### PR DESCRIPTION
This is in general the way we want to define these theorems