### PR TITLE
Remove the `liftExcept` function from the parser

### DIFF
--- a/Veir/Parser/DecidableInBounds.lean
+++ b/Veir/Parser/DecidableInBounds.lean
@@ -15,6 +15,7 @@ import Veir.Rewriter.GetSet
 namespace Veir.Parser
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {m : Type → Type} [Monad m] [MonadExcept String m]
 
 /-! ## Option.maybe decidability
 
@@ -29,70 +30,62 @@ instance instDecidableMaybe (p : α → β → Prop) [inst : ∀ a b, Decidable 
 
 /-- Check that a block is in bounds, returning the proof wrapped in PLift. -/
 def checkBlockInBounds (block : BlockPtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (block.InBounds ctx)) :=
-  if h : block.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: block is not in bounds"
+    m (PLift (block.InBounds ctx)) :=
+  if h : block.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: block is not in bounds"
 
 /-- Check that a block insertion point is in bounds. -/
 def checkBlockInsertPointInBounds (ip : BlockInsertPoint) (ctx : IRContext OpInfo) :
-    Except String (PLift (ip.InBounds ctx)) :=
-  if h : ip.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: block insertion point is not in bounds"
+    m (PLift (ip.InBounds ctx)) :=
+  if h : ip.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: block insertion point is not in bounds"
 
 /-- Check that an optional insertion point satisfies maybe-InBounds. -/
 def checkMaybeInsertPointInBounds (ip : Option InsertPoint) (ctx : IRContext OpInfo) :
-    Except String (PLift (ip.maybe InsertPoint.InBounds ctx)) :=
-  if h : ip.maybe InsertPoint.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: optional insertion point is not in bounds"
+    m (PLift (ip.maybe InsertPoint.InBounds ctx)) :=
+  if h : ip.maybe InsertPoint.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: optional insertion point is not in bounds"
 
 /-- Check that a block has no arguments. -/
 def checkBlockHasNoArgs (block : BlockPtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (block.getNumArguments! ctx = 0)) :=
-  if h : block.getNumArguments! ctx = 0 then .ok ⟨h⟩
-  else .error s!"internal error: block has {block.getNumArguments! ctx} arguments, expected 0"
+    m (PLift (block.getNumArguments! ctx = 0)) :=
+  if h : block.getNumArguments! ctx = 0 then pure ⟨h⟩
+  else throw s!"internal error: block has {block.getNumArguments! ctx} arguments, expected 0"
 
 /-- Check that an operation is in bounds. -/
 def checkOpInBounds (op : OperationPtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (op.InBounds ctx)) :=
-  if h : op.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: operation is not in bounds"
+    m (PLift (op.InBounds ctx)) :=
+  if h : op.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: operation is not in bounds"
 
 /-- Check that a value is in bounds. -/
 def checkValueInBounds (value : ValuePtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (value.InBounds ctx)) :=
-  if h : value.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: value is not in bounds"
+    m (PLift (value.InBounds ctx)) :=
+  if h : value.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: value is not in bounds"
 
 /-- Check that a region is in bounds. -/
 def checkRegionInBounds (region : RegionPtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (region.InBounds ctx)) :=
-  if h : region.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: region is not in bounds"
+    m (PLift (region.InBounds ctx)) :=
+  if h : region.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: region is not in bounds"
 
 /-- Check that all values in an array are in bounds. -/
 def checkAllValuesInBounds (values : Array ValuePtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (∀ v, v ∈ values → v.InBounds ctx)) :=
-  if h : ∀ v, v ∈ values → v.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: not all values are in bounds"
+    m (PLift (∀ v, v ∈ values → v.InBounds ctx)) :=
+  if h : ∀ v, v ∈ values → v.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: not all values are in bounds"
 
 /-- Check that all blocks in an array are in bounds. -/
 def checkAllBlocksInBounds (blocks : Array BlockPtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (∀ b, b ∈ blocks → b.InBounds ctx)) :=
-  if h : ∀ b, b ∈ blocks → b.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: not all blocks are in bounds"
+    m (PLift (∀ b, b ∈ blocks → b.InBounds ctx)) :=
+  if h : ∀ b, b ∈ blocks → b.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: not all blocks are in bounds"
 
 /-- Check that all regions in an array are in bounds. -/
 def checkAllRegionsInBounds (regions : Array RegionPtr) (ctx : IRContext OpInfo) :
-    Except String (PLift (∀ r, r ∈ regions → r.InBounds ctx)) :=
-  if h : ∀ r, r ∈ regions → r.InBounds ctx then .ok ⟨h⟩
-  else .error s!"internal error: not all regions are in bounds"
-
-/-! ## Lifting to Monads -/
-
-/-- Lift an Except computation to any MonadExcept. -/
-def liftExcept [Monad m] [MonadExcept String m] (e : Except String α) : m α :=
-  match e with
-  | .ok a => pure a
-  | .error err => throw err
+    m (PLift (∀ r, r ∈ regions → r.InBounds ctx)) :=
+  if h : ∀ r, r ∈ regions → r.InBounds ctx then pure ⟨h⟩
+  else throw s!"internal error: not all regions are in bounds"
 
 end Veir.Parser

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -138,8 +138,8 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
   | some (block, false) => -- Block of this name was forward declared.
     /- Insert the block at the given location. -/
     modifyContextM fun ctx => do
-      let ⟨hip⟩ ← liftExcept (checkBlockInsertPointInBounds ip ctx.raw)
-      let ⟨hblock⟩ ← liftExcept (checkBlockInBounds block ctx.raw)
+      let ⟨hip⟩ ← checkBlockInsertPointInBounds ip ctx.raw
+      let ⟨hblock⟩ ← checkBlockInBounds block ctx.raw
       match hctx' : Rewriter.insertBlock? ctx block ip hblock hip with
       | none => throw "internal error: failed to insert block"
       | some ctx' => pure ⟨ctx', by grind [Rewriter.insertBlock?_WellFormed]⟩
@@ -152,7 +152,7 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
   | none => -- Block has not yet been declared or referenced.
     /- Create the block. -/
     let block ← modifyContextM' fun ctx => do
-      let ⟨hip⟩ ← liftExcept (checkBlockInsertPointInBounds ip ctx.raw)
+      let ⟨hip⟩ ← checkBlockInsertPointInBounds ip ctx.raw
       match hctx' : Rewriter.createBlock ctx #[] ip (by grind) (by grind) with
       | none => throw "internal error: failed to create block"
       | some (ctx', block) => pure ⟨block, ⟨ctx', by grind [Rewriter.createBlock_WellFormed]⟩⟩
@@ -389,8 +389,8 @@ def parseOptionalBlockLabel (ip : BlockInsertPoint) : MlirParserM (Option BlockP
   /- Insert block arguments in the block. -/
   modifyContextM fun ctx => do
     let argTypes := arguments.map (·.2)
-    let ⟨h_block_InBounds⟩ ← liftExcept (checkBlockInBounds block ctx.raw)
-    let ⟨h_block_NoArgs⟩ ← liftExcept (checkBlockHasNoArgs block ctx.raw)
+    let ⟨h_block_InBounds⟩ ← checkBlockInBounds block ctx.raw
+    let ⟨h_block_NoArgs⟩ ← checkBlockHasNoArgs block ctx.raw
     pure (WfRewriter.setBlockArguments ctx block argTypes h_block_InBounds (by grind [BlockPtr.getArguments!.mem_iff_exists_index]))
   /- Register the block argument names in the parser state. -/
   for ((argName, argType), index) in arguments.zipIdx do
@@ -455,14 +455,14 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   let operands ← operands.zip inputTypes |>.mapM (fun (operand, type) => resolveOperand operand type)
 
   let op ← modifyContextM' fun ctx => do
-    let ⟨hoper⟩ ← liftExcept (checkAllValuesInBounds operands ctx.raw)
-    let ⟨hblockOperands⟩ ← liftExcept (checkAllBlocksInBounds blockOperands ctx.raw)
-    let ⟨hregions⟩ ← liftExcept (checkAllRegionsInBounds regions ctx.raw)
-    let ⟨hins⟩ ← liftExcept (checkMaybeInsertPointInBounds ip ctx.raw)
+    let ⟨hoper⟩ ← checkAllValuesInBounds operands ctx.raw
+    let ⟨hblockOperands⟩ ← checkAllBlocksInBounds blockOperands ctx.raw
+    let ⟨hregions⟩ ← checkAllRegionsInBounds regions ctx.raw
+    let ⟨hins⟩ ← checkMaybeInsertPointInBounds ip ctx.raw
     match hctx' : Rewriter.createOp ctx opId outputTypes operands blockOperands regions properties ip hoper hblockOperands hregions hins with
     | none => throw "internal error: failed to create operation"
     | some (ctx', op) =>
-      let ⟨hop⟩ ← liftExcept (checkOpInBounds op ctx')
+      let ⟨hop⟩ ← checkOpInBounds op ctx'
       let ctx'' := op.setAttributes ctx' attrs hop
       /- Update the parser context. -/
       pure ⟨op, ⟨ctx'', by grind [Rewriter.createOp_WellFormed, OperationPtr.setAttributes_WellFormed]⟩⟩


### PR DESCRIPTION
This function was only used to lift other functions from the `Except` monad to a generic monad. Instead, we can just implement all these other functions in the more generic monad directly.