### PR TITLE
refactor(EDyadic): enforce d ≠ 0 invariant in nonzeroFinite [1/x]

### DIFF
--- a/Veir/Data/FP/EDyadic/Basic.lean
+++ b/Veir/Data/FP/EDyadic/Basic.lean
@@ -14,13 +14,10 @@ inductive EDyadic where
   /-- A zero with a sign bit. -/
   | zero (sign : Bool)
   /-- A nonzero finite number in dyadic notation.
-  While dyadics can be zero, we use the `zero` constructor to
-  represent zero values (so the sign is represent),
-  and we use `nonzeroFinite` to represent nonzero values.
-  Thus, there is an implicit invariant that the `nonzeroFinite`
-  constructor should only be used with nonzero dyadics.
+  The proof `hne : d ≠ 0` enforces that `nonzeroFinite` is never used to
+  represent zero: signed zeros live in the `zero` constructor.
   -/
-  | nonzeroFinite (d : Dyadic)
+  | nonzeroFinite (d : Dyadic) (hne : d ≠ 0)
   /-- An infinite number with a sign bit. -/
   | infinity (sign : Bool)
   /-- A NaN (not a number). -/
@@ -28,11 +25,25 @@ inductive EDyadic where
   deriving Inhabited, DecidableEq
 
 instance : Repr EDyadic where
-  reprPrec 
+  reprPrec
     | .zero sign,  _ => s!"EDyadic.zero {sign}"
-    | .nonzeroFinite d,  _ => s!"EDyadic.finite {repr d.toRat}"
+    | .nonzeroFinite d _,  _ => s!"EDyadic.finite {repr d.toRat}"
     | .infinity sign, _ => s!"EDyadic.infinity {sign}"
     | .nan, _ => "EDyadic.nan"
+
+namespace EDyadic
+
+/--
+Smart constructor that maps an arbitrary `Dyadic` into an `EDyadic`,
+collapsing the `Dyadic.zero` case to `EDyadic.zero sign`. For nonzero
+dyadics, the result is `.nonzeroFinite d _`, with the `d ≠ 0` proof
+discharged automatically.
+-/
+def ofDyadic (sign : Bool) : Dyadic → EDyadic
+  | .zero => .zero sign
+  | .ofOdd n k hn => .nonzeroFinite (.ofOdd n k hn) Dyadic.of_ne_zero
+
+end EDyadic
 
 end -- public section
 

--- a/Veir/Data/FP/EDyadic/ToExtRat.lean
+++ b/Veir/Data/FP/EDyadic/ToExtRat.lean
@@ -18,7 +18,7 @@ Everywhere else, the function is injective.
 -/
 def toExtRat : EDyadic → ExtRat
   | .zero _ => .number 0
-  | .nonzeroFinite d => .number d.toRat
+  | .nonzeroFinite d _ => .number d.toRat
   | .infinity sign => .infinity sign
   | .nan => .nan
 

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -28,7 +28,8 @@ def toEDyadic {e s : Nat} (pf : PackedFloat e s) : EDyadic :=
   else if pf.state = .zero then .zero pf.sign
   else
     -- normal, subnormal.
-    .nonzeroFinite (Dyadic.ofIntWithPrec (signToInt pf.sign * sig) prec)
+    EDyadic.ofDyadic pf.sign
+      (Dyadic.ofIntWithPrec (signToInt pf.sign * sig) prec)
   where
     sig := pf.sig.toNat  + 2 ^ s * (decide (pf.state = .normal)).toNat
     prec := (bias e : Int) + (s : Int) - (Nat.max pf.ex.toNat 1)


### PR DESCRIPTION
This PR makes `EDyadic.nonzeroFinite` carry a proof `hne : d ≠ 0`, lifting the no-zero invariant to the type level. This enforces that signed zeros live in `zero`, `nonzeroFinite` can no longer wrap `Dyadic.zero`. This makes many of the definitions in rounding be way clearer, as they can now manipulate a `Dyadic` while ruling out the zero case statically.