### PR TITLE
Add locations to errors in `Parser/Parser.lean`

### DIFF
--- a/Test/Parsing/invalid-syntax.mlir
+++ b/Test/Parsing/invalid-syntax.mlir
@@ -1,11 +1,12 @@
-// RUN: veir-opt %s 2>&1 | filecheck %s
+// RUN: veir-opt %s 2>&1 | filecheck %s --strict-whitespace
 
 // Verify that parse errors go through ParserError.format.
-// Position are not yet passed to `ParserError` everywhere, so it uses an unknown location here.
 
 "builtin.module"() ({
   ^bb0():
     %a = "test.op"() missing_colon
 }) : () -> ()
 
-// CHECK: <unknown location>: error: Expected punctuation ':'
+// CHECK:Test/Parsing/invalid-syntax.mlir:7:22: error: Expected punctuation ':'
+// CHECK-NEXT:     %a = "test.op"() missing_colon
+// CHECK-NEXT:                      ^

--- a/UnitTest/Parser.lean
+++ b/UnitTest/Parser.lean
@@ -4,16 +4,52 @@ open Veir.Parser
 open Veir.Parser.ParserError
 
 /--
-  Run a parsing function on the given input string.
+  Like `testParser`, but returns the full error including position.
 -/
-def testParser [ToString α] (s : String) (f : EStateM ParserError ParserState α) : String :=
-  match ParserState.fromInput (s.toByteArray) with
+def testParser [ToString α] (s : String) (f : EStateM ParserError ParserState α) : IO Unit :=
+  match ParserState.fromInput s.toByteArray with
   | .ok parser =>
     match f.run parser with
-    | .ok res _ => s!"Success: {toString res}"
-    | .error err _ => s!"Error: {err}"
-  | .error lexErr =>
-    s!"Error: {lexErr}"
+    | .ok res _ => IO.print (reprStr s!"Success: {toString res}")
+    | .error err _ => IO.print (ParserError.format err "<test>" s.toByteArray)
+  | .error lexErr => IO.print (ParserError.format lexErr "<test>" s.toByteArray)
+
+section throwAtCurrentPos
+
+-- throwAtCurrentPos records position 0 at the start of input.
+/-- info: <test>:1:1: error: oops
+foo
+^ -/
+#guard_msgs (whitespace := exact) in
+#eval! testParser "foo" (throwAtCurrentPos "oops" : EStateM ParserError ParserState Unit)
+
+-- throwAtCurrentPos records the position of the current token after consuming one.
+/-- info: <test>:1:5: error: oops
+foo bar
+    ^ -/
+#guard_msgs (whitespace := exact) in
+#eval! testParser "foo bar" (do let _ ← consumeToken; throwAtCurrentPos "oops" : EStateM ParserError ParserState Unit)
+
+
+end throwAtCurrentPos
+
+section throwAt
+
+/-- info: <test>:1:5: error: oops
+foo bar
+    ^ -/
+#guard_msgs (whitespace := exact) in
+#eval! testParser "foo bar" (throwAt 4 "oops" : EStateM ParserError ParserState Unit)
+
+-- throwAt uses the given position even after consuming a token (ignores current position).
+/-- info: <test>:1:1: error: oops
+foo bar
+^ -/
+#guard_msgs (whitespace := exact) in
+#eval! testParser "foo bar" (do let _ ← consumeToken; throwAt 0 "oops" : EStateM ParserError ParserState Unit)
+
+end throwAt
+
 
 section parsePunctuation
 
@@ -39,10 +75,10 @@ section parseIdentifier
 #guard_msgs in
 #eval testParser "foo" (parseIdentifier)
 
-/--
-  info: "Error: custom error"
--/
-#guard_msgs in
+/-- info: <test>:1:1: error: custom error
+->
+^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "->" (parseIdentifier "custom error")
 
 /--
@@ -85,10 +121,10 @@ section parseBoolean
 #guard_msgs in
 #eval testParser "true" (parseBoolean)
 
-/--
-  info: "Error: error message"
--/
-#guard_msgs in
+/-- info: <test>:1:1: error: error message
+no
+^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "no" (parseBoolean "error message")
 
 end parseBoolean
@@ -181,10 +217,10 @@ section parseKeyword
 #guard_msgs in
 #eval testParser "while" (parseKeyword "while".toByteArray)
 
-/--
-  info: "Error: expected keyword 'if'"
--/
-#guard_msgs in
+/-- info: <test>:1:1: error: expected keyword 'if'
+while
+^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "while" (parseKeyword "if".toByteArray)
 
 /--
@@ -208,14 +244,14 @@ section parseStringLiteral
 #guard_msgs in
 #eval testParser "\"hello world!\"" parseStringLiteral
 
-/--
-  info: "Error: string literal expected"
--/
-#guard_msgs in
+/-- info: <test>:1:1: error: string literal expected
+hello world!
+^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "hello world!" parseStringLiteral
 
 /--
-  info: "Error: expected '\"' in string literal"
+  info: <unknown location>: error: expected '"' in string literal
 -/
 #guard_msgs in
 #eval testParser "\"unterminated string" parseStringLiteral
@@ -347,22 +383,22 @@ section parseList
 
 /-! # Test some error cases. -/
 
-/--
-  info: "Error: closing delimiter ')' expected"
--/
-#guard_msgs in
+/-- info: <test>:1:9: error: closing delimiter ')' expected
+(1, 2, 3
+        ^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "(1, 2, 3" (parseDelimitedList .paren (parseInteger false false))
 
-/--
-  info: "Error: integer expected"
--/
-#guard_msgs in
-#eval testParser "(1, 2, " (parseDelimitedList .paren (parseInteger false false))
+/-- info: <test>:1:7: error: integer expected
+(1, 2,
+      ^ -/
+#guard_msgs (whitespace := exact) in
+#eval testParser "(1, 2," (parseDelimitedList .paren (parseInteger false false))
 
-/--
-  info: "Error: integer expected"
--/
-#guard_msgs in
+/-- info: <test>:1:8: error: integer expected
+(1, 2, )
+       ^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "(1, 2, )" (parseDelimitedList .paren (parseInteger false false))
 
 /-! # Test empty list. -/
@@ -479,10 +515,10 @@ section parseList
 #guard_msgs in
 #eval testParser "%foo" (parseOptionalPrefixedKeyword .percentIdent)
 
-/--
-  info: "Error: expected keyword with prefix '@'"
--/
-#guard_msgs in
+/-- info: <test>:1:1: error: expected keyword with prefix '@'
+#foo
+^ -/
+#guard_msgs (whitespace := exact) in
 #eval testParser "#foo" (parsePrefixedKeyword .atIdent)
 
 /--

--- a/Veir/Parser/Parser.lean
+++ b/Veir/Parser/Parser.lean
@@ -51,6 +51,19 @@ def getPos : M Nat := do
   return (←get).pos
 
 /--
+  Throw a `ParserError` whose location is the position currently pointed to by
+  the parser (i.e., the start of the current token).
+-/
+def throwAtCurrentPos (msg : String) : M α := do
+  throw { msg, pos := some (← getPos) }
+
+/--
+  Throw a `ParserError` whose location is the given byte offset.
+-/
+def throwAt (pos : Nat) (msg : String) : M α :=
+  throw { msg, pos := some pos }
+
+/--
   Consume the current token and return the updated parser state.
   Use `parseToken` or `parseOptionalToken` to consume only specific tokens.
   This function should not be used outside of the parser implementation.
@@ -81,7 +94,7 @@ def parseOptionalToken (tokType : TokenKind) : M (Option Token) := do
 def parseToken (tokType : TokenKind) (errorMsg : String) : M Token := do
   match ← parseOptionalToken tokType with
   | some token => return token
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Peek at the current token without consuming it.
@@ -142,7 +155,7 @@ def parseOptionalPunctuation (c : String) (h : (isPunctuation c).isSome := by gr
 def parsePunctuation (c : String) (errorMsg : String := s!"Expected punctuation '{c}'") (h : (isPunctuation c).isSome := by grind) : M Unit := do
   match ← parseOptionalPunctuation c with
   | true => return ()
-  | false => throwString errorMsg
+  | false => throwAtCurrentPos errorMsg
 
 /--
   Parse optionally an identifier with grammar rule `(letter|[_]) (letter|digit|[_$.])*`.
@@ -161,7 +174,7 @@ def parseOptionalIdentifier : M (Option ByteArray) := do
 def parseIdentifier (errorMsg : String := "identifier expected") : M ByteArray := do
   match ← parseOptionalIdentifier with
   | some ident => return ident
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Parse optionally a specific keyword.
@@ -190,7 +203,7 @@ def parseKeyword (keyword : ByteArray) (errorMsg : String := s!"expected keyword
   if ← parseOptionalKeyword keyword then
     return
   else
-    throwString errorMsg
+    throwAtCurrentPos errorMsg
 
 /--
   Parse an identifier with a specific prefix, if present.
@@ -217,13 +230,13 @@ def parsePrefixedKeyword (prefixKind : TokenKind)
       M ByteArray := do
   match ← parseOptionalPrefixedKeyword prefixKind with
   | some ident => return ident
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Process escape sequences in a string literal byte array.
   Supported escapes: `\\`, `\"`, `\n`, `\t`, and `\HH` (hex byte).
 -/
-private def processEscapes (input : ByteArray) : Except ParserError ByteArray := do
+private def processEscapes (input : ByteArray) (basePos : Nat) : Except ParserError ByteArray := do
   let mut result : ByteArray := .empty
   let mut i := 0
   while h : i < input.size do
@@ -233,7 +246,7 @@ private def processEscapes (input : ByteArray) : Except ParserError ByteArray :=
       i := i + 1
       continue
     if i + 1 >= input.size then
-      throwString "unexpected end of string after '\\'"
+      throwAt (basePos + i) "unexpected end of string after '\\'"
     let next := input.getD (i + 1) 0
     if next == '\\'.toUInt8 then
       result := result.push '\\'.toUInt8
@@ -253,11 +266,11 @@ private def processEscapes (input : ByteArray) : Except ParserError ByteArray :=
       continue
     -- Try \HH hex escape
     if i + 2 >= input.size then
-      throwString "unknown escape in string literal"
+      throwAt (basePos + i) "unknown escape in string literal"
     let hex1 := input.getD (i + 1) 0
     let hex2 := input.getD (i + 2) 0
     if !(hex1.isHexDigit && hex2.isHexDigit) then
-      throwString "unknown escape in string literal"
+      throwAt (basePos + i) "unknown escape in string literal"
     let high := if hex1 >= 'a'.toUInt8 then hex1 - 'a'.toUInt8 + 10
       else if hex1 >= 'A'.toUInt8 then hex1 - 'A'.toUInt8 + 10
       else hex1 - '0'.toUInt8
@@ -279,10 +292,10 @@ def parseOptionalStringLiteral : M (Option String) := do
   | some token =>
     let slice : Slice := {start := token.slice.start + 1, stop := token.slice.stop - 1} -- remove quotes
     let raw := slice.of ((← get).input)
-    let processed ← ofExcept (processEscapes raw)
+    let processed ← ofExcept (processEscapes raw (token.slice.start + 1))
     match String.fromUTF8? processed with
     | some str => return some str
-    | none => throwString "internal error: failed converting string literal"
+    | none => throwAt token.slice.start "internal error: failed converting string literal"
   | none => return none
 
 /--
@@ -292,7 +305,7 @@ def parseOptionalStringLiteral : M (Option String) := do
 def parseStringLiteral (errorMsg : String := "string literal expected") : M String := do
   match ← parseOptionalStringLiteral with
   | some str => return str
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Parses either an identifier or a string literal, if present.
@@ -313,7 +326,7 @@ def parseIdentifierOrStringLiteral (errorMsg : String := "identifier or string l
     M ByteArray := do
   match ← parseOptionalIdentifierOrStringLiteral with
   | some identOrStr => return identOrStr
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Parse a boolean with grammar rule `true | false`, if present.
@@ -335,7 +348,7 @@ def parseOptionalBoolean : M (Option Bool) := do
 def parseBoolean (errorMsg : String := "boolean expected") : M Bool := do
   match ← parseOptionalBoolean with
   | some b => return b
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Parse an integer literal, if present.
@@ -344,6 +357,7 @@ def parseBoolean (errorMsg : String := "boolean expected") : M Bool := do
   Optionally, allow parsing `true` or `false` as `1` or `0`, respectively.
 -/
 def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Option Int) := do
+  let startPos ← getPos
   -- First try to parse a boolean if allowed
   if allowBoolean then
     let boolean ← parseOptionalBoolean
@@ -358,7 +372,7 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Optio
   -- Parse the actual integer literal
   let intToken ← parseOptionalToken .intLit
   if intToken = none && isNegative then
-    throwString "expected integer literal after '-'"
+    throwAtCurrentPos "expected integer literal after '-'"
 
   -- Convert the integer literal token to an Int
   let some intToken := intToken | return none
@@ -369,7 +383,7 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Optio
     else
       (String.fromUTF8? slice).bind String.toNat?
   let some value := value
-    | throwString s!"internal error: failed converting '{intToken.slice.of ((← get).input)}' to an integer literal"
+    | throwAt startPos s!"internal error: failed converting '{intToken.slice.of ((← get).input)}' to an integer literal"
   if isNegative then
     return some (Int.negOfNat value)
   else
@@ -385,7 +399,7 @@ def parseOptionalInteger (allowBoolean : Bool) (allowNegative : Bool) : M (Optio
 def parseInteger (allowBoolean : Bool) (allowNegative : Bool) (errorMsg : String := "integer expected") : M Int := do
   match ← parseOptionalInteger allowBoolean allowNegative with
   | some i => return i
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Delimiters that are supported when parsing lists.


### PR DESCRIPTION
`throwAt` and `throwAtCurrentPos` are defined to throw errors at a given location, or at the location of the next token.

The tests are also now checking that the error was thrown at the right location.