### PR TITLE
[notmerge] Add EDyadic rounding, PackedFloat.round, and FastFloat with Float32 bridge

### DIFF
--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -2,3 +2,5 @@ module
 
 public import UnitTest.FP.PackedFloat
 public import UnitTest.FP.EDyadic
+public import UnitTest.FP.FastFloat
+public import UnitTest.FP.FastFloatSmoke

--- a/UnitTest/FP/EDyadic.lean
+++ b/UnitTest/FP/EDyadic.lean
@@ -2,3 +2,4 @@ module
 
 public import UnitTest.FP.EDyadic.Pack
 public import UnitTest.FP.EDyadic.Position
+public import UnitTest.FP.EDyadic.Round

--- a/UnitTest/FP/EDyadic/Round.lean
+++ b/UnitTest/FP/EDyadic/Round.lean
@@ -1,0 +1,102 @@
+module
+
+import Veir.Data.FP.EDyadic.Round
+
+meta import Veir.Data.FP.EDyadic.Round
+
+namespace UnitTest.Fp.EDyadic.Round
+
+open Veir.Data.FP
+
+/-! ## Identity on representable values
+
+A nonzero `Dyadic` whose precision already fits in the target format
+rounds to itself. (Zero is excluded by `Dyadic.round`'s precondition.) -/
+
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 1 0) 11 52 =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 0)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 1) 11 52 =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 1)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec (-3) 1) 11 52 =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec (-3) 1)
+
+/-! ## Tie-break to even (RNE)
+
+At an integer-grade format `(e, s) = (4, 0)`, the only representable
+finite values are integers. Tie cases (`x.5`) round to the even integer. -/
+
+-- 1.5 → 2 (between 1 and 2; pick even = 2)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 1) 4 0 = EDyadic.ofDyadic false 2
+-- 2.5 → 2 (between 2 and 3; pick even = 2)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 5 1) 4 0 = EDyadic.ofDyadic false 2
+-- 3.5 → 4 (between 3 and 4; pick even = 4)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 7 1) 4 0 = EDyadic.ofDyadic false 4
+-- −1.5 → −2
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec (-3) 1) 4 0 = EDyadic.ofDyadic false (-2)
+-- −2.5 → −2
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec (-5) 1) 4 0 = EDyadic.ofDyadic false (-2)
+
+/-! ## Strict closer-of-two (non-tie)
+
+Values strictly closer to one of `lower` / `upper` round there. -/
+
+-- 1.25 → 1 (closer to 1 than 2)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 5 2) 4 0 = EDyadic.ofDyadic false 1
+-- 1.75 → 2 (closer to 2 than 1)
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 7 2) 4 0 = EDyadic.ofDyadic false 2
+-- −1.75 → −2
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec (-7) 2) 4 0 = EDyadic.ofDyadic false (-2)
+
+/-! ## `RTN` / `RTP` pick `lower` / `upper` -/
+
+-- RTN(1.5) = 1, RTP(1.5) = 2 in integer format
+#guard Dyadic.round .RTN (Dyadic.ofIntWithPrec 3 1) 4 0 = EDyadic.ofDyadic false 1
+#guard Dyadic.round .RTP (Dyadic.ofIntWithPrec 3 1) 4 0 = EDyadic.ofDyadic false 2
+
+-- RTN/RTP of an exactly representable value collapse to the value.
+#guard Dyadic.round .RTN (Dyadic.ofIntWithPrec 2 0) 4 0 = EDyadic.ofDyadic false 2
+#guard Dyadic.round .RTP (Dyadic.ofIntWithPrec 2 0) 4 0 = EDyadic.ofDyadic false 2
+
+-- RTN/RTP for negative: RTN(-1.5) = -2, RTP(-1.5) = -1.
+#guard Dyadic.round .RTN (Dyadic.ofIntWithPrec (-3) 1) 4 0 = EDyadic.ofDyadic false (-2)
+#guard Dyadic.round .RTP (Dyadic.ofIntWithPrec (-3) 1) 4 0 = EDyadic.ofDyadic false (-1)
+
+/-! ## Overflow / infinity
+
+Values beyond `maxFinite + half_ulp` (RNE boundary) round to ±∞.
+For `(e, s) = (4, 3)`: bias = 7, maxFinite = (2^4 − 1) · 2^4 = 240.
+Half-ulp = 2^3 = 8. RNE boundary = 248. -/
+
+-- 256 = 2^8 is past the boundary → +∞.
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 1 (-8 : Int)) 4 3 = .infinity false
+-- −256 → −∞.
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec (-1) (-8 : Int)) 4 3 = .infinity true
+
+-- RTN(256) = +maxFinite = 240 in (4, 3); RTP(256) = +∞.
+#guard Dyadic.round .RTN (Dyadic.ofIntWithPrec 1 (-8 : Int)) 4 3 =
+  EDyadic.ofDyadic false 240
+#guard Dyadic.round .RTP (Dyadic.ofIntWithPrec 1 (-8 : Int)) 4 3 = .infinity false
+
+-- RTN(-256) = -∞; RTP(-256) = -maxFinite = -240.
+#guard Dyadic.round .RTN (Dyadic.ofIntWithPrec (-1) (-8 : Int)) 4 3 = .infinity true
+#guard Dyadic.round .RTP (Dyadic.ofIntWithPrec (-1) (-8 : Int)) 4 3 =
+  EDyadic.ofDyadic false (-240)
+
+/-! ## Subnormals
+
+Format `(4, 3)`: bias = 7, smallest subnormal = `2^(1 − 7 − 3) = 2^(-9)`.
+A value smaller than half-min-subnormal rounds to `+0`. -/
+
+-- 2^(-9): the smallest representable positive value, rounds to itself.
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 1 9) 4 3 =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 9)
+
+-- 2^(-10) is half the smallest subnormal: tie between 0 and 2^(-9).
+-- Tie to even: 0 is even, so round to +0.
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 1 10) 4 3 = .zero false
+
+-- 3 · 2^(-11) = 2^(-9) · 3/4: closer to 2^(-9) than to 0, rounds up.
+#guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 11) 4 3 =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 9)
+
+end UnitTest.Fp.EDyadic.Round

--- a/UnitTest/FP/EDyadic/Round.lean
+++ b/UnitTest/FP/EDyadic/Round.lean
@@ -1,12 +1,18 @@
 module
 
 import Veir.Data.FP.EDyadic.Round
+import Veir.Data.FP.EDyadic.Pack
+import Veir.Data.FP.PackedFloat.ToEDyadic
 
 meta import Veir.Data.FP.EDyadic.Round
+meta import Veir.Data.FP.EDyadic.Pack
+meta import Veir.Data.FP.PackedFloat.OfFloat
+meta import Veir.Data.FP.PackedFloat.ToEDyadic
 
 namespace UnitTest.Fp.EDyadic.Round
 
 open Veir.Data.FP
+open Veir.Data.FP.PackedFloat
 
 /-! ## Identity on representable values
 
@@ -98,5 +104,26 @@ A value smaller than half-min-subnormal rounds to `+0`. -/
 -- 3 · 2^(-11) = 2^(-9) · 3/4: closer to 2^(-9) than to 0, rounds up.
 #guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 11) 4 3 =
   EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 9)
+
+/-! ## Round-trip via `pack ∘ round` against IEEE-754 doubles
+
+For doubles already representable in the format, `round` is the identity
+on the dyadic value, and `pack` recovers the original bit pattern. -/
+
+def asDyadic (pf : PackedFloat 11 52) : Dyadic :=
+  match toEDyadic pf with
+  | .nonzeroFinite d _ => d
+  | _ => 0
+
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1.0)) 11 52) =
+  ofFloat 1.0
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1.5)) 11 52) =
+  ofFloat 1.5
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat (-1.5))) 11 52) =
+  ofFloat (-1.5)
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 0.5)) 11 52) =
+  ofFloat 0.5
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1024.0)) 11 52) =
+  ofFloat 1024.0
 
 end UnitTest.Fp.EDyadic.Round

--- a/UnitTest/FP/FastFloat.lean
+++ b/UnitTest/FP/FastFloat.lean
@@ -1,0 +1,81 @@
+module
+
+import Veir.Data.FP.FastFloat
+
+meta import Veir.Data.FP.FastFloat
+
+namespace UnitTest.Fp.FastFloat
+
+open Veir.Data.FP
+
+/-! ## `FastFloat 8 23 .RNE` against native `Float32`
+
+`FastFloat 8 23 .RNE` simulates IEEE-754 single-precision (the same
+shape as `Float32`) by rounding every result to single-precision width
+under round-to-nearest-ties-to-even. This file uses native `Float32`
+results as a golden reference: for each input pair, the bit pattern
+extracted from `(FastFloat.ofFloat32 a + FastFloat.ofFloat32 b).value`
+(when narrowed back to `Float32`) must match `a + b` performed natively.
+
+We narrow `FastFloat`'s underlying `Float` back to `Float32` by routing
+through the packed-float encoding (this is the round-trip that defines
+`FastFloat`'s precision contract). -/
+
+/-- Convert the underlying `Float` of a `FastFloat 8 23 mode` to a `Float32`
+via the packed encoding. -/
+def fastToFloat32 {mode : RoundingMode} (x : FastFloat 8 23 mode) : Float32 :=
+  PackedFloat.toFloat32 (PackedFloat.ofFloat x.value
+    |> PackedFloat.round mode 8 23)
+
+/-- The `Float32` golden value for a pair under `op`. -/
+def goldF32 (op : Float32 → Float32 → Float32) (a b : Float32) : Float32 :=
+  op a b
+
+/-- The simulated value via `FastFloat 8 23 .RNE`. -/
+def simF32
+    (op : ∀ {e s : Nat} {m : RoundingMode},
+      FastFloat e s m → FastFloat e s m → FastFloat e s m)
+    (a b : Float32) : Float32 :=
+  let af : FastFloat 8 23 .RNE := FastFloat.ofFloat32 a
+  let bf : FastFloat 8 23 .RNE := FastFloat.ofFloat32 b
+  fastToFloat32 (op af bf)
+
+/-- Bit-pattern equality on `Float32` (treats `NaN` bit patterns as ordered). -/
+def bitsEq (a b : Float32) : Bool :=
+  Float32.toBits a == Float32.toBits b
+
+/-! ### Addition matches `Float32 + Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a + b) 1.0 2.0) (1.0 + 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.5 2.5) (1.5 + 2.5 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 0.1 0.2) (0.1 + 0.2 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) (-1.0) 1.0) (-1.0 + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.0e10 1.0) (1.0e10 + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.0e-30 1.0e-30) (1.0e-30 + 1.0e-30 : Float32)
+
+/-! ### Subtraction matches `Float32 - Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a - b) 3.0 1.0) (3.0 - 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a - b) 1.0 2.0) (1.0 - 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a - b) 1.0e10 1.0) (1.0e10 - 1.0 : Float32)
+
+/-! ### Multiplication matches `Float32 * Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a * b) 1.5 2.0) (1.5 * 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 0.1 0.1) (0.1 * 0.1 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 1.0e15 1.0e15) (1.0e15 * 1.0e15 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) (-2.0) 3.0) ((-2.0) * 3.0 : Float32)
+
+/-! ### Division matches `Float32 / Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a / b) 1.0 3.0) (1.0 / 3.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a / b) 22.0 7.0) (22.0 / 7.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a / b) (-1.0) 4.0) ((-1.0) / 4.0 : Float32)
+
+/-! ### Specials propagate -/
+
+#guard bitsEq (simF32 (fun a b => a + b) (1.0 / 0.0) 1.0) ((1.0 / 0.0) + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 0.0 0.0) (0.0 * 0.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) (-0.0) 0.0) ((-0.0) + 0.0 : Float32)
+
+end UnitTest.Fp.FastFloat

--- a/UnitTest/FP/FastFloatSmoke.lean
+++ b/UnitTest/FP/FastFloatSmoke.lean
@@ -1,0 +1,90 @@
+module
+
+import Veir.Data.FP.FastFloat
+
+meta import Veir.Data.FP.FastFloat
+
+namespace UnitTest.Fp.FastFloatSmoke
+
+open Veir.Data.FP
+
+/-! # Smoke test: `FastFloat 8 23 .RNE` against native `Float32`
+
+Enumerates a representative sample of `Float32` values — all five
+specials, the boundary subnormal/normal values, and 50
+logarithmically-spaced points across the dynamic range — and verifies
+that for every input pair, each of `add`/`sub`/`mul`/`div` performed
+through `FastFloat 8 23 .RNE` produces the same `Float32` bit pattern as
+the native `Float32` operation. NaNs are compared as
+`isNaN ↔ isNaN` (their bit patterns may differ across paths).
+
+Total cost: with 59 values, every operator runs over `59 × 59 = 3481`
+pairs at elaboration. -/
+
+/-- Round-trip a `FastFloat 8 23 mode`'s underlying `Float` to `Float32`. -/
+private def fastToFloat32 {mode : RoundingMode}
+    (x : FastFloat 8 23 mode) : Float32 :=
+  PackedFloat.toFloat32
+    (PackedFloat.round mode 8 23 (PackedFloat.ofFloat x.value))
+
+/-- Run `op` on `Float32` inputs via the `FastFloat 8 23 .RNE` path. -/
+private def viaFast
+    (op : ∀ {e s : Nat} {m : RoundingMode},
+      FastFloat e s m → FastFloat e s m → FastFloat e s m)
+    (a b : Float32) : Float32 :=
+  let af : FastFloat 8 23 .RNE := FastFloat.ofFloat32 a
+  let bf : FastFloat 8 23 .RNE := FastFloat.ofFloat32 b
+  fastToFloat32 (op af bf)
+
+/-- Equality on `Float32` results: bit-equal, or both NaN. -/
+private def f32eq (a b : Float32) : Bool :=
+  (a.isNaN && b.isNaN) || (Float32.toBits a == Float32.toBits b)
+
+/-- Build a `Float32` from a 32-bit pattern. -/
+private def f32 (bits : UInt32) : Float32 := Float32.ofBits bits
+
+/--
+The smoke-test sample of `Float32` values:
+
+* nine specials (NaN, ±∞, ±0, ±minSubnormal, ±maxNormal),
+* fifty values whose biased exponent steps roughly evenly across
+  `[1, 254]` (significand left at zero), giving 50 powers of two
+  spread logarithmically across the dynamic range.
+-/
+private def smokeValues : List Float32 :=
+  let specials : List Float32 := [
+    f32 0x7fc00000,  -- NaN (canonical quiet)
+    f32 0x7f800000,  -- +∞
+    f32 0xff800000,  -- −∞
+    f32 0x00000000,  -- +0
+    f32 0x80000000,  -- −0
+    f32 0x00000001,  -- +minSubnormal
+    f32 0x80000001,  -- −minSubnormal
+    f32 0x7f7fffff,  -- +maxNormal
+    f32 0xff7fffff   -- −maxNormal
+  ]
+  let logSpaced : List Float32 :=
+    (List.range 50).map fun i =>
+      let biasedExp : Nat := 1 + (i * 253) / 49
+      f32 ((UInt32.ofNat biasedExp) <<< 23)
+  specials ++ logSpaced
+
+/-- All ordered pairs from the smoke set. -/
+private def smokePairs : List (Float32 × Float32) :=
+  smokeValues.flatMap fun a => smokeValues.map fun b => (a, b)
+
+/-! ### Each operator agrees with native `Float32` on every pair -/
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· + ·) a b) (a + b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· - ·) a b) (a - b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· * ·) a b) (a * b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· / ·) a b) (a / b)
+
+end UnitTest.Fp.FastFloatSmoke

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -396,6 +396,7 @@ def round (mode : RoundingMode) (x : Dyadic) (e s : Nat)
     let prec : Int := targetPrec value e s
     computeRoundByMode mode sign n.natAbs k prec e s
 
+
 end Dyadic
 
 end

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -342,6 +342,60 @@ private def computeRoundByMode (mode : RoundingMode)
   | .RTN => computeRoundRTN sign mag k prec e s
   | .RTZ => computeRoundRTZ sign mag k prec e s
 
+/-! ## Public surface: `round` to target format `(e, s)` -/
+
+/--
+We compute `prec`, the number of bits to the right of the point used
+when rounding `x = n · 2^(-k)` into format `(e, s)`. The rounded value
+is of the form `mag · 2^(-prec)` for an *integer* `mag`.
+
+First we read off the exponent of `x`. We normalize the significand
+into `[1, 2)` by writing `mag = n / 2^(n.natAbs.log2)`, so that `mag ∈ [1, 2)`,
+
+x = n · 2^(-k) =
+  = (n / 2^(n.natAbs.log2)) · 2^(-(k - n.natAbs.log2)).
+  = mag · 2^(-(k - n.natAbs.log2)).
+  = (mag · 2^s)  · 2^(-(k - n.natAbs.log2 + s)).
+
+- Case 1: `x` is normal. Comparing the representations, we get:
+    prec = (k - n.natAbs.log2) + s
+
+- Case 2: `x` is subnormal.
+  These are the smallest numbers we can represent. The exponent can drop no
+  further, so it is pinned to `1 - bias e - s`.
+    -prec = 1 - bias e - s
+     prec = bias e + s - 1
+
+`prec` grows as `x` gets smaller, but the subnormals are the largest
+precision, so `bias e + s - 1` is a cap on the precision.
+So, we cap the normal precision at `bias e + s - 1` to get the final formula.
+-/
+private def targetPrec (x : Dyadic) (e s : Nat) : Int :=
+  match x with
+  | .zero => 0  -- unused: callers exclude zero
+  | .ofOdd n k _ =>
+    -- Case 1 (normal): precision implied by the exponent of `x`.
+    let normalPrec := (k : Int) - n.natAbs.log2 + s
+    -- Case 2 (subnormal): the finest grid the format offers, capping the precision.
+    let subnormalPrec := (bias e : Int) + (s : Int) - 1
+    -- `x` is subnormal exactly when its normal precision would exceed the cap.
+    if normalPrec > subnormalPrec then subnormalPrec else normalPrec
+
+/--
+Round nonzero `x` per IEEE-754 mode `mode` in target format `(e, s)`.
+Since zeros have ambiguous signs, we do not allow `x` to be zero,
+and instead require the caller to handle zero as a special case.
+-/
+def round (mode : RoundingMode) (x : Dyadic) (e s : Nat)
+    (hne : x ≠ .zero := by first | decide | native_decide) : EDyadic :=
+  match x, hne with
+  | .zero, hne => absurd rfl hne
+  | .ofOdd n k hn, _ =>
+    let value : Dyadic := .ofOdd n k hn
+    let sign : Bool := decide (n < 0)
+    let prec : Int := targetPrec value e s
+    computeRoundByMode mode sign n.natAbs k prec e s
+
 end Dyadic
 
 end

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -6,3 +6,4 @@ public import Veir.Data.FP.ScientificBV.Basic
 public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.EDyadic
+public import Veir.Data.FP.FastFloat

--- a/Veir/Data/FP/FastFloat.lean
+++ b/Veir/Data/FP/FastFloat.lean
@@ -1,0 +1,98 @@
+module
+
+public import Veir.Data.FP.PackedFloat.OfFloat
+public import Veir.Data.FP.PackedFloat.Round
+
+namespace Veir.Data.FP
+
+public section
+
+/--
+A `FastFloat e s mode` is a Lean `Float` (IEEE-754 double) whose value
+has been rounded to the precision of an `(e, s)`-format packed float
+under the given IEEE-754 rounding `mode`.
+
+The rounding mode is encoded at the type level so that arithmetic
+operations can use it without requiring it as an extra runtime argument:
+`add`, `sub`, `mul`, `div` all delegate to native `Float` arithmetic
+and then re-round the result to `(e, s)` precision via
+`PackedFloat.round` under `mode`.
+
+To switch the rounding mode of an existing value, use
+`FastFloat.setRoundingMode`.
+-/
+@[ext]
+structure FastFloat (e s : Nat) (mode : RoundingMode) where
+  /-- The underlying double, normalized to `(e, s)` precision under `mode`. -/
+  value : Float
+deriving Inhabited
+
+namespace FastFloat
+
+/--
+Round a Lean `Float` to `(e, s)` precision and back to `Float`,
+using rounding `mode`.
+The trip is `Float → PackedFloat 11 52 → PackedFloat e s → PackedFloat 11 52 → Float`,
+applying `PackedFloat.round mode` for each width change.
+-/
+def roundFloat (mode : RoundingMode) (e s : Nat) (f : Float) : Float :=
+  let pfDouble : PackedFloat 11 52 := PackedFloat.ofFloat f
+  let pfTarget : PackedFloat e s := PackedFloat.round mode e s pfDouble
+  let pfBack : PackedFloat 11 52 := PackedFloat.round mode 11 52 pfTarget
+  PackedFloat.toFloat pfBack
+
+/-- Lift a `Float` to a `FastFloat e s mode`, rounding to target precision. -/
+def ofFloat {e s : Nat} {mode : RoundingMode} (f : Float) : FastFloat e s mode :=
+  ⟨roundFloat mode e s f⟩
+
+/--
+Lift a `Float32` to a `FastFloat e s mode`. The single-precision value
+is widened to a `Float` and then rounded to `(e, s)` precision.
+-/
+def ofFloat32 {e s : Nat} {mode : RoundingMode} (f : Float32) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s f.toFloat⟩
+
+/-- Extract the underlying `Float`. -/
+def toFloat {e s : Nat} {mode : RoundingMode} (x : FastFloat e s mode) : Float :=
+  x.value
+
+/--
+Re-tag a `FastFloat` with a different rounding mode. The underlying
+`Float` value is unchanged; subsequent arithmetic on the result will use
+the new mode when re-rounding.
+-/
+def setRoundingMode {e s : Nat} {m : RoundingMode}
+    (newMode : RoundingMode) (x : FastFloat e s m) : FastFloat e s newMode :=
+  ⟨x.value⟩
+
+/-- Add two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def add {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value + b.value)⟩
+
+/-- Subtract two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def sub {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value - b.value)⟩
+
+/-- Multiply two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def mul {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value * b.value)⟩
+
+/-- Divide two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def div {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value / b.value)⟩
+
+instance {e s : Nat} {mode : RoundingMode} : Add (FastFloat e s mode) := ⟨add⟩
+instance {e s : Nat} {mode : RoundingMode} : Sub (FastFloat e s mode) := ⟨sub⟩
+instance {e s : Nat} {mode : RoundingMode} : Mul (FastFloat e s mode) := ⟨mul⟩
+instance {e s : Nat} {mode : RoundingMode} : Div (FastFloat e s mode) := ⟨div⟩
+
+end FastFloat
+
+end -- public section
+
+end Veir.Data.FP

--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -4,4 +4,4 @@ public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.PackedFloat.OfFloat
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.PackedFloat.ToEDyadic
-
+public import Veir.Data.FP.PackedFloat.Round

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -26,5 +26,24 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
   Float.ofBits (UInt64.ofBitVec bits)
 
+/--
+Convert a Lean single-precision float (`Float32`) to a `PackedFloat 8 23`.
+A IEEE single-precision float has the layout:
+  - 1 bit for the sign
+  - 8 bits for the exponent
+  - 23 bits for the significand
+-/
+def ofFloat32 (f : Float32) : PackedFloat 8 23 :=
+  let bits : BitVec 32 := (Float32.toBits f).toBitVec
+  let sign : Bool := (bits >>> 31) ≠ 0#_
+  let exponent := (bits >>> 23) &&& (1 <<< 8 - 1)
+  let significand := bits &&& (1 <<< 23 - 1)
+  PackedFloat.mk sign (exponent.setWidth 8) (significand.setWidth 23)
+
+/-- Convert a `PackedFloat 8 23` back to a Lean single-precision float (`Float32`). -/
+def toFloat32 (pf : PackedFloat 8 23) : Float32 :=
+  let bits : BitVec 32 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
+  Float32.ofBits (UInt32.ofBitVec bits)
+
 end -- public section
 end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/Round.lean
+++ b/Veir/Data/FP/PackedFloat/Round.lean
@@ -1,0 +1,37 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.ToEDyadic
+public import Veir.Data.FP.EDyadic.Round
+public import Veir.Data.FP.EDyadic.Pack
+
+namespace Veir.Data.FP.PackedFloat
+
+public section
+
+/--
+Round a `PackedFloat e s` into target format `PackedFloat etarget starget`
+using the given IEEE-754 rounding mode.
+
+The implementation is the composition
+`PackedFloat → EDyadic → (rounded) EDyadic → PackedFloat`:
+* `PackedFloat.toEDyadic` converts the input to its precise dyadic value
+  (preserving NaN, ±∞, and ±0).
+* `Dyadic.round mode` rounds finite nonzero values to a representable
+  value in `(etarget, starget)` per the given rounding mode.
+* `EDyadic.pack` re-encodes the result in the target packed format.
+
+NaN, ±∞, and ±0 are propagated through; only the exponent and significand
+widths change.
+-/
+def round {e s : Nat} (mode : RoundingMode) (etarget starget : Nat)
+    (pf : PackedFloat e s) : PackedFloat etarget starget :=
+  let edRounded : EDyadic :=
+    match pf.toEDyadic with
+    | .nonzeroFinite d hne => Dyadic.round mode d etarget starget hne
+    | special => special
+  EDyadic.pack etarget starget edRounded
+
+end -- public section
+
+end Veir.Data.FP.PackedFloat


### PR DESCRIPTION
## Summary
- Implement `EDyadic.Round` with all five IEEE-754 rounding modes (`RNE`/`RNA`/`RTN`/`RTP`/`RTZ`); `Dyadic.lower`/`upper` and `Dyadic.round` use `Dyadic.roundDown`/`roundUp` to bracket and pick.
- Add `PackedFloat.round mode etarget starget`: composes `toEDyadic → Dyadic.round → EDyadic.pack`.
- Add `FastFloat e s mode`: a `Float` wrapper with type-level rounding mode; arithmetic ops (`add`/`sub`/`mul`/`div`, with `Add`/`Sub`/`Mul`/`Div` instances) round results back to `(e, s)` precision via `PackedFloat.round`. Includes `setRoundingMode` to re-tag.
- Bridge to single precision: `PackedFloat.ofFloat32`/`toFloat32` and `FastFloat.ofFloat32`.

## Test plan
- [x] `UnitTest.FP.EDyadic.Round` — identity on representable values, RNE tie-break, strict closer-of-two, lower/upper brackets, overflow → ±∞, subnormal rounding.
- [x] `UnitTest.FP.FastFloat` — hand-picked add/sub/mul/div pairs match native `Float32` bit-for-bit; specials propagate.
- [x] `UnitTest.FP.FastFloatSmoke` — smoke test over 9 specials (NaN, ±∞, ±0, ±minSubnormal, ±maxNormal) plus 50 logarithmically-spaced powers of two, exercising every ordered pair under all four operators against native `Float32` (NaNs compared as `isNaN ↔ isNaN`). ~14k cases.
- [x] Full `lake build UnitTest.FP` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)