### PR TITLE
refactor(FP): introduce Veir.Data.FP.FloatFormat namespace

### DIFF
--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -1,5 +1,6 @@
 module
 
+public import Veir.Data.FP.FloatFormat
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.ScientificBV.Basic
 public import Veir.Data.FP.ExtRat.Basic

--- a/Veir/Data/FP/FloatFormat.lean
+++ b/Veir/Data/FP/FloatFormat.lean
@@ -27,8 +27,6 @@ def maxBiasedExponent (e : Nat) : Nat := 2 ^ e - 2
 #guard maxBiasedExponent 8 = 254
 -- Double precision: `maxBiasedExponent 11 = 2^11 - 2 = 2046`.
 #guard maxBiasedExponent 11 = 2046
-
-
 /--
 The smallest biased exponent representing a normal number: `1`.
 

--- a/Veir/Data/FP/FloatFormat.lean
+++ b/Veir/Data/FP/FloatFormat.lean
@@ -4,29 +4,9 @@ namespace Veir.Data.FP.FloatFormat
 
 public section
 
-/-! # IEEE-754 floating-point format computations
-
-A consolidated namespace for the integer/`BitVec` arithmetic that
-describes an IEEE-754 binary format with `e` exponent bits and `s`
-trailing-significand bits. Eventually this will become a structure
-`FloatFormat` bundling `e` and `s`; for now, each helper takes them
-as explicit arguments.
-
-This module currently exposes only the format constants that exist
-elsewhere in the codebase. Encoding/decoding arithmetic
-(`unbiasedExp`, `biasedExp`, shift helpers, …) will be added here as
-the corresponding callers land.
--/
 
 /--
 The IEEE-754 exponent bias for `e` exponent bits: `bias e = 2^(e-1) - 1`.
-
-A stored biased exponent `ex` encodes the unbiased exponent `ex - bias e`.
-The bias is chosen so the unbiased exponent range is roughly symmetric
-around `0`.
-
-For single precision (`e = 8`),  `bias = 127`.
-For double precision (`e = 11`), `bias = 1023`.
 -/
 def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
 
@@ -35,6 +15,89 @@ def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
 -- Double precision: `bias 11 = 2^10 - 1 = 1023`.
 #guard bias 11 = 1023
 
+/--
+The largest biased exponent representing a finite normal number: `2^e - 2`.
+
+Recall that the all-ones bitpattern of `2^e - 1` is reserved for `±∞` / NaN.
+Hence the largest finite biased exponent is `(2^e - 1) - 1 = 2^e - 2`.
+-/
+def maxBiasedExponent (e : Nat) : Nat := 2 ^ e - 2
+
+-- Single precision: `maxBiasedExponent 8 = 2^8 - 2 = 254`.
+#guard maxBiasedExponent 8 = 254
+-- Double precision: `maxBiasedExponent 11 = 2^11 - 2 = 2046`.
+#guard maxBiasedExponent 11 = 2046
+
+
+/--
+The smallest biased exponent representing a normal number: `1`.
+
+Recall that the biased exponent `0` is reserved for `±0` and subnormals
+The next pattern, `1`, is therefore the smallest exponent used by a normal,
+as well as the exponent value for subnormals.
+-/
+def minBiasedExponent : Nat := 1
+
+-- The minimum is independent of the format width.
+#guard minBiasedExponent = 1
+
+/--
+The mathematical (unbiased) base-2 exponent of `n* 2^(-k)`
+
+This gives us the exponent of `n * 2^(-k) = s * 2^unbiasedExp`,
+where `s ∈ [1, 2)` is the significand after normalizing `n`.
+-/
+def unbiasedExp (n : Int) (k : Int) : Int :=
+  (n.natAbs.log2 : Int) - k
+
+
+/--
+The IEEE-754 biased exponent, corresponding to a given unbiased exponent.
+Obtained by adding the bias to the unbiased exponent.
+-/
+def biasedExp (e : Nat) (n : Int) (k : Int) : Int :=
+  (bias e : Int) + unbiasedExp n k
+
+/--
+Left shift required to `n` such that when interprted as a `s`bit bitvetor,
+the leading `1` is in the `msb` position.
+
+Suppose `n = 3 ~ 00011#5 (i.e. s = 5)`
+Then `n.natAbs.log2 = 1`, and `normalSigShift s n = 5 - 1 = 4`.
+This is because:
+
+     n       <<< normalSigShift s n
+  = 00011#5  <<< 4
+  = 11000#5` [the leading `1` is at the `msb`]
+-/
+def normalSigShift (s : Nat) (n : Int) : Nat :=
+  s - n.natAbs.log2
+
+/--
+Left shift required to align a subnormal number `n * 2^(-k)` to the `s`-bits.
+Nonnegative iff `k ≤ bias e + s - 1` (subnormal representability).
+
+Solving for `sig`:
+  sig * 2^(-bias e - s + 1) = n * 2^(-k)
+  sig = n * 2^(bias e + s - 1 - k)
+  sig = n <<< (bias e + s - 1 - k)
+               subnormal sig shift
+-/
+def subnormalSigShift (e s : Nat) (k : Int) : Int :=
+  (bias e : Int) + (s : Int) - 1 - k
+
+/--
+Bitmask of the low `s` bits: `2^s - 1`.
+
+Used to drop the hidden bit from a fully-aligned significand
+`alignedSig ∈ [2^s, 2^(s+1))`. Since bit `s` is set and all higher bits
+are clear in that range,
+  `alignedSig &&& (2^s - 1) = alignedSig - 2^s`,
+which is exactly the stored `s`-bit trailing significand.
+-/
+def trailingSigMask (s : Nat) : Nat := 2 ^ s - 1
+
 end -- public section
 
 end Veir.Data.FP.FloatFormat
+

--- a/Veir/Data/FP/FloatFormat.lean
+++ b/Veir/Data/FP/FloatFormat.lean
@@ -1,0 +1,40 @@
+module
+
+namespace Veir.Data.FP.FloatFormat
+
+public section
+
+/-! # IEEE-754 floating-point format computations
+
+A consolidated namespace for the integer/`BitVec` arithmetic that
+describes an IEEE-754 binary format with `e` exponent bits and `s`
+trailing-significand bits. Eventually this will become a structure
+`FloatFormat` bundling `e` and `s`; for now, each helper takes them
+as explicit arguments.
+
+This module currently exposes only the format constants that exist
+elsewhere in the codebase. Encoding/decoding arithmetic
+(`unbiasedExp`, `biasedExp`, shift helpers, …) will be added here as
+the corresponding callers land.
+-/
+
+/--
+The IEEE-754 exponent bias for `e` exponent bits: `bias e = 2^(e-1) - 1`.
+
+A stored biased exponent `ex` encodes the unbiased exponent `ex - bias e`.
+The bias is chosen so the unbiased exponent range is roughly symmetric
+around `0`.
+
+For single precision (`e = 8`),  `bias = 127`.
+For double precision (`e = 11`), `bias = 1023`.
+-/
+def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
+
+-- Single precision: `bias 8 = 2^7 - 1 = 127`.
+#guard bias 8 = 127
+-- Double precision: `bias 11 = 2^10 - 1 = 1023`.
+#guard bias 11 = 1023
+
+end -- public section
+
+end Veir.Data.FP.FloatFormat

--- a/Veir/Data/FP/FloatFormat.lean
+++ b/Veir/Data/FP/FloatFormat.lean
@@ -49,8 +49,6 @@ where `s ∈ [1, 2)` is the significand after normalizing `n`.
 -/
 def unbiasedExp (n : Int) (k : Int) : Int :=
   (n.natAbs.log2 : Int) - k
-
-
 /--
 The IEEE-754 biased exponent, corresponding to a given unbiased exponent.
 Obtained by adding the bias to the unbiased exponent.
@@ -59,7 +57,7 @@ def biasedExp (e : Nat) (n : Int) (k : Int) : Int :=
   (bias e : Int) + unbiasedExp n k
 
 /--
-Left shift required to `n` such that when interprted as a `s`bit bitvetor,
+Left shift required to `n` such that when interprted as a `s`bit bitvector,
 the leading `1` is in the `msb` position.
 
 Suppose `n = 3 ~ 00011#5 (i.e. s = 5)`
@@ -97,7 +95,7 @@ which is exactly the stored `s`-bit trailing significand.
 -/
 def trailingSigMask (s : Nat) : Nat := 2 ^ s - 1
 
-end -- public section
+end
 
 end Veir.Data.FP.FloatFormat
 

--- a/Veir/Data/FP/PackedFloat/ToEDyadic.lean
+++ b/Veir/Data/FP/PackedFloat/ToEDyadic.lean
@@ -32,7 +32,7 @@ def toEDyadic {e s : Nat} (pf : PackedFloat e s) : EDyadic :=
       (Dyadic.ofIntWithPrec (signToInt pf.sign * sig) prec)
   where
     sig := pf.sig.toNat  + 2 ^ s * (decide (pf.state = .normal)).toNat
-    prec := (bias e : Int) + (s : Int) - (Nat.max pf.ex.toNat 1)
+    prec := (FloatFormat.bias e : Int) + (s : Int) - (Nat.max pf.ex.toNat 1)
 
 
 end

--- a/Veir/Data/FP/PackedFloat/ToExtRat.lean
+++ b/Veir/Data/FP/PackedFloat/ToExtRat.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Data.FP.ExtRat.Basic
+public import Veir.Data.FP.FloatFormat
 public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.Sign
 public import Veir.ForLean
@@ -9,11 +10,7 @@ namespace Veir.Data.FP.PackedFloat
 
 public section
 
-/--
-The exponent bias for a packed float with `e` exponent bits.
-For a double (`e = 11`), this is `2^10 - 1 = 1023`.
--/
-def bias (e : Nat) : Nat := 2 ^ (e - 1) - 1
+open FloatFormat (bias)
 
 /--
 The fractional contribution of the trailing significand: `sig.toNat / 2^s`.


### PR DESCRIPTION
## Summary
- Add `Veir/Data/FP/FloatFormat.lean`: a consolidated home for IEEE-754 format arithmetic over `(e, s)`. Eventually this will become a structure bundling those parameters; for now it is a namespace whose helpers take them as explicit arguments.
- Move `bias` out of `Veir.Data.FP.PackedFloat` (the definition has no `PackedFloat`-specific content) and into `FloatFormat`. Update the two callers (`PackedFloat.toExtRat`, `PackedFloat.toEDyadic`) to use `FloatFormat.bias`.
- The new module also ships `#guard`s that pin down `bias 8 = 127` and `bias 11 = 1023` (single and double precision).

The namespace is intentionally thin today. Follow-on work introducing `unbiasedExp`, `biasedExp`, `minBiasedExponent`, `maxBiasedExponent`, and the various significand-shift helpers will land here as their callers (e.g. `EDyadic.pack`) arrive.

## Test plan
- [x] `lake build` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)