### PR TITLE
Add `Rewriter.setBlockArguments`

### DIFF
--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -1013,6 +1013,16 @@ theorem IRContext.WellFormed.ValuePtr_getFirstUse!_eq_of_back_eq_valueFirstUse
 grind_pattern IRContext.WellFormed.ValuePtr_getFirstUse!_eq_of_back_eq_valueFirstUse =>
   ctx.WellFormed, (firstUse.get! ctx).back, OpOperandPtrPtr.valueFirstUse value
 
+theorem IRContext.WellFormed.ValuePtr_hasUses_iff_operand_value_ne_value
+    (ctxWf : ctx.WellFormed)
+    {value : ValuePtr} (noUses : ¬ value.hasUses! ctx) (valueInBounds : value.InBounds ctx)
+    {operand : OpOperandPtr} (hoperand : operand.InBounds ctx) :
+    (operand.get! ctx).value ≠ value := by
+  grind [valueDefUseChains, ValuePtr.DefUse.hasUses!_iff, ValuePtr.DefUse]
+
+grind_pattern IRContext.WellFormed.ValuePtr_hasUses_iff_operand_value_ne_value =>
+  ctx.WellFormed, value.hasUses! ctx, (operand.get! ctx).value
+
 theorem BlockPtr.OpChain.mem_next!_of_mem
     (op nextOp : OperationPtr) (block : BlockPtr)
     (hWF : block.OpChain ctx array missingOps)

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -499,6 +499,31 @@ theorem Rewriter.createBlock_fieldsInBounds_mono
       split at heq <;> grind
     · grind
 
+def Rewriter.setBlockArguments (ctx : IRContext OpInfo) (blockPtr : BlockPtr)
+    (types : Array TypeAttr) (hblock : blockPtr.InBounds ctx := by grind) : IRContext OpInfo :=
+  let numArgs := blockPtr.getNumArguments ctx (by grind)
+  if _ : numArgs = 0 then
+    Rewriter.initBlockArguments ctx blockPtr types
+  else
+    let ctx := blockPtr.setArguments ctx #[]
+    Rewriter.initBlockArguments ctx blockPtr types
+
+@[grind =]
+theorem Rewriter.setBlockArguments_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (Rewriter.setBlockArguments ctx blockPtr types hblock) ↔
+    match ptr with
+    | .blockArgument argPtr
+    | .value (.blockArgument argPtr)
+    | .opOperandPtr (.valueFirstUse (.blockArgument argPtr)) =>
+      if argPtr.block = blockPtr then argPtr.index < types.size else argPtr.InBounds ctx
+    | _ => ptr.InBounds ctx := by
+  grind [Rewriter.setBlockArguments]
+
+/-!
+`Rewriter.setBlockArguments` preserves `FieldsInBounds` only if the context is well-formed and no
+previous block argument is used. Otherwise, another pointer could point to one of the block arguments.
+-/
+
 @[irreducible, grind]
 def Rewriter.createRegion (ctx: IRContext OpInfo) : Option (IRContext OpInfo × RegionPtr) :=
   RegionPtr.allocEmpty ctx

--- a/Veir/Rewriter/GetSet/BlockArguments.lean
+++ b/Veir/Rewriter/GetSet/BlockArguments.lean
@@ -432,4 +432,208 @@ theorem OpOperandPtrPtr.get!_initBlockArguments {opOperandPtr : OpOperandPtrPtr}
 
 end Rewriter.initBlockArguments
 
+/-! ## `Rewriter.setBlockArguments` -/
+
+section Rewriter.setBlockArguments
+
+variable {op : OperationPtr}
+attribute [local grind] Rewriter.setBlockArguments
+
+@[simp, grind =]
+theorem BlockPtr.firstUse!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).firstUse =
+    (block'.get! ctx).firstUse := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.prev!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).prev =
+    (block'.get! ctx).prev := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.next!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).next =
+    (block'.get! ctx).next := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.parent!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).parent =
+    (block'.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstOp!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).firstOp =
+    (block'.get! ctx).firstOp := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.lastOp!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).lastOp =
+    (block'.get! ctx).lastOp := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.get!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getOpType! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getOpType! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getProperties!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getProperties! (Rewriter.setBlockArguments ctx blockPtr types hblock) opCode =
+    operation.getProperties! ctx opCode := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumResults!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getNumResults! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getNumResults! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpResultPtr.get!_Rewriter_setBlockArguments {opResult : OpResultPtr} :
+    opResult.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    opResult.get! ctx := by
+  grind [cases OpResultPtr]
+
+@[simp, grind =]
+theorem OperationPtr.getNumOperands!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getNumOperands! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getNumOperands! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpOperandPtr.get!_Rewriter_setBlockArguments {opOperand : OpOperandPtr} :
+    opOperand.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    opOperand.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperands!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getOperands! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getOperands! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumSuccessors!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getNumSuccessors! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getNumSuccessors! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockOperandPtr.get!_Rewriter_setBlockArguments {blockOperand : BlockOperandPtr} :
+    blockOperand.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    blockOperand.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessor!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getSuccessor! (Rewriter.setBlockArguments ctx blockPtr types hblock) index =
+    operation.getSuccessor! ctx index := by
+  grind [OperationPtr.getSuccessor!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessors!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getSuccessors! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getSuccessors! ctx := by
+  simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_Rewriter_setBlockArguments,
+    OperationPtr.getNumSuccessors!_Rewriter_setBlockArguments]
+
+@[simp, grind =]
+theorem OperationPtr.getNumRegions!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getNumRegions! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    operation.getNumRegions! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getRegion!_Rewriter_setBlockArguments {operation : OperationPtr} :
+    operation.getRegion! (Rewriter.setBlockArguments ctx blockPtr types hblock) idx =
+    operation.getRegion! ctx idx := by
+  grind
+
+@[simp, grind =]
+theorem BlockOperandPtrPtr.get!_Rewriter_setBlockArguments {blockOperandPtr : BlockOperandPtrPtr} :
+    blockOperandPtr.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    blockOperandPtr.get! ctx := by
+  grind
+
+@[grind =]
+theorem BlockPtr.getNumArguments!_Rewriter_setBlockArguments {block' : BlockPtr} :
+    block'.getNumArguments! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    if blockPtr = block' then
+      types.size
+    else
+      block'.getNumArguments! ctx := by
+  grind
+
+@[grind =]
+theorem BlockArgumentPtr.get!_Rewriter_setBlockArguments {blockArg : BlockArgumentPtr} :
+    blockArg.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    if blockArg.block = blockPtr then
+      if blockArg.index < types.size then
+        { type := types[blockArg.index]!, firstUse := none, index := blockArg.index, owner := blockPtr, loc := () }
+      else
+        default
+    else
+      blockArg.get! ctx := by
+  grind [BlockArgumentPtr.inBounds_def, BlockArgumentPtr.get!_of_not_inBounds]
+
+@[simp, grind =]
+theorem RegionPtr.get!_Rewriter_setBlockArguments {region : RegionPtr} :
+    region.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    region.get! ctx := by
+  grind
+
+@[grind =]
+theorem ValuePtr.getFirstUse!_Rewriter_setBlockArguments {value : ValuePtr} :
+    value.getFirstUse! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    match value with
+    | .blockArgument blockArg =>
+      if blockArg.block = blockPtr then
+        none
+      else value.getFirstUse! ctx
+    | _ => value.getFirstUse! ctx := by
+  cases value <;>
+    grind [BlockArgumentPtr.inBounds_def, BlockArgumentPtr.get!_of_not_inBounds,
+      BlockArgument.default_firstUse_eq]
+
+@[grind =]
+theorem ValuePtr.getType!_Rewriter_setBlockArguments {value : ValuePtr} :
+    value.getType! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    match value with
+    | .blockArgument blockArg =>
+      if blockArg.block = blockPtr then
+        if blockArg.index < types.size then
+          types[blockArg.index]!
+        else
+          default
+      else
+        value.getType! ctx
+    | _ => value.getType! ctx := by
+  cases value <;>
+    grind [BlockArgumentPtr.inBounds_def, BlockArgumentPtr.get!_of_not_inBounds,
+      BlockArgument.default_type_eq]
+
+@[grind =]
+theorem OpOperandPtrPtr.get!_Rewriter_setBlockArguments {opOperandPtr : OpOperandPtrPtr} :
+    opOperandPtr.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
+    match opOperandPtr with
+    | .valueFirstUse (.blockArgument blockArg) =>
+      if blockArg.block = blockPtr then
+        none
+      else opOperandPtr.get! ctx
+    | _ => opOperandPtr.get! ctx := by
+  grind
+
+end Rewriter.setBlockArguments
+
 end Veir

--- a/Veir/Rewriter/WellFormed.lean
+++ b/Veir/Rewriter/WellFormed.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Rewriter.WellFormed.Block
+public import Veir.Rewriter.WellFormed.BlockArguments
 public import Veir.Rewriter.WellFormed.BlockOperands
 public import Veir.Rewriter.WellFormed.IRContext
 public import Veir.Rewriter.WellFormed.Operation

--- a/Veir/Rewriter/WellFormed/BlockArguments.lean
+++ b/Veir/Rewriter/WellFormed/BlockArguments.lean
@@ -89,3 +89,101 @@ theorem IRContext.wellFormed_Rewriter_initBlockArguments :
     ctx.WellFormed →
     (Rewriter.initBlockArguments ctx opPtr resultTypes index hop hindex).WellFormed := by
   fun_induction Rewriter.initBlockArguments <;> grind [IRContext.wellFormed_Rewriter_pushBlockArgument]
+
+/-! ## Rewriter.setBlockArguments -/
+
+theorem IRContext.fieldsInBounds_Rewriter_setBlockArguments (ctxWf : ctx.WellFormed)
+    (noUses : ∀ blockArg ∈ block.getArguments! ctx, ¬ blockArg.hasUses! ctx) :
+    (Rewriter.setBlockArguments ctx block type hblock).FieldsInBounds := by
+  constructor
+  · intro op opInBounds
+    have : Operation.FieldsInBounds op ctx (by grind) := by grind
+    have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇⟩ := this
+    constructor
+    case results_inBounds => intros; constructor <;> grind [Option.maybe_def]
+    case blockOperands_inBounds => intros; constructor <;> grind [Option.maybe_def]
+    case operands_inBounds =>
+      intros; constructor <;>
+        grind (gen := 20) [BlockArgumentPtr.inBounds_def, ValuePtr.hasUses!_def, Option.maybe_def,
+          BlockArgumentPtr.block_of_mem_getArguments!]
+    all_goals try grind [Option.maybe_def]
+  · intros; constructor <;> grind [BlockArgument.FieldsInBounds, Option.maybe_def]
+  · intros; constructor <;> grind [Option.maybe_def]
+
+theorem BlockPtr.opChain_Rewriter_setBlockArguments
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' (Rewriter.setBlockArguments ctx block type hblock) array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem ValuePtr.defUse_Rewriter_setBlockArguments_preserves
+    (hWf : ValuePtr.DefUse value ctx array missingUses) :
+    value ∉ block.getArguments! (Rewriter.setBlockArguments ctx block type hblock) →
+    value.InBounds (Rewriter.setBlockArguments ctx block type hblock) →
+    ValuePtr.DefUse value (Rewriter.setBlockArguments ctx block type hblock) array missingUses := by
+  intros
+  apply ValuePtr.DefUse.unchanged (ctx := ctx) <;>
+    grind [BlockArgumentPtr.block_of_mem_getArguments!]
+
+theorem ValuePtr.defUse_Rewriter_setBlockArguments_new (ctxWf : ctx.WellFormed)
+    (noUses : ∀ blockArg ∈ block.getArguments! ctx, ¬ blockArg.hasUses! ctx) :
+    value ∈ block.getArguments! (Rewriter.setBlockArguments ctx block type hblock) →
+    ValuePtr.DefUse value (Rewriter.setBlockArguments ctx block type hblock) #[] ∅ := by
+  intros
+  have : (Rewriter.setBlockArguments ctx block type hblock).FieldsInBounds :=
+    IRContext.fieldsInBounds_Rewriter_setBlockArguments ctxWf noUses
+  constructor <;> grind [BlockArgumentPtr.block_of_mem_getArguments!,
+      BlockArgumentPtr.exists_blockArgument_of_mem_getArguments!]
+
+theorem BlockPtr.defUse_Rewriter_setBlockArguments
+    (hWf : BlockPtr.DefUse block' ctx array missingUses) :
+    BlockPtr.DefUse block' (Rewriter.setBlockArguments ctx block type hblock) array missingUses := by
+  apply BlockPtr.DefUse.unchanged (ctx := ctx) <;> grind
+
+theorem RegionPtr.blockChain_Rewriter_setBlockArguments
+    (hWf : RegionPtr.BlockChain region ctx array) :
+    RegionPtr.BlockChain region (Rewriter.setBlockArguments ctx block type hblock) array := by
+  apply RegionPtr.blockChain_unchanged (ctx := ctx) hWf <;> grind
+
+theorem IRContext.wellFormed_Rewriter_setBlockArguments
+    (noUses : ∀ blockArg ∈ block.getArguments! ctx, ¬ blockArg.hasUses! ctx)
+    (ctxWf : ctx.WellFormed) :
+    (Rewriter.setBlockArguments ctx block type hblock).WellFormed := by
+  have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := ctxWf
+  have : (Rewriter.setBlockArguments ctx block type hblock).FieldsInBounds :=
+    by grind [IRContext.fieldsInBounds_Rewriter_setBlockArguments]
+  constructor
+  case inBounds => grind
+  case valueDefUseChains =>
+    intros value hvalue
+    cases hInArgs : decide (value ∈ block.getArguments! (Rewriter.setBlockArguments ctx block type hblock))
+    · have ⟨array, harray⟩ := h₂ value (by grind [BlockArgumentPtr.block_of_mem_getArguments!])
+      exists array
+      grind [ValuePtr.defUse_Rewriter_setBlockArguments_preserves]
+    · exists #[]
+      grind [ValuePtr.defUse_Rewriter_setBlockArguments_new]
+  case blockDefUseChains =>
+    intros block hblock
+    have ⟨array, harray⟩ := h₃ block (by grind)
+    exists array
+    grind [BlockPtr.defUse_Rewriter_setBlockArguments]
+  case opChain =>
+    intros block' hBlock'
+    have ⟨array', harray'⟩ := h₄ block' (by grind)
+    exists array'
+    grind [BlockPtr.opChain_Rewriter_setBlockArguments]
+  case blockChain =>
+    intros region hregion
+    have ⟨array, harray⟩ := h₅ region (by grind)
+    exists array
+    apply RegionPtr.blockChain_unchanged harray <;> grind
+  case operations =>
+    intros op' hop'
+    apply OperationPtr.WellFormed_unchanged (ctx := ctx) <;>
+      grind
+  case blocks =>
+    intros bl hbl
+    have : bl.InBounds ctx := by grind
+    have ⟨ha, hb, hc, hd, he⟩ := h₇ bl (by grind)
+    constructor <;> grind
+  case regions =>
+    grind [RegionPtr.WellFormed_unchanged]


### PR DESCRIPTION
As well as its get-set lemmas, and well-formed preservation lemma. It only preserves well-formed (and fields-in-bounds) if the previous arguments weren't used.