### PR TITLE
`VEIR_ROUNDTRIP`: ensure `veir-opt` can reparse its output

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -10,4 +10,4 @@ veir_root = Path(config.test_source_root).parent
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {veir_root}"])
 config.substitutions.append(('veir-opt', "lake exec veir-opt"))
 config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
-config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | filecheck %s"))
+config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | lake exec veir-opt | filecheck %s"))

--- a/Veir/Parser/ParserError.lean
+++ b/Veir/Parser/ParserError.lean
@@ -106,13 +106,12 @@ def lineContaining (input : ByteArray) (loc : Nat) : Option String := Id.run do
   When `loc` is `none`, the header uses `<unknown location>` and no source line
   is printed.
 -/
-def formatLabel (filename : Option String) (input : ByteArray) (severity : String) (loc : Option Nat)
+def formatLabel (filename : String) (input : ByteArray) (severity : String) (loc : Option Nat)
     (msg : String) : String :=
   match loc with
   | none => s!"<unknown location>: {severity}: {msg}"
   | some loc =>
     let (line, col) := byteOffsetToLineCol input loc
-    let filename := if let some f := filename then f else "<stdin>"
     let header := s!"{filename}:{line}:{col}: {severity}: {msg}"
     match lineContaining input loc with
     | some srcLine =>
@@ -128,7 +127,7 @@ public section
   Render one primary `error` label followed by a `note` label per entry in
   `e.notes`, each via `formatLabel`. The primary location is taken from `e.pos`.
 -/
-def format (e : ParserError) (filename : Option String) (input : ByteArray) : String :=
+def format (e : ParserError) (filename : String) (input : ByteArray) : String :=
   let primary := formatLabel filename input "error" e.pos e.msg
   e.notes.foldl
     (fun acc note => acc ++ "\n" ++ formatLabel filename input "note" (some note.pos) note.msg)

--- a/Veir/Parser/ParserError.lean
+++ b/Veir/Parser/ParserError.lean
@@ -106,12 +106,13 @@ def lineContaining (input : ByteArray) (loc : Nat) : Option String := Id.run do
   When `loc` is `none`, the header uses `<unknown location>` and no source line
   is printed.
 -/
-def formatLabel (filename : String) (input : ByteArray) (severity : String) (loc : Option Nat)
+def formatLabel (filename : Option String) (input : ByteArray) (severity : String) (loc : Option Nat)
     (msg : String) : String :=
   match loc with
   | none => s!"<unknown location>: {severity}: {msg}"
   | some loc =>
     let (line, col) := byteOffsetToLineCol input loc
+    let filename := if let some f := filename then f else "<stdin>"
     let header := s!"{filename}:{line}:{col}: {severity}: {msg}"
     match lineContaining input loc with
     | some srcLine =>
@@ -127,7 +128,7 @@ public section
   Render one primary `error` label followed by a `note` label per entry in
   `e.notes`, each via `formatLabel`. The primary location is taken from `e.pos`.
 -/
-def format (e : ParserError) (filename : String) (input : ByteArray) : String :=
+def format (e : ParserError) (filename : Option String) (input : ByteArray) : String :=
   let primary := formatLabel filename input "error" e.pos e.msg
   e.notes.foldl
     (fun acc note => acc ++ "\n" ++ formatLabel filename input "note" (some note.pos) note.msg)

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -35,7 +35,7 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
 -/
 structure VeirOptArgs where
   /-- The input filename. -/
-  filename : String
+  filename : Option String
   /-- List of passes to run. -/
   passes : PassPipeline OpCode
 
@@ -63,24 +63,26 @@ def parseArgs (args : List String) : Except String VeirOptArgs := do
   let pipeline ← parsePipelineOption flags
 
   if positional.length == 0 then -- read from stdin
-    return VeirOptArgs.mk "-" pipeline
+    return VeirOptArgs.mk none pipeline
 
   let [filename] := positional
     | .error "Expected exactly one positional argument for the input filename."
 
-  return VeirOptArgs.mk filename pipeline
-
-def getFileContent (filename : String) : ExceptT String IO ByteArray := do
   if filename == "-" then
-    return ← IO.FS.Stream.readBinToEnd (←IO.getStdin)
-  else
-    -- Read from file
+    return VeirOptArgs.mk none pipeline
+
+  return VeirOptArgs.mk (some filename) pipeline
+
+def getFileContent (filename : Option String) : ExceptT String IO ByteArray := do
+  if let some f := filename then
     try
-      return ← IO.FS.readBinFile filename
+      return ← IO.FS.readBinFile f
     catch e =>
       throw s!"Error reading file '{filename}': {e}"
 
-def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
+  return ← IO.FS.Stream.readBinToEnd (←IO.getStdin)
+
+def parseOperation (filename : Option String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
   let fileContent ← getFileContent filename
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "Failed to create IR context"

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -59,14 +59,29 @@ def parsePipelineOption (args : List String) : Except String (PassPipeline OpCod
 -/
 def parseArgs (args : List String) : Except String VeirOptArgs := do
   let (flags, positional) := args.partition (·.startsWith "-")
-  let [filename] := positional
-    | .error "Expected exactly one positional argument for the input filename."
   -- Parses the `-p` flag if present.
   let pipeline ← parsePipelineOption flags
+
+  if positional.length == 0 then -- read from stdin
+    return VeirOptArgs.mk "-" pipeline
+
+  let [filename] := positional
+    | .error "Expected exactly one positional argument for the input filename."
+
   return VeirOptArgs.mk filename pipeline
 
+def getFileContent (filename : String) : ExceptT String IO ByteArray := do
+  if filename == "-" then
+    return ← IO.FS.Stream.readBinToEnd (←IO.getStdin)
+  else
+    -- Read from file
+    try
+      return ← IO.FS.readBinFile filename
+    catch e =>
+      throw s!"Error reading file '{filename}': {e}"
+
 def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
-  let fileContent ← IO.FS.readBinFile filename
+  let fileContent ← getFileContent filename
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "Failed to create IR context"
   match ParserState.fromInput fileContent with

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -86,6 +86,9 @@ def parseOperation (filename : Option String) : ExceptT String IO (WfIRContext O
   let fileContent ← getFileContent filename
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "Failed to create IR context"
+
+  let filename := if let some f := filename then f else "<stdin>"
+
   match ParserState.fromInput fileContent with
   | .ok parser =>
     match (parseOp none).run (MlirParserState.fromContext ctx) parser with


### PR DESCRIPTION
For this we parse and reprint each mlir file used in `VEIR_ROUNDTRIP` using `veir-opt`.

We also extend `veir-opt` to support reading from stdin if either no command line argument is given or if the filename is `-`. This is consistent with the behaviour of `mlir-opt`.