### PR TITLE
select now blocks poison from the not-selected arm

### DIFF
--- a/UnitTest/Bitblasting/Bitblasting.lean
+++ b/UnitTest/Bitblasting/Bitblasting.lean
@@ -371,14 +371,6 @@ example (e : Veir.Data.LLVM.Int 64) :
     sdiv e (constant 64 (-1)) ⊑ sub (constant 64 0) e := by
   llvm_bv_decide
 
-example (e e_1 : Veir.Data.LLVM.Int 1) :
-    select e (xor e (constant 1 (-1))) e_1 ⊑ and (xor e (constant 1 (-1))) e_1 := by
-  llvm_bv_decide
-
-example (e e_1 : Veir.Data.LLVM.Int 1) :
-    select e e_1 (xor e (constant 1 (-1))) ⊑ or (xor e (constant 1 (-1))) e_1 := by
-  llvm_bv_decide
-
 example (e e_1 : Veir.Data.LLVM.Int 64) :
     select (constant 1 1) e_1 e ⊑ e_1 := by
   llvm_bv_decide

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -482,12 +482,13 @@ def icmp {w : Nat} (x y : Int w) (p : IntPred) : Int 1 := Id.run do
 
 /--
  If the condition is an i1 and it evaluates to 1, the instruction returns the first value argument; otherwise, it returns the second value argument.
+
+ If the condition is poison, the result is poison. Poison on the *non-selected* arm
+ does not propagate to the result.
 -/
 def select {w : Nat} (c : Int 1) (x y : Int w) : Int w := Id.run do
-  let val x' := x | poison
-  let val y' := y | poison
   let val c' := c | poison
-  val (if c' == 1#1 then x' else y')
+  if c' == 1#1 then x else y
 
 end Int
 end

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -385,12 +385,14 @@ attribute [llvm_toBitVec, grind =] IntPred.eval
 
 @[llvm_toBitVec, grind =]
 theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
-    (select c x y).isPoison = decide (x.isPoison ∨ y.isPoison ∨ c.isPoison) := by
+    (select c x y).isPoison =
+      if h : c.isPoison = true then true
+      else if c.getValue = 1#1 then x.isPoison else y.isPoison := by
   simp [select, isPoison, Id.run]
   grind
 
 @[llvm_toBitVec, grind =]
 theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
-    (select c x y).getValue h = if c.getValue = 1#1 then x.getValue else y.getValue := by
-  simp [select, Id.run]
+    (select c x y).getValue h = if c.getValue = 1#1 then x.getValueD else y.getValueD := by
+  simp [select, Id.run, getValueD]
   grind

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -393,6 +393,6 @@ theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
 
 @[llvm_toBitVec, grind =]
 theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
-    (select c x y).getValue h = if c.getValue = 1#1 then x.getValueD else y.getValueD := by
-  simp [select, Id.run, getValueD]
+    (select c x y).getValue h = if _ : c.getValue = 1#1 then x.getValue else y.getValue := by
+  simp [select, Id.run, getValue]
   grind

--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -394,5 +394,5 @@ theorem isPoison_select {w : Nat} (x y : Int w) (c : Int 1) :
 @[llvm_toBitVec, grind =]
 theorem getValue_select {w : Nat} (x y : Int w) (c : Int 1) (h : (select c x y).isPoison = false) :
     (select c x y).getValue h = if _ : c.getValue = 1#1 then x.getValue else y.getValue := by
-  simp [select, Id.run, getValue]
+  simp [select, Id.run]
   grind


### PR DESCRIPTION
also, remove two tests that are definitely incorrect under the current LLVM rules. select *cannot* be lowered to logic unless non-poison can be proved.