### PR TITLE
interpreter executes llvm.func called main, if it exists

### DIFF
--- a/Test/Interpreter/LLVM/main_func.mlir
+++ b/Test/Interpreter/LLVM/main_func.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.constant"() <{value = 20 : i16}> : () -> i16
+    %1 = "llvm.mlir.constant"() <{value = 13 : i16}> : () -> i16
+    %2 = "llvm.add"(%0, %1) <{overflowFlags = 0 : i32}> : (i16, i16) -> i16
+    "llvm.return"(%2) : (i16) -> ()
+  }) : () -> ()
+}) {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.module_asm = [], llvm.target_triple = ""} : () -> ()
+
+// CHECK: Program output: #[0x0021#16]

--- a/Test/Interpreter/main_and_top_level.mlir
+++ b/Test/Interpreter/main_and_top_level.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  %0 = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
+    %1 = "llvm.mlir.constant"() <{value = 13 : i16}> : () -> i16
+    "llvm.return"(%1) : (i16) -> ()
+  }) : () -> ()
+  "func.return"(%0) : (i32) -> ()
+}) : () -> ()
+
+// CHECK: Error: Multiple entry points: define exactly one zero-argument function named 'main' or use only top-level executable ops

--- a/Test/Interpreter/main_with_args_no_entry.mlir
+++ b/Test/Interpreter/main_with_args_no_entry.mlir
@@ -1,0 +1,10 @@
+// RUN: veir-interpret %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 (i16)>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
+  ^0(%arg0 : i16):
+    "llvm.return"(%arg0) : (i16) -> ()
+  }) : () -> ()
+}) {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.module_asm = [], llvm.target_triple = ""} : () -> ()
+
+// CHECK: Error: No entry point: define a function named 'main' or use top-level executable ops

--- a/Test/Interpreter/multiple_mains.mlir
+++ b/Test/Interpreter/multiple_mains.mlir
@@ -1,0 +1,14 @@
+// RUN: veir-interpret %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.constant"() <{value = 20 : i16}> : () -> i16
+    "llvm.return"(%0) : (i16) -> ()
+  }) : () -> ()
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.constant"() <{value = 13 : i16}> : () -> i16
+    "llvm.return"(%0) : (i16) -> ()
+  }) : () -> ()
+}) {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.module_asm = [], llvm.target_triple = ""} : () -> ()
+
+// CHECK: Error: Multiple entry points: define exactly one zero-argument function named 'main' or use only top-level executable ops

--- a/Test/Interpreter/no_entry.mlir
+++ b/Test/Interpreter/no_entry.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "myfunc", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.constant"() <{value = 20 : i16}> : () -> i16
+    %1 = "llvm.mlir.constant"() <{value = 13 : i16}> : () -> i16
+    %2 = "llvm.add"(%0, %1) <{overflowFlags = 0 : i32}> : (i16, i16) -> i16
+    "llvm.return"(%2) : (i16) -> ()
+  }) : () -> ()
+}) {dlti.dl_spec = #dlti.dl_spec<!llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, i64 = dense<[32, 64]> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little">, llvm.module_asm = [], llvm.target_triple = ""} : () -> ()
+
+// CHECK: Error: No entry point: define a function named 'main' or use top-level executable ops

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -75,17 +75,18 @@ def main (args : List String) : IO Unit := do
       match ctx.verify with
       | .ok _ =>
         let rawCtx : IRContext OpCode := ctx
+        let report : Interp (Array RuntimeValue) → String → IO Unit
+          | some (.ok results), _ => IO.println s!"Program output: {results}"
+          | some .ub,           _ => IO.println "Undefined behavior"
+          | none,             msg => IO.eprintln msg
         match findMainFunc rawCtx op with
         | some mainOp =>
-          match interpretRegion rawCtx (mainOp.getRegion! rawCtx 0) InterpreterState.empty (by sorry) (by sorry) with
-          | some (.ok (_, results)) => IO.println s!"Program output: {results}"
-          | some .ub => IO.println "Undefined behavior"
-          | none => IO.eprintln "Error while interpreting module"
+          let result := bind (interpretRegion rawCtx (mainOp.getRegion! rawCtx 0) InterpreterState.empty (by sorry) (by sorry))
+                             (fun (_, r) => pure r)
+          report result "Error while interpreting module"
         | none =>
-          match interpretModule rawCtx op (by sorry) (by sorry) with
-          | some (.ok results) => IO.println s!"Program output: {results}"
-          | some .ub => IO.println "Undefined behavior"
-          | none => IO.eprintln "Error: No entry point: define a function named 'main' or use top-level executable ops"
+          report (interpretModule rawCtx op (by sorry) (by sorry))
+                 "Error: No entry point: define a function named 'main' or use top-level executable ops"
       | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -29,6 +29,43 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode �
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
 
+/-- Returns true if `op` is an `llvm.func` with the given `name`. -/
+def isFuncWithName (ctx : IRContext OpCode) (op : OperationPtr) (name : String) : Bool :=
+  let opType := op.getOpType! ctx
+  let check : (opCode : OpCode) → propertiesOf opCode → Bool
+    | .llvm .func, props =>
+      match props.sym_name with
+      | none => false
+      | some sym_name => String.fromUTF8! sym_name.value == name
+    | _, _ => false
+  check opType (op.getProperties! ctx opType)
+
+/-- Returns true if the `llvm.func` properties describe a function with no arguments. -/
+private def hasNoArgs (props : LLVMFuncProperties) : Bool :=
+  match props.function_type with
+  | none => false
+  | some ft =>
+    match ft.val with
+    | .llvmFunctionType funcType => funcType.inputs.isEmpty
+    | _ => false
+
+/-- Searches the module's top-level ops for an `llvm.func @main` with no arguments. -/
+partial def findMainFunc (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Option OperationPtr :=
+  let region := moduleOp.getRegion! ctx 0
+  match (region.get! ctx).firstBlock with
+  | none => none
+  | some blockPtr =>
+    let rec go : Option OperationPtr → Option OperationPtr
+      | none => none
+      | some op =>
+        let isMain : (opCode : OpCode) → propertiesOf opCode → Bool
+          | .llvm .func, props => isFuncWithName ctx op "main" && hasNoArgs props
+          | _, _ => false
+        let opType := op.getOpType! ctx
+        if isMain opType (op.getProperties! ctx opType) then some op
+        else go (op.get! ctx).next
+    go (blockPtr.get! ctx).firstOp
+
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
   match args with
@@ -37,10 +74,18 @@ def main (args : List String) : IO Unit := do
     | .ok (ctx, op) =>
       match ctx.verify with
       | .ok _ =>
-        match interpretModule ctx op (by sorry) (by sorry) with
-        | some (.ok results) => IO.println s!"Program output: {results}"
-        | some .ub => IO.println "Undefined behavior"
-        | none => IO.eprintln "Error while interpreting module"
+        let rawCtx : IRContext OpCode := ctx
+        match findMainFunc rawCtx op with
+        | some mainOp =>
+          match interpretRegion rawCtx (mainOp.getRegion! rawCtx 0) InterpreterState.empty (by sorry) (by sorry) with
+          | some (.ok (_, results)) => IO.println s!"Program output: {results}"
+          | some .ub => IO.println "Undefined behavior"
+          | none => IO.eprintln "Error while interpreting module"
+        | none =>
+          match interpretModule rawCtx op (by sorry) (by sorry) with
+          | some (.ok results) => IO.println s!"Program output: {results}"
+          | some .ub => IO.println "Undefined behavior"
+          | none => IO.eprintln "Error: No entry point: define a function named 'main' or use top-level executable ops"
       | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -49,22 +49,74 @@ private def hasNoArgs (props : LLVMFuncProperties) : Bool :=
     | .llvmFunctionType funcType => funcType.inputs.isEmpty
     | _ => false
 
-/-- Searches the module's top-level ops for an `llvm.func @main` with no arguments. -/
-partial def findMainFunc (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Option OperationPtr :=
+/-- Returns true if `op` is an `llvm.func @main` with no arguments. -/
+private def isZeroArgMainFunc (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  let opType := op.getOpType! ctx
+  let check : (opCode : OpCode) → propertiesOf opCode → Bool
+    | .llvm .func, props => isFuncWithName ctx op "main" && hasNoArgs props
+    | _, _ => false
+  check opType (op.getProperties! ctx opType)
+
+/--
+  Returns true if a top-level op counts as module-level executable code for the CLI.
+  Under the current execution model, any non-`llvm.func` top-level op counts.
+-/
+private def isTopLevelExecutableOp (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
+  match op.getOpType! ctx with
+  | .llvm .func => false
+  | _ => true
+
+inductive EntryPoint where
+  | mainFunc (op : OperationPtr)
+  | topLevel
+
+inductive EntryPointError where
+  | none
+  | multiple
+
+private structure EntryPointScan where
+  mainOp? : Option OperationPtr := none
+  hasMultipleMains : Bool := false
+  hasTopLevelCode : Bool := false
+
+/-- Scan the module's top-level ops for entry points. -/
+partial def scanEntryPoints (ctx : IRContext OpCode) (op : Option OperationPtr)
+    (scan : EntryPointScan := {}) : EntryPointScan :=
+  match op with
+  | none => scan
+  | some op =>
+    let scan :=
+      if isZeroArgMainFunc ctx op then
+        match scan.mainOp? with
+        | none => { scan with mainOp? := some op }
+        | some _ => { scan with hasMultipleMains := true }
+      else if isTopLevelExecutableOp ctx op then
+        { scan with hasTopLevelCode := true }
+      else
+        scan
+    scanEntryPoints ctx (op.get! ctx).next scan
+
+/-- Resolve the unique entry point of the module, if one exists. -/
+def resolveEntryPoint (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Except EntryPointError EntryPoint :=
   let region := moduleOp.getRegion! ctx 0
   match (region.get! ctx).firstBlock with
-  | none => none
+  | none => .error .none
   | some blockPtr =>
-    let rec go : Option OperationPtr → Option OperationPtr
-      | none => none
-      | some op =>
-        let isMain : (opCode : OpCode) → propertiesOf opCode → Bool
-          | .llvm .func, props => isFuncWithName ctx op "main" && hasNoArgs props
-          | _, _ => false
-        let opType := op.getOpType! ctx
-        if isMain opType (op.getProperties! ctx opType) then some op
-        else go (op.get! ctx).next
-    go (blockPtr.get! ctx).firstOp
+    let scan := scanEntryPoints ctx (blockPtr.get! ctx).firstOp
+    if scan.hasMultipleMains || (scan.mainOp?.isSome && scan.hasTopLevelCode) then
+      .error .multiple
+    else
+      match scan.mainOp?, scan.hasTopLevelCode with
+      | some mainOp, false => .ok (.mainFunc mainOp)
+      | none, true => .ok .topLevel
+      | _, _ => .error .none
+
+/-- Report an interpreter result to the CLI. Hard failures (`none`) use a generic error. -/
+def reportInterpResult (result : Interp (Array RuntimeValue)) : IO Unit :=
+  match result with
+  | some (.ok results) => IO.println s!"Program output: {results}"
+  | some .ub => IO.println "Undefined behavior"
+  | none => IO.eprintln "Error while interpreting module"
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
@@ -75,18 +127,17 @@ def main (args : List String) : IO Unit := do
       match ctx.verify with
       | .ok _ =>
         let rawCtx : IRContext OpCode := ctx
-        let report : Interp (Array RuntimeValue) → String → IO Unit
-          | some (.ok results), _ => IO.println s!"Program output: {results}"
-          | some .ub,           _ => IO.println "Undefined behavior"
-          | none,             msg => IO.eprintln msg
-        match findMainFunc rawCtx op with
-        | some mainOp =>
+        match resolveEntryPoint rawCtx op with
+        | .ok (.mainFunc mainOp) =>
           let result := bind (interpretRegion rawCtx (mainOp.getRegion! rawCtx 0) InterpreterState.empty (by sorry) (by sorry))
                              (fun (_, r) => pure r)
-          report result "Error while interpreting module"
-        | none =>
-          report (interpretModule rawCtx op (by sorry) (by sorry))
-                 "Error: No entry point: define a function named 'main' or use top-level executable ops"
+          reportInterpResult result
+        | .ok .topLevel =>
+          reportInterpResult (interpretModule rawCtx op (by sorry) (by sorry))
+        | .error .none =>
+          IO.eprintln "Error: No entry point: define a function named 'main' or use top-level executable ops"
+        | .error .multiple =>
+          IO.eprintln "Error: Multiple entry points: define exactly one zero-argument function named 'main' or use only top-level executable ops"
       | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -29,31 +29,21 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode �
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
 
-/-- Returns true if `op` is an `llvm.func` with the given `name`. -/
-def isFuncWithName (ctx : IRContext OpCode) (op : OperationPtr) (name : String) : Bool :=
-  let opType := op.getOpType! ctx
-  let check : (opCode : OpCode) → propertiesOf opCode → Bool
-    | .llvm .func, props =>
-      match props.sym_name with
-      | none => false
-      | some sym_name => String.fromUTF8! sym_name.value == name
-    | _, _ => false
-  check opType (op.getProperties! ctx opType)
-
-/-- Returns true if the `llvm.func` properties describe a function with no arguments. -/
-private def hasNoArgs (props : LLVMFuncProperties) : Bool :=
-  match props.function_type with
-  | none => false
-  | some ft =>
-    match ft.val with
-    | .llvmFunctionType funcType => funcType.inputs.isEmpty
-    | _ => false
-
 /-- Returns true if `op` is an `llvm.func @main` with no arguments. -/
 private def isZeroArgMainFunc (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
   let opType := op.getOpType! ctx
   let check : (opCode : OpCode) → propertiesOf opCode → Bool
-    | .llvm .func, props => isFuncWithName ctx op "main" && hasNoArgs props
+    | .llvm .func, props =>
+      match props.sym_name with
+      | some sym_name =>
+        String.fromUTF8! sym_name.value == "main" &&
+          match props.function_type with
+          | some ft =>
+            match ft.val with
+            | .llvmFunctionType funcType => funcType.inputs.isEmpty
+            | _ => false
+          | none => false
+      | none => false
     | _, _ => false
   check opType (op.getProperties! ctx opType)
 


### PR DESCRIPTION
sigh... I closed the previous PR about this so I could work on this branch without bothering people, but after I force-pushed to squash, it would not let me re-open it. 

so anyway: I appreciate your patience @math-fehr, I think I've done a better job this time, and also I've replaced the test cases with fresh ones straight out of `mlir-translate` since as you said I had gotten something confused with properties and attributes

I looked into also trying to find a `func.func` called `main`, but the patch got too big. so I'll add that in a different PR.
