### PR TITLE
Allow to set argument types in `createBlock`

### DIFF
--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -145,7 +145,7 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
     /- Create the block. -/
     let block ← modifyContextM' fun ctx => do
       let ⟨hip⟩ ← liftExcept (checkBlockInsertPointInBounds ip ctx.raw)
-      match hctx' : Rewriter.createBlock ctx ip (by grind) (by grind) with
+      match hctx' : Rewriter.createBlock ctx #[] ip (by grind) (by grind) with
       | none => throw "internal error: failed to create block"
       | some (ctx', block) => pure ⟨block, ⟨ctx', by grind [Rewriter.createBlock_WellFormed]⟩⟩
     /- Notify the parsing context that the block is defined. -/
@@ -166,7 +166,7 @@ def defineBlockUse (name : ByteArray) : MlirParserM BlockPtr := do
   | none => -- Block not yet encountered
     /- Create the block. -/
     let block ← modifyContextM' fun ctx => do
-      match hctx' : Rewriter.createBlock ctx none (by grind) Option.maybe_none with
+      match hctx' : Rewriter.createBlock ctx #[] none (by grind) Option.maybe_none with
       | none => throw "internal error: failed to create block"
       | some (ctx', block) => pure ⟨block, ⟨ctx', by grind [Rewriter.createBlock_WellFormed]⟩⟩
     /- Notify the parsing context that the block is forward declared. -/

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -218,10 +218,11 @@ def replaceValue (rewriter: PatternRewriter OpInfo) (oldVal newVal: ValuePtr)
   }
 
 def createBlock (rewriter: PatternRewriter OpInfo)
+    (argTypes: Array TypeAttr)
     (insertPoint : Option BlockInsertPoint)
     (insertPointIn : insertPoint.maybe BlockInsertPoint.InBounds rewriter.ctx.raw := by grind)
     : Option (PatternRewriter OpInfo × BlockPtr) := do
-  rlet (newCtx, op) ← WfRewriter.createBlock rewriter.ctx insertPoint (by grind)
+  rlet (newCtx, op) ← WfRewriter.createBlock rewriter.ctx argTypes insertPoint (by grind)
   ({ rewriter with ctx := newCtx, hasDoneAction := true }, op)
 
 def insertBlock (rewriter: PatternRewriter OpInfo) (block: BlockPtr) (ip : BlockInsertPoint)

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -464,10 +464,12 @@ theorem Rewriter.initBlockArguments_inBounds_mono (ptr : GenericPtr) :
   fun_induction initBlockArguments <;> grind
 
 @[irreducible]
-def Rewriter.createBlock (ctx: IRContext OpInfo) (insertionPoint: Option BlockInsertPoint)
+def Rewriter.createBlock (ctx: IRContext OpInfo) (argTypes : Array TypeAttr)
+    (insertionPoint: Option BlockInsertPoint)
     (hctx : ctx.FieldsInBounds) (hip : insertionPoint.maybe BlockInsertPoint.InBounds ctx)
     : Option (IRContext OpInfo × BlockPtr) :=
   rlet (ctx, newBlockPtr) ← BlockPtr.allocEmpty ctx
+  let ctx := Rewriter.initBlockArguments ctx newBlockPtr argTypes
   match h : insertionPoint with
   | some insertionPoint => do
     let ctx ← Rewriter.insertBlock? ctx newBlockPtr insertionPoint
@@ -477,7 +479,7 @@ def Rewriter.createBlock (ctx: IRContext OpInfo) (insertionPoint: Option BlockIn
     (ctx, newBlockPtr)
 
 @[grind .]
-theorem Rewriter.createBlock_inBounds_mono (ptr : GenericPtr) (heq : createBlock ctx ip hctx hip = some ⟨newCtx, newPtr⟩) :
+theorem Rewriter.createBlock_inBounds_mono (ptr : GenericPtr) (heq : createBlock ctx types ip hctx hip = some ⟨newCtx, newPtr⟩) :
     ptr.InBounds ctx → ptr.InBounds newCtx := by
   simp only [createBlock] at heq
   split at heq
@@ -489,7 +491,7 @@ theorem Rewriter.createBlock_inBounds_mono (ptr : GenericPtr) (heq : createBlock
 
 @[grind .]
 theorem Rewriter.createBlock_fieldsInBounds_mono
-    (heq : createBlock ctx ip hctx hip = some ⟨newCtx, newPtr⟩) :
+    (heq : createBlock ctx types ip hctx hip = some ⟨newCtx, newPtr⟩) :
     ctx.FieldsInBounds → newCtx.FieldsInBounds := by
   simp only [createBlock] at heq
   split at heq
@@ -877,5 +879,5 @@ theorem Rewriter.createOp_fieldsInBounds
 def IRContext.create OpInfo [HasOpInfo OpInfo] : Option (IRContext OpInfo × OperationPtr) :=
   rlet (ctx, region) ← Rewriter.createRegion (empty OpInfo)
   rlet (ctx, operation) ← Rewriter.createOp ctx HasOpInfo.moduleOpCode #[] #[] #[] #[region] default none
-  rlet (ctx, block) ← Rewriter.createBlock ctx (some (.atEnd region)) (by grind) (by grind)
+  rlet (ctx, block) ← Rewriter.createBlock ctx #[] (some (.atEnd region)) (by grind) (by grind)
   return (ctx, operation)

--- a/Veir/Rewriter/WellFormed/Block.lean
+++ b/Veir/Rewriter/WellFormed/Block.lean
@@ -9,6 +9,7 @@ import Veir.Rewriter.Basic
 import Veir.Rewriter.GetSet
 import Veir.Rewriter.InsertPoint
 import Veir.Rewriter.LinkedList.WellFormed
+import Veir.Rewriter.WellFormed.BlockArguments
 
 public section
 
@@ -76,14 +77,14 @@ theorem BlockPtr.allocEmpty_wellFormed (hctx : ctx.WellFormed)
     apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
 theorem Rewriter.createBlock_WellFormed (ctxWf : ctx.WellFormed) :
-    Rewriter.createBlock ctx ip hctx hip = some (newCtx, newBlock) →
+    Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock) →
     newCtx.WellFormed := by
   simp only [Rewriter.createBlock]
-  split; grind; rename_i ctx₁ newBlock hctx₁
+  split; grind; rename_i ctx₁ newBlock₁ hctx₁
   have : ctx₁.WellFormed := by grind [BlockPtr.allocEmpty_wellFormed]
   split
   · simp only [Option.bind_eq_bind, Option.bind]
-    grind [Rewriter.insertBlock?_WellFormed]
-  · grind
+    grind [IRContext.wellFormed_Rewriter_initBlockArguments, Rewriter.insertBlock?_WellFormed]
+  · grind [IRContext.wellFormed_Rewriter_initBlockArguments]
 
 end Veir

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -104,6 +104,20 @@ def WfRewriter.createBlock (wfCtx : WfIRContext OpInfo)
   rlet (ctx, blk) ← Rewriter.createBlock wfCtx insertionPoint (by grind) hip
   return (⟨ctx, by grind [Rewriter.createBlock_WellFormed]⟩, blk)
 
+/--
+Set the block arguments of a block.
+This replaces all existing block arguments with new ones of the given types, so the existing block
+arguments must have no uses.
+-/
+@[inline]
+def WfRewriter.setBlockArguments (wfCtx : WfIRContext OpInfo) (blockPtr : BlockPtr)
+    (types : Array TypeAttr)
+    (hblock : blockPtr.InBounds wfCtx.raw := by grind)
+    (noUses : ∀ blockArg ∈ blockPtr.getArguments! wfCtx.raw, ¬ blockArg.hasUses! wfCtx.raw := by grind)
+    : WfIRContext OpInfo :=
+  ⟨Rewriter.setBlockArguments wfCtx blockPtr types hblock,
+    by grind [IRContext.wellFormed_Rewriter_setBlockArguments]⟩
+
 /-- Create a new region. -/
 @[inline]
 def WfRewriter.createRegion (wfCtx : WfIRContext OpInfo)

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -98,10 +98,11 @@ def WfRewriter.replaceOp? (wfCtx : WfIRContext OpInfo) (oldOp newOp : OperationP
 /-- Create a new block and insert it at a given location. -/
 @[inline]
 def WfRewriter.createBlock (wfCtx : WfIRContext OpInfo)
+    (argTypes : Array TypeAttr)
     (insertionPoint : Option BlockInsertPoint)
     (hip : insertionPoint.maybe BlockInsertPoint.InBounds wfCtx.raw)
     : Option (WfIRContext OpInfo × BlockPtr) := do
-  rlet (ctx, blk) ← Rewriter.createBlock wfCtx insertionPoint (by grind) hip
+  rlet (ctx, blk) ← Rewriter.createBlock wfCtx argTypes insertionPoint (by grind) hip
   return (⟨ctx, by grind [Rewriter.createBlock_WellFormed]⟩, blk)
 
 /--


### PR DESCRIPTION
`createBlock` only allowed to create block with no arguments.