### PR TITLE
add llvm.select interpreter support

### DIFF
--- a/Test/Interpreter/LLVM/select.mlir
+++ b/Test/Interpreter/LLVM/select.mlir
@@ -1,0 +1,38 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `llvm.select` semantics: poison on the *non-selected* arm is ignored;
+// poison on the selected arm, or on the condition, propagates.
+"builtin.module"() ({
+  %t = "llvm.mlir.constant"() <{ "value" = 1 : i1 }> : () -> i1
+  %f = "llvm.mlir.constant"() <{ "value" = 0 : i1 }> : () -> i1
+  %a = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+  %b = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+
+  // Poison i32 via `llvm.add nuw` of -1 + 1 (unsigned overflow).
+  %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+  %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+  %p32  = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+
+  // Poison i1 via `llvm.add nuw` of 1 + 1.
+  %p1 = "llvm.add"(%t, %t) <{nuw}> : (i1, i1) -> i1
+
+  // Concrete condition, concrete arms.
+  %r1 = "llvm.select"(%t, %a, %b) : (i1, i32, i32) -> i32
+  %r2 = "llvm.select"(%f, %a, %b) : (i1, i32, i32) -> i32
+
+  // Poison on the unselected arm is blocked.
+  %r3 = "llvm.select"(%t, %a, %p32) : (i1, i32, i32) -> i32
+  %r4 = "llvm.select"(%f, %p32, %b) : (i1, i32, i32) -> i32
+
+  // Poison on the selected arm propagates.
+  %r5 = "llvm.select"(%t, %p32, %b) : (i1, i32, i32) -> i32
+  %r6 = "llvm.select"(%f, %a, %p32) : (i1, i32, i32) -> i32
+
+  // Poison condition produces poison.
+  %r7 = "llvm.select"(%p1, %a, %b) : (i1, i32, i32) -> i32
+
+  "func.return"(%r1, %r2, %r3, %r4, %r5, %r6, %r7)
+    : (i32, i32, i32, i32, i32, i32, i32) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000003#32, 0x00000005#32, 0x00000003#32, 0x00000005#32, poison, poison, poison]

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -425,6 +425,11 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     let rhs := rhs.cast (by simpa using h)
     let some p := LLVM.IntPred.fromNat properties.value.value.toNat | none
     return (#[.int 1 (LLVM.Int.icmp lhs rhs p)], none)
+  | .select => do
+    let [.int 1 cond, .int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simpa using h)
+    return (#[.int bw (LLVM.Int.select cond lhs rhs)], none)
   | .return => do
     return (#[], some (.return operands))
   | .br => do


### PR DESCRIPTION
it seems that llvm.select was missing from the interpreter, this adds it (just copying the code of arith.select)