### PR TITLE
Printer: use pack syntax for operations with multiple results

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -45,7 +45,7 @@
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}, %{{.*}} = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
+// CHECK-NEXT:     %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
 // CHECK-NEXT:     %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
@@ -62,8 +62,8 @@
 // CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}, %{{.*}} = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
-// CHECK-NEXT:     %{{.*}}, %{{.*}} = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:     %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:     %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
 // CHECK-NEXT:     %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.remsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.remui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32

--- a/Test/Datapath/identity.mlir
+++ b/Test/Datapath/identity.mlir
@@ -9,7 +9,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^4(%{{.*}} : i3, %{{.*}} : i3, %{{.*}} : i3):
-// CHECK-NEXT:     %{{.*}}, %{{.*}} = "datapath.compress"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3)
-// CHECK-NEXT:     %{{.*}}, %{{.*}}, %{{.*}} = "datapath.partial_product"(%{{.*}}, %{{.*}}) : (i3, i3) -> (i3, i3, i3)
-// CHECK-NEXT:     %{{.*}}, %{{.*}}, %{{.*}} = "datapath.pos_partial_product"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:     %{{.*}}:2 = "datapath.compress"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3)
+// CHECK-NEXT:     %{{.*}}:3 = "datapath.partial_product"(%{{.*}}, %{{.*}}) : (i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:     %{{.*}}:3 = "datapath.pos_partial_product"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3, i3)
 // CHECK-NEXT: }) : () -> ()

--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -47,7 +47,7 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "arith.addi"() ({
   ^4():
-    %5_0, %5_1 = "arith.muli"() : () -> (i32, i32)
+    %5:2 = "arith.muli"() : () -> (i32, i32)
 }, {}) : () -> ()
 -/
 #guard_msgs in
@@ -166,7 +166,7 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "builtin.module"() ({
   ^4():
-    %5_0, %5_1 = "test.test"() : () -> (i32, i64)
+    %5:2 = "test.test"() : () -> (i32, i64)
 }) : () -> ()
 -/
 #guard_msgs in
@@ -177,8 +177,8 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "builtin.module"() ({
   ^4():
-    %5_0, %5_1, %5_2 = "test.test"() : () -> (i10, i32, i64)
-    %6 = "test.test"(%5_2, %5_0) : (i64, i10) -> i1
+    %5:3 = "test.test"() : () -> (i10, i32, i64)
+    %6 = "test.test"(%5#2, %5#0) : (i64, i10) -> i1
 }) : () -> ()
 -/
 #guard_msgs in

--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -41,22 +41,16 @@ def printValue (ctx : IRContext OpCode) (value : ValuePtr) : IO Unit := do
     if opStruct.results.size = 1 then
       IO.print s!"%{opResult.owner.id}"
     else
-      IO.print s!"%{opResult.owner.id}_{opResult.index}"
+      IO.print s!"%{opResult.owner.id}#{opResult.index}"
   | ValuePtr.blockArgument blockArgPtr =>
     let blockArg := blockArgPtr.get! ctx
     IO.print s!"%arg{blockArg.owner.id}_{blockArg.index}"
 
-def printOpResult (ctx: IRContext OpCode) (result: OpResultPtr) : IO Unit := do
-  printValue ctx (ValuePtr.opResult result)
-
 def printOpResults (ctx: IRContext OpCode) (op: OperationPtr) : IO Unit := do
   if op.getNumResults! ctx ≠ 0 then
-    let res := op.getResult 0
-    printValue ctx res
-    for index in 1...(op.getNumResults! ctx) do
-      IO.print ", "
-      let res := op.getResult index
-      printValue ctx res
+    IO.print s!"%{op.id}"
+    if op.getNumResults! ctx > 1 then
+      IO.print s!":{op.getNumResults! ctx}"
     IO.print " = "
 
 def printOpOperands (ctx: IRContext OpCode) (op: OperationPtr) : IO Unit := do


### PR DESCRIPTION
This changes the formatting of operations with multiple results to use the pack syntax, e.g.
```
%5:3 = "test.test"() : () -> (i32, i32, i32)
"test.test"(%5#1) : (i32) -> ()
```

instead of the existing unpacked syntax
```
%5_0, %5_1, %5_2 = "test.test"() : () -> (i32, i32, i32)
"test.test"(%5_1) : (i32) -> ()
```
which is not valid MLIR as names beginning with a digit must only contain digits.
