### PR TITLE
fix: refinement relation is `Prop`

### DIFF
--- a/Veir/Data/Refinement.lean
+++ b/Veir/Data/Refinement.lean
@@ -20,7 +20,7 @@ def isRefinedBy {w : Nat} (i i' : Veir.Data.LLVM.Int w) : Prop :=
   | .val v =>
     match i' with
     | .val v' => v = v'
-    | .poison => false
-  | .poison => true
+    | .poison => False
+  | .poison => True
 
 @[inherit_doc] infix:50 " ⊑ "  => isRefinedBy


### PR DESCRIPTION
We fix the return type of the refinement relation to be `Prop`, avoiding the coercion from booleans to props. 