### PR TITLE
Add LLVM fsub/fmul/fdiv/frem parsing

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -52,6 +52,14 @@
       %36 = "llvm.fadd"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
       %37 = "llvm.fadd"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
       %38 = "llvm.fadd"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %39 = "llvm.fsub"(%fcst, %fcst) : (f64, f64) -> f64
+      %40 = "llvm.fsub"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
+      %41 = "llvm.fmul"(%fcst, %fcst) : (f64, f64) -> f64
+      %42 = "llvm.fmul"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
+      %43 = "llvm.fdiv"(%fcst, %fcst) : (f64, f64) -> f64
+      %44 = "llvm.fdiv"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
+      %45 = "llvm.frem"(%fcst, %fcst) : (f64, f64) -> f64
+      %46 = "llvm.frem"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
       "llvm.return"(%28, %29, %30, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   }) : () -> ()
 }) : () -> ()
@@ -109,6 +117,14 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
 // CHECK-NEXT:       "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -54,12 +54,24 @@
       %38 = "llvm.fadd"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
       %39 = "llvm.fsub"(%fcst, %fcst) : (f64, f64) -> f64
       %40 = "llvm.fsub"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
-      %41 = "llvm.fmul"(%fcst, %fcst) : (f64, f64) -> f64
-      %42 = "llvm.fmul"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
-      %43 = "llvm.fdiv"(%fcst, %fcst) : (f64, f64) -> f64
-      %44 = "llvm.fdiv"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
-      %45 = "llvm.frem"(%fcst, %fcst) : (f64, f64) -> f64
-      %46 = "llvm.frem"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %41 = "llvm.fsub"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
+      %42 = "llvm.fsub"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
+      %43 = "llvm.fsub"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %44 = "llvm.fmul"(%fcst, %fcst) : (f64, f64) -> f64
+      %45 = "llvm.fmul"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
+      %46 = "llvm.fmul"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
+      %47 = "llvm.fmul"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
+      %48 = "llvm.fmul"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %49 = "llvm.fdiv"(%fcst, %fcst) : (f64, f64) -> f64
+      %50 = "llvm.fdiv"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
+      %51 = "llvm.fdiv"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
+      %52 = "llvm.fdiv"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
+      %53 = "llvm.fdiv"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %54 = "llvm.frem"(%fcst, %fcst) : (f64, f64) -> f64
+      %55 = "llvm.frem"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
+      %56 = "llvm.frem"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
+      %57 = "llvm.frem"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
+      %58 = "llvm.frem"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
       "llvm.return"(%28, %29, %30, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   }) : () -> ()
 }) : () -> ()
@@ -119,11 +131,23 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
 // CHECK-NEXT:       "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:   }) : () -> ()

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -29,7 +29,7 @@ match op with
 | .load => LoadProperties
 | .store => StoreProperties
 | .getelementptr => GetelementptrProperties
-| .fadd => FastMathFlagsProperties
+| .fadd | .fsub | .fmul | .fdiv | .frem => FastMathFlagsProperties
 | .func => LLVMFuncProperties
 | _ => Unit
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -107,6 +107,10 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case store => exact (StoreProperties.fromAttrDict attrDict)
     case getelementptr => exact (GetelementptrProperties.fromAttrDict attrDict)
     case fadd => exact (FastMathFlagsProperties.fromAttrDict attrDict)
+    case fsub => exact (FastMathFlagsProperties.fromAttrDict attrDict)
+    case fmul => exact (FastMathFlagsProperties.fromAttrDict attrDict)
+    case fdiv => exact (FastMathFlagsProperties.fromAttrDict attrDict)
+    case frem => exact (FastMathFlagsProperties.fromAttrDict attrDict)
     case func => exact (LLVMFuncProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case func =>
@@ -163,7 +167,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     if props.nuw then
       dict := dict.insert "nuw".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
-  | .llvm .fadd => Id.run do
+  | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
     if props.fast then
       dict := dict.insert "fast".toUTF8 (Attribute.unitAttr UnitAttr.mk)

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -100,6 +100,10 @@ inductive Llvm where
 | func
 | module_flags
 | fadd
+| fsub
+| fmul
+| fdiv
+| frem
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -699,7 +699,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
-  | .llvm .fadd => do
+  | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
       throw "Expected 2 operands"
     if op.getNumResults ctx.raw opIn ≠ 1 then


### PR DESCRIPTION
Summary
- add LLVM opcode support for `fsub`, `fmul`, `fdiv`, and `frem`
- reuse the existing fast-math flag property decode/encode path for those binary float ops
- verify the new ops with the same local invariant shape as `llvm.fadd`
- extend the LLVM identity FileCheck test with no-flag and representative fast-math flag cases

Fixes #593.

Validation
- `lake test`
- `uv sync`
- `uv run lit Test/LLVM/identity.mlir -v`
- `uv run lit Test/ -v`
- `git diff --check HEAD~1 HEAD`
- `git diff HEAD~1 HEAD | gitleaks stdin --no-banner --redact --timeout 30`

Notes
- This is scoped to parsing/printing/properties/local-invariant support for the requested LLVM floating point binary ops.
- I used OpenAI Codex to inspect the issue, make the focused change, and run the checks above. I reviewed the diff before submission.
