### PR TITLE
Test: tidy some testcases to pass MLIR verification

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -7,14 +7,14 @@
   %addi_nsw = "arith.addi"(%5, %5) <{nws}> : (i32, i32) -> i32
   %addi_nuw = "arith.addi"(%5, %5) <{nuw}> : (i32, i32) -> i32
   %addi_nsw_nuw = "arith.addi"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
-  %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i32)
+  %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
   %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
   %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
   %10 = "arith.ceildivui"(%5, %5) : (i32, i32) -> i32
-  %11 = "arith.cmpi"(%5, %5) : (i32, i32) -> i1
+  %11 = "arith.cmpi"(%5, %5) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
   %12 = "arith.divsi"(%5, %5) : (i32, i32) -> i32
   %13 = "arith.divui"(%5, %5) : (i32, i32) -> i32
-  %14 = "arith.extui"(%5) : (i32) -> i32
+  %14 = "arith.extui"(%5) : (i32) -> i64
   %15 = "arith.floordivsi"(%5, %5) : (i32, i32) -> i32
   %16 = "arith.maxsi"(%5, %5) : (i32, i32) -> i32
   %17 = "arith.maxui"(%5, %5) : (i32, i32) -> i32
@@ -34,7 +34,7 @@
   %28 = "arith.shrsi"(%5, %5) : (i32, i32) -> i32
   %29 = "arith.shrui"(%5, %5) : (i32, i32) -> i32
   %30 = "arith.subi"(%5, %5) : (i32, i32) -> i32
-  %31 = "arith.trunci"(%5) : (i32) -> i32
+  %31 = "arith.trunci"(%5) : (i32) -> i16
   %32 = "arith.xori"(%5, %5) : (i32, i32) -> i32
 }) : () -> ()
 
@@ -45,14 +45,14 @@
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}, %{{.*}} = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:     %{{.*}}, %{{.*}} = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
 // CHECK-NEXT:     %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i1
 // CHECK-NEXT:     %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.divui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i64
 // CHECK-NEXT:     %{{.*}} = "arith.floordivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.maxsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.maxui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
@@ -72,6 +72,6 @@
 // CHECK-NEXT:     %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.shrui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.trunci"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:     %{{.*}} = "arith.trunci"(%{{.*}}) : (i32) -> i16
 // CHECK-NEXT:     %{{.*}} = "arith.xori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/types.mlir
+++ b/Test/Builtin/types.mlir
@@ -5,7 +5,7 @@
   %0 = "test.test"() : () -> i32
   %1 = "test.test"() : () -> ((i32) -> (i32))
   %2 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
-  %2 = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+  %3 = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -6,7 +6,7 @@
     ^bb0():
       %5 = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
       %6 = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i1
-      %8 = "llvm.and"(%5, %5) : (i32, i32) -> i32
+      %7 = "llvm.and"(%5, %5) : (i32, i32) -> i32
       %8 = "llvm.or"(%5, %5) : (i32, i32) -> i32
       %9 = "llvm.xor"(%5, %5) : (i32, i32) -> i32
       %add = "llvm.add"(%5, %5) : (i32, i32) -> i32


### PR DESCRIPTION
This fixes some of the testcases up so that they don't fail verification
in MLIR which makes it slightly easier to compare parser behaviour with
MLIR when modifying the tests.
