### PR TITLE
feat: implement PackedFloat.toEDyadic

### DIFF
--- a/UnitTest/FP/PackedFloat.lean
+++ b/UnitTest/FP/PackedFloat.lean
@@ -1,4 +1,5 @@
 module
 
 public import UnitTest.FP.PackedFloat.ToExtRat
+public import UnitTest.FP.PackedFloat.ToEDyadic
 

--- a/UnitTest/FP/PackedFloat/ToEDyadic.lean
+++ b/UnitTest/FP/PackedFloat/ToEDyadic.lean
@@ -1,0 +1,68 @@
+module
+
+import Veir.Data.FP.PackedFloat.ToEDyadic
+import Veir.Data.FP.EDyadic.ToExtRat
+
+meta import Veir.Data.FP.PackedFloat.OfFloat
+meta import Veir.Data.FP.PackedFloat.ToEDyadic
+meta import Veir.Data.FP.PackedFloat.ToExtRat
+meta import Veir.Data.FP.EDyadic.ToExtRat
+
+namespace UnitTest.Fp.PackedFloat.ToEDyadic
+
+open Veir.Data.FP
+open Veir.Data.FP.PackedFloat
+
+/-! ## Tests for `PackedFloat.toEDyadic` against Lean's native `Float`.
+
+The conversion preserves the sign of `±0` (unlike `toExtRat`), and otherwise
+agrees with `toExtRat` after passing through `EDyadic.toExtRat`. -/
+
+#guard toEDyadic (ofFloat 0.0) = .zero false
+#guard toEDyadic (ofFloat (-0.0)) = .zero true
+
+#guard (toEDyadic (ofFloat 0.0)).toExtRat = .number 0
+#guard (toEDyadic (ofFloat (-0.0))).toExtRat = .number 0
+
+#guard (toEDyadic (ofFloat 1.0)).toExtRat = .number 1
+#guard (toEDyadic (ofFloat (-1.0))).toExtRat = .number (-1)
+#guard (toEDyadic (ofFloat 2.0)).toExtRat = .number 2
+#guard (toEDyadic (ofFloat 0.5)).toExtRat = .number (1 / 2)
+#guard (toEDyadic (ofFloat 1.5)).toExtRat = .number (3 / 2)
+#guard (toEDyadic (ofFloat (-1.5))).toExtRat = .number (-3 / 2)
+#guard (toEDyadic (ofFloat 1024.0)).toExtRat = .number 1024
+
+#guard toEDyadic (ofFloat (1.0 / 0.0)) = .infinity false
+#guard toEDyadic (ofFloat (-1.0 / 0.0)) = .infinity true
+#guard toEDyadic (ofFloat (0.0 / 0.0)) = .nan
+
+/-! ## Agreement with `PackedFloat.toExtRat`
+
+For every finite, non-`±0` packed float, `(toEDyadic pf).toExtRat = pf.toExtRat`.
+For `±0` the EDyadic preserves the sign while `toExtRat` collapses to `number 0`. -/
+
+#guard (toEDyadic (ofFloat 1.0)).toExtRat = (ofFloat 1.0).toExtRat
+#guard (toEDyadic (ofFloat (-1.0))).toExtRat = (ofFloat (-1.0)).toExtRat
+#guard (toEDyadic (ofFloat 0.5)).toExtRat = (ofFloat 0.5).toExtRat
+#guard (toEDyadic (ofFloat 1.5)).toExtRat = (ofFloat 1.5).toExtRat
+#guard (toEDyadic (ofFloat 1024.0)).toExtRat = (ofFloat 1024.0).toExtRat
+#guard (toEDyadic (ofFloat (1.0 / 0.0))).toExtRat = (ofFloat (1.0 / 0.0)).toExtRat
+
+/-! ## Subnormals
+
+The smallest representable positive double is the subnormal `2^(-1074)`. -/
+
+def smallestPositiveSubnormal : PackedFloat 11 52 :=
+  PackedFloat.mk (sign := false) (ex := 0#11) (sig := 1#52)
+
+#guard (toEDyadic smallestPositiveSubnormal).toExtRat =
+  .number (1 / ((2 ^ 1074 : Nat) : Rat))
+
+/-- The negative counterpart: `-2^(-1074)`. -/
+def smallestNegativeSubnormal : PackedFloat 11 52 :=
+  PackedFloat.mk (sign := true) (ex := 0#11) (sig := 1#52)
+
+#guard (toEDyadic smallestNegativeSubnormal).toExtRat =
+  .number (-1 / ((2 ^ 1074 : Nat) : Rat))
+
+end UnitTest.Fp.PackedFloat.ToEDyadic

--- a/UnitTest/FP/PackedFloat/ToEDyadic.lean
+++ b/UnitTest/FP/PackedFloat/ToEDyadic.lean
@@ -1,11 +1,9 @@
 module
 
 import Veir.Data.FP.PackedFloat.ToEDyadic
-import Veir.Data.FP.EDyadic.ToExtRat
 
 meta import Veir.Data.FP.PackedFloat.OfFloat
 meta import Veir.Data.FP.PackedFloat.ToEDyadic
-meta import Veir.Data.FP.PackedFloat.ToExtRat
 meta import Veir.Data.FP.EDyadic.ToExtRat
 
 namespace UnitTest.Fp.PackedFloat.ToEDyadic

--- a/Veir/Data/FP/EDyadic/Basic.lean
+++ b/Veir/Data/FP/EDyadic/Basic.lean
@@ -25,7 +25,7 @@ inductive EDyadic where
   | infinity (sign : Bool)
   /-- A NaN (not a number). -/
   | nan
-  deriving Inhabited
+  deriving Inhabited, DecidableEq
 
 instance : Repr EDyadic where
   reprPrec 

--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -3,4 +3,5 @@ module
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.PackedFloat.OfFloat
 public import Veir.Data.FP.PackedFloat.ToExtRat
+public import Veir.Data.FP.PackedFloat.ToEDyadic
 

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.PackedFloat.State
 public import Veir.Data.FP.PackedFloat.ToExtRat
+public import Veir.Data.FP.Sign
 public import Veir.Data.FP.EDyadic.Basic
 
 namespace Veir.Data.FP.PackedFloat
@@ -28,10 +29,10 @@ def toEDyadic {e s : Nat} (pf : PackedFloat e s) : EDyadic :=
   else if pf.state =.zero then .zero pf.sign
   else
     -- normal, subnormal.
-    .nonzeroFinite (Dyadic.ofIntWithPrec (pf.sign.toInt * sig) prec)
+    .nonzeroFinite (Dyadic.ofIntWithPrec (signToInt pf.sign * sig) prec)
   where
     sig := pf.sig.toNat  + 2 ^ s * (decide (pf.state = .normal)).toNat
-    prec := (bias e : Int) + (s : Int) - (Nat.min pf.ex.toNat 1)
+    prec := (bias e : Int) + (s : Int) - (Nat.max pf.ex.toNat 1)
 
 
 end

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.State
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.EDyadic.Basic
 
@@ -22,22 +23,17 @@ following the IEEE-754 interpretation:
 Unlike `toExtRat`, this preserves the sign of `±0`.
 -/
 def toEDyadic {e s : Nat} (pf : PackedFloat e s) : EDyadic :=
-  if pf.ex = BitVec.allOnes e then
-    if pf.sig = 0#s then .infinity pf.sign
-    else .nan
-  else if pf.ex = 0#e then
-    if pf.sig = 0#s then .zero pf.sign
-    else
-      let n : Int :=
-        if pf.sign then -(pf.sig.toNat : Int) else (pf.sig.toNat : Int)
-      let prec : Int := (bias e : Int) + (s : Int) - 1
-      .nonzeroFinite (Dyadic.ofIntWithPrec n prec)
+  if pf.state = .nan then .nan
+  else if pf.state = .infinite then .infinity pf.sign
+  else if pf.state =.zero then .zero pf.sign
   else
-    let mantissa : Nat := 2 ^ s + pf.sig.toNat
-    let n : Int := if pf.sign then -(mantissa : Int) else (mantissa : Int)
-    let prec : Int := (bias e : Int) + (s : Int) - (pf.ex.toNat : Int)
-    .nonzeroFinite (Dyadic.ofIntWithPrec n prec)
+    -- normal, subnormal.
+    .nonzeroFinite (Dyadic.ofIntWithPrec (pf.sign.toInt * sig) prec)
+  where
+    sig := pf.sig.toNat  + 2 ^ s * (decide (pf.state = .normal)).toNat
+    prec := (bias e : Int) + (s : Int) - (Nat.min pf.ex.toNat 1)
 
-end -- public section
+
+end
 
 end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -1,9 +1,8 @@
 module
 
-public import Veir.Data.FP.PackedFloat.Basic
-public import Veir.Data.FP.PackedFloat.State
+import Veir.Data.FP.PackedFloat.State
 public import Veir.Data.FP.PackedFloat.ToExtRat
-public import Veir.Data.FP.Sign
+import Veir.Data.FP.Sign
 public import Veir.Data.FP.EDyadic.Basic
 
 namespace Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -26,7 +26,7 @@ Unlike `toExtRat`, this preserves the sign of `±0`.
 def toEDyadic {e s : Nat} (pf : PackedFloat e s) : EDyadic :=
   if pf.state = .nan then .nan
   else if pf.state = .infinite then .infinity pf.sign
-  else if pf.state =.zero then .zero pf.sign
+  else if pf.state = .zero then .zero pf.sign
   else
     -- normal, subnormal.
     .nonzeroFinite (Dyadic.ofIntWithPrec (signToInt pf.sign * sig) prec)

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -1,0 +1,43 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.ToExtRat
+public import Veir.Data.FP.EDyadic.Basic
+
+namespace Veir.Data.FP.PackedFloat
+
+public section
+
+/--
+Convert a `PackedFloat e s` to its precise mathematical value as an `EDyadic`,
+following the IEEE-754 interpretation:
+- biased exponent `allOnes` with non-zero significand → `nan`
+- biased exponent `allOnes` with zero significand → signed `infinity`
+- biased exponent `0` with zero significand → signed `zero`
+- biased exponent `0` with non-zero significand → subnormal:
+  `sig.toNat * 2^(1 - bias - s)` (with sign on the integer)
+- otherwise normal:
+  `(2^s + sig.toNat) * 2^(ex.toNat - bias - s)` (with sign on the integer)
+
+Unlike `toExtRat`, this preserves the sign of `±0`.
+-/
+def toEDyadic {e s : Nat} (pf : PackedFloat e s) : EDyadic :=
+  if pf.ex = BitVec.allOnes e then
+    if pf.sig = 0#s then .infinity pf.sign
+    else .nan
+  else if pf.ex = 0#e then
+    if pf.sig = 0#s then .zero pf.sign
+    else
+      let n : Int :=
+        if pf.sign then -(pf.sig.toNat : Int) else (pf.sig.toNat : Int)
+      let prec : Int := (bias e : Int) + (s : Int) - 1
+      .nonzeroFinite (Dyadic.ofIntWithPrec n prec)
+  else
+    let mantissa : Nat := 2 ^ s + pf.sig.toNat
+    let n : Int := if pf.sign then -(mantissa : Int) else (mantissa : Int)
+    let prec : Int := (bias e : Int) + (s : Int) - (pf.ex.toNat : Int)
+    .nonzeroFinite (Dyadic.ofIntWithPrec n prec)
+
+end -- public section
+
+end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/Sign.lean
+++ b/Veir/Data/FP/Sign.lean
@@ -6,5 +6,5 @@ namespace Veir.Data.FP
 Treat a boolean as a sign,
 where `true` corresponds to `-1` and `false` corresponds to `1`.
 -/
-public def signToInt (s : Bool) : Rat :=
+public def signToInt (s : Bool) : Int :=
   if s then -1 else 1


### PR DESCRIPTION
This PR implements `PackedFloat.toEDyadic`, which interprets a `PackedFloat` as an extended dyadic number. This will be used to implement rounding, where the rounder will inspect the exponent and value of the extended dyadic number in order to then round to the closest packed-bit-representable value. 