### PR TITLE
properties for func.func

### DIFF
--- a/Test/Func/func_properties.mlir
+++ b/Test/Func/func_properties.mlir
@@ -1,7 +1,4 @@
-// RUN: veir-opt %s | filecheck %s
-//
-// Lossless round-trip of a `func.func` carrying both the modelled `sym_name`
-// property and an unmodelled property preserved via `extra`.
+// RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "f", visibility = "private"}> ({

--- a/Test/Func/func_properties.mlir
+++ b/Test/Func/func_properties.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-opt %s | filecheck %s
+//
+// Lossless round-trip of a `func.func` carrying both the modelled `sym_name`
+// property and an unmodelled property preserved via `extra`.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "f", visibility = "private"}> ({
+  ^bb0(%arg0: i32):
+    "func.return"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "func.func"() <{
+// CHECK-SAME:   "sym_name" = "f"
+// CHECK-SAME:   "visibility" = "private"
+// CHECK-SAME: }> ({

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -27,6 +27,7 @@ match opCode with
 | .comb op => Comb.propertiesOf op
 | .hw op => HW.propertiesOf op
 | .builtin .unregistered => UnregisteredProperties
+| .func .func => FuncFuncProperties
 | _ => Unit
 
 instance : HasDialectOpInfo OpCode where
@@ -113,7 +114,9 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case frem => exact (FastMathFlagsProperties.fromAttrDict attrDict)
     case func => exact (LLVMFuncProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
-  case func =>
+  case func op =>
+    cases op
+    case func => exact (FuncFuncProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case cf op =>
     cases op
@@ -266,6 +269,11 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
       dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
     if let some function_type := props.function_type then
       dict := dict.insert "function_type".toUTF8 function_type
+    dict
+  | .func .func => Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    if let some sym_name := props.sym_name then
+      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
     dict
   | .builtin .unregistered =>
     Std.HashMap.ofList props.properties.entries.toList

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -394,6 +394,25 @@ def HWConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribut
   return { value := intAttr }
 
 /--
+  Properties of `func.func`. The `sym_name` attribute is modelled explicitly;
+  all other attributes are preserved verbatim in `extra`.
+-/
+structure FuncFuncProperties where
+  sym_name : Option StringAttr
+  extra : DictionaryAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def FuncFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String FuncFuncProperties := do
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr s) => pure (some s)
+    | some attr => throw s!"func.func: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => pure none
+  let extra := DictionaryAttr.fromArray
+    (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8)
+  return { sym_name := symName, extra }
+
+/--
   Properties of `llvm.func`. The `sym_name` and `function_type` attributes are
   modelled explicitly; all other attributes (e.g. `CConv`, `linkage`, `visibility_`)
   are preserved verbatim in `extra`.


### PR DESCRIPTION
we need sym_name on func.func if we're going to have the interpreter find main().

and of course, I hope we can support function calls in the interpreter soon!

this PR mirrors my earlier one for llvm.func.