### PR TITLE
Use `ParserError` instead of `String` in the parser

### DIFF
--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -3,34 +3,35 @@ import Veir.IR.Basic
 
 open Veir
 open Veir.Parser
+open Veir.Parser.ParserError
 open Veir.AttrParser
 open Veir.Attribute
 
 /--
   Run parseOptionalType on the given input string.
 -/
-def testOptionalType (s : String) : Except String (Option TypeAttr) := do
+def testOptionalType (s : String) : Except ParserError (Option TypeAttr) := do
   let parser ← ParserState.fromInput (s.toByteArray)
   parseOptionalType.run' AttrParserState.mk parser
 
 /--
   Run parseType on the given input string.
 -/
-def testType (s : String) : Except String TypeAttr := do
+def testType (s : String) : Except ParserError TypeAttr := do
   let parser ← ParserState.fromInput (s.toByteArray)
   parseType.run' AttrParserState.mk parser
 
 /--
   Run parseOptionalAttr on the given input string.
 -/
-def testOptionalAttr (s : String) : Except String (Option Attribute) := do
+def testOptionalAttr (s : String) : Except ParserError (Option Attribute) := do
   let parser ← ParserState.fromInput (s.toByteArray)
   parseOptionalAttribute.run' AttrParserState.mk parser
 
 /--
   Run parseType on the given input string.
 -/
-def testAttr (s : String) : Except String Attribute := do
+def testAttr (s : String) : Except ParserError Attribute := do
   let parser ← ParserState.fromInput (s.toByteArray)
   parseAttribute.run' AttrParserState.mk parser
 
@@ -51,26 +52,28 @@ def expectSuccessAttr (s : String) (expected : Attribute) : Bool :=
   and returns the expected error in the parse variant.
 -/
 def expectMissingType (s : String) : Bool :=
-  testOptionalType s = .ok none && testType s = .error "type expected"
+  testOptionalType s = .ok none && (testType s).mapError (·.msg) = .error "type expected"
 
 /--
   Test that parsing an attribute in the given string returns none in the parseOptional variant,
   and returns the expected error in the parse variant.
 -/
 def expectMissingAttr (s : String) : Bool :=
-  testOptionalAttr s = .ok none && testAttr s = .error "attribute expected"
+  testOptionalAttr s = .ok none && (testAttr s).mapError (·.msg) = .error "attribute expected"
 
 /--
   Test that parsing a type in the given string returns the expected error in both variants.
 -/
 def expectErrorType (s : String) (expected : String) : Bool :=
-  testOptionalType s = .error expected && testType s = .error expected
+  (testOptionalType s).mapError (·.msg) = .error expected
+    && (testType s).mapError (·.msg) = .error expected
 
 /--
   Test that parsing an attribute in the given string returns the expected error in both variants.
 -/
 def expectErrorAttr (s : String) (expected : String) : Bool :=
-  testOptionalAttr s = .error expected && testAttr s = .error expected
+  (testOptionalAttr s).mapError (·.msg) = .error expected
+    && (testAttr s).mapError (·.msg) = .error expected
 
 /--
   Macro to simplify test assertions. Wraps the test in #guard_msgs and #eval,

--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -16,8 +16,8 @@ def testParseOp (s : String) : IO Unit :=
     | .ok parser =>
       match (parseOp none).run (MlirParserState.fromContext ctx) parser with
       | .ok (op, state, _) => Printer.printOperation state.ctx op
-      | .error err => .error err
-    | .error err => .error err
+      | .error err => .error (toString err)
+    | .error err => .error (toString err)
   | none => .error "internal error: failed to create IR context"
 
 /--

--- a/UnitTest/Parser.lean
+++ b/UnitTest/Parser.lean
@@ -1,11 +1,12 @@
 import Veir.Parser.Parser
 
 open Veir.Parser
+open Veir.Parser.ParserError
 
 /--
   Run a parsing function on the given input string.
 -/
-def testParser [ToString α] (s : String) (f : EStateM String ParserState α) : String :=
+def testParser [ToString α] (s : String) (f : EStateM ParserError ParserState α) : String :=
   match ParserState.fromInput (s.toByteArray) with
   | .ok parser =>
     match f.run parser with

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -6,16 +6,18 @@ open Veir.Parser
 
 namespace Veir.AttrParser
 
+open Veir.Parser.ParserError
+
 structure AttrParserState
 
-abbrev AttrParserM := StateT AttrParserState (EStateM String ParserState)
+abbrev AttrParserM := StateT AttrParserState (EStateM ParserError ParserState)
 
 /--
   Execute the action with the given initial state.
   Returns the result along with the final state, or an error message.
 -/
 def AttrParserM.run (self : AttrParserM α)
-  (attrState : AttrParserState) (parserState: ParserState) : Except String (α × AttrParserState × ParserState) :=
+  (attrState : AttrParserState) (parserState: ParserState) : Except ParserError (α × AttrParserState × ParserState) :=
   match (StateT.run self attrState).run parserState with
   | .ok (a, attrState) parserState => .ok (a, attrState, parserState)
   | .error err _ => .error err
@@ -25,7 +27,7 @@ def AttrParserM.run (self : AttrParserM α)
   Returns the result or an error message.
 -/
 def AttrParserM.run' (self : AttrParserM α)
-  (attrState : AttrParserState) (parserState: ParserState) : Except String α :=
+  (attrState : AttrParserState) (parserState: ParserState) : Except ParserError α :=
   match self.run attrState parserState with
   | .ok (a, _, _) => .ok a
   | .error err => .error err
@@ -87,7 +89,7 @@ def parseOptionalRegisterType : AttrParserM (Option RegisterType) := do
 def parseIntegerType (errorMsg : String := "integer type expected") : AttrParserM IntegerType := do
   match ← parseOptionalIntegerType with
   | some integerType => return integerType
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse a register type, throwing an error if it is not present.
@@ -96,7 +98,7 @@ def parseIntegerType (errorMsg : String := "integer type expected") : AttrParser
 def parseRegisterType (errorMsg : String := "register type expected") : AttrParserM RegisterType := do
   match ← parseOptionalRegisterType with
   | some registerType => return registerType
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse an integer attribute, if present.
@@ -132,7 +134,7 @@ def parseStringAttr (errorMsg : String := "string attribute expected") :
     AttrParserM StringAttr := do
   match ← parseOptionalStringAttr with
   | some stringAttr => return stringAttr
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse a unit attribute, if present.
@@ -208,17 +210,17 @@ private def parseUnregisteredAttrBody (endToken : TokenKind := .greater) (startP
         if token.kind == endToken then
           endPos := token.slice.start
           break
-        throw s!"unexpected closing bracket {closingName} in attribute body"
+        throwString s!"unexpected closing bracket {closingName} in attribute body"
       /- If we have an open bracket, check that we are closing it
          with the right bracket kind. -/
       if bracketStack.back! != expected then
-        throw s!"unexpected closing bracket {closingName} in attribute body"
+        throwString s!"unexpected closing bracket {closingName} in attribute body"
       let _ ← consumeToken
       bracketStack := bracketStack.pop
 
     /- Checking for unexpected EOF -/
     else if token.kind == .eof then
-      throw "unexpected end of file before closing of attribute body"
+      throwString "unexpected end of file before closing of attribute body"
 
     /- Other tokens -/
     else
@@ -227,7 +229,7 @@ private def parseUnregisteredAttrBody (endToken : TokenKind := .greater) (startP
   let body := (Slice.mk startPos endPos).of input
   match String.fromUTF8? body with
   | some s => return s
-  | none => throw "failed converting attribute body to string"
+  | none => throwString "failed converting attribute body to string"
 
 /--
   Parse a dialect type, if present.
@@ -307,7 +309,7 @@ partial def parseOptionalCudaTilePointerType : AttrParserM (Option TypeAttr) := 
   let _ ← consumeToken
   parsePunctuation "<"
   let some intTy ← parseOptionalIntegerType
-    | throw "integer type expected"
+    | throwString "integer type expected"
   parsePunctuation ">"
   return some (CudaTile.PointerType.mk intTy)
 
@@ -325,7 +327,7 @@ def parseOptionalModArithType : AttrParserM (Option TypeAttr) := do
   let _ ← consumeToken
   parsePunctuation "<"
   let some modulus ← parseOptionalInteger false false
-    | throw "modarith type modulus expected"
+    | throwString "modarith type modulus expected"
   let modulusType ←
     if ← parseOptionalPunctuation ":" then
       some <$> parseIntegerType "integer type expected after ':' in modarith type"
@@ -361,7 +363,7 @@ def parseOptionalHWModulePort : AttrParserM (Option HW.ModulePort) := do
 def parseHWModulePort (errorMsg : String := "module port expected") : AttrParserM (HW.ModulePort) := do
   match ← parseOptionalHWModulePort with
   | some ty => return ty
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse CIRCT's HW dialect's `ModuleType` type.
@@ -465,7 +467,7 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
 partial def parseType (errorMsg : String := "type expected") : AttrParserM TypeAttr := do
   match ← parseOptionalType with
   | some ty => return ty
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse an entry in an attribute dictionary, which has the form `name = value`
@@ -493,7 +495,7 @@ partial def parseAttributeDictionary (errorMsg : String := "attribute dictionary
     AttrParserM (Array (ByteArray × Attribute)) := do
   match ← parseOptionalAttributeDictionary with
   | some dict => return dict
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse an array attribute, if present.
@@ -547,7 +549,7 @@ partial def parseAttribute (errorMsg : String := "attribute expected") :
     AttrParserM Attribute := do
   match ← parseOptionalAttribute with
   | some attr => return attr
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 end
 

--- a/Veir/Parser/DecidableInBounds.lean
+++ b/Veir/Parser/DecidableInBounds.lean
@@ -14,8 +14,10 @@ import Veir.Rewriter.GetSet
 
 namespace Veir.Parser
 
+open Veir.Parser.ParserError
+
 variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {m : Type → Type} [Monad m] [MonadExcept String m]
+variable {m : Type → Type} [Monad m] [MonadExcept ParserError m]
 
 /-! ## Option.maybe decidability
 
@@ -32,60 +34,60 @@ instance instDecidableMaybe (p : α → β → Prop) [inst : ∀ a b, Decidable 
 def checkBlockInBounds (block : BlockPtr) (ctx : IRContext OpInfo) :
     m (PLift (block.InBounds ctx)) :=
   if h : block.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: block is not in bounds"
+  else throwString s!"internal error: block is not in bounds"
 
 /-- Check that a block insertion point is in bounds. -/
 def checkBlockInsertPointInBounds (ip : BlockInsertPoint) (ctx : IRContext OpInfo) :
     m (PLift (ip.InBounds ctx)) :=
   if h : ip.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: block insertion point is not in bounds"
+  else throwString s!"internal error: block insertion point is not in bounds"
 
 /-- Check that an optional insertion point satisfies maybe-InBounds. -/
 def checkMaybeInsertPointInBounds (ip : Option InsertPoint) (ctx : IRContext OpInfo) :
     m (PLift (ip.maybe InsertPoint.InBounds ctx)) :=
   if h : ip.maybe InsertPoint.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: optional insertion point is not in bounds"
+  else throwString s!"internal error: optional insertion point is not in bounds"
 
 /-- Check that a block has no arguments. -/
 def checkBlockHasNoArgs (block : BlockPtr) (ctx : IRContext OpInfo) :
     m (PLift (block.getNumArguments! ctx = 0)) :=
   if h : block.getNumArguments! ctx = 0 then pure ⟨h⟩
-  else throw s!"internal error: block has {block.getNumArguments! ctx} arguments, expected 0"
+  else throwString s!"internal error: block has {block.getNumArguments! ctx} arguments, expected 0"
 
 /-- Check that an operation is in bounds. -/
 def checkOpInBounds (op : OperationPtr) (ctx : IRContext OpInfo) :
     m (PLift (op.InBounds ctx)) :=
   if h : op.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: operation is not in bounds"
+  else throwString s!"internal error: operation is not in bounds"
 
 /-- Check that a value is in bounds. -/
 def checkValueInBounds (value : ValuePtr) (ctx : IRContext OpInfo) :
     m (PLift (value.InBounds ctx)) :=
   if h : value.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: value is not in bounds"
+  else throwString s!"internal error: value is not in bounds"
 
 /-- Check that a region is in bounds. -/
 def checkRegionInBounds (region : RegionPtr) (ctx : IRContext OpInfo) :
     m (PLift (region.InBounds ctx)) :=
   if h : region.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: region is not in bounds"
+  else throwString s!"internal error: region is not in bounds"
 
 /-- Check that all values in an array are in bounds. -/
 def checkAllValuesInBounds (values : Array ValuePtr) (ctx : IRContext OpInfo) :
     m (PLift (∀ v, v ∈ values → v.InBounds ctx)) :=
   if h : ∀ v, v ∈ values → v.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: not all values are in bounds"
+  else throwString s!"internal error: not all values are in bounds"
 
 /-- Check that all blocks in an array are in bounds. -/
 def checkAllBlocksInBounds (blocks : Array BlockPtr) (ctx : IRContext OpInfo) :
     m (PLift (∀ b, b ∈ blocks → b.InBounds ctx)) :=
   if h : ∀ b, b ∈ blocks → b.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: not all blocks are in bounds"
+  else throwString s!"internal error: not all blocks are in bounds"
 
 /-- Check that all regions in an array are in bounds. -/
 def checkAllRegionsInBounds (regions : Array RegionPtr) (ctx : IRContext OpInfo) :
     m (PLift (∀ r, r ∈ regions → r.InBounds ctx)) :=
   if h : ∀ r, r ∈ regions → r.InBounds ctx then pure ⟨h⟩
-  else throw s!"internal error: not all regions are in bounds"
+  else throwString s!"internal error: not all regions are in bounds"
 
 end Veir.Parser

--- a/Veir/Parser/Lexer.lean
+++ b/Veir/Parser/Lexer.lean
@@ -1,6 +1,9 @@
 import Veir.ForLean
+import Veir.Parser.ParserError
 
 namespace Veir.Parser
+
+open Veir.Parser.ParserError
 
 namespace Lexer
 
@@ -238,16 +241,16 @@ decreasing_by
 
   The opening `"` is expected to have already been consumed at position `tokStart`.
 -/
-def lexStringLiteral (state : LexerState) (tokStart : Nat) : Except String (Token × LexerState) := do
+def lexStringLiteral (state : LexerState) (tokStart : Nat) : Except ParserError (Token × LexerState) := do
   if h: state.isEof then
-    .error "expected '\"' in string literal"
+    .error { msg := "expected '\"' in string literal" }
   else
     let c := state.input[state.pos]'(by grind [LexerState.isEof])
     if c == '"'.toUInt8 then
       let newState := { state with pos := state.pos + 1 }
       return (newState.mkToken .stringLit tokStart, newState)
     else if c == '\n'.toUInt8 then
-      .error "expected '\"' in string literal"
+      .error { msg := "expected '\"' in string literal" }
     else if c == '\\'.toUInt8 then
       if h: state.pos + 1 < state.input.size then
         let c1 := state.input[state.pos + 1]
@@ -260,11 +263,11 @@ def lexStringLiteral (state : LexerState) (tokStart : Nat) : Except String (Toke
             let nextState := { state with pos := state.pos + 3 }
             lexStringLiteral nextState tokStart
           else
-            .error "unknown escape in string literal"
+            .error { msg := "unknown escape in string literal" }
         else
-          .error "unknown escape in string literal"
+          .error { msg := "unknown escape in string literal" }
       else
-        .error "unknown escape in string literal"
+        .error { msg := "unknown escape in string literal" }
     else
       lexStringLiteral { state with pos := state.pos + 1 } tokStart
 termination_by state.input.size - state.pos
@@ -277,9 +280,9 @@ decreasing_by
 
   The first character `@` is expected to have already been parsed.
 -/
-def lexAtIdentifier (state : LexerState) (tokStart : Nat) : Except String (Token × LexerState) := do
+def lexAtIdentifier (state : LexerState) (tokStart : Nat) : Except ParserError (Token × LexerState) := do
   if h: state.isEof then
-    .error "expected identifier or string literal after '@'"
+    .error { msg := "expected identifier or string literal after '@'" }
   else
     let c := state.input[state.pos]'(by grind [LexerState.isEof])
     if UInt8.isAlphaOrUnderscore c then
@@ -290,7 +293,7 @@ def lexAtIdentifier (state : LexerState) (tokStart : Nat) : Except String (Token
       let (token, state) ← lexStringLiteral newState tokStart
       return (LexerState.mkToken state .atIdent tokStart, state)
     else
-      .error "expected identifier or string literal after '@'"
+      .error { msg := "expected identifier or string literal after '@'" }
 
 /--
   Lex an identifier that starts with a prefix followed by suffix-id.
@@ -305,7 +308,7 @@ def lexAtIdentifier (state : LexerState) (tokStart : Nat) : Except String (Token
   id-punct      ::= `$` | `.` | `_` | `-`
 -/
 def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
-    (kind : TokenKind) : Except String (Token × LexerState) := do
+    (kind : TokenKind) : Except ParserError (Token × LexerState) := do
   let errorString := match kind with
     | .hashIdent => "invalid attribute name"
     | .percentIdent => "invalid SSA name"
@@ -314,7 +317,7 @@ def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
     | _ => "internal error: invalid kind for prefixed identifier"
 
   if h: state.isEof then
-    .error errorString
+    .error { msg := errorString }
   else
     let c := state.input[state.pos]'(by grind [LexerState.isEof])
     if UInt8.isDigit c then
@@ -340,7 +343,7 @@ def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
       let newState := { state with pos := pos }
       return (newState.mkToken kind tokStart, newState)
     else
-      .error errorString
+      .error { msg := errorString }
 
 /--
   Lex a number literal.
@@ -419,7 +422,7 @@ def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Nat) : Token 
 /--
   Lex the next token from the input.
 -/
-partial def lex (state : LexerState) : Except String (Token × LexerState) :=
+partial def lex (state : LexerState) : Except ParserError (Token × LexerState) :=
   let tokStart := state.pos
   -- Check for end of file
   if h: state.isEof then
@@ -485,9 +488,9 @@ partial def lex (state : LexerState) : Except String (Token × LexerState) :=
           let newState := { state with pos := state.pos + 3 }
           return (newState.mkToken .ellipsis tokStart, newState)
         else
-          .error "expected three consecutive '.' for an ellipsis"
+          .error { msg := "expected three consecutive '.' for an ellipsis" }
       else
-        .error "expected three consecutive '.' for an ellipsis"
+        .error { msg := "expected three consecutive '.' for an ellipsis" }
     -- Parse `-` or `->`
     else if c == '-'.toUInt8 then
       if h: state.pos + 1 < state.input.size then
@@ -555,7 +558,7 @@ partial def lex (state : LexerState) : Except String (Token × LexerState) :=
       let newState := { state with pos := state.pos + 1 }
       return lexNumber newState c tokStart
     else
-      .error s!"Unexpected character '{Char.ofUInt8 c}' at position {state.pos}"
+      .error { msg := s!"Unexpected character '{Char.ofUInt8 c}' at position {state.pos}" }
 
 end Lexer
 

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -16,6 +16,8 @@ open Veir.AttrParser
 
 namespace Veir.Parser
 
+open Veir.Parser.ParserError
+
 variable {ctx : IRContext OpCode}
 
 structure MlirParserState where
@@ -34,14 +36,14 @@ structure MlirParserState where
 def MlirParserState.fromContext (ctx : WfIRContext OpCode) : MlirParserState :=
   {ctx := ctx, values := Std.HashMap.emptyWithCapacity 128, blocks := Std.HashMap.emptyWithCapacity 1}
 
-abbrev MlirParserM := StateT MlirParserState (EStateM String ParserState)
+abbrev MlirParserM := StateT MlirParserState (EStateM ParserError ParserState)
 
 /--
   Execute the action with the given initial state.
   Returns the result along with the final state, or an error message.
 -/
 def MlirParserM.run (self : MlirParserM α)
-  (mlirParserState : MlirParserState) (parserState: ParserState) : Except String (α × MlirParserState × ParserState) :=
+  (mlirParserState : MlirParserState) (parserState: ParserState) : Except ParserError (α × MlirParserState × ParserState) :=
   match (StateT.run self mlirParserState).run parserState with
   | .ok (a, mlirParserState) parserState => .ok (a, mlirParserState, parserState)
   | .error err _ => .error err
@@ -51,7 +53,7 @@ def MlirParserM.run (self : MlirParserM α)
   Returns the result or an error message.
 -/
 def MlirParserM.run' (self : MlirParserM α)
-  (mlirParserState : MlirParserState) (parserState: ParserState) : Except String α :=
+  (mlirParserState : MlirParserState) (parserState: ParserState) : Except ParserError α :=
   match self.run mlirParserState parserState with
   | .ok (a, _, _) => .ok a
   | .error err => .error err
@@ -134,14 +136,14 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
   let state ← get
   match state.blocks[name]? with
   | some (block, true) => -- Block of this name is already defined.
-    throw s!"block %{String.fromUTF8! name} has already been defined"
+    throwString s!"block %{String.fromUTF8! name} has already been defined"
   | some (block, false) => -- Block of this name was forward declared.
     /- Insert the block at the given location. -/
     modifyContextM fun ctx => do
       let ⟨hip⟩ ← checkBlockInsertPointInBounds ip ctx.raw
       let ⟨hblock⟩ ← checkBlockInBounds block ctx.raw
       match hctx' : Rewriter.insertBlock? ctx block ip hblock hip with
-      | none => throw "internal error: failed to insert block"
+      | none => throwString "internal error: failed to insert block"
       | some ctx' => pure ⟨ctx', by grind [Rewriter.insertBlock?_WellFormed]⟩
     /- Notify the parsing context that the block is defined. -/
     modifyThe MlirParserState (fun state =>
@@ -154,7 +156,7 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) : MlirParserM BlockPt
     let block ← modifyContextM' fun ctx => do
       let ⟨hip⟩ ← checkBlockInsertPointInBounds ip ctx.raw
       match hctx' : Rewriter.createBlock ctx #[] ip (by grind) (by grind) with
-      | none => throw "internal error: failed to create block"
+      | none => throwString "internal error: failed to create block"
       | some (ctx', block) => pure ⟨block, ⟨ctx', by grind [Rewriter.createBlock_WellFormed]⟩⟩
     /- Notify the parsing context that the block is defined. -/
     modifyThe MlirParserState fun s =>
@@ -175,7 +177,7 @@ def defineBlockUse (name : ByteArray) : MlirParserM BlockPtr := do
     /- Create the block. -/
     let block ← modifyContextM' fun ctx => do
       match hctx' : Rewriter.createBlock ctx #[] none (by grind) Option.maybe_none with
-      | none => throw "internal error: failed to create block"
+      | none => throwString "internal error: failed to create block"
       | some (ctx', block) => pure ⟨block, ⟨ctx', by grind [Rewriter.createBlock_WellFormed]⟩⟩
     /- Notify the parsing context that the block is forward declared. -/
     modifyThe MlirParserState fun s =>
@@ -197,7 +199,7 @@ def parseOpResult : MlirParserM (ByteArray × Nat) := do
 
   let count := (← parseInteger false false).toNat
   if count ≤ 1 then
-    throw "expected named operation to have at least 1 result"
+    throwString "expected named operation to have at least 1 result"
 
   return (name, count)
 
@@ -258,7 +260,7 @@ def parseOperand : MlirParserM UnresolvedOperand := do
   /- Parse the result count as a Nat. -/
   let resultCount := { resultCount.slice with start := resultCount.slice.start + 1 }.of (← getInput) -- skip # character
   let some resultCount := String.fromUTF8? resultCount >>= String.toNat?
-    | throw "invalid SSA value result number"
+    | throwString "invalid SSA value result number"
   return UnresolvedOperand.mk name resultCount
 
 /--
@@ -288,12 +290,12 @@ def parseBlockOperands : MlirParserM (Array BlockPtr) := do
   Throw an error if the value is not defined or if the type does not match.
 -/
 def resolveOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) : MlirParserM ValuePtr := do
-  let some values := (← getValues? operand.name) | throw s!"use of undefined value %{operand.nameString}"
-  let some value := values[operand.indexD]? | throw s!"invalid result index {operand.indexD} for %{operand.nameString}"
+  let some values := (← getValues? operand.name) | throwString s!"use of undefined value %{operand.nameString}"
+  let some value := values[operand.indexD]? | throwString s!"invalid result index {operand.indexD} for %{operand.nameString}"
   let ⟨ctx, _⟩ ← getContext
   let parsedType := value.getType! ctx
   if parsedType ≠ expectedType then
-    throw s!"type mismatch for value {operand}: expected {expectedType}, got {parsedType}"
+    throwString s!"type mismatch for value {operand}: expected {expectedType}, got {parsedType}"
   return value
 
 /--
@@ -312,7 +314,7 @@ def parseOptionalType : MlirParserM (Option TypeAttr) := do
 def parseType (errorMsg : String := "type expected") : MlirParserM TypeAttr := do
   match ← parseOptionalType with
   | some ty => return ty
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse an operation type, consisting of a colon followed by a function type.
@@ -348,14 +350,14 @@ def parseOpProperties (opCode : OpCode) : MlirParserM (propertiesOf opCode) := d
   if not (← parseOptionalPunctuation "<") then
     match Properties.fromAttrDict opCode {} with
     | .ok properties => return properties
-    | .error err => throw err
+    | .error err => throwString err
   match AttrParser.parseAttributeDictionary.run AttrParserState.mk (← getThe ParserState) with
   | .ok (properties, _, parserState) =>
     set parserState
     parsePunctuation ">"
     match Properties.fromAttrDict opCode (.ofArray properties) with
     | .ok properties => return properties
-    | .error err => throw err
+    | .error err => throwString err
   | .error err => throw err
 
 /--
@@ -447,11 +449,11 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
 
   /- Check that the number of results matches with the operation type. -/
   if outputTypes.size ≠ numResults then
-    throw s!"operation '{opName}' declares {outputTypes.size} result types, but {numResults} result values were provided"
+    throwString s!"operation '{opName}' declares {outputTypes.size} result types, but {numResults} result values were provided"
 
   /- Check that the number and types of operands matches with the operation type. -/
   if inputTypes.size ≠ operands.size then
-    throw s!"operation '{opName}' declares {inputTypes.size} operand types, but {operands.size} operands were provided"
+    throwString s!"operation '{opName}' declares {inputTypes.size} operand types, but {operands.size} operands were provided"
   let operands ← operands.zip inputTypes |>.mapM (fun (operand, type) => resolveOperand operand type)
 
   let op ← modifyContextM' fun ctx => do
@@ -460,7 +462,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
     let ⟨hregions⟩ ← checkAllRegionsInBounds regions ctx.raw
     let ⟨hins⟩ ← checkMaybeInsertPointInBounds ip ctx.raw
     match hctx' : Rewriter.createOp ctx opId outputTypes operands blockOperands regions properties ip hoper hblockOperands hregions hins with
-    | none => throw "internal error: failed to create operation"
+    | none => throwString "internal error: failed to create operation"
     | some (ctx', op) =>
       have hop : op.InBounds ctx' := Rewriter.createOp_new_inBounds op hctx'
       let ctx'' := op.setAttributes ctx' attrs hop
@@ -481,7 +483,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   Parse an operation.
 -/
 partial def parseOp (ip : Option InsertPoint) : MlirParserM OperationPtr := do
-  let some op ← parseOptionalOp ip | throw "operation expected"
+  let some op ← parseOptionalOp ip | throwString "operation expected"
   return op
 
 /--
@@ -496,7 +498,7 @@ partial def parseRegion : MlirParserM RegionPtr := do
   parsePunctuation "{"
   let region := ← modifyContextM' fun ctx => do
     match hctx' : Rewriter.createRegion ctx with
-    | none => throw "internal error: failed to create region"
+    | none => throwString "internal error: failed to create region"
     | some (ctx', region) => pure (region, ⟨ctx', by grind [IRContext.wellFormed_Rewriter_createRegion]⟩)
 
   /- Case where there are no blocks inside the region. -/
@@ -516,7 +518,7 @@ partial def parseRegion : MlirParserM RegionPtr := do
   /- Check that all blocks in the regions that were forward declared were parsed. -/
   for (blockName, (_, parsed)) in (← getThe MlirParserState).blocks do
     if !parsed then
-      throw s!"block %{String.fromUTF8! blockName} was declared but not defined"
+      throwString s!"block %{String.fromUTF8! blockName} was declared but not defined"
 
   /- Restore the previous block parsing state. -/
   modifyThe MlirParserState fun s => {s with blocks := oldBlocks}

--- a/Veir/Parser/Parser.lean
+++ b/Veir/Parser/Parser.lean
@@ -3,6 +3,8 @@ open Veir.Parser.Lexer
 
 namespace Veir.Parser
 
+open Veir.Parser.ParserError
+
 /--
   The state of a generic parser.
   It contains the state of the lexer (which includes the input and the current
@@ -16,7 +18,7 @@ structure ParserState where
 /--
   Create a new parser state at the beginning of the given input.
 -/
-def ParserState.fromInput (input : ByteArray) : Except String ParserState := do
+def ParserState.fromInput (input : ByteArray) : Except ParserError ParserState := do
   let lexerState := LexerState.mk input 0
   let (firstToken, lexerState) ← lex lexerState
   return ParserState.mk lexerState firstToken
@@ -39,7 +41,7 @@ def ParserState.input (state : ParserState) : ByteArray :=
 -/
 section ParserStateMethods
 
-variable [Monad M] [MonadExcept String M] [MonadStateOf ParserState M]
+variable [Monad M] [MonadExcept ParserError M] [MonadStateOf ParserState M]
 
 /--
   Get the current position in the input.
@@ -79,7 +81,7 @@ def parseOptionalToken (tokType : TokenKind) : M (Option Token) := do
 def parseToken (tokType : TokenKind) (errorMsg : String) : M Token := do
   match ← parseOptionalToken tokType with
   | some token => return token
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Peek at the current token without consuming it.
@@ -140,7 +142,7 @@ def parseOptionalPunctuation (c : String) (h : (isPunctuation c).isSome := by gr
 def parsePunctuation (c : String) (errorMsg : String := s!"Expected punctuation '{c}'") (h : (isPunctuation c).isSome := by grind) : M Unit := do
   match ← parseOptionalPunctuation c with
   | true => return ()
-  | false => throw errorMsg
+  | false => throwString errorMsg
 
 /--
   Parse optionally an identifier with grammar rule `(letter|[_]) (letter|digit|[_$.])*`.
@@ -159,7 +161,7 @@ def parseOptionalIdentifier : M (Option ByteArray) := do
 def parseIdentifier (errorMsg : String := "identifier expected") : M ByteArray := do
   match ← parseOptionalIdentifier with
   | some ident => return ident
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse optionally a specific keyword.
@@ -188,7 +190,7 @@ def parseKeyword (keyword : ByteArray) (errorMsg : String := s!"expected keyword
   if ← parseOptionalKeyword keyword then
     return
   else
-    throw errorMsg
+    throwString errorMsg
 
 /--
   Parse an identifier with a specific prefix, if present.
@@ -215,13 +217,13 @@ def parsePrefixedKeyword (prefixKind : TokenKind)
       M ByteArray := do
   match ← parseOptionalPrefixedKeyword prefixKind with
   | some ident => return ident
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Process escape sequences in a string literal byte array.
   Supported escapes: `\\`, `\"`, `\n`, `\t`, and `\HH` (hex byte).
 -/
-private def processEscapes (input : ByteArray) : Except String ByteArray := do
+private def processEscapes (input : ByteArray) : Except ParserError ByteArray := do
   let mut result : ByteArray := .empty
   let mut i := 0
   while h : i < input.size do
@@ -231,7 +233,7 @@ private def processEscapes (input : ByteArray) : Except String ByteArray := do
       i := i + 1
       continue
     if i + 1 >= input.size then
-      throw "unexpected end of string after '\\'"
+      throwString "unexpected end of string after '\\'"
     let next := input.getD (i + 1) 0
     if next == '\\'.toUInt8 then
       result := result.push '\\'.toUInt8
@@ -251,11 +253,11 @@ private def processEscapes (input : ByteArray) : Except String ByteArray := do
       continue
     -- Try \HH hex escape
     if i + 2 >= input.size then
-      throw "unknown escape in string literal"
+      throwString "unknown escape in string literal"
     let hex1 := input.getD (i + 1) 0
     let hex2 := input.getD (i + 2) 0
     if !(hex1.isHexDigit && hex2.isHexDigit) then
-      throw "unknown escape in string literal"
+      throwString "unknown escape in string literal"
     let high := if hex1 >= 'a'.toUInt8 then hex1 - 'a'.toUInt8 + 10
       else if hex1 >= 'A'.toUInt8 then hex1 - 'A'.toUInt8 + 10
       else hex1 - '0'.toUInt8
@@ -280,7 +282,7 @@ def parseOptionalStringLiteral : M (Option String) := do
     let processed ← ofExcept (processEscapes raw)
     match String.fromUTF8? processed with
     | some str => return some str
-    | none => throw "internal error: failed converting string literal"
+    | none => throwString "internal error: failed converting string literal"
   | none => return none
 
 /--
@@ -290,7 +292,7 @@ def parseOptionalStringLiteral : M (Option String) := do
 def parseStringLiteral (errorMsg : String := "string literal expected") : M String := do
   match ← parseOptionalStringLiteral with
   | some str => return str
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parses either an identifier or a string literal, if present.
@@ -311,7 +313,7 @@ def parseIdentifierOrStringLiteral (errorMsg : String := "identifier or string l
     M ByteArray := do
   match ← parseOptionalIdentifierOrStringLiteral with
   | some identOrStr => return identOrStr
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse a boolean with grammar rule `true | false`, if present.
@@ -333,7 +335,7 @@ def parseOptionalBoolean : M (Option Bool) := do
 def parseBoolean (errorMsg : String := "boolean expected") : M Bool := do
   match ← parseOptionalBoolean with
   | some b => return b
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Parse an integer literal, if present.
@@ -356,7 +358,7 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Optio
   -- Parse the actual integer literal
   let intToken ← parseOptionalToken .intLit
   if intToken = none && isNegative then
-    throw "expected integer literal after '-'"
+    throwString "expected integer literal after '-'"
 
   -- Convert the integer literal token to an Int
   let some intToken := intToken | return none
@@ -367,7 +369,7 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Optio
     else
       (String.fromUTF8? slice).bind String.toNat?
   let some value := value
-    | throw s!"internal error: failed converting '{intToken.slice.of ((← get).input)}' to an integer literal"
+    | throwString s!"internal error: failed converting '{intToken.slice.of ((← get).input)}' to an integer literal"
   if isNegative then
     return some (Int.negOfNat value)
   else
@@ -383,7 +385,7 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Optio
 def parseInteger (allowBoolean : Bool) (allowNegative : Bool) (errorMsg : String := "integer expected") : M Int := do
   match ← parseOptionalInteger allowBoolean allowNegative with
   | some i => return i
-  | none => throw errorMsg
+  | none => throwString errorMsg
 
 /--
   Delimiters that are supported when parsing lists.

--- a/Veir/Parser/ParserError.lean
+++ b/Veir/Parser/ParserError.lean
@@ -133,6 +133,30 @@ def format (e : ParserError) (filename : String) (input : ByteArray) : String :=
     (fun acc note => acc ++ "\n" ++ formatLabel filename input "note" (some note.pos) note.msg)
     primary
 
+/-!
+  ## Temporary Compatibility Functions
+
+  This section contains temporary functions that are only used to port existing code to the new
+  `ParserError`. Once all existing call sites have been updated to use `ParserError` with source
+  locations and notes, these functions will be removed.
+-/
+
+/--
+  Print a `ParserError` as just its message, so existing `#guard_msgs` /
+  FileCheck output are unchanged until all parser errors are enriched with source locations
+  and notes.
+-/
+instance : ToString ParserError := ⟨ParserError.msg⟩
+
+/--
+  Throws a `ParserError` with no source location or notes, given the error message.
+
+  This function is just temporary to avoid moving all existing `throw "msg"` to the new `ParserError`
+  at once, and will be removed once all call sites have been updated to provide source locations and
+  notes.
+-/
+def throwString [Monad M] [MonadExcept ParserError M] (msg : String) : M α :=
+  throw { msg }
 
 end -- public section
 

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -72,10 +72,10 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode Ã
     match (parseOp none).run (MlirParserState.fromContext ctx) parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
-    | .error errMsg =>
-      throw s!"Error parsing operation: {errMsg}"
-  | .error errMsg =>
-    throw s!"Error reading file: {errMsg}"
+    | .error err =>
+      throw s!"Error parsing operation: {err}"
+  | .error err =>
+    throw s!"Error reading file: {err}"
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do


### PR DESCRIPTION
In particular, no error output is being changed, as the `ParserError` is converted to a string at the end in `veir-opt`

This PR only contains the change from `String` to `ParserError`, and the temporary addition of `ParserError.throwString` and the coercion from `ParserError` to `String`. These two last additions will be removed once everything moves to `ParserError`.