### PR TITLE
Add FlatSymbolRefAttr and BoolAttr; fix GEP verifier operand count

### DIFF
--- a/Test/Builtin/attributes.mlir
+++ b/Test/Builtin/attributes.mlir
@@ -16,6 +16,10 @@
   %14 = "test.test"() {arr = [0 : i32, "hello"]} : () -> i32
   %15 = "test.test"() {da = array<i8>} : () -> i32
   %16 = "test.test"() {da = array<i32: 10, 42>} : () -> i32
+  %17 = "test.test"() {sym = @foo} : () -> i32
+  %18 = "test.test"() {sym = @"my.func"} : () -> i32
+  %19 = "test.test"() {flag = true} : () -> i32
+  %20 = "test.test"() {flag = false} : () -> i32
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
@@ -34,4 +38,8 @@
 // CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [0 : i32, "hello"]} : () -> i32
 // CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i8>} : () -> i32
 // CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i32: 10, 42>} : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() {"sym" = @foo} : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() {"sym" = @"my.func"} : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() {"flag" = true} : () -> i32
+// CHECK-NEXT:     %{{.*}} = "test.test"() {"flag" = false} : () -> i32
 // CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -181,3 +181,15 @@ macro "#assert " e:term : command =>
 #assert expectSuccessType "!cuda_tile.ptr<i1>" (CudaTile.PointerType.mk (IntegerType.mk 1))
 #assert expectSuccessType "!cuda_tile.ptr<i32>" (CudaTile.PointerType.mk (IntegerType.mk 32))
 #assert expectErrorType "!cuda_tile.ptr<16>" "integer type expected"
+
+/-! ## Flat symbol reference attribute -/
+#assert expectSuccessAttr "@foo" (FlatSymbolRefAttr.mk "@foo")
+#assert expectSuccessAttr "@printf" (FlatSymbolRefAttr.mk "@printf")
+#assert expectSuccessAttr "@\"my.func\"" (FlatSymbolRefAttr.mk "@\"my.func\"")
+#assert expectMissingAttr "foo"
+
+/-! ## Boolean attribute -/
+#assert expectSuccessAttr "true" (BoolAttr.mk true)
+#assert expectSuccessAttr "false" (BoolAttr.mk false)
+#assert expectMissingAttr "True"
+#assert expectMissingAttr "False"

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -107,6 +107,21 @@ structure UnregisteredAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  A flat symbol reference attribute, e.g. `@foo` or `@"my.func"`.
+  The value stores the raw text including the `@` prefix.
+-/
+structure FlatSymbolRefAttr where
+  value : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  A boolean attribute, written as `true` or `false`.
+-/
+structure BoolAttr where
+  value : Bool
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   The `!mod_arith.int` type from HEIR's modarith dialect.
   The modulus type annotation is optional in syntax.
 -/
@@ -202,6 +217,10 @@ inductive Attribute
 | functionType (type : FunctionType)
 /-- An attribute from an unknown dialect. -/
 | unregisteredAttr (attr : UnregisteredAttr)
+/-- A flat symbol reference, e.g. `@foo` or `@"my.func"`. -/
+| flatSymbolRefAttr (attr : FlatSymbolRefAttr)
+/-- A boolean attribute, written as `true` or `false`. -/
+| boolAttr (attr : BoolAttr)
 /-- HEIR modarith type -/
 | modArithType (type : ModArithType)
 /-- LLVM pointer type -/
@@ -349,6 +368,14 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case flatSymbolRefAttr.flatSymbolRefAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case boolAttr.boolAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -404,6 +431,12 @@ instance : ToString DenseArrayAttr where
 
 instance : ToString UnregisteredAttr where
   toString attr := attr.value
+
+instance : ToString FlatSymbolRefAttr where
+  toString attr := attr.value
+
+instance : ToString BoolAttr where
+  toString attr := if attr.value then "true" else "false"
 
 instance : ToString ModArithType where
   toString type := s!"!mod_arith.int<{type.modulus}" ++
@@ -482,6 +515,8 @@ def Attribute.toString (attr : Attribute) : String :=
   | .denseArrayAttr attr => ToString.toString attr
   | .dictionaryAttr attr => attr.toString
   | .unregisteredAttr attr => ToString.toString attr
+  | .flatSymbolRefAttr attr => ToString.toString attr
+  | .boolAttr attr => ToString.toString attr
   | .functionType type => type.toString
   | .modArithType type => ToString.toString type
   | .llvmPointerType type => ToString.toString type
@@ -524,6 +559,12 @@ instance : Coe LocationAttr Attribute where
 
 instance : Coe UnregisteredAttr Attribute where
   coe attr := .unregisteredAttr attr
+
+instance : Coe FlatSymbolRefAttr Attribute where
+  coe attr := .flatSymbolRefAttr attr
+
+instance : Coe BoolAttr Attribute where
+  coe attr := .boolAttr attr
 
 instance : Coe ArrayAttr Attribute where
   coe attr := .arrayAttr attr
@@ -570,6 +611,8 @@ def isType (attr : Attribute) : Bool :=
   | .denseArrayAttr _ => false
   | .dictionaryAttr _ => false
   | .unregisteredAttr attr => attr.isType
+  | .flatSymbolRefAttr _ => false
+  | .boolAttr _ => false
   | .functionType _ => true
   | .modArithType _ => true
   | .registerType _ => true

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -239,6 +239,29 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   return some (UnregisteredAttr.mk (String.fromUTF8! value) false)
 
 /--
+  Parse a boolean attribute, if present.
+  Its syntax is `true` or `false`.
+-/
+def parseOptionalBoolAttr : AttrParserM (Option BoolAttr) := do
+  if ← parseOptionalKeyword "true".toByteArray then
+    return some (BoolAttr.mk true)
+  else if ← parseOptionalKeyword "false".toByteArray then
+    return some (BoolAttr.mk false)
+  else
+    return none
+
+/--
+  Parse a flat symbol reference attribute, if present.
+  Its syntax is `@ident` or `@"string"`.
+-/
+def parseOptionalFlatSymbolRefAttr : AttrParserM (Option FlatSymbolRefAttr) := do
+  let token ← peekToken
+  let .atIdent := token.kind | return none
+  let _ ← consumeToken
+  let value := token.slice.of (← getThe ParserState).input
+  return some (FlatSymbolRefAttr.mk (String.fromUTF8! value))
+
+/--
   Parse a location attribute, if present.
   A location attribute has the form `loc(body)`.
 -/
@@ -427,6 +450,10 @@ partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
     return some arrayAttr
   else if let some dictAttr ← parseOptionalDictionaryAttr then
     return some dictAttr
+  else if let some symRefAttr ← parseOptionalFlatSymbolRefAttr then
+    return some symRefAttr
+  else if let some boolAttr ← parseOptionalBoolAttr then
+    return some boolAttr
   else
     return none
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -678,10 +678,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     pure ()
   | .llvm .getelementptr => do
-    let props := op.getProperties! ctx.raw (.llvm .getelementptr)
-    let dynamicCount := props.rawConstantIndices.values.filter (· == -2147483648) |>.size
-    if op.getNumOperands ctx.raw opIn ≠ 1 + dynamicCount then
-      throw s!"Expected {1 + dynamicCount} operands"
+    if op.getNumOperands ctx.raw opIn ≠ 2 then
+      throw "Expected 2 operands"
     if op.getNumResults ctx.raw opIn ≠ 1 then
       throw "Expected 1 results"
     if op.getNumRegions ctx.raw opIn ≠ 0 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -668,8 +668,10 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     pure ()
   | .llvm .getelementptr => do
-    if op.getNumOperands ctx.raw opIn ≠ 2 then
-      throw "Expected 2 operands"
+    let props := op.getProperties! ctx.raw (.llvm .getelementptr)
+    let dynamicCount := props.rawConstantIndices.values.filter (· == -2147483648) |>.size
+    if op.getNumOperands ctx.raw opIn ≠ 1 + dynamicCount then
+      throw s!"Expected {1 + dynamicCount} operands"
     if op.getNumResults ctx.raw opIn ≠ 1 then
       throw "Expected 1 results"
     if op.getNumRegions ctx.raw opIn ≠ 0 then


### PR DESCRIPTION
@math-fehr: this is Claude's attempt to follow your attribute playbook. I read the code and it seems plausible, but I'm very much out of my depth here. the result of this patch is that VeIR can parse in a sudodu solver that I wrote, compiled to LLVM. however, the resulting MLIR has a substantial number of "unregistered" in it, so there's definitely more work that needs to be done here.

If this PR looks decent on its own, then I can work on those unregistereds after we merge this, but I'm also happy to close this and do some more work if this doesn't make sense to merge right now.