### PR TITLE
support two function properties required by mlir-translate

### DIFF
--- a/Test/LLVM/fastntt.mlir
+++ b/Test/LLVM/fastntt.mlir
@@ -189,7 +189,7 @@
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^[[BB_MOD:.*]]():
 // CHECK-NEXT:     "llvm.module_flags"() : () -> ()
-// CHECK-NEXT:     "llvm.func"() ({
+// CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_L2FA_ENTRY:.*]]([[L2FA_ARG:%.*]] : i32):
 // CHECK-NEXT:         [[L2FA_C0:%.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
 // CHECK-NEXT:         [[L2FA_C1:%.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
@@ -204,7 +204,7 @@
 // CHECK-NEXT:       ^[[BB_L2FA_EXIT]]():
 // CHECK-NEXT:         "llvm.return"([[L2FA_V0]]) : (i32) -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:     "llvm.func"() ({
+// CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_L2F_ENTRY:.*]]([[L2F_ARG:%.*]] : i32):
 // CHECK-NEXT:         [[L2F_C0:%.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
 // CHECK-NEXT:         [[L2F_C1:%.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
@@ -219,7 +219,7 @@
 // CHECK-NEXT:       ^[[BB_L2F_EXIT]]():
 // CHECK-NEXT:         "llvm.return"([[L2F_V0]]) : (i32) -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:     "llvm.func"() ({
+// CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_BCT:.*]]([[BCT_A0:%.*]] : i32, [[BCT_A1:%.*]] : i32, [[BCT_A2:%.*]] : i32, [[BCT_A3:%.*]] : i32, [[BCT_P0:%.*]] : !llvm.ptr, [[BCT_P1:%.*]] : !llvm.ptr):
 // CHECK-NEXT:         [[BCT_M0:%.*]] = "llvm.mul"([[BCT_A2]], [[BCT_A1]]) : (i32, i32) -> i32
 // CHECK-NEXT:         [[BCT_R0:%.*]] = "llvm.srem"([[BCT_M0]], [[BCT_A3]]) : (i32, i32) -> i32
@@ -234,7 +234,7 @@
 // CHECK-NEXT:         "llvm.store"([[BCT_R3]], [[BCT_P1]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:         "llvm.return"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:     "llvm.func"() ({
+// CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_BGS:.*]]([[BGS_A0:%.*]] : i32, [[BGS_A1:%.*]] : i32, [[BGS_A2:%.*]] : i32, [[BGS_A3:%.*]] : i32, [[BGS_P0:%.*]] : !llvm.ptr, [[BGS_P1:%.*]] : !llvm.ptr):
 // CHECK-NEXT:         [[BGS_S0:%.*]] = "llvm.add"([[BGS_A0]], [[BGS_A1]]) : (i32, i32) -> i32
 // CHECK-NEXT:         [[BGS_R0:%.*]] = "llvm.srem"([[BGS_S0]], [[BGS_A3]]) : (i32, i32) -> i32
@@ -245,7 +245,7 @@
 // CHECK-NEXT:         "llvm.store"([[BGS_R1]], [[BGS_P1]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:         "llvm.return"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:     "llvm.func"() ({
+// CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_NTT:.*]]([[NTT_A0:%.*]] : !llvm.ptr, [[NTT_A1:%.*]] : i32, [[NTT_A2:%.*]] : i32, [[NTT_A3:%.*]] : !llvm.ptr, [[NTT_A4:%.*]] : i32, [[NTT_A5:%.*]] : i32):
 // CHECK-NEXT:         [[NTT_C0:%.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
 // CHECK-NEXT:         [[NTT_C1:%.*]] = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32

--- a/Test/LLVM/func_properties.mlir
+++ b/Test/LLVM/func_properties.mlir
@@ -1,0 +1,21 @@
+// RUN: veir-opt %s | filecheck %s
+//
+// Lossless round-trip of an `llvm.func` carrying both modelled properties
+// (`sym_name`, `function_type`) and unmodelled ones (`CConv`, `linkage`,
+// `visibility_`). The latter are preserved verbatim via the `extra`
+// catch-all dictionary in `LLVMFuncProperties`.
+
+"builtin.module"() ({
+  "llvm.func"() <{sym_name = "f", function_type = !llvm.func<i32 (i32)>, CConv = #llvm.cconv<ccc>, linkage = #llvm.linkage<external>, visibility_ = 0 : i64}> ({
+  ^bb0(%arg0: i32):
+    "llvm.return"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "llvm.func"() <{
+// CHECK-SAME:   "CConv" = #llvm.cconv<ccc>
+// CHECK-SAME:   "function_type" = !llvm.func<i32 (i32)>
+// CHECK-SAME:   "linkage" = #llvm.linkage<external>
+// CHECK-SAME:   "sym_name" = "f"
+// CHECK-SAME:   "visibility_" = 0 : i64
+// CHECK-SAME: }> ({

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -30,6 +30,7 @@ match op with
 | .store => StoreProperties
 | .getelementptr => GetelementptrProperties
 | .fadd => FastMathFlagsProperties
+| .func => LLVMFuncProperties
 | _ => Unit
 
 instance : HasDialectOpInfo Llvm where

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -107,6 +107,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case store => exact (StoreProperties.fromAttrDict attrDict)
     case getelementptr => exact (GetelementptrProperties.fromAttrDict attrDict)
     case fadd => exact (FastMathFlagsProperties.fromAttrDict attrDict)
+    case func => exact (LLVMFuncProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case func =>
     all_goals exact (Except.ok ())
@@ -255,6 +256,13 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr props.predicate)
   | .hw .constant => Id.run do
     (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr props.value)
+  | .llvm .func => Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    if let some sym_name := props.sym_name then
+      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
+    if let some function_type := props.function_type then
+      dict := dict.insert "function_type".toUTF8 function_type
+    dict
   | .builtin .unregistered =>
     Std.HashMap.ofList props.properties.entries.toList
   | .hw .module => Id.run do

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -394,6 +394,33 @@ def HWConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribut
   return { value := intAttr }
 
 /--
+  Properties of `llvm.func`. The `sym_name` and `function_type` attributes are
+  modelled explicitly; all other attributes (e.g. `CConv`, `linkage`, `visibility_`)
+  are preserved verbatim in `extra`.
+-/
+structure LLVMFuncProperties where
+  sym_name : Option StringAttr
+  function_type : Option TypeAttr
+  extra : DictionaryAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMFuncProperties := do
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr s) => pure (some s)
+    | some attr => throw s!"llvm.func: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => pure none
+  let funcType ← match attrDict["function_type".toUTF8]? with
+    | some attr =>
+      if _ : attr.isType = false then
+        throw "llvm.func: expected 'function_type' to be a type attribute"
+      else pure (some attr.asType)
+    | none => pure none
+  let extra := DictionaryAttr.fromArray
+    (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8 && k ≠ "function_type".toUTF8)
+  return { sym_name := symName, function_type := funcType, extra }
+
+/--
   Properties of `hw.module`.
 -/
 structure HWModuleProperties where


### PR DESCRIPTION
support for parsing/print the `sym_name` and  `function_type` LLVM properties.

this requires updating an existing test case, since these are no longer dropped.