### PR TITLE
Use caret-style formatting in `veir-opt` for parsing

### DIFF
--- a/Test/Parsing/invalid-syntax.mlir
+++ b/Test/Parsing/invalid-syntax.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-opt %s 2>&1 | filecheck %s
+
+// Verify that parse errors go through ParserError.format.
+// Position are not yet passed to `ParserError` everywhere, so it uses an unknown location here.
+
+"builtin.module"() ({
+  ^bb0():
+    %a = "test.op"() missing_colon
+}) : () -> ()
+
+// CHECK: <unknown location>: error: Expected punctuation ':'

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -1,4 +1,5 @@
 import Veir.Parser.MlirParser
+import Veir.Parser.ParserError
 import Veir.Printer
 import Veir.IR.Basic
 import Veir.Verifier
@@ -13,6 +14,7 @@ import Veir.Passes.CastsReconciliation.Reconciliation
 import Veir.Passes.Combines.Combine
 
 open Veir.Parser
+open Veir.Parser.ParserError
 open Veir
 
 /--
@@ -73,9 +75,9 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode Ã
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error err =>
-      throw s!"Error parsing operation: {err}"
+      throw (err.format filename fileContent)
   | .error err =>
-    throw s!"Error reading file: {err}"
+    throw (err.format filename fileContent)
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
@@ -85,8 +87,7 @@ def main (args : List String) : IO Unit := do
     IO.eprintln "Usage: veir-opt <filename> [-p=\"pass1,pass2,...\"]"
   | .ok { filename, passes } =>
     match â† parseOperation filename with
-    | .error errMsg =>
-      IO.eprintln s!"Error: {errMsg}"
+    | .error errMsg => IO.eprintln errMsg
     | .ok (ctx, op) =>
       match ctx.verify with
       | .error errMsg =>


### PR DESCRIPTION
When `veir-opt` parsing fails, the error is now returned with the failure location. Additionally, it prints the line where the parsing error occured.

Errors are currently only showing `<unknown location>`, as locations are not yet passed to the created `ParserError` in the parser.