### PR TITLE
Replace an OperationPtr.InBounds runtime check with proof

### DIFF
--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -462,7 +462,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
     match hctx' : Rewriter.createOp ctx opId outputTypes operands blockOperands regions properties ip hoper hblockOperands hregions hins with
     | none => throw "internal error: failed to create operation"
     | some (ctx', op) =>
-      let ⟨hop⟩ ← checkOpInBounds op ctx'
+      have hop : op.InBounds ctx' := Rewriter.createOp_new_inBounds op hctx'
       let ctx'' := op.setAttributes ctx' attrs hop
       /- Update the parser context. -/
       pure ⟨op, ⟨ctx'', by grind [Rewriter.createOp_WellFormed, OperationPtr.setAttributes_WellFormed]⟩⟩


### PR DESCRIPTION
Replaces an unnecessary `OperationPtr.InBounds` runtime check with proof. The helper function `checkOpInBounds` is no longer used but still kept because we might need it in the future when expanding the parser.