### PR TITLE
Only use the `propertiesOf` from `HasOpInfo`

### DIFF
--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -18,7 +18,7 @@ public section
   For operations that do not have any properties, the type is `Unit`.
 -/
 @[expose, properties_of]
-def propertiesOf (opCode : OpCode) : Type :=
+def _propertiesOf (opCode : OpCode) : Type :=
 match opCode with
 | .arith op => Arith.propertiesOf op
 | .llvm op => Llvm.propertiesOf op
@@ -33,22 +33,12 @@ match opCode with
 | _ => Unit
 
 instance : HasDialectOpInfo OpCode where
-  propertiesOf := propertiesOf
+  propertiesOf := _propertiesOf
 
 instance : HasOpInfo OpCode where
   moduleOpCode := .builtin .module
 
-instance (opCode : OpCode) : Inhabited (propertiesOf opCode) := by
-  simp only [properties_of]
-  cases opCode <;> (try simp) <;> (rename_i op; cases op <;> infer_instance)
-
-instance (opCode : OpCode) : Repr (propertiesOf opCode) := by
-  simp only [properties_of]
-  cases opCode <;> (try simp) <;> (rename_i op; cases op <;> infer_instance)
-
-instance (opCode : OpCode) : Hashable (propertiesOf opCode) := by
-  simp only [properties_of]
-  cases opCode <;> (try simp) <;> (rename_i op; cases op <;> infer_instance)
+abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
 
 def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String (propertiesOf opCode) := by

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -6,7 +6,7 @@ public section
 
 class HasDialectOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode where
-  propertiesOf : opCode → Type := λ _ => Unit
+  propertiesOf : opCode → Type
   propertiesHash {op : opCode} : Hashable (propertiesOf op) := by
     simp only [properties_of]
     intros opCode; cases opCode <;>
@@ -35,7 +35,10 @@ instance [HasDialectOpInfo opCode] {op : opCode} : Inhabited (HasDialectOpInfo.p
 instance [HasDialectOpInfo opCode] {op : opCode} : Repr (HasDialectOpInfo.propertiesOf op) where
   reprPrec := HasDialectOpInfo.propertiesRepr.reprPrec
 
-instance [HasDialectOpInfo opCode] : DecidableEq (opCode) :=
+instance [HasDialectOpInfo opCode] {op : opCode} : DecidableEq (HasDialectOpInfo.propertiesOf op) := 
+  HasDialectOpInfo.propertiesDecideEq
+
+instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
   HasDialectOpInfo.decideEq
 
 /--
@@ -57,7 +60,10 @@ instance [HasOpInfo opCode] {op : opCode} : Inhabited (HasOpInfo.propertiesOf op
 instance [HasOpInfo opCode] {op : opCode} : Repr (HasOpInfo.propertiesOf op) where
   reprPrec := HasOpInfo.propertiesRepr.reprPrec
 
-instance [HasOpInfo opCode] : DecidableEq (opCode) :=
+instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) := 
+  HasOpInfo.propertiesDecideEq
+
+instance [HasOpInfo opCode] : DecidableEq opCode :=
   HasOpInfo.decideEq
 
 end -- public section


### PR DESCRIPTION
This removes redundant instance definitions.