### PR TITLE
introduce VEIR_ROUNDTRIP to lit

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^4():

--- a/Test/Builtin/attributes.mlir
+++ b/Test/Builtin/attributes.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^bb0():

--- a/Test/Builtin/types.mlir
+++ b/Test/Builtin/types.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^bb0():

--- a/Test/Builtin/unrealized_conversion_cast.mlir
+++ b/Test/Builtin/unrealized_conversion_cast.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^bb0():

--- a/Test/Cf/identity.mlir
+++ b/Test/Cf/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
   ^4():

--- a/Test/Comb/identity.mlir
+++ b/Test/Comb/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^4():

--- a/Test/CudaTile/types.mlir
+++ b/Test/CudaTile/types.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 "builtin.module"() ({
 ^bb0(%arg0: !cuda_tile.ptr<i1>):
     %0 = "test.test"() : () -> !cuda_tile.ptr<i1>

--- a/Test/Datapath/identity.mlir
+++ b/Test/Datapath/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^bb0(%arg0: i3, %arg1: i3, %arg2: i3):

--- a/Test/Func/identity.mlir
+++ b/Test/Func/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
   ^4():

--- a/Test/HW/identity.mlir
+++ b/Test/HW/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^4():

--- a/Test/LLVM/fastntt.mlir
+++ b/Test/LLVM/fastntt.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 // This test results from the lowering of a C implementation of the FastNTT algorithm, based on the Heir 
 // pseudocode: https://github.com/google/heir/blob/1210ad37dc9531d6e60d8ddbce81dbd79f7626a6/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp#L1060. 

--- a/Test/LLVM/getelementptr.mlir
+++ b/Test/LLVM/getelementptr.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 //
 // Tests for llvm.getelementptr with 1, 2, 3, and 4 dynamic indices.
 // The operand count must equal 1 (base pointer) + number of kDynamic

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
   "llvm.module_flags"() : () -> ()

--- a/Test/ModArith/identity.mlir
+++ b/Test/ModArith/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
 ^bb0():

--- a/Test/Parsing/attributes.mlir
+++ b/Test/Parsing/attributes.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
     "test.test"() { test = 23 : i32, "fo/no" = 1 : i32, "location" = loc("source":10:20) } : () -> ()

--- a/Test/Parsing/properties.mlir
+++ b/Test/Parsing/properties.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
     "test.test"() <{test = 23 : i32, "fo/no" = 1 : i32}> : () -> ()

--- a/Test/Parsing/unregistered_ops.mlir
+++ b/Test/Parsing/unregistered_ops.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
     "unregistered.op_one"() : () -> ()

--- a/Test/RISCV/identity.mlir
+++ b/Test/RISCV/identity.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
   ^bb0():

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -10,3 +10,4 @@ veir_root = Path(config.test_source_root).parent
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {veir_root}"])
 config.substitutions.append(('veir-opt', "lake exec veir-opt"))
 config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
+config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | filecheck %s"))


### PR DESCRIPTION
Replace `veir-opt %s | filecheck %s` with `VEIR_ROUNDTRIP`. This makes tests explicit that roundtrip through VeIR to test the parser/printer.

When `veir-opt` supports input from stdin, we may replace this with `veir-opt %s | veir-opt | filecheck %s` for added testing.

This pattern follows `xdsl`'s `XDSL_ROUNDTRIP`.