### PR TITLE
Introduce `VariableState` in the interpreter and fix remainnig sorries

### DIFF
--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -55,68 +55,71 @@ structure MemoryState where
 def MemoryState.empty : MemoryState :=
   { contents := (ByteArray.emptyWithCapacity 1024).extend 8 0xff }
 
+structure VariableState where
+  variables : Std.ExtHashMap ValuePtr RuntimeValue
+
 /--
   The state of the interpreter at a given point in time.
   It includes a mapping from IR values to their runtime values.
 -/
+@[ext]
 structure InterpreterState where
-  variables : Std.ExtHashMap ValuePtr RuntimeValue
+  variables : VariableState
   memory : MemoryState
 
 /--
   Set the value of a variable.
 -/
-def InterpreterState.setVar (state : InterpreterState) (var : ValuePtr) (val : RuntimeValue) :
-    InterpreterState :=
-  {state with variables := state.variables.insert var val}
+def VariableState.setVar (state : VariableState) (var : ValuePtr) (val : RuntimeValue) :
+    VariableState :=
+  ⟨state.variables.insert var val⟩
 
 /--
   Get the value of a variable, if the variable exists.
 -/
-def InterpreterState.getVar? (state : InterpreterState) (var : ValuePtr)
+def VariableState.getVar? (state : VariableState) (var : ValuePtr)
     : Option RuntimeValue :=
   state.variables[var]?
 
 @[ext]
-theorem InterpreterState.ext {s₁ s₂ : InterpreterState} :
+theorem VariableState.ext {s₁ s₂ : VariableState} :
     (∀ var, s₁.getVar? var = s₂.getVar? var) →
-    s₁.memory = s₂.memory →
     s₁ = s₂ := by
   rcases s₁; rcases s₂
-  simp only [getVar?, mk.injEq]
+  simp only [VariableState.getVar?, mk.injEq]
   grind
 
 /--
   Get the value of the operands of an operation.
   If any operand is not in the state, return `none`.
 -/
-def InterpreterState.getOperandValues (state : InterpreterState)
+def VariableState.getOperandValues (state : VariableState)
     (ctx : IRContext OpInfo) (op : OperationPtr) : Option (Array RuntimeValue) := do
   (op.getOperands! ctx).mapM state.getVar?
 
-def InterpreterState.setResultValues_loop (state : InterpreterState)
-    (ctx : IRContext OpInfo) (op : OperationPtr) (resultValues : Array RuntimeValue) (i : Nat) : InterpreterState :=
+def VariableState.setResultValues_loop (state : VariableState)
+    (ctx : IRContext OpInfo) (op : OperationPtr) (resultValues : Array RuntimeValue) (i : Nat) : VariableState :=
   match i with
   | 0 => state
   | i + 1 =>
     let result := op.getResult i
     let value := resultValues[i]!
     let newState := state.setVar result value
-    InterpreterState.setResultValues_loop newState ctx op resultValues i
+    VariableState.setResultValues_loop newState ctx op resultValues i
 
 /--
   Set the values of the results of an operation.
 -/
-def InterpreterState.setResultValues (state : InterpreterState) (ctx : IRContext OpInfo)
-    (op : OperationPtr) (resultValues : Array RuntimeValue) : InterpreterState :=
-  InterpreterState.setResultValues_loop state ctx op resultValues (op.getNumResults! ctx)
+def VariableState.setResultValues (state : VariableState) (ctx : IRContext OpInfo)
+    (op : OperationPtr) (resultValues : Array RuntimeValue) : VariableState :=
+  VariableState.setResultValues_loop state ctx op resultValues (op.getNumResults! ctx)
 
 /--
   Set the values of block arguments.
 -/
-def InterpreterState.setArgumentValues (state : InterpreterState) (ctx : IRContext OpInfo)
-    (block : BlockPtr) (values : Array RuntimeValue) : InterpreterState :=
-  let rec loop (state : InterpreterState) (i : Nat) :=
+def VariableState.setArgumentValues (state : VariableState) (ctx : IRContext OpInfo)
+    (block : BlockPtr) (values : Array RuntimeValue) : VariableState :=
+  let rec loop (state : VariableState) (i : Nat) :=
     match i with
     | 0 => state
     | i + 1 =>
@@ -130,7 +133,7 @@ def InterpreterState.setArgumentValues (state : InterpreterState) (ctx : IRConte
   Create an interpreter state with no variables defined.
 -/
 def InterpreterState.empty : InterpreterState :=
-  { variables := Std.ExtHashMap.emptyWithCapacity 8, memory := .empty }
+  { variables := ⟨Std.ExtHashMap.emptyWithCapacity 8⟩, memory := .empty }
 
 /--
   How the control flow should proceed after interpreting a terminator.
@@ -959,10 +962,10 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
 -/
 def interpretOp (ctx : IRContext OpCode) (op : OperationPtr) (state : InterpreterState)
     : Interp (InterpreterState × Option ControlFlowAction) := do
-  let some operands := state.getOperandValues ctx op | none
+  let some operands := state.variables.getOperandValues ctx op | none
   let opType := op.getOpType! ctx
   let (resultValues, mem, action) ← interpretOp' opType (op.getProperties! ctx opType) (op.getResultTypes! ctx) operands (op.getSuccessors! ctx) state.memory
-  let newState := {state.setResultValues ctx op resultValues with memory := mem}
+  let newState := ⟨state.variables.setResultValues ctx op resultValues, mem⟩
   return (newState, action)
 
 /--
@@ -1005,7 +1008,7 @@ def interpretBlockCFG (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : In
   | some (.ok (state, .return res)) => some (.ok (state, res))
   | some (.ok (state, .branch res succ)) =>
     if h : succ.InBounds ctx then
-      let state := state.setArgumentValues ctx succ res
+      let state := ⟨state.variables.setArgumentValues ctx succ res, state.memory⟩
       interpretBlockCFG ctx succ state h wf else none
   | some .ub => Interp.ub
   | none => none

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -4,111 +4,92 @@ import Veir.Dominance
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {varState varState' : VariableState}
 variable {state state' : InterpreterState}
 variable {op op' : OperationPtr}
 
 @[grind =]
-theorem InterpreterState.getVar?_setVar :
-    (InterpreterState.setVar state var' val).getVar? var =
-    if var = var' then some val else state.getVar? var := by
-  grind [InterpreterState.setVar, InterpreterState.getVar?]
+theorem VariableState.getVar?_setVar :
+    (VariableState.setVar varState var' val).getVar? var =
+    if var = var' then some val else varState.getVar? var := by
+  grind [VariableState.setVar, VariableState.getVar?]
 
-theorem InterpreterState.getVar?_setResultValues_loop {ctx : IRContext OpInfo} :
-    (state.setResultValues_loop ctx op resultValues idx).getVar? value =
+theorem VariableState.getVar?_setResultValues_loop {ctx : IRContext OpInfo} :
+    (varState.setResultValues_loop ctx op resultValues idx).getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
       if op' = op ∧ index < idx then
         some resultValues[index]!
        else
-         state.getVar? value
+         varState.getVar? value
     | _ =>
-      state.getVar? value := by
-  fun_induction InterpreterState.setResultValues_loop
+      varState.getVar? value := by
+  fun_induction VariableState.setResultValues_loop
   next => grind
   next => grind [cases OpResultPtr, OperationPtr.getResult_def, cases ValuePtr]
 
 @[grind =]
-theorem InterpreterState.getVar?_setResultValues {ctx : IRContext OpInfo} :
-    (state.setResultValues ctx op resultValues).getVar? value =
+theorem VariableState.getVar?_setResultValues {ctx : IRContext OpInfo} :
+    (varState.setResultValues ctx op resultValues).getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
       if op' = op ∧ index < op.getNumResults! ctx then
         some resultValues[index]!
        else
-         state.getVar? value
+         varState.getVar? value
     | _ =>
-      state.getVar? value := by
-  simp [InterpreterState.setResultValues, InterpreterState.getVar?_setResultValues_loop]
+      varState.getVar? value := by
+  simp [VariableState.setResultValues, VariableState.getVar?_setResultValues_loop]
 
 @[grind =]
-theorem InterpreterState.getVar?_setResultValues_of_value_inBounds
+theorem VariableState.getVar?_setResultValues_of_value_inBounds
     {ctx : IRContext OpInfo} (valueInBounds : value.InBounds ctx) :
-    (state.setResultValues ctx op resultValues).getVar? value =
+    (varState.setResultValues ctx op resultValues).getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
       if op' = op then
         some resultValues[index]!
        else
-         state.getVar? value
+         varState.getVar? value
     | _ =>
-      state.getVar? value := by
+      varState.getVar? value := by
   simp only [getVar?_setResultValues]
   cases value <;> grind
 
-set_option warn.sorry false in
 theorem interpretOp_some_iff :
   interpretOp ctx op state = some (.ok (state', cf)) ↔
   ∃ operandValues resValues mem',
-    (state.getOperandValues ctx op) = some operandValues ∧
+    (state.variables.getOperandValues ctx op) = some operandValues ∧
     interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
       (op.getResultTypes! ctx) operandValues (op.getSuccessors! ctx) state.memory = some (.ok (resValues, mem', cf)) ∧
-    state' = state.setResultValues ctx op resValues := by
+    state' = ⟨state.variables.setResultValues ctx op resValues, mem'⟩ := by
   simp only [interpretOp, bind, pure]
-  rcases hOps : state.getOperandValues ctx op with _ | operands
-  · grind
-  rcases hOp : interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
-      (op.getResultTypes! ctx) operands (op.getSuccessors! ctx) state.memory with _ | u
-  · grind
-  · sorry
+  grind
 
-theorem InterpreterState.getOperandValues_eq_of_getVar?_eq {ctx : IRContext OpInfo} :
-    (∀ val, val ∈ op.getOperands! ctx → state.getVar? val = state'.getVar? val) →
-    state.getOperandValues ctx op = state'.getOperandValues ctx op := by
+theorem VariableState.getOperandValues_eq_of_getVar?_eq {ctx : IRContext OpInfo} :
+    (∀ val, val ∈ op.getOperands! ctx → varState.getVar? val = varState'.getVar? val) →
+    varState.getOperandValues ctx op = varState'.getOperandValues ctx op := by
   intro h
   simp only [getOperandValues, Array.mapM_eq_mapM_toList]
-  suffices H : ∀ (l : List _), (∀ val ∈ l, state.getVar? val = state'.getVar? val) →
-               l.mapM state.getVar? = l.mapM state'.getVar? by grind
+  suffices H : ∀ (l : List _), (∀ val ∈ l, varState.getVar? val = varState'.getVar? val) →
+               l.mapM varState.getVar? = l.mapM varState'.getVar? by grind
   intro l hl
   induction l <;> grind
 
-theorem InterpreterState.setResultValues_memory {ctx : WfIRContext OpInfo}
-    {state : InterpreterState} :
-    (state.setResultValues ctx.raw op resValues).memory = state.memory := by
-  simp only [setResultValues]
-  generalize (op.getNumResults! ctx.raw) = numResults at *
-  fun_induction InterpreterState.setResultValues_loop
-  next =>
-    rfl
-  next newState ih1 =>
-    simp [ih1, newState]
-    rfl
-
-theorem InterpreterState.setResultValues_comm {ctx : WfIRContext OpInfo}
-    {state : InterpreterState} (hOp : op₁ ≠ op₂) :
-    (state.setResultValues ctx.raw op₁ resValues₁).setResultValues ctx.raw op₂ resValues₂ =
-    (state.setResultValues ctx.raw op₂ resValues₂).setResultValues ctx.raw op₁ resValues₁ := by
+theorem VariableState.setResultValues_comm {ctx : WfIRContext OpInfo}
+    (hOp : op₁ ≠ op₂) :
+    (varState.setResultValues ctx.raw op₁ resValues₁).setResultValues ctx.raw op₂ resValues₂ =
+    (varState.setResultValues ctx.raw op₂ resValues₂).setResultValues ctx.raw op₁ resValues₁ := by
   ext val runtimeVal
-  · cases val <;> grind
-  · grind [InterpreterState.setResultValues_memory]
-  · grind [InterpreterState.setResultValues_memory]
+  cases val <;> grind
 
-theorem InterpreterState.getVar?_setResultValues_operand_of_dominates {ctx : WfIRContext OpInfo}
+theorem VariableState.getVar?_setResultValues_operand_of_dominates {ctx : WfIRContext OpInfo}
     (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
     value ∈ op'.getOperands! ctx.raw →
-    (state.setResultValues ctx.raw op resValues).getVar? value =
-    state.getVar? value := by
+    (varState.setResultValues ctx.raw op resValues).getVar? value =
+    varState.getVar? value := by
   intro valueInOperands
-  simp only [InterpreterState.getVar?_setResultValues]
+  simp only [VariableState.getVar?_setResultValues]
   have := IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom hdom value valueInOperands
   cases value
   case blockArgument blockArg => grind
@@ -119,26 +100,24 @@ theorem InterpreterState.getVar?_setResultValues_operand_of_dominates {ctx : WfI
     grind [OperationPtr.getResult_def, cases OpResultPtr]
 
 @[grind =>]
-theorem InterpreterState.getOperandValues_setResultValues_of_dominates {ctx : WfIRContext OpInfo}
+theorem VariableState.getOperandValues_setResultValues_of_dominates {ctx : WfIRContext OpInfo}
     (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
-    (state.setResultValues ctx.raw op resValues).getOperandValues ctx.raw op' =
-    state.getOperandValues ctx.raw op' := by
-  apply InterpreterState.getOperandValues_eq_of_getVar?_eq
-  grind [InterpreterState.getVar?_setResultValues_operand_of_dominates]
+    (varState.setResultValues ctx.raw op resValues).getOperandValues ctx.raw op' =
+    varState.getOperandValues ctx.raw op' := by
+  apply VariableState.getOperandValues_eq_of_getVar?_eq
+  grind [VariableState.getVar?_setResultValues_operand_of_dominates]
 
 @[grind =>]
-theorem InterpreterState.getOperandValues_setResultValues_self {ctx : WfIRContext OpInfo}
+theorem VariableState.getOperandValues_setResultValues_self {ctx : WfIRContext OpInfo}
     (ctxDom : ctx.Dom) :
-    (state.setResultValues ctx.raw op resValues).getOperandValues ctx.raw op =
-    state.getOperandValues ctx.raw op := by
+    (varState.setResultValues ctx.raw op resValues).getOperandValues ctx.raw op =
+    varState.getOperandValues ctx.raw op := by
   exact getOperandValues_setResultValues_of_dominates ctxDom OperationPtr.dominates_refl
 
 @[grind = ]
-theorem InterpreterState.setResultValues_setResultValues_self {ctx : WfIRContext OpCode} :
-    (state.setResultValues ctx.raw op resValues).setResultValues ctx.raw op resValues' =
-    state.setResultValues ctx.raw op resValues' := by
+theorem VariableState.setResultValues_setResultValues_self {ctx : WfIRContext OpCode} :
+    (varState.setResultValues ctx.raw op resValues).setResultValues ctx.raw op resValues' =
+    varState.setResultValues ctx.raw op resValues' := by
   ext val runtimeVal
-  · simp only [InterpreterState.getVar?_setResultValues]
-    grind
-  · grind [InterpreterState.setResultValues_memory]
-  · grind [InterpreterState.setResultValues_memory]
+  simp only [VariableState.getVar?_setResultValues]
+  grind


### PR DESCRIPTION
The idea is that getting/setting variables in a `VariableState` that is contained in the `InterpreterState` makes things easier for proofs. This is because we do not have to write many small lemmas about separation between memory and variable states. In general, it just makes things easier to manipulate.