### PR TITLE
Prove OperationPtr.setAttributes_WellFormed for sorry in parseOptionalOp

### DIFF
--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -357,7 +357,6 @@ def parseEntryBlockLabel (ip : BlockInsertPoint) : MlirParserM BlockPtr := do
     let block ← defineBlock ByteArray.empty ip
     return block
 
-set_option warn.sorry false in
 mutual
 
 /--
@@ -404,7 +403,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
       let ⟨hop⟩ ← liftExcept (checkOpInBounds op ctx')
       let ctx'' := op.setAttributes ctx' attrs hop
       /- Update the parser context. -/
-      pure ⟨op, ⟨ctx'', by sorry⟩⟩
+      pure ⟨op, ⟨ctx'', by grind [Rewriter.createOp_WellFormed, OperationPtr.setAttributes_WellFormed]⟩⟩
 
   let ctx ← getContext
   for index in 0...(op.getNumResults! ctx.raw) do

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -198,6 +198,44 @@ theorem Rewriter.detachOpIfAttached_WellFormed (ctx : IRContext OpInfo) (wf : ct
 
 end detachOpIfAttached
 
+section setAttributes
+
+theorem OperationPtr.setAttributes_WellFormed (ctx : IRContext OpInfo) (op : OperationPtr)
+    (hctx : ctx.WellFormed) (hop : op.InBounds ctx) (newAttrs : DictionaryAttr) :
+    (op.setAttributes ctx newAttrs hop).WellFormed := by
+  have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := hctx
+  constructor
+  · grind
+  · intro val hval
+    have ⟨array, harray⟩ := h₂ val (by grind)
+    exists array
+    simp only [Std.ExtHashSet.filter_empty] at harray ⊢
+    apply ValuePtr.DefUse.unchanged harray (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+  · intro blk hblk
+    have ⟨array, harray⟩ := h₃ blk (by grind)
+    exists array
+    simp only [Std.ExtHashSet.filter_empty] at harray ⊢
+    apply BlockPtr.DefUse.unchanged harray (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+  · intro blk hblk
+    have ⟨array, harray⟩ := h₄ blk (by grind)
+    exists array
+    apply BlockPtr.OpChain_unchanged harray (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+  · intro reg hreg
+    have ⟨array, harray⟩ := h₅ reg (by grind)
+    exists array
+    apply RegionPtr.blockChain_unchanged harray (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+  · intro op' hop'
+    have h_wf := h₆ op' (by grind)
+    apply OperationPtr.WellFormed_unchanged h_wf (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+  · intro blk hblk
+    have h_wf := h₇ blk (by grind)
+    apply BlockPtr.WellFormed_unchanged h_wf (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+  · intro reg hreg
+    have h_wf := h₈ reg (by grind)
+    apply RegionPtr.WellFormed_unchanged h_wf (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+
+end setAttributes
+
 theorem Rewriter.detachOperands.loop_wellFormed
     (wf : IRContext.WellFormed ctx missingOperands missingSuccessors)
     (hMissingOperands : ∀ i, i <= index → (OpOperandPtr.mk op i) ∉ missingOperands) :


### PR DESCRIPTION
Proves `OperationPtr.setAttributes_WellFormed` to remove the last `sorry` in the parser. This finally makes our parser `sorry`-less!

```
> lake build Veir.Parser.MlirParser
ℹ [67/67] Built Veir.Parser.MlirParser
info: Veir/Parser/MlirParser.lean:485:0: 'Veir.Parser.parseOp' depends on axioms: [propext, Classical.choice, Quot.sound]
```
(`parseOp` is the entrypoint to the parser used by `VeirOpt` and `VeirInterpret`)