### PR TITLE
bitblast all `LLVM.Int` operations

### DIFF
--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -15,9 +15,7 @@ open Veir.Data.LLVM.Int
 
 /-- We introduce a tactic to automatically prove all the lemmas. -/
 macro "llvm_bv_decide" : tactic =>
-  `(tactic| ((try simp only [llvm_toBitVec]; try simp only [getValue_eq_getValueD]; try bv_decide); all_goals sorry))
-
-set_option warn.sorry false
+  `(tactic| ((try simp only [llvm_toBitVec]; try simp [getValue_eq_getValueD]; try bv_decide)))
 
 /-
   `LLVM.not` is not supported in

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -391,6 +391,6 @@ theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
 
 @[llvm_toBitVec, grind =]
 theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
-    (select c x y).getValue = if c.getValue = 1#1 then x.getValue else y.getValue := by
+    (select c x y).getValue h = if c.getValue = 1#1 then x.getValue else y.getValue := by
   simp [select, Id.run]
   grind

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -391,6 +391,6 @@ theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
 
 @[llvm_toBitVec, grind =]
 theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
-    (select c x y).getValue = if c.getValue == 1#1 then x.getValue else y.getValue := by
+    (select c x y).getValue h = if c.getValue == 1#1 then x.getValue else y.getValue := by
   simp [select, Id.run]
   grind

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -133,8 +133,7 @@ theorem getValue_sub {w : Nat} (x y : Int w) {nsw nuw : Bool} (h : (sub x y nsw 
 @[llvm_toBitVec, grind =]
 theorem isPoison_mul {w : Nat} (x y : Int w) {nsw nuw : Bool} :
     (mul x y nsw nuw).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         (nsw ∧ BitVec.smulOverflow x.getValue y.getValue) ∨
         (nuw ∧ BitVec.umulOverflow x.getValue y.getValue) := by
@@ -151,8 +150,7 @@ theorem getValue_mul {w : Nat} (x y : Int w) {nsw nuw : Bool} (h : (mul x y nsw 
 @[llvm_toBitVec, grind =]
 theorem isPoison_udiv {w : Nat} (x y : Int w) {exact : Bool} :
     (udiv x y exact).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         (exact ∧ BitVec.umod x.getValue y.getValue ≠ 0) ∨
         (y.getValue = 0) := by
@@ -169,8 +167,7 @@ theorem getValue_udiv {w : Nat} (x y : Int w) {exact : Bool} (h : (udiv x y exac
 @[llvm_toBitVec, grind =]
 theorem isPoison_sdiv {w : Nat} (x y : Int w) {exact : Bool} :
     (sdiv x y exact).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         (y.getValue == 0 || (w != 1 && x.getValue == (BitVec.intMin w) && y.getValue == -1)) ∨
         (exact ∧ BitVec.smod x.getValue y.getValue ≠ 0) ∨
@@ -188,8 +185,7 @@ theorem getValue_sdiv {w : Nat} (x y : Int w) {exact : Bool} (h : (sdiv x y exac
 @[llvm_toBitVec, grind =]
 theorem isPoison_urem {w : Nat} (x y : Int w) :
     (urem x y).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         y.getValue = 0 := by
   simp only [urem, isPoison, getValue, Id.run, pure_bind]
@@ -205,8 +201,7 @@ theorem getValue_urem {w : Nat} (x y : Int w) (h : (urem x y).isPoison = false) 
 @[llvm_toBitVec, grind =]
 theorem isPoison_srem {w : Nat} (x y : Int w) :
     (srem x y).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         (y.getValue == 0 || (w != 1 && x.getValue  == (BitVec.intMin w) && y.getValue == -1)) := by
   simp only [srem, isPoison, getValue, Id.run, pure_bind]
@@ -222,8 +217,7 @@ theorem getValue_srem {w : Nat} (x y : Int w) (h : (srem x y).isPoison = false) 
 @[llvm_toBitVec, grind =]
 theorem isPoison_shl {w : Nat} (x y : Int w) {nsw nuw : Bool} :
     (shl x y nsw nuw).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         (nsw ∧ (x.getValue <<< y.getValue).sshiftRight' y.getValue ≠ x.getValue) ∨
         (nuw ∧ (x.getValue <<< y.getValue) >>> y.getValue ≠ x.getValue) ∨
@@ -243,8 +237,7 @@ theorem getValue_shl {w : Nat} (x y : Int w) {nsw nuw : Bool} (h : (shl x y nsw 
 @[llvm_toBitVec, grind =]
 theorem isPoison_lshr {w : Nat} (x y : Int w) {exact : Bool} :
     (lshr x y exact).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         y.getValue ≥ w ∨
         (exact ∧ (x.getValue >>> y.getValue) <<< y.getValue ≠ x.getValue) := by
@@ -263,8 +256,7 @@ theorem getValue_lshr {w : Nat} (x y : Int w) {exact : Bool} (h : (lshr x y exac
 @[llvm_toBitVec, grind =]
 theorem isPoison_ashr {w : Nat} (x y : Int w) {exact : Bool} :
     (ashr x y exact).isPoison =
-      if h : x.isPoison = true ∨ y.isPoison = true then
-        true
+      if h : x.isPoison = true ∨ y.isPoison = true then true
       else
         y.getValue ≥ w ∨
         (exact ∧ (x.getValue >>> y.getValue) <<< y.getValue ≠ x.getValue) := by
@@ -307,8 +299,7 @@ theorem getValue_and {w : Nat} (x y : Int w) (h : (and x y).isPoison = false) :
 @[llvm_toBitVec, grind =]
 theorem isPoison_or {w : Nat} (x y : Int w) {disjoint : Bool} :
     (or x y disjoint).isPoison =
-      if h : x.isPoison ∨ y.isPoison then
-        true
+      if h : x.isPoison ∨ y.isPoison then true
       else
         disjoint ∧ ((x.getValue &&& y.getValue) ≠ 0) := by
   simp only [or, isPoison, getValue, Id.run, pure_bind]
@@ -336,8 +327,7 @@ theorem getValue_xor {w : Nat} (x y : Int w) (h : (xor x y).isPoison = false) :
 @[llvm_toBitVec, grind =]
 theorem isPoison_trunc {w₁ w₂: Nat} (x : Int w₁) {nsw nuw : Bool} (h : w₁ > w₂) :
     (trunc x w₂ nsw nuw h).isPoison =
-      if h : x.isPoison then
-        true
+      if h : x.isPoison then true
       else
         (nsw ∧ (x.getValue.truncate w₂).signExtend w₁ ≠ x.getValue) ∨
         (nuw ∧ (x.getValue.truncate w₂).zeroExtend w₁ ≠ x.getValue) := by
@@ -354,8 +344,7 @@ theorem getValue_trunc {w₁ w₂: Nat} (x : Int w₁) {nsw nuw : Bool} (h : w�
 @[llvm_toBitVec, grind =]
 theorem isPoison_zext {w₁ w₂: Nat} (x : Int w₁) {nneg : Bool} (h : w₁ < w₂) :
     (zext x w₂ nneg h).isPoison =
-      if h : x.isPoison then
-        true
+      if h : x.isPoison then true
       else
         nneg ∧ x.getValue.msb := by
   simp only [zext, isPoison, getValue, Id.run, pure_bind]

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -129,3 +129,279 @@ theorem getValue_sub {w : Nat} (x y : Int w) {nsw nuw : Bool} (h : (sub x y nsw 
     (sub x y nsw nuw).getValue h = x.getValue - y.getValue := by
   simp [sub, Id.run]
   grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_mul {w : Nat} (x y : Int w) {nsw nuw : Bool} :
+    (mul x y nsw nuw).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        (nsw ∧ BitVec.smulOverflow x.getValue y.getValue) ∨
+        (nuw ∧ BitVec.umulOverflow x.getValue y.getValue) := by
+  simp only [mul, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_mul {w : Nat} (x y : Int w) {nsw nuw : Bool} (h : (mul x y nsw nuw).isPoison = false) :
+    (mul x y nsw nuw).getValue h = x.getValue * y.getValue := by
+  simp [mul, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_udiv {w : Nat} (x y : Int w) {exact : Bool} :
+    (udiv x y exact).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        (exact ∧ BitVec.umod x.getValue y.getValue ≠ 0) ∨
+        (y.getValue = 0) := by
+  simp only [udiv, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_udiv {w : Nat} (x y : Int w) {exact : Bool} (h : (udiv x y exact).isPoison = false) :
+    (udiv x y exact).getValue h = x.getValue.udiv y.getValue := by
+  simp [udiv, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_sdiv {w : Nat} (x y : Int w) {exact : Bool} :
+    (sdiv x y exact).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        (y.getValue == 0 || (w != 1 && x.getValue == (BitVec.intMin w) && y.getValue == -1)) ∨
+        (exact ∧ BitVec.smod x.getValue y.getValue ≠ 0) ∨
+        (y.getValue = 0) := by
+  simp only [sdiv, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_sdiv {w : Nat} (x y : Int w) {exact : Bool} (h : (sdiv x y exact).isPoison = false) :
+    (sdiv x y exact).getValue h = x.getValue.sdiv y.getValue := by
+  simp [sdiv, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_urem {w : Nat} (x y : Int w) :
+    (urem x y).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        y.getValue = 0 := by
+  simp only [urem, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_urem {w : Nat} (x y : Int w) (h : (urem x y).isPoison = false) :
+    (urem x y).getValue h = x.getValue.umod y.getValue := by
+  simp [urem, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_srem {w : Nat} (x y : Int w) :
+    (srem x y).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        (y.getValue == 0 || (w != 1 && x.getValue  == (BitVec.intMin w) && y.getValue == -1)) := by
+  simp only [srem, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_srem {w : Nat} (x y : Int w) (h : (srem x y).isPoison = false) :
+    (srem x y).getValue h = x.getValue.srem y.getValue := by
+  simp [srem, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_shl {w : Nat} (x y : Int w) {nsw nuw : Bool} :
+    (shl x y nsw nuw).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        (nsw ∧ (x.getValue <<< y.getValue).sshiftRight' y.getValue ≠ x.getValue) ∨
+        (nuw ∧ (x.getValue <<< y.getValue) >>> y.getValue ≠ x.getValue) ∨
+        (y.getValue ≥ w) := by
+  simp only [shl, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_shl {w : Nat} (x y : Int w) {nsw nuw : Bool} (h : (shl x y nsw nuw).isPoison = false) :
+    (shl x y nsw nuw).getValue h = x.getValue <<< y.getValue := by
+  simp only [shl, Id.run, BitVec.shiftLeft_eq', BitVec.sshiftRight_eq', ne_eq,
+    BitVec.ushiftRight_eq', BitVec.natCast_eq_ofNat, ge_iff_le, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_lshr {w : Nat} (x y : Int w) {exact : Bool} :
+    (lshr x y exact).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        y.getValue ≥ w ∨
+        (exact ∧ (x.getValue >>> y.getValue) <<< y.getValue ≠ x.getValue) := by
+  simp only [lshr, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_lshr {w : Nat} (x y : Int w) {exact : Bool} (h : (lshr x y exact).isPoison = false) :
+    (lshr x y exact).getValue h = x.getValue >>> y.getValue := by
+  simp only [lshr, Id.run, BitVec.natCast_eq_ofNat, ge_iff_le, BitVec.ushiftRight_eq',
+    BitVec.shiftLeft_eq', ne_eq, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_ashr {w : Nat} (x y : Int w) {exact : Bool} :
+    (ashr x y exact).isPoison =
+      if h : x.isPoison = true ∨ y.isPoison = true then
+        true
+      else
+        y.getValue ≥ w ∨
+        (exact ∧ (x.getValue >>> y.getValue) <<< y.getValue ≠ x.getValue) := by
+  simp only [ashr, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_ashr {w : Nat} (x y : Int w) {exact : Bool} (h : (ashr x y exact).isPoison = false) :
+    (ashr x y exact).getValue h = x.getValue.sshiftRight' y.getValue := by
+  simp only [ashr, Id.run, BitVec.natCast_eq_ofNat, ge_iff_le, BitVec.ushiftRight_eq',
+    BitVec.shiftLeft_eq', ne_eq, BitVec.sshiftRight_eq', pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_cast {w₁ w₂ : Nat} (x : Int w₁) (h : w₁ = w₂) :
+    (cast x h).isPoison = x.isPoison := by
+  simp [cast, isPoison]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_cast {w₁ w₂ : Nat} (x : Int w₁) (h : w₁ = w₂) (hpoison : (cast x h).isPoison = false) :
+    (cast x h).getValue hpoison = x.getValue.cast h := by
+  simp [cast, getValue]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_and {w : Nat} (x y : Int w) :
+    (and x y).isPoison = decide (x.isPoison ∨ y.isPoison) := by
+  simp [and, isPoison, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_and {w : Nat} (x y : Int w) (h : (and x y).isPoison = false) :
+    (and x y).getValue h = x.getValue &&& y.getValue := by
+  simp [and, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_or {w : Nat} (x y : Int w) {disjoint : Bool} :
+    (or x y disjoint).isPoison =
+      if h : x.isPoison ∨ y.isPoison then
+        true
+      else
+        disjoint ∧ ((x.getValue &&& y.getValue) ≠ 0) := by
+  simp only [or, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_or {w : Nat} (x y : Int w) {disjoint : Bool} (h : (or x y disjoint).isPoison = false) :
+    (or x y disjoint).getValue h = x.getValue ||| y.getValue := by
+  simp [or, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_xor {w : Nat} (x y : Int w) :
+    (xor x y).isPoison = decide (x.isPoison ∨ y.isPoison) := by
+  simp [xor, isPoison, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_xor {w : Nat} (x y : Int w) (h : (xor x y).isPoison = false) :
+    (xor x y).getValue h = x.getValue ^^^ y.getValue := by
+  simp [xor, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_trunc {w₁ w₂: Nat} (x : Int w₁) {nsw nuw : Bool} (h : w₁ > w₂) :
+    (trunc x w₂ nsw nuw h).isPoison =
+      if h : x.isPoison then
+        true
+      else
+        (nsw ∧ (x.getValue.truncate w₂).signExtend w₁ ≠ x.getValue) ∨
+        (nuw ∧ (x.getValue.truncate w₂).zeroExtend w₁ ≠ x.getValue) := by
+  simp only [trunc, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_trunc {w₁ w₂: Nat} (x : Int w₁) {nsw nuw : Bool} (h : w₁ > w₂) (hpoison : (trunc x w₂ nsw nuw h).isPoison = false) :
+    (trunc x w₂ nsw nuw h).getValue hpoison = x.getValue.truncate w₂ := by
+  simp [trunc, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_zext {w₁ w₂: Nat} (x : Int w₁) {nneg : Bool} (h : w₁ < w₂) :
+    (zext x w₂ nneg h).isPoison =
+      if h : x.isPoison then
+        true
+      else
+        nneg ∧ x.getValue.msb := by
+  simp only [zext, isPoison, getValue, Id.run, pure_bind]
+  simp [pure]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_zext (x : Int w₁) {nneg : Bool} (h : w₁ < w₂) (hpoison : (zext x w₂ nneg h).isPoison = false) :
+    (zext x w₂ nneg h).getValue hpoison = x.getValue.zeroExtend w₂ := by
+  simp [zext, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_sext {w₁ w₂: Nat} (x : Int w₁) (h : w₁ < w₂) :
+    (sext x w₂ h).isPoison = x.isPoison := by
+  simp [sext, isPoison, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_sext (x : Int w₁) (h : w₁ < w₂) (hpoison : (sext x w₂ h).isPoison = false) :
+    (sext x w₂ h).getValue hpoison = x.getValue.signExtend w₂ := by
+  simp [sext, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_icmp {w : Nat} (x y : Int w) (p : IntPred) :
+    (icmp x y p).isPoison = decide (x.isPoison ∨ y.isPoison) := by
+  simp [icmp, isPoison, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_icmp {w : Nat} (x y : Int w) (p : IntPred) (h : (icmp x y p).isPoison = false) :
+    (icmp x y p).getValue h = BitVec.ofBool (IntPred.eval p x.getValue y.getValue) := by
+  simp [icmp, Id.run]
+  grind
+
+attribute [llvm_toBitVec, grind =] IntPred.eval
+
+@[llvm_toBitVec, grind =]
+theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
+    (select c x y).isPoison = decide (x.isPoison ∨ y.isPoison ∨ c.isPoison) := by
+  simp [select, isPoison, Id.run]
+  grind
+
+@[llvm_toBitVec, grind =]
+theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
+    (select c x y).getValue = if c.getValue == 1#1 then x.getValue else y.getValue := by
+  simp [select, Id.run]
+  grind

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -169,7 +169,7 @@ theorem isPoison_sdiv {w : Nat} (x y : Int w) {exact : Bool} :
     (sdiv x y exact).isPoison =
       if h : x.isPoison = true ∨ y.isPoison = true then true
       else
-        (y.getValue == 0 || (w != 1 && x.getValue == (BitVec.intMin w) && y.getValue == -1)) ∨
+        (y.getValue = 0 ∨ (w ≠ 1 ∧ x.getValue = (BitVec.intMin w) ∧ y.getValue = -1)) ∨
         (exact ∧ BitVec.smod x.getValue y.getValue ≠ 0) ∨
         (y.getValue = 0) := by
   simp only [sdiv, isPoison, getValue, Id.run, pure_bind]
@@ -203,7 +203,7 @@ theorem isPoison_srem {w : Nat} (x y : Int w) :
     (srem x y).isPoison =
       if h : x.isPoison = true ∨ y.isPoison = true then true
       else
-        (y.getValue == 0 || (w != 1 && x.getValue  == (BitVec.intMin w) && y.getValue == -1)) := by
+        (y.getValue = 0 ∨ (w ≠ 1 ∧ x.getValue = (BitVec.intMin w) ∧ y.getValue = -1)) := by
   simp only [srem, isPoison, getValue, Id.run, pure_bind]
   simp [pure]
   grind
@@ -364,7 +364,7 @@ theorem isPoison_sext {w₁ w₂: Nat} (x : Int w₁) (h : w₁ < w₂) :
   grind
 
 @[llvm_toBitVec, grind =]
-theorem getValue_sext (x : Int w₁) (h : w₁ < w₂) (hpoison : (sext x w₂ h).isPoison = false) :
+theorem getValue_sext {w₁ w₂ : Nat} (x : Int w₁) (h : w₁ < w₂) (hpoison : (sext x w₂ h).isPoison = false) :
     (sext x w₂ h).getValue hpoison = x.getValue.signExtend w₂ := by
   simp [sext, Id.run]
   grind
@@ -391,6 +391,6 @@ theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
 
 @[llvm_toBitVec, grind =]
 theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
-    (select c x y).getValue h = if c.getValue == 1#1 then x.getValue else y.getValue := by
+    (select c x y).getValue = if c.getValue = 1#1 then x.getValue else y.getValue := by
   simp [select, Id.run]
   grind


### PR DESCRIPTION
Add the missing infrastructure to complete bitblasting coverage of `LLVM.Int` operations. In this way we solve all the problems in the `Bitblasting` unittest.

In the next PR we shall use this infrastructure in the checks performed by the interpreter.