### PR TITLE
cross-check veir-interpret results against llubi and/or alive-exec

### DIFF
--- a/Tools/veir2llvm
+++ b/Tools/veir2llvm
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+"""Translate a small VEIR LLVM-dialect MLIR module to LLVM IR.
+
+This is intentionally not a general MLIR parser.  It accepts one
+``builtin.module`` containing exactly one ``llvm.func`` and supports the small
+integer LLVM subset used by ``Tools/vsmith_generate.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+IDENT = r"[%@^]?[A-Za-z0-9_.$-]+"
+
+
+class Error(Exception):
+    pass
+
+
+def die(msg: str) -> None:
+    print(f"veir2llvm: error: {msg}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def strip_comments(text: str) -> str:
+    out: list[str] = []
+    for line in text.splitlines():
+        in_string = False
+        i = 0
+        while i < len(line):
+            ch = line[i]
+            if ch == '"':
+                in_string = not in_string
+            if not in_string and line.startswith("//", i):
+                break
+            i += 1
+        out.append(line[:i].rstrip())
+    return "\n".join(out)
+
+
+def split_top_level(s: str, sep: str = ",") -> list[str]:
+    parts: list[str] = []
+    start = 0
+    angle = paren = bracket = brace = 0
+    in_string = False
+    i = 0
+    while i < len(s):
+        ch = s[i]
+        if ch == '"':
+            in_string = not in_string
+        elif not in_string:
+            if ch == "<":
+                angle += 1
+            elif ch == ">":
+                angle -= 1
+            elif ch == "(":
+                paren += 1
+            elif ch == ")":
+                paren -= 1
+            elif ch == "[":
+                bracket += 1
+            elif ch == "]":
+                bracket -= 1
+            elif ch == "{":
+                brace += 1
+            elif ch == "}":
+                brace -= 1
+            elif ch == sep and angle == paren == bracket == brace == 0:
+                parts.append(s[start:i].strip())
+                start = i + 1
+        i += 1
+    tail = s[start:].strip()
+    if tail:
+        parts.append(tail)
+    return parts
+
+
+def find_matching_region_end(text: str, open_pos: int) -> int:
+    if text[open_pos : open_pos + 2] != "({":
+        raise Error("internal error: region does not start with ({")
+    depth = 1
+    attr_depth = 0
+    in_string = False
+    i = open_pos + 2
+    while i < len(text):
+        if text[i] == '"':
+            in_string = not in_string
+            i += 1
+            continue
+        if in_string:
+            i += 1
+            continue
+        if text.startswith("<{", i):
+            attr_depth += 1
+            i += 2
+            continue
+        if text.startswith("}>", i) and attr_depth:
+            attr_depth -= 1
+            i += 2
+            continue
+        if attr_depth == 0:
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    if i + 1 >= len(text) or text[i + 1] != ")":
+                        raise Error("region closing brace is not followed by ')'")
+                    return i
+        i += 1
+    raise Error("unterminated region")
+
+
+def find_matching_angle(s: str, open_pos: int) -> int:
+    depth = 0
+    in_string = False
+    for i in range(open_pos, len(s)):
+        ch = s[i]
+        if ch == '"':
+            in_string = not in_string
+        elif not in_string:
+            if ch == "<":
+                depth += 1
+            elif ch == ">":
+                depth -= 1
+                if depth == 0:
+                    return i
+    raise Error("unterminated angle bracket")
+
+
+def value_name(name: str) -> str:
+    if not name.startswith("%"):
+        raise Error(f"expected SSA value, got {name}")
+    return name
+
+
+def label_name(label: str) -> str:
+    return label[1:] if label.startswith("^") else label
+
+
+def llvm_block_name(label: str) -> str:
+    return "mlir_" + label_name(label)
+
+
+def llvm_label(label: str) -> str:
+    return "%" + llvm_block_name(label)
+
+
+def llvm_ssa_name(name: str) -> str:
+    if not name.startswith("%"):
+        raise Error(f"expected SSA value, got {name}")
+    return "%mlir_" + name[1:]
+
+
+def llvm_value(name: str, aliases: dict[str, str]) -> str:
+    return aliases.get(name, llvm_ssa_name(name))
+
+
+def parse_value_list(s: str) -> list[str]:
+    if not s.strip():
+        return []
+    vals = split_top_level(s)
+    for val in vals:
+        if not val.startswith("%"):
+            raise Error(f"expected SSA operand, got {val}")
+    return vals
+
+
+def parse_type_list(s: str) -> list[str]:
+    if not s.strip():
+        return []
+    return split_top_level(s)
+
+
+def parse_block_args(s: str | None) -> list[tuple[str, str]]:
+    if not s or not s.strip():
+        return []
+    args: list[tuple[str, str]] = []
+    for part in split_top_level(s):
+        m = re.fullmatch(rf"\s*({IDENT})\s*:\s*(.+?)\s*", part)
+        if not m:
+            raise Error(f"could not parse block argument: {part}")
+        name = value_name(m.group(1))
+        args.append((name, m.group(2).strip()))
+    return args
+
+
+def parse_attr_items(attr: str) -> set[str]:
+    if not attr:
+        return set()
+    items = set()
+    for item in split_top_level(attr):
+        item = item.strip()
+        if not item:
+            continue
+        if "=" in item:
+            key = item.split("=", 1)[0].strip().strip('"')
+            items.add(key)
+        else:
+            items.add(item.strip('"'))
+    return items
+
+
+def parse_int_attr(attr: str, name: str) -> int:
+    pat = rf'"?{re.escape(name)}"?\s*=\s*(-?\d+)\s*:\s*i\d+'
+    m = re.search(pat, attr)
+    if not m:
+        raise Error(f"missing integer attribute {name}")
+    return int(m.group(1))
+
+
+def parse_segment_sizes(attr: str) -> tuple[int, int, int]:
+    m = re.search(
+        r'"?operandSegmentSizes"?\s*=\s*array<i32:\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*>',
+        attr,
+    )
+    if not m:
+        raise Error("llvm.cond_br is missing operandSegmentSizes")
+    sizes = tuple(int(x) for x in m.groups())
+    if sizes[0] != 1:
+        raise Error("llvm.cond_br condition segment must have size 1")
+    return sizes
+
+
+def parse_constant_attr(attr: str) -> tuple[str, str]:
+    m = re.search(r'"?value"?\s*=\s*(-?\d+)\s*:\s*([^,\s>}]+)', attr)
+    if not m:
+        raise Error("llvm.mlir.constant is missing integer value")
+    return m.group(1), m.group(2)
+
+
+def convert_type(typ: str) -> str:
+    typ = typ.strip()
+    if re.fullmatch(r"i\d+", typ):
+        return typ
+    if typ in ("void", "!llvm.void"):
+        return "void"
+    if typ in ("ptr", "!llvm.ptr"):
+        return "ptr"
+    if typ == "f16":
+        return "half"
+    if typ == "f32":
+        return "float"
+    if typ == "f64":
+        return "double"
+    if typ == "f128":
+        return "fp128"
+    raise Error(f"unsupported type: {typ}")
+
+
+def parse_function_type(attr_text: str) -> tuple[str, list[str]]:
+    key = "function_type"
+    idx = attr_text.find(key)
+    if idx < 0:
+        raise Error("llvm.func is missing function_type")
+    func_idx = attr_text.find("!llvm.func<", idx)
+    if func_idx < 0:
+        raise Error("llvm.func function_type is not !llvm.func<...>")
+    open_pos = attr_text.find("<", func_idx)
+    close_pos = find_matching_angle(attr_text, open_pos)
+    inner = attr_text[open_pos + 1 : close_pos].strip()
+    m = re.fullmatch(r"(.+?)\s*\((.*)\)\s*", inner)
+    if not m:
+        raise Error(f"could not parse function type: {inner}")
+    return m.group(1).strip(), parse_type_list(m.group(2))
+
+
+def parse_sym_name(attr_text: str) -> str:
+    m = re.search(r'"?sym_name"?\s*=\s*"([^"]+)"', attr_text)
+    if not m:
+        raise Error("llvm.func is missing sym_name")
+    name = m.group(1)
+    if not re.fullmatch(r"[A-Za-z_.$][A-Za-z0-9_.$-]*", name):
+        raise Error(f"unsupported function symbol name: {name}")
+    return name
+
+
+@dataclass
+class Operation:
+    result: str | None
+    name: str
+    operands: list[str]
+    successors: list[str]
+    attr: str
+    operand_types: list[str]
+    result_types: list[str]
+    line: str
+
+
+@dataclass
+class Block:
+    label: str
+    args: list[tuple[str, str]]
+    ops: list[Operation] = field(default_factory=list)
+
+
+@dataclass
+class Edge:
+    pred: str
+    target: str
+    values: list[str]
+
+
+@dataclass
+class EdgeBlock:
+    label: str
+    target: str
+
+
+def parse_operation(line: str) -> Operation:
+    m = re.fullmatch(
+        rf'\s*(?:({IDENT})\s*=\s*)?"([^"]+)"\((.*?)\)\s*'
+        rf'(?:\[(.*?)\]\s*)?(?:<\{{(.*?)\}}>\s*)?:\s*'
+        rf'\((.*?)\)\s*->\s*(.+?)\s*',
+        line,
+    )
+    if not m:
+        raise Error(f"could not parse operation: {line}")
+    result = m.group(1)
+    if result is not None:
+        result = value_name(result)
+    successors = []
+    if m.group(4) is not None and m.group(4).strip():
+        successors = [label_name(x.strip()) for x in split_top_level(m.group(4))]
+    return Operation(
+        result=result,
+        name=m.group(2),
+        operands=parse_value_list(m.group(3)),
+        successors=successors,
+        attr=m.group(5) or "",
+        operand_types=parse_type_list(m.group(6)),
+        result_types=parse_type_list(m.group(7)) if m.group(7).strip() != "()" else [],
+        line=line,
+    )
+
+
+def parse_blocks(body: str) -> list[Block]:
+    blocks: list[Block] = []
+    current: Block | None = None
+    implicit_index = 0
+    for raw_line in body.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        header = re.fullmatch(rf"\^([A-Za-z0-9_.$-]+)\s*(?:\((.*?)\))?\s*:", line)
+        if header:
+            current = Block(header.group(1), parse_block_args(header.group(2)))
+            blocks.append(current)
+            continue
+        if '"' not in line:
+            raise Error(f"unexpected line in function body: {line}")
+        if current is None:
+            current = Block("entry", [])
+            blocks.append(current)
+            implicit_index += 1
+        current.ops.append(parse_operation(line))
+    if implicit_index > 1:
+        raise Error("internal error: multiple implicit entry blocks")
+    if not blocks:
+        raise Error("llvm.func has an empty body")
+    seen: set[str] = set()
+    for block in blocks:
+        if block.label in seen:
+            raise Error(f"duplicate block label: {block.label}")
+        seen.add(block.label)
+    return blocks
+
+
+def extract_function(text: str) -> tuple[str, list[Block], str, list[str]]:
+    op_names = re.findall(r'"([^"]+)"\s*\(', text)
+    for op in op_names:
+        if op != "builtin.module" and not op.startswith("llvm."):
+            raise Error(f"unsupported non-LLVM operation: {op}")
+    if op_names.count("llvm.func") != 1:
+        raise Error(f"expected exactly one llvm.func, found {op_names.count('llvm.func')}")
+    func_pos = text.find('"llvm.func"')
+    head_end = text.find("({", func_pos)
+    if head_end < 0:
+        raise Error("llvm.func has no region body")
+    body_close = find_matching_region_end(text, head_end)
+    outside_func = text[:func_pos] + text[body_close + 2 :]
+    outside_ops = re.findall(r'"([^"]+)"\s*\(', outside_func)
+    extra_ops = [op for op in outside_ops if op != "builtin.module"]
+    if extra_ops:
+        raise Error(
+            "expected the module to contain only one llvm.func; "
+            f"found extra top-level op {extra_ops[0]}"
+        )
+    head = text[func_pos:head_end]
+    attr_match = re.search(r"<\{(.*)\}>\s*$", head.strip())
+    if not attr_match:
+        raise Error("llvm.func must have an attribute dictionary")
+    attrs = attr_match.group(1)
+    name = parse_sym_name(attrs)
+    ret_type, arg_types = parse_function_type(attrs)
+    body = text[head_end + 2 : body_close]
+    blocks = parse_blocks(body)
+    return name, blocks, ret_type, arg_types
+
+
+def validate_function_args(blocks: list[Block], arg_types: list[str]) -> None:
+    entry = blocks[0]
+    if len(entry.args) != len(arg_types):
+        raise Error(
+            f"entry block has {len(entry.args)} args but function type has {len(arg_types)} args"
+        )
+    for idx, ((arg_name, block_type), func_type) in enumerate(zip(entry.args, arg_types)):
+        if block_type != func_type:
+            raise Error(
+                f"entry block arg {idx} ({arg_name}) has type {block_type}, "
+                f"but function type has {func_type}"
+            )
+
+
+def flags_from_attrs(op: str, attr: str) -> list[str]:
+    items = parse_attr_items(attr)
+    flags: list[str] = []
+    if op in {"llvm.add", "llvm.sub", "llvm.mul", "llvm.shl", "llvm.trunc"}:
+        if "overflowFlags" in items:
+            overflow = parse_int_attr(attr, "overflowFlags")
+            if overflow & ~3:
+                raise Error(f"unsupported overflowFlags value on {op}: {overflow}")
+            if overflow & 2:
+                flags.append("nuw")
+            if overflow & 1:
+                flags.append("nsw")
+        for flag in ("nuw", "nsw"):
+            if flag in items and flag not in flags:
+                flags.append(flag)
+    if op in {"llvm.udiv", "llvm.sdiv", "llvm.lshr", "llvm.ashr"} and "exact" in items:
+        flags.append("exact")
+    if op == "llvm.or" and "disjoint" in items:
+        flags.append("disjoint")
+    if op == "llvm.zext" and "nneg" in items:
+        flags.append("nneg")
+    unsupported = items - {
+        "nuw",
+        "nsw",
+        "exact",
+        "disjoint",
+        "nneg",
+        "predicate",
+        "operandSegmentSizes",
+        "overflowFlags",
+    }
+    if unsupported:
+        raise Error(f"unsupported attributes on {op}: {', '.join(sorted(unsupported))}")
+    return flags
+
+
+ICMP_PREDICATES = {
+    0: "eq",
+    1: "ne",
+    2: "slt",
+    3: "sle",
+    4: "sgt",
+    5: "sge",
+    6: "ult",
+    7: "ule",
+    8: "ugt",
+    9: "uge",
+}
+
+
+def require_result(op: Operation) -> str:
+    if op.result is None:
+        raise Error(f"{op.name} must have one result")
+    if len(op.result_types) != 1:
+        raise Error(f"{op.name} must have exactly one result type")
+    return op.result
+
+
+def require_operands(op: Operation, count: int) -> None:
+    if len(op.operands) != count or len(op.operand_types) != count:
+        raise Error(f"{op.name} expects {count} operands")
+
+
+def translate_nonterminator(
+    op: Operation, aliases: dict[str, str], value_types: dict[str, str]
+) -> list[str]:
+    name = op.name
+    if name == "llvm.mlir.constant":
+        result = require_result(op)
+        if op.operands or op.operand_types:
+            raise Error("llvm.mlir.constant cannot have operands")
+        value, typ = parse_constant_attr(op.attr)
+        if len(op.result_types) != 1 or op.result_types[0] != typ:
+            raise Error("llvm.mlir.constant result type does not match value type")
+        aliases[result] = value
+        value_types[result] = typ
+        return []
+
+    result = require_result(op)
+    out_result = llvm_ssa_name(result)
+    dst_type = op.result_types[0]
+    value_types[result] = dst_type
+    flags = flags_from_attrs(name, op.attr)
+    flag_text = (" " + " ".join(flags)) if flags else ""
+
+    binary_ops = {
+        "llvm.add": "add",
+        "llvm.sub": "sub",
+        "llvm.mul": "mul",
+        "llvm.and": "and",
+        "llvm.or": "or",
+        "llvm.xor": "xor",
+        "llvm.shl": "shl",
+        "llvm.lshr": "lshr",
+        "llvm.ashr": "ashr",
+        "llvm.sdiv": "sdiv",
+        "llvm.udiv": "udiv",
+        "llvm.srem": "srem",
+        "llvm.urem": "urem",
+    }
+    if name in binary_ops:
+        require_operands(op, 2)
+        if op.operand_types[0] != op.operand_types[1] or op.operand_types[0] != dst_type:
+            raise Error(f"{name} operand/result types must match")
+        lhs = llvm_value(op.operands[0], aliases)
+        rhs = llvm_value(op.operands[1], aliases)
+        typ = convert_type(dst_type)
+        return [f"  {out_result} = {binary_ops[name]}{flag_text} {typ} {lhs}, {rhs}"]
+
+    if name == "llvm.icmp":
+        require_operands(op, 2)
+        if op.operand_types[0] != op.operand_types[1] or dst_type != "i1":
+            raise Error("llvm.icmp expects equal operand types and i1 result")
+        pred_num = parse_int_attr(op.attr, "predicate")
+        pred = ICMP_PREDICATES.get(pred_num)
+        if pred is None:
+            raise Error(f"unsupported llvm.icmp predicate: {pred_num}")
+        lhs = llvm_value(op.operands[0], aliases)
+        rhs = llvm_value(op.operands[1], aliases)
+        typ = convert_type(op.operand_types[0])
+        return [f"  {out_result} = icmp {pred} {typ} {lhs}, {rhs}"]
+
+    if name == "llvm.select":
+        require_operands(op, 3)
+        if op.operand_types[0] != "i1":
+            raise Error("llvm.select condition must have type i1")
+        if op.operand_types[1] != op.operand_types[2] or op.operand_types[1] != dst_type:
+            raise Error("llvm.select value operand/result types must match")
+        cond = llvm_value(op.operands[0], aliases)
+        tv = llvm_value(op.operands[1], aliases)
+        fv = llvm_value(op.operands[2], aliases)
+        typ = convert_type(dst_type)
+        return [f"  {out_result} = select i1 {cond}, {typ} {tv}, {typ} {fv}"]
+
+    casts = {"llvm.trunc": "trunc", "llvm.sext": "sext", "llvm.zext": "zext"}
+    if name in casts:
+        require_operands(op, 1)
+        src = llvm_value(op.operands[0], aliases)
+        src_type = convert_type(op.operand_types[0])
+        out_type = convert_type(dst_type)
+        return [f"  {out_result} = {casts[name]}{flag_text} {src_type} {src} to {out_type}"]
+
+    raise Error(f"unsupported LLVM operation: {name}")
+
+
+def translate_terminator(
+    block: Block,
+    op: Operation,
+    aliases: dict[str, str],
+    blocks_by_label: dict[str, Block],
+    edge_blocks: list[EdgeBlock],
+) -> tuple[list[str], list[Edge]]:
+    if op.result is not None or op.result_types:
+        raise Error(f"{op.name} terminator cannot have results")
+
+    if op.name == "llvm.return":
+        if op.successors:
+            raise Error("llvm.return cannot have successors")
+        if len(op.operands) == 0 and len(op.operand_types) == 0:
+            return ["  ret void"], []
+        if len(op.operands) != 1 or len(op.operand_types) != 1:
+            raise Error("llvm.return with multiple values is not supported")
+        value = llvm_value(op.operands[0], aliases)
+        return [f"  ret {convert_type(op.operand_types[0])} {value}"], []
+
+    if op.name == "llvm.br":
+        if len(op.successors) != 1:
+            raise Error("llvm.br must have exactly one successor")
+        target = op.successors[0]
+        if target not in blocks_by_label:
+            raise Error(f"llvm.br targets unknown block ^{target}")
+        target_args = blocks_by_label[target].args
+        if len(op.operands) != len(target_args):
+            raise Error(
+                f"llvm.br to ^{target} passes {len(op.operands)} values, "
+                f"but target has {len(target_args)} block args"
+            )
+        values = [llvm_value(v, aliases) for v in op.operands]
+        return [f"  br label {llvm_label(target)}"], [Edge(block.label, target, values)]
+
+    if op.name == "llvm.cond_br":
+        if len(op.successors) != 2:
+            raise Error("llvm.cond_br must have exactly two successors")
+        for target in op.successors:
+            if target not in blocks_by_label:
+                raise Error(f"llvm.cond_br targets unknown block ^{target}")
+        true_target, false_target = op.successors
+        cond_n, true_n, false_n = parse_segment_sizes(op.attr)
+        if cond_n + true_n + false_n != len(op.operands):
+            raise Error("llvm.cond_br operandSegmentSizes do not match operand count")
+        cond = llvm_value(op.operands[0], aliases)
+        true_values = [llvm_value(v, aliases) for v in op.operands[1 : 1 + true_n]]
+        false_values = [llvm_value(v, aliases) for v in op.operands[1 + true_n :]]
+        if true_n != len(blocks_by_label[true_target].args):
+            raise Error(
+                f"true edge to ^{true_target} passes {true_n} values, "
+                f"but target has {len(blocks_by_label[true_target].args)} block args"
+            )
+        if false_n != len(blocks_by_label[false_target].args):
+            raise Error(
+                f"false edge to ^{false_target} passes {false_n} values, "
+                f"but target has {len(blocks_by_label[false_target].args)} block args"
+            )
+        if op.operand_types[:1] != ["i1"]:
+            raise Error("llvm.cond_br condition must have type i1")
+
+        edges: list[Edge] = []
+        if true_target == false_target and (true_n or false_n):
+            true_edge_label = f"{block.label}_to_{true_target}_true"
+            false_edge_label = f"{block.label}_to_{false_target}_false"
+            edge_blocks.append(EdgeBlock(true_edge_label, true_target))
+            edge_blocks.append(EdgeBlock(false_edge_label, false_target))
+            edges.append(Edge(true_edge_label, true_target, true_values))
+            edges.append(Edge(false_edge_label, false_target, false_values))
+            return (
+                [
+                    f"  br i1 {cond}, label {llvm_label(true_edge_label)}, label {llvm_label(false_edge_label)}",
+                ],
+                edges,
+            )
+
+        edges.append(Edge(block.label, true_target, true_values))
+        edges.append(Edge(block.label, false_target, false_values))
+        return (
+            [f"  br i1 {cond}, label {llvm_label(true_target)}, label {llvm_label(false_target)}"],
+            edges,
+        )
+
+    raise Error(f"unsupported LLVM terminator: {op.name}")
+
+
+def translate_function(name: str, blocks: list[Block], ret_type: str, arg_types: list[str]) -> str:
+    validate_function_args(blocks, arg_types)
+    blocks_by_label = {block.label: block for block in blocks}
+    aliases: dict[str, str] = {}
+    value_types: dict[str, str] = {}
+    body_lines: dict[str, list[str]] = {}
+    edges: list[Edge] = []
+    edge_blocks: list[EdgeBlock] = []
+
+    for idx, block in enumerate(blocks):
+        for arg_name, arg_type in block.args:
+            value_types[arg_name] = arg_type
+        lines: list[str] = []
+        if not block.ops:
+            raise Error(f"block ^{block.label} is empty")
+        for op_index, op in enumerate(block.ops):
+            is_last = op_index == len(block.ops) - 1
+            if op.name in {"llvm.return", "llvm.br", "llvm.cond_br"}:
+                if not is_last:
+                    raise Error(f"terminator {op.name} is not last in ^{block.label}")
+                term_lines, term_edges = translate_terminator(
+                    block, op, aliases, blocks_by_label, edge_blocks
+                )
+                lines.extend(term_lines)
+                edges.extend(term_edges)
+            else:
+                if is_last:
+                    raise Error(f"block ^{block.label} has no terminator")
+                lines.extend(translate_nonterminator(op, aliases, value_types))
+        body_lines[block.label] = lines
+
+    incoming: dict[str, list[list[tuple[str, str]]]] = {
+        block.label: [[] for _ in block.args] for block in blocks
+    }
+    for edge in edges:
+        target_args = blocks_by_label[edge.target].args
+        if len(edge.values) != len(target_args):
+            raise Error(f"edge to ^{edge.target} has wrong value count")
+        for idx, value in enumerate(edge.values):
+            incoming[edge.target][idx].append((value, edge.pred))
+
+    params: list[str] = []
+    for (arg_name, arg_type), func_type in zip(blocks[0].args, arg_types):
+        params.append(f"{convert_type(func_type)} {llvm_ssa_name(arg_name)}")
+
+    out: list[str] = [f"define {convert_type(ret_type)} @{name}({', '.join(params)}) {{"]
+    for idx, block in enumerate(blocks):
+        out.append(f"{llvm_block_name(block.label)}:")
+        if idx != 0:
+            for arg_index, (arg_name, arg_type) in enumerate(block.args):
+                typ = convert_type(arg_type)
+                incs = incoming[block.label][arg_index]
+                if incs:
+                    incoming_text = ", ".join(f"[ {val}, %{llvm_block_name(pred)} ]" for val, pred in incs)
+                    out.append(f"  {llvm_ssa_name(arg_name)} = phi {typ} {incoming_text}")
+                else:
+                    out.append(f"  {llvm_ssa_name(arg_name)} = freeze {typ} poison")
+        out.extend(body_lines[block.label])
+
+    for edge_block in edge_blocks:
+        out.append(f"{llvm_block_name(edge_block.label)}:")
+        out.append(f"  br label {llvm_label(edge_block.target)}")
+
+    out.append("}")
+    return "\n".join(out) + "\n"
+
+
+def translate(text: str) -> str:
+    text = strip_comments(text)
+    name, blocks, ret_type, arg_types = extract_function(text)
+    return translate_function(name, blocks, ret_type, arg_types)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path, help="input MLIR file")
+    args = parser.parse_args(argv)
+    try:
+        sys.stdout.write(translate(args.input.read_text()))
+    except (OSError, Error) as e:
+        die(str(e))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/Tools/vsmith
+++ b/Tools/vsmith
@@ -6,11 +6,6 @@ running an optimizer pipeline, and reports a reproducer if the observable
 outputs differ.
 """
 
-# TODO
-#
-# - convert both src and tgt to LLVM IR and run llubi, check for
-#   agreement with veir-interpret
-
 from __future__ import annotations
 
 import argparse
@@ -18,6 +13,7 @@ import itertools
 import multiprocessing
 import os
 import random
+import re
 import secrets
 import shutil
 import signal
@@ -29,6 +25,7 @@ import traceback
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Callable
 
 sys.path.insert(0, str(Path(__file__).parent))
 from vsmith_generate import generate
@@ -43,10 +40,26 @@ class ToolResult:
 @dataclass(frozen=True)
 class CheckResult:
     ok: bool
-    skipped: bool
     before: str
     after: str | None
     message: str
+    before_llvm: tuple[tuple[str, str], ...] = ()
+    after_llvm: tuple[tuple[str, str], ...] = ()
+
+
+@dataclass(frozen=True)
+class LlvmInterpResult:
+    veir_output: str
+    final_value: str
+    log: str
+
+
+@dataclass(frozen=True)
+class LlvmInterpreter:
+    name: str
+    bin: Path
+    extra_args: tuple[str, ...]
+    classifier: Callable[[str], tuple[str, str]]
 
 
 class Spinner:
@@ -137,6 +150,183 @@ def interpret(repo: Path, interp_bin: Path, path: Path) -> tuple[str, str]:
     return output, result.output
 
 
+def translate_to_llvm(repo: Path, mlir_path: Path, ll_path: Path) -> tuple[bool, str]:
+    """Translate VEIR's LLVM dialect to LLVM IR."""
+    translator = repo / "Tools" / "veir2llvm"
+    result = run_tool(repo, [str(translator), str(mlir_path)])
+    if result.returncode != 0:
+        return False, result.output
+    if not result.output.strip().startswith("define "):
+        return False, result.output
+    ll_path.write_text(result.output)
+    return True, result.output
+
+
+def format_int_output(width: int, value: int) -> str:
+    mask = (1 << width) - 1
+    unsigned = value & mask
+    digits = max(1, (width + 3) // 4)
+    return f"0x{unsigned:0{digits}x}#{width}"
+
+
+def classify_llubi_output(log: str) -> tuple[str, str]:
+    """Return llubi's result in veir-interpret format and llubi's final value."""
+    for line in log.splitlines():
+        if "Immediate UB detected" in line:
+            return "Undefined behavior", line.strip()
+    for line in log.splitlines():
+        if "poison return value" in line:
+            return "Program output: #[poison]", "poison"
+
+    values: dict[str, str] = {}
+    llubi_values: dict[str, str] = {}
+    for line in log.splitlines():
+        assignment = re.search(r"^\s*(%[-A-Za-z0-9_.$]+)\s*=.*=>\s*(poison|i(\d+)\s+(-?\d+))\s*$", line)
+        if assignment:
+            name = assignment.group(1)
+            if assignment.group(2) == "poison":
+                values[name] = "poison"
+                llubi_values[name] = "poison"
+            else:
+                values[name] = format_int_output(int(assignment.group(3)), int(assignment.group(4)))
+                llubi_values[name] = assignment.group(2)
+            continue
+
+        bool_assignment = re.search(r"^\s*(%[-A-Za-z0-9_.$]+)\s*=.*=>\s*([TF])\s*$", line)
+        if bool_assignment:
+            values[bool_assignment.group(1)] = "0x1#1" if bool_assignment.group(2) == "T" else "0x0#1"
+            llubi_values[bool_assignment.group(1)] = bool_assignment.group(2)
+            continue
+
+        ret_const = re.search(r"^\s*ret\s+i(\d+)\s+(-?\d+)\s*$", line)
+        if ret_const:
+            width = int(ret_const.group(1))
+            value = int(ret_const.group(2))
+            return f"Program output: #[{format_int_output(width, value)}]", f"i{width} {value}"
+
+        ret_bool = re.search(r"^\s*ret\s+i1\s+(true|false)\s*$", line)
+        if ret_bool:
+            value = ret_bool.group(1)
+            return f"Program output: #[{'0x1#1' if value == 'true' else '0x0#1'}]", value
+
+        ret_value = re.search(r"^\s*ret\s+i(\d+)\s+(%[-A-Za-z0-9_.$]+)\s*$", line)
+        if ret_value:
+            value = values.get(ret_value.group(2))
+            llubi_value = llubi_values.get(ret_value.group(2))
+            if value is None:
+                raise ValueError(f"llubi return value was not recorded:\n{log}")
+            if llubi_value is None:
+                raise ValueError(f"llubi return value was not recorded:\n{log}")
+            return f"Program output: #[{value}]", llubi_value
+
+        if re.fullmatch(r"\s*ret\s+void\s*", line):
+            return "Program output: #[]", "void"
+
+    raise ValueError(f"llubi produced no recognizable result:\n{log}")
+
+
+ALIVE_EXEC_RETURNED_RE = re.compile(
+    r"^Returned\s+#([xb])([0-9a-fA-F]+)\s+/\s+non-poison=(true|false)\s*$"
+)
+
+
+def classify_alive_exec_output(log: str) -> tuple[str, str]:
+    """Return alive-exec's result in veir-interpret format and alive-exec's final value."""
+    if "UB triggered!" in log:
+        return "Undefined behavior", "UB triggered"
+
+    final_line: str | None = None
+    for line in log.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Returned "):
+            final_line = stripped
+
+    if final_line is None:
+        raise ValueError(f"alive-exec produced no recognizable result:\n{log}")
+
+    m = ALIVE_EXEC_RETURNED_RE.match(final_line)
+    if not m:
+        raise ValueError(
+            f"alive-exec result line not recognized:\n  {final_line}\nfull log:\n{log}"
+        )
+    radix, digits, non_poison = m.group(1), m.group(2), m.group(3)
+    if non_poison == "false":
+        return "Program output: #[poison]", "poison"
+    if radix == "x":
+        width = 4 * len(digits)
+        unsigned = int(digits, 16)
+    else:
+        width = len(digits)
+        unsigned = int(digits, 2)
+    return f"Program output: #[{format_int_output(width, unsigned)}]", final_line
+
+
+def run_llvm_interp(repo: Path, interp: LlvmInterpreter, ll_path: Path) -> LlvmInterpResult:
+    """Run an LLVM IR interpreter and return its classified result plus raw output."""
+    result = run_tool(repo, [str(interp.bin), *interp.extra_args, str(ll_path)])
+    veir_output, final_value = interp.classifier(result.output)
+    return LlvmInterpResult(veir_output, final_value, result.output)
+
+
+def check_llvm_interp_equiv(
+    repo: Path,
+    interp: LlvmInterpreter,
+    mlir_path: Path,
+    ll_path: Path,
+    veir_output: str,
+    label: str,
+) -> tuple[bool, str, str | None]:
+    """Check that an LLVM IR interpreter exactly agrees with veir-interpret."""
+    try:
+        result = run_llvm_interp(repo, interp, ll_path)
+    except ValueError as e:
+        return (
+            False,
+            f"{interp.name} output could not be classified for {label} program\n"
+            f"source: {mlir_path}\nllvm: {ll_path}\n{e}",
+            None,
+        )
+    if result.veir_output != veir_output:
+        pad = max(len("veir-interpret"), len(interp.name))
+        return (
+            False,
+            f"{interp.name} mismatch on {label} program\n"
+            f"source: {mlir_path}\nllvm: {ll_path}\n"
+            f"{'veir-interpret':<{pad}}: {veir_output}\n"
+            f"{interp.name:<{pad}}: {result.veir_output}\n"
+            f"{interp.name} log:\n{result.log}",
+            result.final_value,
+        )
+    return True, "", result.final_value
+
+
+def check_llvm_interps(
+    repo: Path,
+    interps: list[LlvmInterpreter],
+    mlir_path: Path,
+    veir_output: str,
+    label: str,
+) -> tuple[bool, str, tuple[tuple[str, str], ...]]:
+    """Translate to LLVM IR once, then cross-check each interpreter against veir-interpret."""
+    ll_path = mlir_path.with_suffix(".ll")
+    ok, translate_log = translate_to_llvm(repo, mlir_path, ll_path)
+    if not ok:
+        return (
+            False,
+            f"veir2llvm failed on {label} program\n"
+            f"source: {mlir_path}\nllvm: {ll_path}\n{translate_log}",
+            (),
+        )
+    collected: list[tuple[str, str]] = []
+    for interp in interps:
+        ok, msg, value = check_llvm_interp_equiv(repo, interp, mlir_path, ll_path, veir_output, label)
+        if value is not None:
+            collected.append((interp.name, value))
+        if not ok:
+            return False, msg, tuple(collected)
+    return True, "", tuple(collected)
+
+
 def optimize(repo: Path, opt_bin: Path, src: Path, dst: Path, passes: str) -> tuple[bool, str]:
     """Run veir-opt and write the result to dst. Returns (success, log)."""
     result = run_tool(repo, [str(opt_bin), str(src), f"-p={passes}"])
@@ -169,8 +359,13 @@ def parse_output_values(line: str) -> list[str] | None:
 def refines(original: str, optimized: str) -> bool:
     """Return True if optimized is a valid refinement of original.
 
-    poison in the original may map to any value; all other values must match.
+    Undefined behavior in the original may map to any interpreter outcome.
+    Poison values in the original may map to poison or concrete values.
+    Concrete values in the original must be preserved exactly.
     """
+    if original == "Undefined behavior":
+        return optimized == "Undefined behavior" or optimized.startswith("Program output:")
+
     orig = parse_output_values(original)
     opt = parse_output_values(optimized)
     if orig is None or opt is None or len(orig) != len(opt):
@@ -178,53 +373,60 @@ def refines(original: str, optimized: str) -> bool:
     return all(o == "poison" or o == p for o, p in zip(orig, opt))
 
 
-def check(repo: Path, interp_bin: Path, opt_bin: Path, src: Path, opt: Path, passes: str) -> CheckResult:
+def check(
+    repo: Path,
+    interp_bin: Path,
+    opt_bin: Path,
+    llvm_interps: list[LlvmInterpreter],
+    src: Path,
+    opt: Path,
+    passes: str,
+) -> CheckResult:
     """Interpret, optimize, re-interpret, and compare."""
-    before, before_log = interpret(repo, interp_bin, src)
+    before, _ = interpret(repo, interp_bin, src)
+    before_llvm: tuple[tuple[str, str], ...] = ()
+    if llvm_interps:
+        ok, message, before_llvm = check_llvm_interps(repo, llvm_interps, src, before, "source")
+        if not ok:
+            return CheckResult(
+                ok=False,
+                before=before,
+                after=None,
+                message=message,
+                before_llvm=before_llvm,
+            )
 
     ok, opt_log = optimize(repo, opt_bin, src, opt, passes)
     if not ok:
         return CheckResult(
             ok=False,
-            skipped=False,
             before=before,
             after=None,
             message=f"optimizer failed on {src}\n{opt_log}",
+            before_llvm=before_llvm,
         )
 
-    after, after_log = interpret(repo, interp_bin, opt)
-    if not before.startswith("Program output:"):
-        return CheckResult(
-            ok=True,
-            skipped=True,
-            before=before,
-            after=after,
-            message=(
-                f"skipped ({before})\n"
-                f"source: {src}\noptimized: {opt}\n"
-                f"optimized output: {after}\n"
-                f"source log:\n{before_log}"
-                f"optimized log:\n{after_log}"
-            ),
-        )
-    if not after.startswith("Program output:"):
-        return CheckResult(
-            ok=False,
-            skipped=False,
-            before=before,
-            after=after,
-            message=(
-                f"optimized program is not interpretable\n"
-                f"source: {src}\noptimized: {opt}\n"
-                f"original output: {before}\ninterpreter output: {after}\n{after_log}"
-            ),
-        )
+    after, _ = interpret(repo, interp_bin, opt)
+    after_llvm: tuple[tuple[str, str], ...] = ()
+    if llvm_interps:
+        ok, message, after_llvm = check_llvm_interps(repo, llvm_interps, opt, after, "optimized")
+        if not ok:
+            return CheckResult(
+                ok=False,
+                before=before,
+                after=after,
+                message=message,
+                before_llvm=before_llvm,
+                after_llvm=after_llvm,
+            )
+
     if not refines(before, after):
         return CheckResult(
             ok=False,
-            skipped=False,
             before=before,
             after=after,
+            before_llvm=before_llvm,
+            after_llvm=after_llvm,
             message=(
                 f"semantic mismatch\n"
                 f"source: {src}\noptimized: {opt}\n"
@@ -232,13 +434,21 @@ def check(repo: Path, interp_bin: Path, opt_bin: Path, src: Path, opt: Path, pas
                 f"optimized: {after}"
             ),
         )
-    return CheckResult(ok=True, skipped=False, before=before, after=after, message=before)
+    return CheckResult(
+        ok=True,
+        before=before,
+        after=after,
+        message=before,
+        before_llvm=before_llvm,
+        after_llvm=after_llvm,
+    )
 
 
 def _worker(
     repo: Path,
     interp_bin: Path,
     opt_bin: Path,
+    llvm_interps: list[LlvmInterpreter],
     workdir: Path,
     seed: int,
     count: int,
@@ -256,7 +466,7 @@ def _worker(
             src = workdir / f"case_{idx}.mlir"
             opt = workdir / f"case_{idx}.opt.mlir"
             generate(src, rng)
-            result = check(repo, interp_bin, opt_bin, src, opt, passes)
+            result = check(repo, interp_bin, opt_bin, llvm_interps, src, opt, passes)
             if not result.ok:
                 queue.put(("fail", result.message))
                 return
@@ -264,13 +474,16 @@ def _worker(
                 "ok",
                 outcome_key(result.before),
                 outcome_key(result.after),
-                result.skipped,
                 idx,
                 result.before,
                 result.after,
+                result.before_llvm,
+                result.after_llvm,
             ))
             src.unlink(missing_ok=True)
             opt.unlink(missing_ok=True)
+            src.with_suffix(".ll").unlink(missing_ok=True)
+            opt.with_suffix(".ll").unlink(missing_ok=True)
         queue.put(("done",))
     except BaseException:
         queue.put(("fail", f"worker crashed:\n{traceback.format_exc()}"))
@@ -280,6 +493,7 @@ def fuzz(
     repo: Path,
     interp_bin: Path,
     opt_bin: Path,
+    llvm_interps: list[LlvmInterpreter],
     workdir: Path,
     iterations: int,
     passes: str,
@@ -310,7 +524,7 @@ def fuzz(
         subdir = workdir / f"w{w}"
         p = ctx.Process(
             target=_worker,
-            args=(repo, interp_bin, opt_bin, subdir, seed, count, start, passes, queue),
+            args=(repo, interp_bin, opt_bin, llvm_interps, subdir, seed, count, start, passes, queue),
         )
         p.start()
         processes.append(p)
@@ -337,15 +551,19 @@ def fuzz(
                 failure_message = msg[1]
                 break
             elif tag == "ok":
-                _, src_key, opt_key, skipped, idx, before, after = msg
+                _, src_key, opt_key, idx, before, after, before_llvm, after_llvm = msg
                 source_counts[src_key] += 1
                 opt_counts[opt_key] += 1
                 if verbose:
                     print(f"case {idx}:")
                     print(f"  source:    {before}")
+                    for name, value in before_llvm:
+                        print(f"  source {name}: {value}")
                     print(f"  optimized: {after}")
-                elif not skipped:
-                    spinner.update(f"passed {source_counts['program output']} cases")
+                    for name, value in after_llvm:
+                        print(f"  optimized {name}: {value}")
+                else:
+                    spinner.update(f"passed {sum(source_counts.values())} cases")
     finally:
         if failure_message is not None or interrupted:
             for p in processes:
@@ -385,12 +603,30 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
                         help="number of parallel workers (default: all available cores)")
     parser.add_argument("--verbose", action="store_true",
                         help="print per-case source/optimized outputs instead of the spinner")
+    parser.add_argument("--llubi", action="store_true",
+                        help="cross-check veir-interpret against llubi via Tools/veir2llvm")
+    parser.add_argument("--alive-exec", action="store_true",
+                        help="cross-check veir-interpret against alive-exec via Tools/veir2llvm")
     return parser.parse_args(argv)
+
+
+def resolve_llvm_interp(
+    name: str, flag: str, extra_args: tuple[str, ...], classifier: Callable[[str], tuple[str, str]]
+) -> LlvmInterpreter:
+    resolved = shutil.which(name)
+    if resolved is None:
+        raise SystemExit(f"{flag} was requested, but {name!r} was not found in PATH")
+    return LlvmInterpreter(name=name, bin=Path(resolved), extra_args=extra_args, classifier=classifier)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     repo = Path(__file__).resolve().parents[1]
+    llvm_interps: list[LlvmInterpreter] = []
+    if args.llubi:
+        llvm_interps.append(resolve_llvm_interp("llubi", "--llubi", ("--verbose",), classify_llubi_output))
+    if args.alive_exec:
+        llvm_interps.append(resolve_llvm_interp("alive-exec", "--alive-exec", (), classify_alive_exec_output))
     seed = args.seed if args.seed is not None else secrets.randbits(64)
     rng = random.Random(seed)
 
@@ -400,13 +636,15 @@ def main(argv: list[str]) -> int:
     print(f"seed:    {seed}")
     print(f"passes:  {args.passes}")
     print(f"workers: {args.workers}")
+    for interp in llvm_interps:
+        print(f"{interp.name + ':':<12}{interp.bin}")
 
     prebuild(repo)
     interp_bin = repo / ".lake" / "build" / "bin" / "veir-interpret"
     opt_bin = repo / ".lake" / "build" / "bin" / "veir-opt"
 
     success = fuzz(
-        repo, interp_bin, opt_bin, workdir,
+        repo, interp_bin, opt_bin, llvm_interps, workdir,
         args.iterations, args.passes, rng,
         args.workers, Spinner(), args.verbose,
     )


### PR DESCRIPTION
this PR only changes vsmith and associated scripts.

this adds the ability to cross-check veir-interpret against llubi and alive-exec, although alive-exec doesn't work very well since it is solver based and is sometimes really slow.

unfortunately I was not able to reuse mlir-translate to convert llvm-dialect MLIR into LLVM IR. I wanted the translation to be an equivalence, but mlir-translate folds constants, eliminating UB, making it only a refinement. so this PR adds a custom llvm-dialect -> LLVM IR translator. it's totally vibe coded but if it ever messes up, a bug will be signaled, so this should not be a problem.

2 bugs found so far: one that I had added to veir earlier and one in llubi, an incorrect poison condition in the code for exact lshr and ashr.