### PR TITLE
feat: implement EDyadic.pack

### DIFF
--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -1,3 +1,4 @@
-module 
+module
 
 public import UnitTest.FP.PackedFloat
+public import UnitTest.FP.EDyadic

--- a/UnitTest/FP/EDyadic.lean
+++ b/UnitTest/FP/EDyadic.lean
@@ -1,0 +1,3 @@
+module
+
+public import UnitTest.FP.EDyadic.Pack

--- a/UnitTest/FP/EDyadic/Pack.lean
+++ b/UnitTest/FP/EDyadic/Pack.lean
@@ -1,0 +1,80 @@
+module
+
+import Veir.Data.FP.EDyadic.Pack
+import Veir.Data.FP.PackedFloat.ToEDyadic
+
+meta import Veir.Data.FP.EDyadic.Pack
+meta import Veir.Data.FP.PackedFloat.OfFloat
+meta import Veir.Data.FP.PackedFloat.ToEDyadic
+meta import Veir.Data.FP.PackedFloat.State
+
+namespace UnitTest.Fp.EDyadic.Pack
+
+open Veir.Data.FP
+open Veir.Data.FP.PackedFloat
+
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat 0.0)) = ofFloat 0.0
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat (-0.0))) = ofFloat (-0.0)
+
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat 1.0)) = ofFloat 1.0
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat (-1.0))) = ofFloat (-1.0)
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat 2.0)) = ofFloat 2.0
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat 0.5)) = ofFloat 0.5
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat 1.5)) = ofFloat 1.5
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat (-1.5))) = ofFloat (-1.5)
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat 1024.0)) = ofFloat 1024.0
+
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat (1.0 / 0.0))) = ofFloat (1.0 / 0.0)
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic (ofFloat (-1.0 / 0.0))) = ofFloat (-1.0 / 0.0)
+
+#guard (EDyadic.pack (e := 11) (s := 52) .nan).state = .nan
+
+#guard EDyadic.pack (e := 11) (s := 52) (.zero false) =
+  PackedFloat.mk (sign := false) (ex := 0#11) (sig := 0#52)
+#guard EDyadic.pack (e := 11) (s := 52) (.zero true) =
+  PackedFloat.mk (sign := true) (ex := 0#11) (sig := 0#52)
+#guard EDyadic.pack (e := 11) (s := 52) (.infinity false) =
+  PackedFloat.mk (sign := false) (ex := BitVec.allOnes 11) (sig := 0#52)
+#guard EDyadic.pack (e := 11) (s := 52) (.infinity true) =
+  PackedFloat.mk (sign := true) (ex := BitVec.allOnes 11) (sig := 0#52)
+
+/-- Smallest positive representable double (subnormal `2^(-1074)`). -/
+def smallestPositiveSubnormal : PackedFloat 11 52 :=
+  PackedFloat.mk (sign := false) (ex := 0#11) (sig := 1#52)
+
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic smallestPositiveSubnormal) =
+  smallestPositiveSubnormal
+
+/-- The negative counterpart: `-2^(-1074)`. -/
+def smallestNegativeSubnormal : PackedFloat 11 52 :=
+  PackedFloat.mk (sign := true) (ex := 0#11) (sig := 1#52)
+
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic smallestNegativeSubnormal) =
+  smallestNegativeSubnormal
+
+/-- A larger subnormal with several bits set in the significand. -/
+def someSubnormal : PackedFloat 11 52 :=
+  PackedFloat.mk (sign := false) (ex := 0#11) (sig := 7#52)
+
+#guard EDyadic.pack (e := 11) (s := 52) (toEDyadic someSubnormal) = someSubnormal
+
+/-- The packed value `1.0` in `(e, s) = (5, 10)`: bias `15`, biased exponent `15`. -/
+def oneHalfPrec : PackedFloat 5 10 :=
+  PackedFloat.mk (sign := false) (ex := 15#5) (sig := 0#10)
+
+#guard EDyadic.pack (e := 5) (s := 10) (toEDyadic oneHalfPrec) = oneHalfPrec
+
+/-- Smallest positive subnormal in `(5, 10)`: `2^(-24)`. -/
+def smallestPositiveSubnormalHalf : PackedFloat 5 10 :=
+  PackedFloat.mk (sign := false) (ex := 0#5) (sig := 1#10)
+
+#guard EDyadic.pack (e := 5) (s := 10) (toEDyadic smallestPositiveSubnormalHalf) =
+  smallestPositiveSubnormalHalf
+
+/-- Largest finite normal in `(5, 10)`: biased exponent `30`, all significand bits set. -/
+def largestNormalHalf : PackedFloat 5 10 :=
+  PackedFloat.mk (sign := false) (ex := 30#5) (sig := BitVec.allOnes 10)
+
+#guard EDyadic.pack (e := 5) (s := 10) (toEDyadic largestNormalHalf) = largestNormalHalf
+
+end UnitTest.Fp.EDyadic.Pack

--- a/Veir/Data/FP/EDyadic.lean
+++ b/Veir/Data/FP/EDyadic.lean
@@ -1,3 +1,4 @@
 module
 
 public import Veir.Data.FP.EDyadic.Basic
+public import Veir.Data.FP.EDyadic.Pack

--- a/Veir/Data/FP/EDyadic/Pack.lean
+++ b/Veir/Data/FP/EDyadic/Pack.lean
@@ -27,13 +27,13 @@ def packOfOdd (e s : Nat) (n k : Int) : PackedFloat e s :=
     -- Mask out the implicit hidden bit to obtain the stored trailing
     -- significand (equivalent to `alignedSig - 2^s` since bit `s` is set).
     let trailingSig : Nat := alignedSig &&& trailingSigMask s
-    PackedFloat.mkNumber sign (BitVec.ofInt e biasedEx) (BitVec.ofNat s trailingSig)
+    PackedFloat.mk sign (BitVec.ofInt e biasedEx) (BitVec.ofNat s trailingSig)
   else if biasedEx ≤ 0 then
     -- Subnormal range. Stored exponent is zero; shift `|n|` into the
     -- subnormal grid so its value matches `|n| * 2^(-k)` at the scale
     -- `2^(-bias - s + 1)`.
     let subnormalSig : Nat := n.natAbs <<< (subnormalSigShift e s k).toNat
-    PackedFloat.mkNumber sign 0#e (BitVec.ofNat s subnormalSig)
+    PackedFloat.mk sign 0#e (BitVec.ofNat s subnormalSig)
   else
     -- Overflow: biased exponent exceeds `maxBiasedExponent`; saturate.
     PackedFloat.mkInfinity e s sign

--- a/Veir/Data/FP/EDyadic/Pack.lean
+++ b/Veir/Data/FP/EDyadic/Pack.lean
@@ -1,0 +1,50 @@
+module
+
+public import Veir.Data.FP.FloatFormat
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.ToExtRat
+public import Veir.Data.FP.EDyadic.Basic
+
+namespace Veir.Data.FP.EDyadic
+
+public section
+
+open FloatFormat (biasedExp normalSigShift subnormalSigShift trailingSigMask
+  minBiasedExponent maxBiasedExponent)
+
+/-- Pack a nonzero dyadic `(-1)^sign * |n| * 2^(-k)` (with `n` odd) into a `PackedFloat e s`. -/
+def packOfOdd (e s : Nat) (n k : Int) : PackedFloat e s :=
+  -- Sign extracted from the integer numerator.
+  let sign : Bool := decide (n < 0)
+  -- Biased exponent of the value in the target format.
+  let biasedEx : Int := biasedExp e n k
+  -- Boundary between normal and overflow regimes.
+  let maxEx : Int := (maxBiasedExponent e : Int)
+  if (minBiasedExponent : Int) ≤ biasedEx ∧ biasedEx ≤ maxEx then
+    -- Normal range. Align `|n|` so its leading bit lands at position `s`,
+    -- giving the full significand (with hidden bit) in `[2^s, 2^(s+1))`.
+    let alignedSig : Nat := n.natAbs <<< normalSigShift s n
+    -- Mask out the implicit hidden bit to obtain the stored trailing
+    -- significand (equivalent to `alignedSig - 2^s` since bit `s` is set).
+    let trailingSig : Nat := alignedSig &&& trailingSigMask s
+    PackedFloat.mkNumber sign (BitVec.ofInt e biasedEx) (BitVec.ofNat s trailingSig)
+  else if biasedEx ≤ 0 then
+    -- Subnormal range. Stored exponent is zero; shift `|n|` into the
+    -- subnormal grid so its value matches `|n| * 2^(-k)` at the scale
+    -- `2^(-bias - s + 1)`.
+    let subnormalSig : Nat := n.natAbs <<< (subnormalSigShift e s k).toNat
+    PackedFloat.mkNumber sign 0#e (BitVec.ofNat s subnormalSig)
+  else
+    -- Overflow: biased exponent exceeds `maxBiasedExponent`; saturate.
+    PackedFloat.mkInfinity e s sign
+
+/-- Pack an `EDyadic` value into a `PackedFloat e s`; `∀ (x : PackedFloat e s), pack (toEDyadic x) = x` on representable `x`. -/
+def pack (e s : Nat) : EDyadic → PackedFloat e s
+  | .nan => PackedFloat.mkNaN e s
+  | .infinity sign => PackedFloat.mkInfinity e s sign
+  | .zero sign => PackedFloat.mkZero e s sign
+  | .nonzeroFinite (.ofOdd n k _) _ => packOfOdd e s n k
+
+end
+
+end Veir.Data.FP.EDyadic

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -28,7 +28,7 @@ https://standards.ieee.org/ieee/754/6210/):
 - biased exponent `allOnes` with zero significand → signed `Infinity`
 - biased exponent `0` with zero significand → `Number 0` (sign discarded)
 - biased exponent `0` with non-zero significand → subnormal:
-  `(-1)^sign * 2^(1 - bias) * (sig / 2^s)`
+  `(-1)^sign * 2^(-bias + 1) * (sig / 2^s)`
 - otherwise normal:
   `(-1)^sign * 2^(ex - bias) * (1 + sig / 2^s)`
 -/
@@ -39,7 +39,7 @@ def toExtRat {e s : Nat} (pf : PackedFloat e s) : ExtRat :=
   else if pf.ex = 0#e then
     if pf.sig = 0#s then .number 0
     else
-      .number (signToInt pf.sign * Rat.twoPow (1 - (bias e : Int)) * sigFrac pf.sig)
+      .number (signToInt pf.sign * Rat.twoPow (-(bias e : Int) + 1) * sigFrac pf.sig)
   else
     .number (signToInt pf.sign *
       Rat.twoPow ((pf.ex.toNat : Int) - (bias e : Int)) * (1 + sigFrac pf.sig))


### PR DESCRIPTION
First in a stack of PRs splitting the rounding work. This PR introduces only `EDyadic.pack`.

- `EDyadic.packOfOdd e s n k` packs EDyadic numbers into `PackedFloat`.
- `EDyadic.pack`: top-level, dispatches NaN / ±∞ / ±0 / `nonzeroFinite`.
