### PR TITLE
Ensure unregistered operations do not lose information

### DIFF
--- a/Test/Parsing/unregistered_ops.mlir
+++ b/Test/Parsing/unregistered_ops.mlir
@@ -1,10 +1,12 @@
 // RUN: veir-opt %s | filecheck %s
 
 "builtin.module"() ({
-    "unregistered.op"() : () -> ()
-    %1 = "unregistered.op"() : () -> !foo.bar
-    %2 = "unregistered.op"() : () -> !foo.bar<baz>
-    // CHECK:     "builtin.unregistered"() : () -> ()
-    // CHECK-NEXT: %{{.*}} = "builtin.unregistered"() : () -> !foo.bar
-    // CHECK-NEXT: %{{.*}} = "builtin.unregistered"() : () -> !foo.bar<baz>
+    "unregistered.op_one"() : () -> ()
+    %1 = "unregistered.op_two"() : () -> !foo.bar
+    %2 = "unregistered.op_three"() : () -> !foo.bar<baz>
+    "unregistered.op_four"() <{foo = 1 : i32}> : () -> ()
+    // CHECK:      "unregistered.op_one"() : () -> ()
+    // CHECK-NEXT: %{{.*}} = "unregistered.op_two"() : () -> !foo.bar
+    // CHECK-NEXT: %{{.*}} = "unregistered.op_three"() : () -> !foo.bar<baz>
+    // CHECK-NEXT: "unregistered.op_four"() <{"foo" = 1 : i32}> : () -> ()
 }) : () -> ()

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -26,6 +26,7 @@ match opCode with
 | .cf op => Cf.propertiesOf op
 | .comb op => Comb.propertiesOf op
 | .hw op => HW.propertiesOf op
+| .builtin .unregistered => UnregisteredProperties
 | _ => Unit
 
 instance : HasDialectOpInfo OpCode where
@@ -112,7 +113,9 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     cases op
     case cond_br => exact (CondBrProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
-  case builtin =>
+  case builtin op =>
+    cases op
+    case unregistered => exact (UnregisteredProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case arith op =>
     cases op
@@ -240,6 +243,8 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr props.predicate)
   | .hw .constant => Id.run do
     (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr props.value)
+  | .builtin .unregistered =>
+    Std.HashMap.ofList props.properties.entries.toList
   | .hw .module => Id.run do
     let dict := Std.HashMap.emptyWithCapacity 4
     let dict := dict.insert "module_type".toUTF8 (.hwModuleType props.module_type)

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -380,6 +380,12 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   let opId := OpCode.fromName opName.toByteArray
 
   let properties ← parseOpProperties opId
+  /- For `builtin.unregistered`, record the original op name in the properties so it can be
+     printed back out. The properties dictionary itself has already been populated by
+     `Properties.fromAttrDict` (see `UnregisteredProperties.fromAttrDict`). -/
+  let properties : propertiesOf opId := match opId, properties with
+    | .builtin .unregistered, props => { props with opName := opName.toByteArray }
+    | _, props => props
   let regions ← parseOpRegions
   let attrs ← parseOpAttributes
   let (inputTypes, outputTypes) ← parseOperationType

--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -184,7 +184,13 @@ partial def printOperation (ctx: IRContext OpCode) (op: OperationPtr) (indent: N
   let opStruct := op.get! ctx
   printIndent indent
   printOpResults ctx op
-  IO.print s!"\"{String.fromUTF8! opStruct.opType.name}\""
+  /- Unregistered operations store their original operation name in the properties. -/
+  let nameBytes : ByteArray :=
+    match opStruct.opType with
+    | .builtin .unregistered =>
+      (op.getProperties! ctx (.builtin .unregistered)).opName
+    | _ => opStruct.opType.name
+  IO.print s!"\"{String.fromUTF8! nameBytes}\""
   printOpOperands ctx op
   printBlockOperands ctx op
   printOpProperties ctx op

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -6,9 +6,26 @@ public import Veir.IR.Simp
 public import Veir.ForLean
 public import Veir.IR.OpInfo
 
+/- This is needed as some properties have ByteArray and require Repr instances -/
+deriving instance Repr for ByteArray
+
 namespace Veir
 
 public section
+
+/--
+  Properties of a `builtin.unregistered` operation. Holds the original (parsed) operation name
+  and the original `<{...}>` properties dictionary so that the operation can be printed back
+  with its source representation preserved.
+-/
+structure UnregisteredProperties where
+  opName : ByteArray
+  properties : DictionaryAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def UnregisteredProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String UnregisteredProperties :=
+  .ok { opName := .empty, properties := DictionaryAttr.fromArray attrDict.toArray }
 
 def getUnitAttr (key : String) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String Bool := do


### PR DESCRIPTION
Previously, unregistered operations were discarding the parsed operation name and properties.

Now, unregistered operations store in their properties the original properties, as well as the parsed operation name.

The parser and printer are now using these properties to pass the original operation information.