### PR TITLE
fuzzer and fuzzer driver for the LLVM dialect

### DIFF
--- a/Tools/vsmith
+++ b/Tools/vsmith
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Differential fuzzer for VeIR optimization passes.
+
+Repeatedly generates random MLIR programs, interprets them before and after
+running an optimizer pipeline, and reports a reproducer if the observable
+outputs differ.
+"""
+
+# TODO
+#
+# - convert both src and tgt to LLVM IR and run llubi, check for
+#   agreement with veir-interpret
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import multiprocessing
+import os
+import random
+import secrets
+import shutil
+import signal
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from vsmith_generate import generate
+
+
+@dataclass(frozen=True)
+class ToolResult:
+    returncode: int
+    output: str
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    ok: bool
+    skipped: bool
+    before: str
+    after: str | None
+    message: str
+
+
+class Spinner:
+    MIN_INTERVAL = 0.2
+
+    def __init__(self) -> None:
+        self.frames = ("|", "/", "-", "\\")
+        self.index = 0
+        self.last_len = 0
+        self.interactive = sys.stdout.isatty()
+        self.last_update = 0.0
+
+    def update(self, message: str) -> None:
+        now = time.monotonic()
+        if now - self.last_update < self.MIN_INTERVAL:
+            return
+        self.last_update = now
+        frame = self.frames[self.index % len(self.frames)]
+        self.index += 1
+        text = f"{frame} {message}"
+        if self.interactive:
+            padding = " " * max(0, self.last_len - len(text))
+            print(f"\r{text}{padding}", end="", flush=True)
+            self.last_len = len(text)
+        else:
+            print(text, flush=True)
+
+    def clear(self) -> None:
+        if self.interactive and self.last_len:
+            print(f"\r{' ' * self.last_len}\r", end="", flush=True)
+            self.last_len = 0
+
+    def finish(self, message: str) -> None:
+        self.clear()
+        print(message)
+
+
+def run_tool(repo: Path, cmd: list[str]) -> ToolResult:
+    result = subprocess.run(
+        cmd,
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    return ToolResult(result.returncode, result.stdout + result.stderr)
+
+
+KNOWN_INTERPRETER_FAILURES = ("Undefined behavior",)
+
+
+def classify_failure(log: str) -> str:
+    for pattern in KNOWN_INTERPRETER_FAILURES:
+        if pattern in log:
+            return pattern
+    raise ValueError(f"interpreter produced no 'Program output:' line and no known failure pattern:\n{log}")
+
+
+def outcome_key(output: str | None) -> str:
+    if output is None:
+        return "optimizer failed"
+    if output.startswith("Program output:"):
+        values = parse_output_values(output)
+        if values is not None and any(v == "poison" for v in values):
+            return "program output (poison)"
+        return "program output"
+    return output
+
+
+def prebuild(repo: Path) -> None:
+    """Build veir-opt and veir-interpret so workers can exec them directly."""
+    result = subprocess.run(
+        ["lake", "build", "veir-opt", "veir-interpret"],
+        cwd=repo,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SystemExit(f"lake build failed:\n{result.stdout}")
+
+
+def interpret(repo: Path, interp_bin: Path, path: Path) -> tuple[str, str]:
+    """Return the last 'Program output: ...' line, or a classified failure string."""
+    result = run_tool(repo, [str(interp_bin), str(path)])
+    outputs = [line for line in result.output.splitlines() if line.startswith("Program output:")]
+    output = outputs[-1] if outputs else classify_failure(result.output)
+    return output, result.output
+
+
+def optimize(repo: Path, opt_bin: Path, src: Path, dst: Path, passes: str) -> tuple[bool, str]:
+    """Run veir-opt and write the result to dst. Returns (success, log)."""
+    result = run_tool(repo, [str(opt_bin), str(src), f"-p={passes}"])
+    output = result.output
+    failed = (
+        result.returncode != 0
+        or "Error:" in output
+        or "uncaught exception" in output
+        or "panic" in output.lower()
+        or not output.strip().startswith('"builtin.module"')
+    )
+    if failed:
+        return False, output
+    dst.write_text(output)
+    return True, output
+
+
+def parse_output_values(line: str) -> list[str] | None:
+    """Parse 'Program output: #[a, b, c]' into a list of element strings."""
+    prefix = "Program output:"
+    if not line.startswith(prefix):
+        return None
+    body = line[len(prefix):].strip()
+    if not (body.startswith("#[") and body.endswith("]")):
+        return None
+    inner = body[2:-1].strip()
+    return [elem.strip() for elem in inner.split(",")] if inner else []
+
+
+def refines(original: str, optimized: str) -> bool:
+    """Return True if optimized is a valid refinement of original.
+
+    poison in the original may map to any value; all other values must match.
+    """
+    orig = parse_output_values(original)
+    opt = parse_output_values(optimized)
+    if orig is None or opt is None or len(orig) != len(opt):
+        return original == optimized
+    return all(o == "poison" or o == p for o, p in zip(orig, opt))
+
+
+def check(repo: Path, interp_bin: Path, opt_bin: Path, src: Path, opt: Path, passes: str) -> CheckResult:
+    """Interpret, optimize, re-interpret, and compare."""
+    before, before_log = interpret(repo, interp_bin, src)
+
+    ok, opt_log = optimize(repo, opt_bin, src, opt, passes)
+    if not ok:
+        return CheckResult(
+            ok=False,
+            skipped=False,
+            before=before,
+            after=None,
+            message=f"optimizer failed on {src}\n{opt_log}",
+        )
+
+    after, after_log = interpret(repo, interp_bin, opt)
+    if not before.startswith("Program output:"):
+        return CheckResult(
+            ok=True,
+            skipped=True,
+            before=before,
+            after=after,
+            message=(
+                f"skipped ({before})\n"
+                f"source: {src}\noptimized: {opt}\n"
+                f"optimized output: {after}\n"
+                f"source log:\n{before_log}"
+                f"optimized log:\n{after_log}"
+            ),
+        )
+    if not after.startswith("Program output:"):
+        return CheckResult(
+            ok=False,
+            skipped=False,
+            before=before,
+            after=after,
+            message=(
+                f"optimized program is not interpretable\n"
+                f"source: {src}\noptimized: {opt}\n"
+                f"original output: {before}\ninterpreter output: {after}\n{after_log}"
+            ),
+        )
+    if not refines(before, after):
+        return CheckResult(
+            ok=False,
+            skipped=False,
+            before=before,
+            after=after,
+            message=(
+                f"semantic mismatch\n"
+                f"source: {src}\noptimized: {opt}\n"
+                f"original:  {before}\n"
+                f"optimized: {after}"
+            ),
+        )
+    return CheckResult(ok=True, skipped=False, before=before, after=after, message=before)
+
+
+def _worker(
+    repo: Path,
+    interp_bin: Path,
+    opt_bin: Path,
+    workdir: Path,
+    seed: int,
+    count: int,
+    start_index: int,
+    passes: str,
+    queue: "multiprocessing.Queue",
+) -> None:
+    signal.signal(signal.SIGINT, signal.SIG_IGN)
+    try:
+        workdir.mkdir(parents=True, exist_ok=True)
+        rng = random.Random(seed)
+        iterator = itertools.count() if count < 0 else range(count)
+        for i in iterator:
+            idx = start_index + i
+            src = workdir / f"case_{idx}.mlir"
+            opt = workdir / f"case_{idx}.opt.mlir"
+            generate(src, rng)
+            result = check(repo, interp_bin, opt_bin, src, opt, passes)
+            if not result.ok:
+                queue.put(("fail", result.message))
+                return
+            queue.put((
+                "ok",
+                outcome_key(result.before),
+                outcome_key(result.after),
+                result.skipped,
+                idx,
+                result.before,
+                result.after,
+            ))
+            src.unlink(missing_ok=True)
+            opt.unlink(missing_ok=True)
+        queue.put(("done",))
+    except BaseException:
+        queue.put(("fail", f"worker crashed:\n{traceback.format_exc()}"))
+
+
+def fuzz(
+    repo: Path,
+    interp_bin: Path,
+    opt_bin: Path,
+    workdir: Path,
+    iterations: int,
+    passes: str,
+    rng: random.Random,
+    num_workers: int,
+    spinner: Spinner,
+    verbose: bool,
+) -> bool:
+    infinite = iterations < 0
+    if not infinite and iterations == 0:
+        spinner.finish("no iterations")
+        return True
+
+    if infinite:
+        num_workers = max(1, num_workers)
+        base, extra = 0, 0
+    else:
+        num_workers = max(1, min(num_workers, iterations))
+        base, extra = divmod(iterations, num_workers)
+
+    ctx = multiprocessing.get_context()
+    queue: "multiprocessing.Queue" = ctx.Queue()
+    processes: list[multiprocessing.Process] = []
+    start = 0
+    for w in range(num_workers):
+        count = -1 if infinite else base + (1 if w < extra else 0)
+        seed = rng.getrandbits(64)
+        subdir = workdir / f"w{w}"
+        p = ctx.Process(
+            target=_worker,
+            args=(repo, interp_bin, opt_bin, subdir, seed, count, start, passes, queue),
+        )
+        p.start()
+        processes.append(p)
+        if not infinite:
+            start += count
+
+    source_counts: defaultdict[str, int] = defaultdict(int)
+    opt_counts: defaultdict[str, int] = defaultdict(int)
+    done = 0
+    failure_message: str | None = None
+    interrupted = False
+
+    try:
+        while infinite or done < num_workers:
+            try:
+                msg = queue.get()
+            except KeyboardInterrupt:
+                interrupted = True
+                break
+            tag = msg[0]
+            if tag == "done":
+                done += 1
+            elif tag == "fail":
+                failure_message = msg[1]
+                break
+            elif tag == "ok":
+                _, src_key, opt_key, skipped, idx, before, after = msg
+                source_counts[src_key] += 1
+                opt_counts[opt_key] += 1
+                if verbose:
+                    print(f"case {idx}:")
+                    print(f"  source:    {before}")
+                    print(f"  optimized: {after}")
+                elif not skipped:
+                    spinner.update(f"passed {source_counts['program output']} cases")
+    finally:
+        if failure_message is not None or interrupted:
+            for p in processes:
+                if p.is_alive():
+                    p.terminate()
+        for p in processes:
+            p.join()
+
+    if failure_message is not None:
+        spinner.clear()
+        print(failure_message)
+        return False
+
+    def fmt_counts(counts: defaultdict[str, int]) -> str:
+        return ", ".join(f"{k}: {v}" for k, v in sorted(counts.items()))
+
+    header = "interrupted, no mismatches detected" if interrupted else "no mismatches detected"
+    spinner.finish(
+        f"{header}\n"
+        f"  source:    {fmt_counts(source_counts)}\n"
+        f"  optimized: {fmt_counts(opt_counts)}"
+    )
+    return True
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=100,
+                        help="number of random programs to test, or -1 to run forever (default: 100)")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="random seed (default: fresh system entropy)")
+    parser.add_argument("--passes", default="instcombine,dce",
+                        help="veir-opt pass pipeline (default: instcombine,dce)")
+    parser.add_argument("--keep", action="store_true",
+                        help="keep workdir on success (always kept on failure)")
+    parser.add_argument("--workers", type=int, default=os.cpu_count() or 1,
+                        help="number of parallel workers (default: all available cores)")
+    parser.add_argument("--verbose", action="store_true",
+                        help="print per-case source/optimized outputs instead of the spinner")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    repo = Path(__file__).resolve().parents[1]
+    seed = args.seed if args.seed is not None else secrets.randbits(64)
+    rng = random.Random(seed)
+
+    workdir = Path(tempfile.mkdtemp(prefix="vsmith-"))
+
+    print(f"workdir: {workdir}")
+    print(f"seed:    {seed}")
+    print(f"passes:  {args.passes}")
+    print(f"workers: {args.workers}")
+
+    prebuild(repo)
+    interp_bin = repo / ".lake" / "build" / "bin" / "veir-interpret"
+    opt_bin = repo / ".lake" / "build" / "bin" / "veir-opt"
+
+    success = fuzz(
+        repo, interp_bin, opt_bin, workdir,
+        args.iterations, args.passes, rng,
+        args.workers, Spinner(), args.verbose,
+    )
+
+    if success and not args.keep:
+        shutil.rmtree(workdir)
+    else:
+        print(f"kept workdir: {workdir}")
+
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tools/vsmith_generate.py
+++ b/Tools/vsmith_generate.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Generate a single random closed MLIR module for VeIR testing."""
+
+# TODO:
+# - support llvm.[load,store,alloca]
+
+from __future__ import annotations
+
+import argparse
+import random
+import secrets
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+BINARY_OPS = ("llvm.add", "llvm.sub", "llvm.mul", "llvm.and", "llvm.or", "llvm.xor")
+SHIFT_OPS = ("llvm.shl", "llvm.lshr", "llvm.ashr")
+DIV_OPS = ("llvm.sdiv", "llvm.udiv", "llvm.srem", "llvm.urem")
+ICMP_PREDS = tuple(range(10))
+
+
+def bitwidth(typ: str) -> int:
+    return int(typ[1:])
+
+
+def rand_int_type(rng: random.Random) -> str:
+    if rng.random() < 0.5:
+        common = ("i1", "i8", "i16", "i32", "i64")
+        return rng.choice(common)
+    else:
+        return f"i{rng.randint(1, 95)}"
+
+
+def laplace_bias(rng: random.Random, scale: float, clip: int) -> int:
+    mag = rng.expovariate(1.0 / scale)
+    bias = mag if rng.random() < 0.5 else -mag
+    return max(-clip, min(clip, round(bias)))
+
+
+def rand_const_val(rng: random.Random, width: int) -> int:
+    if rng.random() < 0.05:
+        int_min = -(1 << (width - 1))
+        int_max = (1 << (width - 1)) - 1
+        base = rng.choice([int_min, int_max])
+        val = (base + laplace_bias(rng, 2.43, 10))
+        val &= (1 << width) - 1
+        if val >= 1 << (width - 1):
+            val -= 1 << width
+        return val
+    if width >= 9 and rng.random() < 0.75:
+        mask = (1 << width) - 1
+        val = 0
+        for _ in range(rng.randint(0, 5)):
+            val |= 1 << rng.randint(0, width - 1)
+        val += laplace_bias(rng, 2.43, 10)
+        if rng.random() < 0.5:
+            val ^= mask
+        val &= mask
+        if val >= 1 << (width - 1):
+            val -= 1 << width
+        return val
+    return rng.randint(-(2 ** (width - 1)), 2 ** (width - 1) - 1)
+
+
+def format_block_arguments(arg_names: list[str], arg_types: list[str]) -> str:
+    if not arg_names:
+        return ""
+    return ", ".join(f"{name} : {typ}" for name, typ in zip(arg_names, arg_types))
+
+
+class Generator:
+    def __init__(self, rng: random.Random) -> None:
+        self.rng = rng
+        self.counter = 0
+        self.lines: list[str] = []
+        self.imported: dict[str, list[str]] = defaultdict(list)
+        self.imported_all: list[tuple[str, str]] = []
+        self.local: dict[str, list[str]] = defaultdict(list)
+        self.local_all: list[tuple[str, str]] = []
+
+    def name(self, prefix: str) -> str:
+        self.counter += 1
+        return f"%{prefix}{self.counter}"
+
+    def set_state(
+        self,
+        lines: list[str],
+        imported: dict[str, list[str]],
+        imported_all: list[tuple[str, str]],
+        local_args: list[tuple[str, str]],
+    ) -> None:
+        self.lines = lines
+        self.imported = imported
+        self.imported_all = imported_all
+        self.local = defaultdict(list)
+        self.local_all = []
+        for name, typ in local_args:
+            self.local[typ].append(name)
+            self.local_all.append((name, typ))
+
+    def random_dominating_value(self, width: int) -> str:
+        typ = f"i{width}"
+        local = self.local.get(typ, [])
+        imported = self.imported.get(typ, [])
+        if local and imported:
+            pool = local if self.rng.random() < 0.7 else imported
+        else:
+            pool = local or imported
+        if not pool:
+            return self.add_const(typ, rand_const_val(self.rng, width))
+        return self.rng.choice(pool)
+
+    def binary_props(self, op: str) -> str:
+        if op in ("llvm.add", "llvm.sub", "llvm.mul"):
+            return self.rng.choice(("", " <{nsw}>", " <{nuw}>", " <{nsw, nuw}>"))
+        if op == "llvm.or":
+            return self.rng.choice(("", " <{disjoint}>"))
+        return ""
+
+    def shift_props(self, op: str) -> str:
+        if op == "llvm.shl":
+            return self.rng.choice(("", " <{nsw}>", " <{nuw}>", " <{nsw, nuw}>"))
+        return self.rng.choice(("", " <{exact}>"))
+
+    def shift_amount(self, width: int) -> str:
+        """Generate a shift amount for a width-`width` shift.
+
+        50%: constant in [0, width-1] (always inbounds).
+        25%: dominating value masked with `(1 << floor_log2(width)) - 1` (always inbounds).
+        25%: raw dominating value (may be out of bounds, producing poison).
+        """
+        typ = f"i{width}"
+        r = self.rng.random()
+        if r < 0.50:
+            return self.add_const(typ, self.rng.randint(0, width - 1))
+        if r < 0.75:
+            var = self.random_dominating_value(width)
+            mask = (1 << (width.bit_length() - 1)) - 1
+            mask_const = self.add_const(typ, mask)
+            return self.add_operation("llvm.and", [var, mask_const], [typ, typ], typ)
+        return self.random_dominating_value(width)
+
+    def div_props(self, op: str) -> str:
+        if op in ("llvm.sdiv", "llvm.udiv"):
+            return self.rng.choice(("", " <{exact}>"))
+        return ""
+
+    def divisor(self, width: int) -> str:
+        """Generate a divisor for a width-`width` div/rem.
+
+        50%: constant (occasionally zero -> UB).
+        25%: dominating value OR'd with 1 (guaranteed non-zero, but still poison if input is).
+        25%: raw dominating value (may be zero, producing UB).
+        """
+        typ = f"i{width}"
+        r = self.rng.random()
+        if r < 0.50:
+            return self.add_const(typ, rand_const_val(self.rng, width))
+        if r < 0.75:
+            var = self.random_dominating_value(width)
+            one = self.add_const(typ, 1)
+            return self.add_operation("llvm.or", [var, one], [typ, typ], typ)
+        return self.random_dominating_value(width)
+
+    def add_const(self, typ: str, val: int) -> str:
+        name = self.name("c")
+        self.lines.append(f'  {name} = "llvm.mlir.constant"() <{{"value" = {val} : {typ}}}> : () -> {typ}')
+        self.local[typ].append(name)
+        self.local_all.append((name, typ))
+        return name
+
+    def add_operation(
+        self,
+        op: str,
+        operands: list[str],
+        operand_types: list[str],
+        result_type: str,
+        props: str = "",
+        name_prefix: str = "v",
+    ) -> str:
+        name = self.name(name_prefix)
+        operands_str = ", ".join(operands)
+        operand_types_str = ", ".join(operand_types)
+        self.lines.append(f'  {name} = "{op}"({operands_str}){props} : ({operand_types_str}) -> {result_type}')
+        self.local[result_type].append(name)
+        self.local_all.append((name, result_type))
+        return name
+
+    def seed_block(self) -> None:
+        typ = rand_int_type(self.rng)
+        width = bitwidth(typ)
+        self.add_const(typ, rand_const_val(self.rng, width))
+        self.add_const(typ, rand_const_val(self.rng, width))
+        if self.rng.random() < 0.5:
+            extra_typ = rand_int_type(self.rng)
+            self.add_const(extra_typ, rand_const_val(self.rng, bitwidth(extra_typ)))
+
+    def random_branch_condition(self) -> str:
+        return self.random_dominating_value(1)
+
+    def random_return_value(self) -> tuple[str, str]:
+        pool = self.local_all + self.imported_all
+        if not pool:
+            typ = rand_int_type(self.rng)
+            return self.add_const(typ, rand_const_val(self.rng, bitwidth(typ))), typ
+        n = min(self.rng.randint(1, 25), len(pool))
+        chosen = self.rng.sample(pool, n)
+        target_width = self.rng.choice([bitwidth(typ) for _, typ in chosen])
+        target = f"i{target_width}"
+        casted: list[str] = []
+        for name, typ in chosen:
+            w = bitwidth(typ)
+            if w == target_width:
+                casted.append(name)
+            elif w < target_width:
+                op = self.rng.choice(("llvm.zext", "llvm.sext"))
+                casted.append(self.add_operation(op, [name], [typ], target))
+            else:
+                casted.append(self.add_operation("llvm.trunc", [name], [typ], target))
+        result = casted[0]
+        for other in casted[1:]:
+            result = self.add_operation("llvm.xor", [result, other], [target, target], target)
+        return result, target
+
+    def add_block_body(self, count: int) -> None:
+        exprs: list[tuple[str, str, str, str, str]] = []
+        for _ in range(count):
+            choice = self.rng.random()
+            if choice < 0.35:
+                typ = rand_int_type(self.rng)
+                same_type_exprs = [e for e in exprs if e[3] == typ]
+                if same_type_exprs and self.rng.random() < 0.55:
+                    op, lhs, rhs, typ, props = self.rng.choice(same_type_exprs)
+                else:
+                    op = self.rng.choice(BINARY_OPS)
+                    width = bitwidth(typ)
+                    lhs = self.random_dominating_value(width)
+                    rhs = self.random_dominating_value(width)
+                    props = self.binary_props(op)
+                    exprs.append((op, lhs, rhs, typ, props))
+                self.add_operation(op, [lhs, rhs], [typ, typ], typ, props)
+            elif choice < 0.48:
+                typ = rand_int_type(self.rng)
+                width = bitwidth(typ)
+                lhs = self.random_dominating_value(width)
+                rhs = self.shift_amount(width)
+                op = self.rng.choice(SHIFT_OPS)
+                props = self.shift_props(op)
+                self.add_operation(op, [lhs, rhs], [typ, typ], typ, props)
+            elif choice < 0.60:
+                typ = rand_int_type(self.rng)
+                width = bitwidth(typ)
+                lhs = self.random_dominating_value(width)
+                rhs = self.divisor(width)
+                op = self.rng.choice(DIV_OPS)
+                props = self.div_props(op)
+                self.add_operation(op, [lhs, rhs], [typ, typ], typ, props)
+            elif choice < 0.72:
+                src = rand_int_type(self.rng)
+                src_w = bitwidth(src)
+                if src_w >= 95:
+                    continue
+                op = self.rng.choice(("llvm.sext", "llvm.zext"))
+                dst = f"i{self.rng.randint(src_w + 1, 95)}"
+                props = " <{nneg}>" if op == "llvm.zext" and self.rng.random() < 0.5 else ""
+                operand = self.random_dominating_value(src_w)
+                self.add_operation(op, [operand], [src], dst, props)
+            elif choice < 0.82:
+                src = rand_int_type(self.rng)
+                src_w = bitwidth(src)
+                if src_w <= 1:
+                    continue
+                dst = f"i{self.rng.randint(1, src_w - 1)}"
+                props = self.rng.choice(("", " <{nsw}>", " <{nuw}>", " <{nsw, nuw}>"))
+                operand = self.random_dominating_value(src_w)
+                self.add_operation("llvm.trunc", [operand], [src], dst, props)
+            elif choice < 0.90:
+                typ = rand_int_type(self.rng)
+                width = bitwidth(typ)
+                lhs = self.random_dominating_value(width)
+                rhs = self.random_dominating_value(width)
+                pred = self.rng.choice(ICMP_PREDS)
+                props = f' <{{"predicate" = {pred} : i64}}>'
+                self.add_operation("llvm.icmp", [lhs, rhs], [typ, typ], "i1", props)
+            elif choice < 0.96:
+                typ = rand_int_type(self.rng)
+                width = bitwidth(typ)
+                cond = self.random_dominating_value(1)
+                tval = self.random_dominating_value(width)
+                fval = self.random_dominating_value(width)
+                self.add_operation("llvm.select", [cond, tval, fval], ["i1", typ, typ], typ)
+            else:
+                typ = rand_int_type(self.rng)
+                self.add_const(typ, rand_const_val(self.rng, bitwidth(typ)))
+
+
+def generate(path: Path, rng: random.Random) -> None:
+    """Write a random closed MLIR module to path."""
+    gen = Generator(rng)
+    lines = ['"builtin.module"() ({']
+    num_blocks = rng.randint(1, 20)
+    block_arg_types: list[list[str]] = [[]]
+    block_arg_names: list[list[str]] = [[]]
+
+    for block_id in range(1, num_blocks):
+        arg_count = rng.randint(0, 5)
+        arg_types = [rand_int_type(rng) for _ in range(arg_count)]
+        arg_names = [f"%arg{block_id}_{arg_idx}" for arg_idx in range(arg_count)]
+        block_arg_types.append(arg_types)
+        block_arg_names.append(arg_names)
+
+    preds: list[set[int]] = [set() for _ in range(num_blocks)]
+    doms: list[set[int]] = [set() for _ in range(num_blocks)]
+    snap_values: list[dict[str, list[str]]] = [defaultdict(list) for _ in range(num_blocks)]
+    snap_all: list[list[tuple[str, str]]] = [[] for _ in range(num_blocks)]
+
+    for block_id in range(num_blocks):
+        if block_id == 0:
+            doms[0] = {0}
+        elif preds[block_id]:
+            doms[block_id] = {block_id} | set.intersection(*(doms[p] for p in preds[block_id]))
+        else:
+            doms[block_id] = set(range(block_id + 1))
+
+        imported: dict[str, list[str]] = defaultdict(list)
+        imported_all: list[tuple[str, str]] = []
+        for d in sorted(doms[block_id] - {block_id}):
+            for typ, names in snap_values[d].items():
+                imported[typ].extend(names)
+            imported_all.extend(snap_all[d])
+
+        local_args = list(zip(block_arg_names[block_id], block_arg_types[block_id]))
+        header_args = format_block_arguments(block_arg_names[block_id], block_arg_types[block_id])
+        lines.append(f"^bb{block_id}({header_args}):")
+        gen.set_state(lines, imported, imported_all, local_args)
+        gen.seed_block()
+        gen.add_block_body(rng.randint(3, 18))
+
+        snap_values[block_id] = {t: list(vs) for t, vs in gen.local.items()}
+        snap_all[block_id] = list(gen.local_all)
+
+        successors = [f"^bb{succ}" for succ in range(block_id + 1, num_blocks)]
+        if not successors:
+            returned, typ = gen.random_return_value()
+            lines.append(f'  "llvm.return"({returned}) : ({typ}) -> ()')
+            continue
+
+        if rng.random() < 0.20:
+            target = rng.choice(range(block_id + 1, num_blocks))
+            target_types = block_arg_types[target]
+            target_args = [gen.random_dominating_value(bitwidth(typ)) for typ in target_types]
+            operands_str = ", ".join(target_args)
+            operand_types_str = ", ".join(target_types)
+            lines.append(
+                f'  "llvm.br"({operands_str}) [^bb{target}] '
+                f': ({operand_types_str}) -> ()'
+            )
+            preds[target].add(block_id)
+            continue
+
+        cond = gen.random_branch_condition()
+        if len(successors) == 1:
+            true_block = false_block = block_id + 1
+        else:
+            true_block, false_block = rng.sample(range(block_id + 1, num_blocks), 2)
+        true_dest = f"^bb{true_block}"
+        false_dest = f"^bb{false_block}"
+        true_types = block_arg_types[true_block]
+        false_types = block_arg_types[false_block]
+        true_args = [gen.random_dominating_value(bitwidth(typ)) for typ in true_types]
+        false_args = [gen.random_dominating_value(bitwidth(typ)) for typ in false_types]
+        operands = [cond] + true_args + false_args
+        operand_types = ["i1"] + true_types + false_types
+        operands_str = ", ".join(operands)
+        operand_types_str = ", ".join(operand_types)
+        lines.append(
+            f'  "llvm.cond_br"({operands_str}) [{true_dest}, {false_dest}] '
+            f'<{{"operandSegmentSizes" = array<i32: 1, {len(true_args)}, {len(false_args)}>}}> '
+            f': ({operand_types_str}) -> ()'
+        )
+        preds[true_block].add(block_id)
+        preds[false_block].add(block_id)
+
+    lines.append("}) : () -> ()")
+    path.write_text("\n".join(lines) + "\n")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("output", type=Path, help="path for the generated MLIR file")
+    parser.add_argument("--seed", type=int, default=None, help="random seed; defaults to fresh system entropy")
+    args = parser.parse_args(argv)
+    seed = args.seed if args.seed is not None else secrets.randbits(64)
+    generate(args.output, random.Random(seed))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
this generates a random collection of LLVM dialect instructions. it is loop-free to ensure termination, but there is control flow. VeIR doesn't do yet do much of the stuff that would contain bugs that this script can find, but I still think it's useful.

I should add that this code already caught 2 `veir-interpret` bugs: the one where SSA values were not being passed across blocks, and also the one where gigantic shift amounts were causing the interpreter to terminate abnormally!

what I will do soon is modify this code so that it exports generated code to LLVM IR and then cross checks to make sure `veir-interpret` produces the same result as `llubi`. this should be very helpful in validating our semantics against LLVM's!