### PR TITLE
Add `simp_getset` tactic for `WfIRContext`

### DIFF
--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.Rewriter.WfRewriter.Basic
 public import Veir.Rewriter.GetSet
+public import Veir.Rewriter.WfRewriter.GetSetTactic
 
 import all Veir.Rewriter.WfRewriter.Basic
 
@@ -56,28 +57,28 @@ BlockPtr.firstUse!_WfRewriter_createOp is too complex to be expressed, and shoul
 in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.prev!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     (block.get! ctx'.raw).prev = (block.get! ctx.raw).prev := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.next!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     (block.get! ctx'.raw).next = (block.get! ctx.raw).next := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.parent!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     (block.get! ctx'.raw).parent = (block.get! ctx.raw).parent := by
   grind
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem BlockPtr.firstOp!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -90,7 +91,7 @@ theorem BlockPtr.firstOp!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem BlockPtr.lastOp!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -103,7 +104,7 @@ theorem BlockPtr.lastOp!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.prev!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -118,7 +119,7 @@ theorem OperationPtr.prev!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.next!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -133,7 +134,7 @@ theorem OperationPtr.next!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20) (splits := 20) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.parent!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -146,7 +147,7 @@ theorem OperationPtr.parent!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20) [cases InsertPoint, Operation.empty]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getOpType!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -155,7 +156,7 @@ theorem OperationPtr.getOpType!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.attrs!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -164,7 +165,7 @@ theorem OperationPtr.attrs!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getProperties!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -173,7 +174,7 @@ theorem OperationPtr.getProperties!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumResults!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -182,7 +183,7 @@ theorem OperationPtr.getNumResults!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumOperands!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -191,7 +192,7 @@ theorem OperationPtr.getNumOperands!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getOperand!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -202,7 +203,7 @@ theorem OperationPtr.getOperand!_WfRewriter_createOp :
   -- lemma for `getOperands!` instead.
   grind (gen := 20) [=_ getOperands!.getElem!_eq_getOperand!]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getOperands!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -211,7 +212,7 @@ theorem OperationPtr.getOperands!_WfRewriter_createOp :
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumSuccessors!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -219,7 +220,7 @@ theorem OperationPtr.getNumSuccessors!_WfRewriter_createOp :
     if operation = newOp then blockOperands.size else operation.getNumSuccessors! ctx.raw := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getSuccessor!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -227,7 +228,7 @@ theorem OperationPtr.getSuccessor!_WfRewriter_createOp :
     if operation = newOp then blockOperands[index]! else operation.getSuccessor! ctx.raw index := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getSuccessors!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -236,7 +237,7 @@ theorem OperationPtr.getSuccessors!_WfRewriter_createOp :
   grind (gen := 20)
 
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumRegions!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -244,7 +245,7 @@ theorem OperationPtr.getNumRegions!_WfRewriter_createOp :
     if operation = newOp then regions.size else operation.getNumRegions! ctx.raw := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getRegion!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -253,28 +254,28 @@ theorem OperationPtr.getRegion!_WfRewriter_createOp :
     else operation.getRegion! ctx.raw idx := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.getNumArguments!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     block.getNumArguments! ctx'.raw = block.getNumArguments! ctx.raw := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.firstBlock!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     (region.get! ctx'.raw).firstBlock = (region.get! ctx.raw).firstBlock := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.lastBlock!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     (region.get! ctx'.raw).lastBlock = (region.get! ctx.raw).lastBlock := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.parent!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -282,7 +283,7 @@ theorem RegionPtr.parent!_WfRewriter_createOp :
     if region ∈ regions then some newOp else (region.get! ctx.raw).parent := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem ValuePtr.getType!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
@@ -295,7 +296,7 @@ theorem ValuePtr.getType!_WfRewriter_createOp :
     | .blockArgument _ => value.getType! ctx.raw := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getResultTypes!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →

--- a/Veir/Rewriter/WfRewriter/GetSetTactic.lean
+++ b/Veir/Rewriter/WfRewriter/GetSetTactic.lean
@@ -1,0 +1,119 @@
+module
+
+public import Lean
+
+public section
+
+/-!
+# `@[simp_getset]` attribute and `simp_getset` tactics
+
+This module defines the `simp_getset` and `simp_getset?` tactics, which tries to apply all
+`@[simp_getset]`-tagged theorems. These theorems are equalities with a single explicit argument
+of the form `f ... = ...`. The tactic then looks for hypotheses matching this shape, and
+applies the theorems with these hypothesese passed as arguments.
+-/
+
+namespace Veir
+
+open Lean Meta
+
+/-!
+## `@[simp_getset]` attribute
+-/
+
+/-- State of the `simp_getset` attribute: a map from a head constant
+    to the array of theorem names tagged with `@[simp_getset]`
+    that have that constant as the head of the LHS of their first explicit
+    hypothesis. -/
+abbrev SimpGetSetState := Std.HashMap Name (Array Name)
+
+/-- Add a theorem to the `headFun` entry. -/
+private meta def SimpGetSetState.add (s : SimpGetSetState) (headFun th : Name) : SimpGetSetState :=
+  s.insert headFun ((s.get? headFun |>.getD #[]).push th)
+
+/-- A persistent environment variable that holds a `SimpGetSetState`. -/
+public meta initialize simpGetSetExt :
+    SimplePersistentEnvExtension (Name × Name) SimpGetSetState ←
+  registerSimplePersistentEnvExtension {
+    name          := `simpGetSetExt
+    addImportedFn := fun ass => ass.foldl (init := {}) fun s as =>
+      as.foldl (init := s) fun s (target, th) => s.add target th
+    addEntryFn    := fun s (target, th) => s.add target th
+  }
+
+/-- Infer the target head function of a `@[simp_getset]` theorem: take its first explicit
+    argument, require it to be an equality, and return the head constant of the LHS. -/
+private meta def inferWfGetSetTarget (declName : Name) : MetaM Name := do
+  let info ← getConstInfo declName
+  forallTelescopeReducing info.type fun xs _ => do
+    for x in xs do
+      let ldecl ← x.fvarId!.getDecl
+      unless ldecl.binderInfo.isExplicit do continue
+      let some (_, lhs, _) := (← whnf ldecl.type).eq?
+        | throwError "@[simp_getset]: first explicit argument must be an equality"
+      let some head := lhs.getAppFn.constName?
+        | throwError
+          "@[simp_getset]: LHS of the first explicit argument must be an constant application"
+      return head
+    throwError "@[simp_getset]: theorem has no explicit argument"
+
+/-- Register the `@[simp_getset]` attribute. -/
+meta initialize registerBuiltinAttribute {
+  name  := `simp_getset
+  descr := "Get-set theorem; used by the `simp_getset` tactic. The theorem must take a \
+            `f ... = _` hypothesis as its first explicit argument, and the theorem \
+            conclusion must be an equality."
+  applicationTime := .afterCompilation
+  add   := fun decl _stx kind => do
+    unless kind == .global do
+      throwError "@[simp_getset] only supports the global attribute kind"
+    let target ← MetaM.run' (inferWfGetSetTarget decl)
+    setEnv (simpGetSetExt.addEntry (← getEnv) (target, decl))
+}
+
+/-!
+## `simp_getset` tactics
+-/
+
+/-- Collect simp lemma arguments for the `simp_getset` family of tactics: for every
+    hypothesis `h : f ... = _` in the local context where `f` is the head constant
+    of some `@[simp_getset]`-tagged theorem, produce one `lem h` simp argument per
+    matching theorem `lem`. -/
+private meta def collectSimpGetSetArgs :
+    Elab.Tactic.TacticM (Array (TSyntax `Lean.Parser.Tactic.simpLemma)) := do
+  let state := simpGetSetExt.getState (← getEnv)
+  let mut simpArgs : Array (TSyntax `Lean.Parser.Tactic.simpLemma) := #[]
+  for ldecl in ← getLCtx do
+    let some (_, lhs, _) := ldecl.type.eq? | continue
+    let some head := lhs.getAppFn.constName? | continue
+    let some lemmas := state.get? head | continue
+    let h := mkIdent ldecl.userName
+    for n in lemmas do
+      let lem := mkIdent n
+      simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| $lem:ident $h:ident))
+  return simpArgs
+
+open Elab Tactic in
+/-- For every hypothesis `h : f ... = _` in the local context where `f` is the
+    head constant of some `@[simp_getset]`-tagged theorem, applies all the matching
+    theorems with `h` plugged in via a single `simp only` invocation. -/
+elab "simp_getset" : tactic => withMainContext do
+  let simpArgs ← collectSimpGetSetArgs
+  if simpArgs.isEmpty then
+    logWarning "simp_getset: no hypothesis matching a registered `@[simp_getset]` target found in context"
+    return
+  evalTactic <| ← `(tactic| simp only [$simpArgs,*])
+
+open Elab Tactic in
+/-- For every hypothesis `h : f ... = _` in the local context where `f` is the
+    head constant of some `@[simp_getset]`-tagged theorem, applies all the matching
+    theorems with `h` plugged in via a single `simp only?` invocation. -/
+elab "simp_getset?" : tactic => withMainContext do
+  let simpArgs ← collectSimpGetSetArgs
+  if simpArgs.isEmpty then
+    logWarning "simp_getset?: no hypothesis matching a registered `@[simp_getset]` target found in context"
+    return
+  evalTactic <| ← `(tactic| simp? only [$simpArgs,*])
+
+
+end Veir


### PR DESCRIPTION
This PR is adding the `simp_getset` tactic that is used to automatically find the get-set lemmas that can be applied in a goal.

The way it works is by first registering a set of lemmas defined by the `@[simp_getset]` annotation. These lemmas are expected to have a single explicit argument, of the form `f ... = ...`. The registration groups these lemmas by the `f` constant.

The tactic goes over all hypotheses, and tries to find all hypotheses of the form `f ... = ...` where `f` is a constant registered by one of the `@[simp_getset]` lemmas. Once all hypotheses are scanned, it adds all the lemmas that were matched, applied to the hypotheses they got matched with, to a `simp only` tactic.

A second version, `simp_getset?`, is also defined, with uses a `simp? only` tactic, so that `[apply]` can be used in the IDE to convert `simp_getset?` to a more efficient `simp only` tactic.

For now, `simp_getset` is only defined for the `WfIRContext` get-set lemmas. We can think of porting it to the `IRContext` get-set lemmas as well.