### PR TITLE
make the veir interpreter report immediate UB explicitly, instead of simply failing

### DIFF
--- a/Test/Interpreter/Arith/divsi.mlir
+++ b/Test/Interpreter/Arith/divsi.mlir
@@ -3,15 +3,13 @@
 "builtin.module"() ({
   %lhs = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
   %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negone = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
   %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "arith.divsi"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "arith.divsi"(%lhs, %zero) : (i32, i32) -> i32
   %z = "arith.divsi"(%lhs, %negone) : (i32, i32) -> i32
   %a = "arith.divsi"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z, %a) : (i32, i32, i32, i32) -> ()
+  "func.return"(%x, %z, %a) : (i32, i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000003#32, poison, 0xfffffff9#32, 0x00000001#32]
+// CHECK: Program output: #[0x00000003#32, 0xfffffff9#32, 0x00000001#32]

--- a/Test/Interpreter/Arith/divsi_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/divsi_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed division with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "arith.divsi"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/divsi_intmin_neg1.mlir
+++ b/Test/Interpreter/Arith/divsi_intmin_neg1.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `divsi intMin, -1` is immediate UB (signed overflow of the quotient).
+"builtin.module"() ({
+  %intmin = "arith.constant"() <{ "value" = -2147483648 : i32 }> : () -> i32
+  %negone = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %y = "arith.divsi"(%intmin, %negone) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/divsi_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/Arith/divsi_poison_dividend_neg1.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `divsi poison, -1` (width > 1) is immediate UB: the poison dividend could
+// refine to intMin, in which case the overflow case applies.
+"builtin.module"() ({
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.divsi"(%poison, %neg1) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/divsi_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/divsi_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed division by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.divsi"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/divui.mlir
+++ b/Test/Interpreter/Arith/divui.mlir
@@ -3,13 +3,11 @@
 "builtin.module"() ({
   %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
   %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "arith.divui"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "arith.divui"(%lhs, %zero) : (i32, i32) -> i32
   %a = "arith.divui"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %a) : (i32, i32, i32) -> ()
+  "func.return"(%x, %a) : (i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x0000002b#32, poison, 0x00000000#32]
+// CHECK: Program output: #[0x0000002b#32, 0x00000000#32]

--- a/Test/Interpreter/Arith/divui_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/divui_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned division with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "arith.divui"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/divui_poison_dividend.mlir
+++ b/Test/Interpreter/Arith/divui_poison_dividend.mlir
@@ -1,0 +1,14 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Regression check: a poison dividend with a concrete safe (nonzero) divisor
+// propagates as poison — NOT immediate UB.
+"builtin.module"() ({
+  %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.divui"(%poison, %five) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison]

--- a/Test/Interpreter/Arith/divui_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/divui_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned division by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.divui"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/remsi.mlir
+++ b/Test/Interpreter/Arith/remsi.mlir
@@ -3,15 +3,13 @@
 "builtin.module"() ({
   %lhs = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
   %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negone = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
   %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "arith.remsi"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "arith.remsi"(%lhs, %zero) : (i32, i32) -> i32
   %z = "arith.remsi"(%lhs, %negone) : (i32, i32) -> i32
   %a = "arith.remsi"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z, %a) : (i32, i32, i32, i32) -> ()
+  "func.return"(%x, %z, %a) : (i32, i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000001#32, poison, 0x00000000#32, 0xffffffff#32]
+// CHECK: Program output: #[0x00000001#32, 0x00000000#32, 0xffffffff#32]

--- a/Test/Interpreter/Arith/remsi_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/remsi_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed remainder with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "arith.remsi"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/remsi_intmin_neg1.mlir
+++ b/Test/Interpreter/Arith/remsi_intmin_neg1.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `remsi intMin, -1` is immediate UB (signed overflow in the implicit division).
+"builtin.module"() ({
+  %intmin = "arith.constant"() <{ "value" = -2147483648 : i32 }> : () -> i32
+  %negone = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %y = "arith.remsi"(%intmin, %negone) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/remsi_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/Arith/remsi_poison_dividend_neg1.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `remsi poison, -1` (width > 1) is immediate UB: the poison dividend could
+// refine to intMin, hitting the overflow case.
+"builtin.module"() ({
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.remsi"(%poison, %neg1) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/remsi_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/remsi_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed remainder by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.remsi"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/remui.mlir
+++ b/Test/Interpreter/Arith/remui.mlir
@@ -3,13 +3,11 @@
 "builtin.module"() ({
   %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
   %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "arith.remui"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "arith.remui"(%lhs, %zero) : (i32, i32) -> i32
   %a = "arith.remui"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %a) : (i32, i32, i32) -> ()
+  "func.return"(%x, %a) : (i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000001#32, poison, 0xfffffffd#32]
+// CHECK: Program output: #[0x00000001#32, 0xfffffffd#32]

--- a/Test/Interpreter/Arith/remui_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/remui_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned remainder with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "arith.remui"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/remui_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/remui_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned remainder by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "arith.remui"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Cf/cond_br_poison.mlir
+++ b/Test/Interpreter/Cf/cond_br_poison.mlir
@@ -1,0 +1,19 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Branching on a poison i1 in the cf dialect is undefined behaviour. The i1
+// poison is produced by `arith.addi nuw` on i1 (1 + 1 overflows unsigned).
+"builtin.module"() ({
+  ^entry():
+    %one    = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
+    %poison = "arith.addi"(%one, %one) <{nuw}> : (i1, i1) -> i1
+    %tval   = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
+    %fval   = "arith.constant"() <{"value" = 99 : i32}> : () -> i32
+    "cf.cond_br"(%poison, %tval, %fval) [^t, ^f]
+      <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+  ^t(%x : i32):
+    "func.return"(%x) : (i32) -> ()
+  ^f(%y : i32):
+    "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/cond_br_poison.mlir
+++ b/Test/Interpreter/LLVM/cond_br_poison.mlir
@@ -1,0 +1,19 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Branching on a poison i1 is undefined behaviour. The i1 poison is produced by
+// `llvm.add nuw` on i1 (1 + 1 overflows unsigned).
+"builtin.module"() ({
+  ^entry():
+    %one    = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
+    %poison = "llvm.add"(%one, %one) <{nuw}> : (i1, i1) -> i1
+    %tval   = "llvm.mlir.constant"() <{"value" = 42 : i32}> : () -> i32
+    %fval   = "llvm.mlir.constant"() <{"value" = 99 : i32}> : () -> i32
+    "llvm.cond_br"(%poison, %tval, %fval) [^t, ^f]
+      <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+  ^t(%x : i32):
+    "llvm.return"(%x) : (i32) -> ()
+  ^f(%y : i32):
+    "llvm.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/cond_br_poison_propagates.mlir
+++ b/Test/Interpreter/LLVM/cond_br_poison_propagates.mlir
@@ -1,0 +1,22 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// UB triggered by a poison cond_br in a non-entry block must propagate up
+// through `interpretBlockCFG`'s recursive call rather than being lost or
+// reported as a malformed-program error.
+"builtin.module"() ({
+  ^entry():
+    "llvm.br"() [^poison_block] : () -> ()
+  ^poison_block():
+    %one    = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
+    %poison = "llvm.add"(%one, %one) <{nuw}> : (i1, i1) -> i1
+    %tval   = "llvm.mlir.constant"() <{"value" = 42 : i32}> : () -> i32
+    %fval   = "llvm.mlir.constant"() <{"value" = 99 : i32}> : () -> i32
+    "llvm.cond_br"(%poison, %tval, %fval) [^t, ^f]
+      <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+  ^t(%x : i32):
+    "llvm.return"(%x) : (i32) -> ()
+  ^f(%y : i32):
+    "llvm.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/sdiv.mlir
+++ b/Test/Interpreter/LLVM/sdiv.mlir
@@ -3,15 +3,13 @@
 "builtin.module"() ({
   %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
   %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negone = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
   %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.sdiv"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "llvm.sdiv"(%lhs, %zero) : (i32, i32) -> i32
   %z = "llvm.sdiv"(%lhs, %negone) : (i32, i32) -> i32
   %a = "llvm.sdiv"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z, %a) : (i32, i32, i32, i32) -> ()
+  "func.return"(%x, %z, %a) : (i32, i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000003#32, poison, 0xfffffff9#32, 0x00000001#32]
+// CHECK: Program output: #[0x00000003#32, 0xfffffff9#32, 0x00000001#32]

--- a/Test/Interpreter/LLVM/sdiv_div_by_zero.mlir
+++ b/Test/Interpreter/LLVM/sdiv_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed division with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "llvm.sdiv"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/sdiv_intmin_neg1.mlir
+++ b/Test/Interpreter/LLVM/sdiv_intmin_neg1.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `sdiv intMin, -1` is immediate UB (signed overflow of the quotient).
+"builtin.module"() ({
+  %intmin = "llvm.mlir.constant"() <{ "value" = -2147483648 : i32 }> : () -> i32
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %y = "llvm.sdiv"(%intmin, %negone) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/sdiv_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/LLVM/sdiv_poison_dividend_neg1.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `sdiv poison, -1` (width > 1) is immediate UB: the poison dividend could
+// refine to intMin, in which case the overflow case applies.
+"builtin.module"() ({
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.sdiv"(%poison, %neg1) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/sdiv_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/sdiv_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed division by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.sdiv"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/srem.mlir
+++ b/Test/Interpreter/LLVM/srem.mlir
@@ -3,15 +3,13 @@
 "builtin.module"() ({
   %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
   %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negone = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
   %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.srem"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "llvm.srem"(%lhs, %zero) : (i32, i32) -> i32
   %z = "llvm.srem"(%lhs, %negone) : (i32, i32) -> i32
   %a = "llvm.srem"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z, %a) : (i32, i32, i32, i32) -> ()
+  "func.return"(%x, %z, %a) : (i32, i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000001#32, poison, 0x00000000#32, 0xffffffff#32]
+// CHECK: Program output: #[0x00000001#32, 0x00000000#32, 0xffffffff#32]

--- a/Test/Interpreter/LLVM/srem_div_by_zero.mlir
+++ b/Test/Interpreter/LLVM/srem_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed remainder with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "llvm.srem"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/srem_intmin_neg1.mlir
+++ b/Test/Interpreter/LLVM/srem_intmin_neg1.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `srem intMin, -1` is immediate UB (signed overflow in the implicit division).
+"builtin.module"() ({
+  %intmin = "llvm.mlir.constant"() <{ "value" = -2147483648 : i32 }> : () -> i32
+  %negone = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %y = "llvm.srem"(%intmin, %negone) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/srem_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/LLVM/srem_poison_dividend_neg1.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `srem poison, -1` (width > 1) is immediate UB: the poison dividend could
+// refine to intMin, hitting the overflow case.
+"builtin.module"() ({
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.srem"(%poison, %neg1) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/srem_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/srem_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed remainder by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.srem"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/udiv.mlir
+++ b/Test/Interpreter/LLVM/udiv.mlir
@@ -3,13 +3,11 @@
 "builtin.module"() ({
   %lhs = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
   %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.udiv"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "llvm.udiv"(%lhs, %zero) : (i32, i32) -> i32
   %a = "llvm.udiv"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %a) : (i32, i32, i32) -> ()
+  "func.return"(%x, %a) : (i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x0000002b#32, poison, 0x00000000#32]
+// CHECK: Program output: #[0x0000002b#32, 0x00000000#32]

--- a/Test/Interpreter/LLVM/udiv_div_by_zero.mlir
+++ b/Test/Interpreter/LLVM/udiv_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned division with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "llvm.udiv"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/udiv_poison_dividend.mlir
+++ b/Test/Interpreter/LLVM/udiv_poison_dividend.mlir
@@ -1,0 +1,14 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Regression check: a poison dividend with a concrete safe (nonzero) divisor
+// propagates as poison — NOT immediate UB.
+"builtin.module"() ({
+  %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.udiv"(%poison, %five) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison]

--- a/Test/Interpreter/LLVM/udiv_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/udiv_poison_divisor.mlir
@@ -1,0 +1,15 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned division by a poison divisor is immediate UB: the poison value
+// could refine to 0, so the operation could be division by zero.
+"builtin.module"() ({
+  %lhs  = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  // -1 + 1 with `nuw` on i32 unsigned-overflows -> poison i32.
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.udiv"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/urem.mlir
+++ b/Test/Interpreter/LLVM/urem.mlir
@@ -3,13 +3,11 @@
 "builtin.module"() ({
   %lhs = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
   %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
   %negthree = "llvm.mlir.constant"() <{ "value" = -3 : i32 }> : () -> i32
   %negtwo = "llvm.mlir.constant"() <{ "value" = -2 : i32 }> : () -> i32
   %x = "llvm.urem"(%lhs, %rhs) : (i32, i32) -> i32
-  %y = "llvm.urem"(%lhs, %zero) : (i32, i32) -> i32
   %a = "llvm.urem"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %y, %a) : (i32, i32, i32) -> ()
+  "func.return"(%x, %a) : (i32, i32) -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000001#32, poison, 0xfffffffd#32]
+// CHECK: Program output: #[0x00000001#32, 0xfffffffd#32]

--- a/Test/Interpreter/LLVM/urem_div_by_zero.mlir
+++ b/Test/Interpreter/LLVM/urem_div_by_zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned remainder with a concrete zero divisor is immediate UB.
+"builtin.module"() ({
+  %lhs = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+  %y = "llvm.urem"(%lhs, %zero) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/urem_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/urem_poison_divisor.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned remainder by a poison divisor is immediate UB.
+"builtin.module"() ({
+  %lhs  = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+  %y = "llvm.urem"(%lhs, %poison) : (i32, i32) -> i32
+  "func.return"(%y) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -125,12 +125,48 @@ inductive ControlFlowAction where
   | return (vals : Array RuntimeValue)
   | branch (vals : Array RuntimeValue) (dest : BlockPtr)
 
+/--
+  Wrapper for interpreter step results: either a successful value `ok` or the
+  program has triggered undefined behaviour (`ub`). UB is a property of the
+  execution, not of any value, so it lives here rather than inside `RuntimeValue`
+  or `LLVM.Int`.
+-/
+inductive UBOr (α : Type) where
+  | ok : α → UBOr α
+  | ub : UBOr α
+deriving Inhabited
+
+/--
+  The interpreter monad. `Option (UBOr α)` has three states:
+  - `some (.ok x)` — successful execution producing `x`.
+  - `some .ub`     — execution triggered undefined behaviour.
+  - `none`         — interpreter could not proceed (malformed IR, unsupported op).
+-/
+def Interp (α : Type) : Type := Option (UBOr α)
+
+instance : Monad Interp where
+  pure x := (some (.ok x) : Option (UBOr _))
+  bind x f := match (x : Option (UBOr _)) with
+    | none => none
+    | some .ub => some .ub
+    | some (.ok a) => f a
+
+instance : MonadLift Option Interp where
+  monadLift
+    | none => none
+    | some v => some (.ok v)
+
+instance : Inhabited (Interp α) := ⟨(none : Option (UBOr α))⟩
+
+/-- Signal undefined behaviour from inside the interpreter monad. -/
+@[inline] def Interp.ub : Interp α := some .ub
+
 def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
-    : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
+    : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
   | .constant => do
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType bw := resType.val
       | none
     return (#[.int bw.bitwidth
@@ -154,22 +190,56 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], none)
+    -- A poison divisor could refine to 0, so it is immediate UB just like a
+    -- concrete-zero divisor.
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], none)
   | .divsi => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else if bw ≠ 1 ∧ v' = -1 then
+        -- Divisor is concretely -1; if the dividend could be intMin, the
+        -- overflow case applies and is UB.
+        match lhs with
+        | .poison => Interp.ub
+        | .val v =>
+          if v = BitVec.intMin bw then Interp.ub
+          else return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
+      else
+        return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
   | .remui => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.urem lhs rhs)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else return (#[.int bw (LLVM.Int.urem lhs rhs)], none)
   | .remsi => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else if bw ≠ 1 ∧ v' = -1 then
+        match lhs with
+        | .poison => Interp.ub
+        | .val v =>
+          if v = BitVec.intMin bw then Interp.ub
+          else return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
+      else
+        return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
   | .shli => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -202,19 +272,19 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     return (#[.int bw (LLVM.Int.xor lhs rhs)], none)
   | .trunci => do
     let [.int w val] := operands.toList | none
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth >= w then none else
     return (#[.int resBw.bitwidth (LLVM.Int.trunc val resBw.bitwidth properties.nsw properties.nuw (by omega))], none)
   | .extui => do
     let [.int w val] := operands.toList | none
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth <= w then none else
     return (#[.int resBw.bitwidth (LLVM.Int.zext val resBw.bitwidth properties.nneg (by omega))], none)
   | .extsi => do
     let [.int w val] := operands.toList | none
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth <= w then none else
     return (#[.int resBw.bitwidth (LLVM.Int.sext val resBw.bitwidth (by omega))], none)
@@ -227,10 +297,10 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
 
 def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
-    : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
+    : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
   | .mlir__constant => do
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType bw := resType.val
       | none
     return (#[.int bw.bitwidth (LLVM.Int.constant bw.bitwidth properties.value.value)], none)
@@ -253,22 +323,52 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else if bw ≠ 1 ∧ v' = -1 then
+        match lhs with
+        | .poison => Interp.ub
+        | .val v =>
+          if v = BitVec.intMin bw then Interp.ub
+          else return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
+      else
+        return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
   | .udiv => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], none)
   | .srem => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else if bw ≠ 1 ∧ v' = -1 then
+        match lhs with
+        | .poison => Interp.ub
+        | .val v =>
+          if v = BitVec.intMin bw then Interp.ub
+          else return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
+      else
+        return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
   | .urem => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.urem lhs rhs)], none)
+    match rhs with
+    | .poison => Interp.ub
+    | .val v' =>
+      if v' = 0 then Interp.ub
+      else return (#[.int bw (LLVM.Int.urem lhs rhs)], none)
   | .shl => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -301,19 +401,19 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     return (#[.int bw (LLVM.Int.xor lhs rhs)], none)
   | .trunc => do
     let [.int w val] := operands.toList | none
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth >= w then none else
     return (#[.int resBw.bitwidth (LLVM.Int.trunc val resBw.bitwidth properties.nsw properties.nuw (by omega))], none)
   | .zext => do
     let [.int w val] := operands.toList | none
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth <= w then none else
     return (#[.int resBw.bitwidth (LLVM.Int.zext val resBw.bitwidth properties.nneg (by omega))], none)
   | .sext => do
     let [.int w val] := operands.toList | none
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth <= w then none else
     return (#[.int resBw.bitwidth (LLVM.Int.sext val resBw.bitwidth (by omega))], none)
@@ -330,18 +430,22 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     return (#[], some (.branch operands dest))
   | .cond_br => do
     let [destTrue, destFalse] := blockOperands.toList | none
-    let some (RuntimeValue.int 1 (.val cond)) := operands[0]? | none
-    let some trueSize := properties.operandSegmentSizes.values[1]? | none
-    let trueSize := trueSize.toNat
-    if cond = 1#1 then
-      return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
-    else
-      return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
+    let some condVal := operands[0]? | none
+    let some (trueSizeInt : Int) := properties.operandSegmentSizes.values[1]? | none
+    let trueSize := trueSizeInt.toNat
+    match condVal with
+    | .int 1 (.val cond) =>
+      if cond = 1#1 then
+        return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
+      else
+        return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
+    | .int 1 .poison => Interp.ub
+    | _ => none
   | _ => none
 
 def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasDialectOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
-    : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
+    : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
   | .li => do
     let imm := BitVec.ofInt 64 properties.value.value
@@ -656,20 +760,24 @@ def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasDialectOpInfo.prop
 
 def Cf.interpretOp' (opType : Veir.Cf) (properties : HasDialectOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
-    : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
+    : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
   | .br => do
     let [dest] := blockOperands.toList | none
     return (#[], some (.branch operands dest))
   | .cond_br => do
     let [destTrue, destFalse] := blockOperands.toList | none
-    let some (RuntimeValue.int 1 (.val cond)) := operands[0]? | none
-    let some trueSize := properties.operandSegmentSizes.values[1]? | none
-    let trueSize := trueSize.toNat
-    if cond = 1#1 then
-      return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
-    else
-      return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
+    let some condVal := operands[0]? | none
+    let some (trueSizeInt : Int) := properties.operandSegmentSizes.values[1]? | none
+    let trueSize := trueSizeInt.toNat
+    match condVal with
+    | .int 1 (.val cond) =>
+      if cond = 1#1 then
+        return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
+      else
+        return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
+    | .int 1 .poison => Interp.ub
+    | _ => none
 
 /--
   Interpret a single operation given its opcode, type-dependent properties,
@@ -681,7 +789,7 @@ def Cf.interpretOp' (opType : Veir.Cf) (properties : HasDialectOpInfo.properties
 -/
 def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
-    : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
+    : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
   | .arith arithOp => do
     Arith.interpretOp' arithOp properties resultTypes operands blockOperands
@@ -694,7 +802,7 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
   | .func .return => do
     return (#[], some (.return operands))
   | .builtin .unrealized_conversion_cast => do
-    let resType ← resultTypes[0]?
+    let some resType := resultTypes[0]? | none
     match resType.val, operands.toList with
     | .registerType _, [.int _bw val] =>
       return (#[.reg (LLVM.Int.toReg val )], none)
@@ -712,8 +820,8 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
   return `none`.
 -/
 def interpretOp (ctx : IRContext OpCode) (op : OperationPtr) (state : InterpreterState)
-    : Option (InterpreterState × Option ControlFlowAction) := do
-  let operands ← state.getOperandValues ctx op
+    : Interp (InterpreterState × Option ControlFlowAction) := do
+  let some operands := state.getOperandValues ctx op | none
   let opType := op.getOpType! ctx
   let (resultValues, action) ← interpretOp' opType (op.getProperties! ctx opType) (op.getResultTypes! ctx) operands (op.getSuccessors! ctx)
   let newState := state.setResultValues ctx op resultValues
@@ -728,7 +836,7 @@ def interpretOp (ctx : IRContext OpCode) (op : OperationPtr) (state : Interprete
 -/
 def interpretOpList (ctx : IRContext OpCode) (op : OperationPtr) (state : InterpreterState)
     (opInBounds : op.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind)
-    : Option ControlFlowAction := do
+    : Interp ControlFlowAction := do
   let (state, action) ← interpretOp ctx op state
   match action with
   | none =>
@@ -744,7 +852,7 @@ decreasing_by grind
   Return a ControlFlowAction indicating how to continue the interpretation.
   Return `none` if any errors occur during interpretation.
 -/
-def interpretBlock (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : InterpreterState) (blockInBounds : blockPtr.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Option ControlFlowAction := do
+def interpretBlock (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : InterpreterState) (blockInBounds : blockPtr.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Interp ControlFlowAction := do
   let block := blockPtr.get ctx (by grind)
   rlet firstOp ← (blockPtr.get ctx).firstOp
   interpretOpList ctx firstOp state
@@ -754,13 +862,14 @@ def interpretBlock (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : Inter
   Return the values eventually returned, if any.
   Return `none` if any errors occur during interpretation.
 -/
-def interpretBlockCFG (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : InterpreterState) (blockInBounds : blockPtr.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Option (Array RuntimeValue) := do
+def interpretBlockCFG (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : InterpreterState) (blockInBounds : blockPtr.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Interp (Array RuntimeValue) := do
   match interpretBlock ctx blockPtr state blockInBounds wf with
-  | some (.return res) => some res
-  | some (.branch res succ) =>
+  | some (.ok (.return res)) => some (.ok res)
+  | some (.ok (.branch res succ)) =>
     if h : succ.InBounds ctx then
       let state := state.setArgumentValues ctx succ res
       interpretBlockCFG ctx succ state h wf else none
+  | some .ub => Interp.ub
   | none => none
 partial_fixpoint
 
@@ -768,7 +877,7 @@ partial_fixpoint
   Interpret a region, starting from its first block.
   Return the values eventually returned, or `none` if any errors occur during interpretation.
 -/
-def interpretRegion (ctx : IRContext OpCode) (region : RegionPtr) (state : InterpreterState) (regionIn : region.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Option (Array RuntimeValue) := do
+def interpretRegion (ctx : IRContext OpCode) (region : RegionPtr) (state : InterpreterState) (regionIn : region.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Interp (Array RuntimeValue) := do
   rlet block ← (region.get ctx).firstBlock
   interpretBlockCFG ctx block state
 
@@ -779,7 +888,7 @@ def interpretRegion (ctx : IRContext OpCode) (region : RegionPtr) (state : Inter
 -/
 def interpretModule (ctx : IRContext OpCode) (op : OperationPtr)
     (opIn : op.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind)
-    : Option (Array RuntimeValue) := do
+    : Interp (Array RuntimeValue) := do
   if h: op.getNumRegions ctx ≠ 1 then
     none
   else

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -30,11 +30,11 @@ equivalent to saying that the results of interpreting `op` on the given `state` 
 -/
 def InterpreterState.EquationHolds (state : InterpreterState) (ctx : WfIRContext OpCode)
     (op : OperationPtr) : Prop :=
-  ∃ controlFlow, interpretOp ctx op state = some (state, controlFlow)
+  ∃ controlFlow, interpretOp ctx op state = some (.ok (state, controlFlow))
 
 theorem interpretOp_equationHolds_self
     {ctx : WfIRContext OpCode} (ctxDom : ctx.Dom) :
-    interpretOp ctx op state = some (state', controlFlow) →
+    interpretOp ctx op state = some (.ok (state', controlFlow)) →
     state'.EquationHolds ctx op := by
   simp only [InterpreterState.EquationHolds]
   intro hInterp
@@ -44,7 +44,7 @@ theorem interpretOp_equationHolds_self
 
 theorem interpretOp_equationHolds_other
     {ctx : WfIRContext OpCode} (ctxDom : ctx.Dom) :
-    interpretOp ctx op₁ state = some (state', cf₁) →
+    interpretOp ctx op₁ state = some (.ok (state', cf₁)) →
     op₂.dominates op₁ ctx →
     state.EquationHolds ctx op₂ →
     state'.EquationHolds ctx op₂ := by
@@ -55,10 +55,9 @@ theorem interpretOp_equationHolds_other
   have ⟨operandValues₁, resValues₁, hOperandValues₁, hInterp₁', hResValues₁⟩ := interpretOp_some_iff.mp hInterp₁
   have ⟨operandValues₂, resValues₂, hOperandValues₂, hInterp₂', hResValues₂⟩ := interpretOp_some_iff.mp hInterp₂
   subst state'
-  simp only [interpretOp, bind, Option.bind, Option.pure_def]
+  simp only [interpretOp, bind, pure]
   simp only [InterpreterState.getOperandValues_setResultValues_of_dominates ctxDom hDom]
   simp only [hOperandValues₂, hInterp₂']
-  simp only [Option.some.injEq, Prod.mk.injEq, and_true]
   by_cases hOp : op₁ = op₂
   · grind
   · simp [InterpreterState.setResultValues_comm hOp, ←hResValues₂]
@@ -82,7 +81,7 @@ def InterpreterState.EquationLemmaAt (state : InterpreterState) (ctx : WfIRConte
 theorem interpretOp_equationLemmaAt (ctxDom : ctx.Dom)
     (stateWf : state.EquationLemmaAt ctx (InsertPoint.before op) opInBounds)
     (opHasParent : (op.get! ctx.raw).parent = some block) :
-    interpretOp ctx op state = some (state', controlFlow) →
+    interpretOp ctx op state = some (.ok (state', controlFlow)) →
     state'.EquationLemmaAt ctx (InsertPoint.after op ctx.raw block) := by
   intro hInterp
   simp only [InterpreterState.EquationLemmaAt] at stateWf ⊢

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -56,14 +56,19 @@ theorem InterpreterState.getVar?_setResultValues_of_value_inBounds
   cases value <;> grind
 
 theorem interpretOp_some_iff :
-  interpretOp ctx op state = some (state', cf) ↔
+  interpretOp ctx op state = some (.ok (state', cf)) ↔
   ∃ operandValues resValues,
     (state.getOperandValues ctx op) = some operandValues ∧
     interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
-      (op.getResultTypes! ctx) operandValues (op.getSuccessors! ctx) = some (resValues, cf) ∧
+      (op.getResultTypes! ctx) operandValues (op.getSuccessors! ctx) = some (.ok (resValues, cf)) ∧
     state' = state.setResultValues ctx op resValues := by
-  simp only [interpretOp, bind, Option.bind]
-  grind
+  simp only [interpretOp, bind, pure]
+  rcases hOps : state.getOperandValues ctx op with _ | operands
+  · grind
+  rcases hOp : interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
+      (op.getResultTypes! ctx) operands (op.getSuccessors! ctx) with _ | u
+  · grind
+  cases u <;> grind
 
 theorem InterpreterState.getOperandValues_eq_of_getVar?_eq {ctx : IRContext OpInfo} :
     (∀ val, val ∈ op.getOperands! ctx → state.getVar? val = state'.getVar? val) →

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -38,7 +38,8 @@ def main (args : List String) : IO Unit := do
       match ctx.verify with
       | .ok _ =>
         match interpretModule ctx op (by sorry) (by sorry) with
-        | some results => IO.println s!"Program output: {results}"
+        | some (.ok results) => IO.println s!"Program output: {results}"
+        | some .ub => IO.println "Undefined behavior"
         | none => IO.eprintln "Error while interpreting module"
       | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
     | .error errMsg =>


### PR DESCRIPTION
sorry, this is a big patch. and surely the details here have implications for our proof strategy that I don't foresee or understand. but, I'm pretty sure the new behavior as indicated by the test cases is solid. 