### PR TITLE
Adaptive sampling and stddev reporting in benchmark script

### DIFF
--- a/.github/scripts/run_benchmarks.sh
+++ b/.github/scripts/run_benchmarks.sh
@@ -42,6 +42,8 @@ BENCHMARKS=(
 
 OUTPUT_FILE="${BENCHMARK_OUTPUT:-benchmark-results.json}"
 
+lake build run-benchmarks >&2
+
 median() {
   local sorted
   sorted=($(printf '%s\n' "$@" | sort -g))
@@ -86,7 +88,7 @@ flt_lt() {
 
 run_one() {
   local bench="$1" out cs rs
-  out=$(lake exe run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || return 1
+  out=$(lake env run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || return 1
   cs=$(echo "$out" | sed -n 's/.*create time (s): \([0-9.]*\).*/\1/p')
   rs=$(echo "$out" | sed -n 's/.*rewrite time (s): \([0-9.]*\).*/\1/p')
   [ -n "$cs" ] && [ -n "$rs" ] && echo "$cs $rs"

--- a/.github/scripts/run_benchmarks.sh
+++ b/.github/scripts/run_benchmarks.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
 # Runs all benchmarks and outputs results in github-action-benchmark JSON format.
-# Each benchmark is run multiple times; the median is reported to reduce noise.
-# Usage: ./run_benchmarks.sh [count] [pc] [iterations]
-#   count:      tree size (default: 1000)
-#   pc:         program counter param (default: 50)
-#   iterations: number of runs per benchmark for median (default: 5)
+# Adaptive sampling: warmup + minimum samples + extra samples until relative
+# stddev (CV) drops below threshold, sample cap is hit, or time budget runs out.
+# Reports median as `value` and stddev as `range` (rendered as error bars).
+#
+# Usage: ./run_benchmarks.sh [count] [pc] [min_iterations]
+#   count:           tree size (default: 1000)
+#   pc:              program counter param (default: 50)
+#   min_iterations:  minimum samples per benchmark (default: 5)
+#
+# Tunable via env vars:
+#   SAMPLES_MAX       max samples per benchmark (default: 30)
+#   TIME_BUDGET_SECS  max wall time per benchmark, seconds (default: 180)
+#   CV_THRESHOLD      target relative stddev in percent (default: 5.0)
+#   WARMUP            warmup iterations to discard (default: 2)
 
 set -euo pipefail
 
 COUNT="${1:-1000}"
 PC="${2:-50}"
-ITERATIONS="${3:-5}"
+SAMPLES_MIN="${3:-5}"
+
+SAMPLES_MAX="${SAMPLES_MAX:-30}"
+TIME_BUDGET_SECS="${TIME_BUDGET_SECS:-180}"
+CV_THRESHOLD="${CV_THRESHOLD:-5.0}"
+WARMUP="${WARMUP:-2}"
 
 BENCHMARKS=(
   "add-fold-worklist"
@@ -28,7 +42,6 @@ BENCHMARKS=(
 
 OUTPUT_FILE="${BENCHMARK_OUTPUT:-benchmark-results.json}"
 
-# Compute median of a list of numbers passed as arguments.
 median() {
   local sorted
   sorted=($(printf '%s\n' "$@" | sort -g))
@@ -41,27 +54,83 @@ median() {
   fi
 }
 
+stddev() {
+  printf '%s\n' "$@" | awk '
+    { x[NR]=$1; s+=$1 }
+    END {
+      if (NR < 2) { print "0"; exit }
+      m = s/NR
+      for (i=1;i<=NR;i++) v += (x[i]-m)*(x[i]-m)
+      printf "%.9f", sqrt(v/(NR-1))
+    }
+  '
+}
+
+mean() {
+  printf '%s\n' "$@" | awk '
+    { s+=$1 }
+    END { if (NR==0) {print "0"} else {printf "%.9f", s/NR} }
+  '
+}
+
+cv_pct() {
+  local m sd
+  m=$(mean "$@")
+  sd=$(stddev "$@")
+  awk -v m="$m" -v sd="$sd" 'BEGIN { if (m+0==0) print "0"; else printf "%.4f", (sd/m)*100 }'
+}
+
+flt_lt() {
+  awk -v a="$1" -v b="$2" 'BEGIN { exit !(a+0 < b+0) }'
+}
+
+run_one() {
+  local bench="$1" out cs rs
+  out=$(lake exe run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || return 1
+  cs=$(echo "$out" | sed -n 's/.*create time (s): \([0-9.]*\).*/\1/p')
+  rs=$(echo "$out" | sed -n 's/.*rewrite time (s): \([0-9.]*\).*/\1/p')
+  [ -n "$cs" ] && [ -n "$rs" ] && echo "$cs $rs"
+}
+
 echo "[" > "$OUTPUT_FILE"
 first=true
 
 for bench in "${BENCHMARKS[@]}"; do
-  echo "Running benchmark: $bench (count=$COUNT, pc=$PC, iterations=$ITERATIONS)" >&2
+  echo "Running benchmark: $bench (count=$COUNT, pc=$PC, min=$SAMPLES_MIN, max=$SAMPLES_MAX, budget=${TIME_BUDGET_SECS}s, cv<${CV_THRESHOLD}%, warmup=$WARMUP)" >&2
+
+  for ((i = 1; i <= WARMUP; i++)); do
+    run_one "$bench" >/dev/null || true
+  done
 
   create_times=()
   rewrite_times=()
+  start=$SECONDS
 
-  for ((i = 1; i <= ITERATIONS; i++)); do
-    raw_output=$(lake exe run-benchmarks "$bench" "$COUNT" "$PC" 2>&1) || {
-      echo "  FAILED: $bench (iteration $i)" >&2
-      echo "  Output: $raw_output" >&2
-      continue
-    }
+  for ((i = 1; i <= SAMPLES_MIN; i++)); do
+    if pair=$(run_one "$bench"); then
+      create_times+=("${pair% *}")
+      rewrite_times+=("${pair#* }")
+    else
+      echo "  FAILED: $bench (sample $i)" >&2
+    fi
+  done
 
-    rs=$(echo "$raw_output" | sed -n 's/.*rewrite time (s): \([0-9.]*\).*/\1/p')
-    cs=$(echo "$raw_output" | sed -n 's/.*create time (s): \([0-9.]*\).*/\1/p')
+  while (( ${#rewrite_times[@]} < SAMPLES_MAX )); do
+    elapsed=$(( SECONDS - start ))
+    (( elapsed >= TIME_BUDGET_SECS )) && break
 
-    [ -n "$cs" ] && create_times+=("$cs")
-    [ -n "$rs" ] && rewrite_times+=("$rs")
+    if (( ${#rewrite_times[@]} >= 2 )); then
+      cv_c=$(cv_pct "${create_times[@]}")
+      cv_r=$(cv_pct "${rewrite_times[@]}")
+      if flt_lt "$cv_c" "$CV_THRESHOLD" && flt_lt "$cv_r" "$CV_THRESHOLD"; then
+        break
+      fi
+    fi
+
+    if pair=$(run_one "$bench"); then
+      create_times+=("${pair% *}")
+      rewrite_times+=("${pair#* }")
+    fi
   done
 
   for phase_name in create rewrite; do
@@ -74,9 +143,11 @@ for bench in "${BENCHMARKS[@]}"; do
     [ ${#times[@]} -eq 0 ] && continue
 
     secs=$(median "${times[@]}")
+    sd_secs=$(stddev "${times[@]}")
+    cv=$(cv_pct "${times[@]}")
 
-    # Convert seconds (float) to nanoseconds (integer) using awk
-    value_ns=$(echo "$secs" | awk '{printf "%.0f", $1 * 1000000000}')
+    value_ns=$(echo "$secs"    | awk '{printf "%.0f", $1 * 1000000000}')
+    range_ns=$(echo "$sd_secs" | awk '{printf "%.0f", $1 * 1000000000}')
 
     if [ "$first" = true ]; then
       first=false
@@ -89,11 +160,12 @@ for bench in "${BENCHMARKS[@]}"; do
     "name": "${bench}/${phase_name}",
     "unit": "ns",
     "value": $value_ns,
-    "extra": "count=$COUNT pc=$PC iterations=$ITERATIONS median_${phase_name}=${secs}s"
+    "range": "± $range_ns",
+    "extra": "count=$COUNT pc=$PC samples=${#times[@]} median=${secs}s stddev=${sd_secs}s cv=${cv}%"
   }
 ENTRY
 
-    echo "  $bench/$phase_name: ${secs}s (median of $ITERATIONS runs)" >&2
+    echo "  $bench/$phase_name: median=${secs}s stddev=${sd_secs}s cv=${cv}% n=${#times[@]}" >&2
   done
 done
 


### PR DESCRIPTION
Replace fixed-iteration runs with adaptive sampling: warmup, minimum samples, then extra samples until per-phase CV drops below 5% or the sample/time caps (30 / 180s) are hit. Emit stddev as the `range` field so github-action-benchmark renders error bars on the chart.