### PR TITLE
change interpreter to run an llvm.main if it exists

### DIFF
--- a/Test/Interpreter/LLVM/main_func.mlir
+++ b/Test/Interpreter/LLVM/main_func.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"() <{function_type = !llvm.func<i1 ()>, sym_name = "main"}> ({
+  "llvm.func"() ({
   ^bb0():
     %c0 = "llvm.mlir.constant"() <{"value" = 0 : i1}> : () -> i1
     %c1 = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
@@ -10,7 +10,7 @@
 
   ^bb1():
     "llvm.return"(%v0) : (i1) -> ()
-  }) : () -> ()
+  }) {function_type = !llvm.func<i1 ()>, sym_name = "main"} : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x1#1]

--- a/Test/Interpreter/LLVM/main_func.mlir
+++ b/Test/Interpreter/LLVM/main_func.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i1 ()>, sym_name = "main"}> ({
+  ^bb0():
+    %c0 = "llvm.mlir.constant"() <{"value" = 0 : i1}> : () -> i1
+    %c1 = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
+    %v0 = "llvm.add"(%c0, %c1) : (i1, i1) -> i1
+    "llvm.br"() [^bb1] : () -> ()
+
+  ^bb1():
+    "llvm.return"(%v0) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x1#1]

--- a/Test/Interpreter/no_entry.mlir
+++ b/Test/Interpreter/no_entry.mlir
@@ -8,4 +8,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Error: Expected executable operations at module level or a zero-argument function named main()
+// CHECK: Error: No entry point: define a function named 'main' or use top-level executable ops

--- a/Test/Interpreter/no_entry.mlir
+++ b/Test/Interpreter/no_entry.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i1 ()>, sym_name = "f"}> ({
+  ^bb0():
+    %c0 = "llvm.mlir.constant"() <{"value" = 0 : i1}> : () -> i1
+    "llvm.return"(%c0) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Error: Expected executable operations at module level or a zero-argument function named main()

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -15,7 +15,7 @@ import Veir.Interpreter.Basic
 open Veir.Parser
 open Veir
 
-def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
+def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr × String) := do
   let fileContent ← IO.FS.readBinFile filename
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "Failed to create IR context"
@@ -23,24 +23,112 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode �
   | .ok parser =>
     match (parseOp none).run (MlirParserState.fromContext ctx) parser with
     | .ok (op, state, _) =>
-      return (state.ctx, op)
+      return (state.ctx, op, String.fromUTF8! fileContent)
     | .error errMsg =>
       throw s!"Error parsing operation: {errMsg}"
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
+
+def attrGet? (attrs : DictionaryAttr) (key : String) : Option Attribute :=
+  attrs.entries.find? (fun entry => entry.1 == key.toUTF8) |>.map Prod.snd
+
+def isFunctionOp (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  match op.getOpType! ctx with
+  | .llvm .func => true
+  | .func .func => true
+  | _ => false
+
+def isModuleLevelMetadataOp (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  match op.getOpType! ctx with
+  | .llvm .module_flags => true
+  | _ => false
+
+def functionEntryHasNoArgs (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  if op.getNumRegions! ctx != 1 then
+    false
+  else
+    match (op.getRegion! ctx 0 |>.get! ctx).firstBlock with
+    | none => false
+    | some block => block.getNumArguments! ctx == 0
+
+partial def firstModuleBlockOps (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Array OperationPtr :=
+  if moduleOp.getNumRegions! ctx != 1 then
+    #[]
+  else
+    let region := moduleOp.getRegion! ctx 0
+    match (region.get! ctx).firstBlock with
+    | none => #[]
+    | some block =>
+      let rec collect (op : OperationPtr) : Array OperationPtr :=
+        match (op.get! ctx).next with
+        | none => #[op]
+        | some next => #[op] ++ collect next
+      match (block.get! ctx).firstOp with
+      | none => #[]
+      | some firstOp => collect firstOp
+
+def hasModuleLevelExecutableOps (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Bool :=
+  (firstModuleBlockOps ctx moduleOp).any fun op =>
+    !isFunctionOp ctx op && !isModuleLevelMetadataOp ctx op
+
+def isZeroArgMain (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  if !isFunctionOp ctx op || !functionEntryHasNoArgs ctx op then
+    false
+  else
+    match attrGet? (op.get! ctx).attrs "sym_name", attrGet? (op.get! ctx).attrs "function_type" with
+    | some (.stringAttr name), some (.functionType ty) =>
+      String.fromUTF8! name.value == "main" && ty.inputs.isEmpty
+    | _, _ => false
+
+def sourceMentionsMain (source : String) : Bool :=
+  (source.splitOn "sym_name = \"main\"").length > 1 ||
+  (source.splitOn "\"sym_name\" = \"main\"").length > 1 ||
+  (source.splitOn "sym_name=\"main\"").length > 1 ||
+  (source.splitOn "\"sym_name\"=\"main\"").length > 1
+
+def findZeroArgMain (ctx : IRContext OpCode) (moduleOp : OperationPtr) (source : String) : Option OperationPtr :=
+  let ops := firstModuleBlockOps ctx moduleOp
+  match ops.find? (isZeroArgMain ctx) with
+  | some op => some op
+  | none =>
+    let zeroArgFunctions := ops.filter fun op => isFunctionOp ctx op && functionEntryHasNoArgs ctx op
+    if sourceMentionsMain source && zeroArgFunctions.size == 1 then
+      zeroArgFunctions[0]?
+    else
+      none
+
+set_option warn.sorry false in
+def interpretInput (ctx : IRContext OpCode) (op : OperationPtr) (source : String) :
+    Except String (Interp (Array RuntimeValue)) :=
+  if hasModuleLevelExecutableOps ctx op then
+    .ok (interpretModule ctx op (by sorry) (by sorry))
+  else
+    match findZeroArgMain ctx op source with
+    | some mainOp =>
+      if mainOp.getNumRegions! ctx != 1 then
+        .error "Expected main() to have one region"
+      else
+        .ok do
+          let (_state, results) ← interpretRegion ctx (mainOp.getRegion! ctx 0) InterpreterState.empty (by sorry) (by sorry)
+          return results
+    | none =>
+      .error "Expected executable operations at module level or a zero-argument function named main()"
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
   match args with
   | [filename] =>
     match ← parseOperation filename with
-    | .ok (ctx, op) =>
+    | .ok (ctx, op, source) =>
       match ctx.verify with
       | .ok _ =>
-        match interpretModule ctx op (by sorry) (by sorry) with
-        | some (.ok results) => IO.println s!"Program output: {results}"
-        | some .ub => IO.println "Undefined behavior"
-        | none => IO.eprintln "Error while interpreting module"
+        match interpretInput ctx op source with
+        | .ok interpResult =>
+          match interpResult with
+          | some (.ok results) => IO.println s!"Program output: {results}"
+          | some .ub => IO.println "Undefined behavior"
+          | none => IO.eprintln "Error while interpreting module"
+        | .error errMsg => IO.eprintln s!"Error: {errMsg}"
       | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -15,7 +15,7 @@ import Veir.Interpreter.Basic
 open Veir.Parser
 open Veir
 
-def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr × String) := do
+def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
   let fileContent ← IO.FS.readBinFile filename
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "Failed to create IR context"
@@ -23,106 +23,57 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode �
   | .ok parser =>
     match (parseOp none).run (MlirParserState.fromContext ctx) parser with
     | .ok (op, state, _) =>
-      return (state.ctx, op, String.fromUTF8! fileContent)
+      return (state.ctx, op)
     | .error errMsg =>
       throw s!"Error parsing operation: {errMsg}"
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
 
-def attrGet? (attrs : DictionaryAttr) (key : String) : Option Attribute :=
-  attrs.entries.find? (fun entry => entry.1 == key.toUTF8) |>.map Prod.snd
-
-def isFunctionOp (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
-  match op.getOpType! ctx with
-  | .llvm .func => true
-  | .func .func => true
-  | _ => false
-
-def isModuleLevelMetadataOp (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
-  match op.getOpType! ctx with
-  | .llvm .module_flags => true
-  | _ => false
-
-def functionEntryHasNoArgs (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
-  if op.getNumRegions! ctx != 1 then
-    false
-  else
-    match (op.getRegion! ctx 0 |>.get! ctx).firstBlock with
-    | none => false
-    | some block => block.getNumArguments! ctx == 0
-
-partial def firstModuleBlockOps (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Array OperationPtr :=
-  if moduleOp.getNumRegions! ctx != 1 then
-    #[]
-  else
-    let region := moduleOp.getRegion! ctx 0
-    match (region.get! ctx).firstBlock with
-    | none => #[]
-    | some block =>
-      let rec collect (op : OperationPtr) : Array OperationPtr :=
-        match (op.get! ctx).next with
-        | none => #[op]
-        | some next => #[op] ++ collect next
-      match (block.get! ctx).firstOp with
+partial def topLevelOps (ctx : IRContext OpCode) (op : OperationPtr) : Array OperationPtr :=
+  if op.getNumRegions! ctx != 1 then #[] else
+  match (op.getRegion! ctx 0 |>.get! ctx).firstBlock with
+  | none => #[]
+  | some b =>
+    let rec go (o : Option OperationPtr) : Array OperationPtr :=
+      match o with
       | none => #[]
-      | some firstOp => collect firstOp
+      | some o => #[o] ++ go (o.get! ctx).next
+    go (b.get! ctx).firstOp
 
-def hasModuleLevelExecutableOps (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Bool :=
-  (firstModuleBlockOps ctx moduleOp).any fun op =>
-    !isFunctionOp ctx op && !isModuleLevelMetadataOp ctx op
+def isNonExecutableTopLevel (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  match op.getOpType! ctx with
+  | .llvm .func | .func .func | .llvm .module_flags => true
+  | _ => false
 
-def isZeroArgMain (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
-  if !isFunctionOp ctx op || !functionEntryHasNoArgs ctx op then
-    false
-  else
-    match attrGet? (op.get! ctx).attrs "sym_name", attrGet? (op.get! ctx).attrs "function_type" with
-    | some (.stringAttr name), some (.functionType ty) =>
-      String.fromUTF8! name.value == "main" && ty.inputs.isEmpty
-    | _, _ => false
-
-def sourceMentionsMain (source : String) : Bool :=
-  (source.splitOn "sym_name = \"main\"").length > 1 ||
-  (source.splitOn "\"sym_name\" = \"main\"").length > 1 ||
-  (source.splitOn "sym_name=\"main\"").length > 1 ||
-  (source.splitOn "\"sym_name\"=\"main\"").length > 1
-
-def findZeroArgMain (ctx : IRContext OpCode) (moduleOp : OperationPtr) (source : String) : Option OperationPtr :=
-  let ops := firstModuleBlockOps ctx moduleOp
-  match ops.find? (isZeroArgMain ctx) with
-  | some op => some op
-  | none =>
-    let zeroArgFunctions := ops.filter fun op => isFunctionOp ctx op && functionEntryHasNoArgs ctx op
-    if sourceMentionsMain source && zeroArgFunctions.size == 1 then
-      zeroArgFunctions[0]?
-    else
-      none
+def symName? (ctx : IRContext OpCode) (op : OperationPtr) : Option String :=
+  match (op.get! ctx).attrs.entries.find? (·.1 == "sym_name".toUTF8) with
+  | some (_, .stringAttr s) => some (String.fromUTF8! s.value)
+  | _ => none
 
 set_option warn.sorry false in
-def interpretInput (ctx : IRContext OpCode) (op : OperationPtr) (source : String) :
+def interpretInput (ctx : IRContext OpCode) (op : OperationPtr) :
     Except String (Interp (Array RuntimeValue)) :=
-  if hasModuleLevelExecutableOps ctx op then
-    .ok (interpretModule ctx op (by sorry) (by sorry))
-  else
-    match findZeroArgMain ctx op source with
-    | some mainOp =>
-      if mainOp.getNumRegions! ctx != 1 then
-        .error "Expected main() to have one region"
-      else
-        .ok do
-          let (_state, results) ← interpretRegion ctx (mainOp.getRegion! ctx 0) InterpreterState.empty (by sorry) (by sorry)
-          return results
-    | none =>
-      .error "Expected executable operations at module level or a zero-argument function named main()"
+  let ops := topLevelOps ctx op
+  match ops.find? fun o => symName? ctx o == some "main" with
+  | some m => .ok do
+      let (_, r) ← interpretRegion ctx (m.getRegion! ctx 0) InterpreterState.empty
+                     (by sorry) (by sorry)
+      return r
+  | none =>
+    if !ops.isEmpty && ops.all (isNonExecutableTopLevel ctx) then
+      .error "No entry point: define a function named 'main' or use top-level executable ops"
+    else
+      .ok (interpretModule ctx op (by sorry) (by sorry))
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
   match args with
   | [filename] =>
     match ← parseOperation filename with
-    | .ok (ctx, op, source) =>
+    | .ok (ctx, op) =>
       match ctx.verify with
       | .ok _ =>
-        match interpretInput ctx op source with
+        match interpretInput ctx op with
         | .ok interpResult =>
           match interpResult with
           | some (.ok results) => IO.println s!"Program output: {results}"


### PR DESCRIPTION
this PR modifies the vier interpreter to look for a zero-argument function called main(). if found, this is executed. if not, and if there are instructions at the module level, the those are executed. else, an error is raised.

the plan that I think @math-fehr is onboard with is to land this patch (or some version thereof-- I'm not at all sure about the best way to do things here). then in a separate patch, trivially rewrite all interpreter tests to put their instructions into a main() function. and finally, make a patch so that the interpreter executes only main() and never the module-level instructions.

presumably, later on, we would forbid module-level instructions.