### PR TITLE
Make `hw.constant` use `LLVM.Int` instead of `BitVec`

### DIFF
--- a/Test/Interpreter/Comb/add.mlir
+++ b/Test/Interpreter/Comb/add.mlir
@@ -1,15 +1,15 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %c3 = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
-  %c5 = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
-  %c10 = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
+  %c3 = "hw.constant"() <{ "value" = 3 : i8 }> : () -> i8
+  %c5 = "hw.constant"() <{ "value" = 5 : i8 }> : () -> i8
+  %c10 = "hw.constant"() <{ "value" = 10 : i8 }> : () -> i8
   %x = "comb.add"(%c3) : (i8) -> i8
   %y = "comb.add"(%c3, %c5) : (i8, i8) -> i8
   %z = "comb.add"(%c3, %c5, %c10) : (i8, i8, i8) -> i8
 
-  %c255 = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
-  %c5 = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
+  %c255 = "hw.constant"() <{ "value" = 255 : i8 }> : () -> i8
+  %c5 = "hw.constant"() <{ "value" = 5 : i8 }> : () -> i8
   %nuw_nsw = "llvm.add"(%c255, %c5) <{nuw, nsw}> : (i8, i8) -> i8
   %poison = "comb.add"(%nuw_nsw, %c5) : (i8, i8) -> i8
   "func.return"(%x, %y, %z, %poison) : (i8, i8, i8, i8) -> ()

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -36,14 +36,12 @@ variable {OpInfo : Type} [HasOpInfo OpInfo]
 inductive RuntimeValue where
 | int (bitwidth : Nat) (value : LLVM.Int bitwidth)
 | reg (value : RISCV.Reg)
-| bvInt (bitwidth : Nat) (value : BitVec bitwidth)
 deriving Inhabited
 
 instance : ToString (RuntimeValue) where
   toString
     | .int _ val => ToString.toString val
     | .reg val => ToString.toString val
-    | .bvInt _ val => ToString.toString val
 
 /--
   The state of the interpreter at a given point in time.
@@ -806,7 +804,8 @@ def HW.interpretOp' (opType : Veir.HW) (properties : HasDialectOpInfo.properties
     let resType ← resultTypes[0]?
     let .integerType bw := resType.val
       | none
-    return (#[.bvInt bw.bitwidth (Veir.Data.HW.constant (BitVec.ofInt bw.bitwidth properties.value.value)).val], none)
+    return (#[.int bw.bitwidth
+      (.val (Veir.Data.HW.constant (BitVec.ofInt bw.bitwidth properties.value.value)).val)], none)
   | _ => none
 /--
   Interpret a single operation given its opcode, type-dependent properties,


### PR DESCRIPTION
As `IntegerType` should map to a unique Lean Type, we are using `LLVM.Int` even though `comb` uses `IntegerType` as bitvectors.

As `RuntimeValue.intBv` is not used anymore, I removed it as well for the time being.