### PR TITLE
the shift amount check has to be done first

### DIFF
--- a/Test/Interpreter/Arith/shli_oversized_amount.mlir
+++ b/Test/Interpreter/Arith/shli_oversized_amount.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  %c = "arith.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
+  %none = "arith.shli"(%c, %c) : (i66, i66) -> i66
+  %nsw = "arith.shli"(%c, %c) <{nsw}> : (i66, i66) -> i66
+  %nuw = "arith.shli"(%c, %c) <{nuw}> : (i66, i66) -> i66
+  %nsw_nuw = "arith.shli"(%c, %c) <{nsw, nuw}> : (i66, i66) -> i66
+  "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison, poison, poison, poison]

--- a/Test/Interpreter/LLVM/shl_oversized_amount.mlir
+++ b/Test/Interpreter/LLVM/shl_oversized_amount.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  %c = "llvm.mlir.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
+  %none = "llvm.shl"(%c, %c) : (i66, i66) -> i66
+  %nsw = "llvm.shl"(%c, %c) <{nsw}> : (i66, i66) -> i66
+  %nuw = "llvm.shl"(%c, %c) <{nuw}> : (i66, i66) -> i66
+  %nsw_nuw = "llvm.shl"(%c, %c) <{nsw, nuw}> : (i66, i66) -> i66
+  "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison, poison, poison, poison]

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -274,13 +274,13 @@ def shl {w : Nat} (x y : Int w) (nsw : Bool := false) (nuw : Bool := false) : In
   let val x' := x | poison
   let val y' := y | poison
 
+  if y' ≥ w then
+    return poison
+
   if nsw ∧ (x' <<< y').sshiftRight' y' ≠ x' then
     return poison
 
   if nuw ∧ (x' <<< y') >>> y' ≠ x' then
-    return poison
-
-  if y' ≥ w then
     return poison
 
   val (x' <<< y')


### PR DESCRIPTION
this is what happens currently:
```bash
~/veir$ lake exec veir-interpret ./shli_oversized_amount.mlir 
INTERNAL PANIC: Nat.shiftl exponent is too big
~/veir$ 
```
after this PR:
```bash
~/veir$ lake exec veir-interpret ./shli_oversized_amount.mlir 
Program output: #[poison, poison, poison, poison]
~/veir$ 
```
