### PR TITLE
trivial rewrite of some tests to put instructions into a main function

### DIFF
--- a/Test/Interpreter/Arith/addi.mlir
+++ b/Test/Interpreter/Arith/addi.mlir
@@ -1,10 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %x = "arith.addi"(%lhs, %rhs) : (i32, i32) -> i32
-  "func.return"(%x) : (i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+    %x = "arith.addi"(%lhs, %rhs) : (i32, i32) -> i32
+    "func.return"(%x) : (i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000008#32]

--- a/Test/Interpreter/Arith/and.mlir
+++ b/Test/Interpreter/Arith/and.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
-  %x = "arith.andi"(%three, %five) : (i32, i32) -> i32
-  %y = "arith.andi"(%eight, %negseven) : (i32, i32) -> i32
-  %z = "arith.andi"(%three, %eight) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %three = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+    %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
+    %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
+    %x = "arith.andi"(%three, %five) : (i32, i32) -> i32
+    %y = "arith.andi"(%eight, %negseven) : (i32, i32) -> i32
+    %z = "arith.andi"(%three, %eight) : (i32, i32) -> i32
+    "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000001#32, 0x00000008#32, 0x00000000#32]

--- a/Test/Interpreter/Arith/divui.mlir
+++ b/Test/Interpreter/Arith/divui.mlir
@@ -1,13 +1,15 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
-  %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
-  %x = "arith.divui"(%lhs, %rhs) : (i32, i32) -> i32
-  %a = "arith.divui"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %a) : (i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
+    %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
+    %x = "arith.divui"(%lhs, %rhs) : (i32, i32) -> i32
+    %a = "arith.divui"(%negthree, %negtwo) : (i32, i32) -> i32
+    "func.return"(%x, %a) : (i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x0000002b#32, 0x00000000#32]

--- a/Test/Interpreter/Arith/extui.mlir
+++ b/Test/Interpreter/Arith/extui.mlir
@@ -1,11 +1,13 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %c255 = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
-  %cneg = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
-  %a = "arith.extui"(%c255) : (i8) -> i32
-  %b = "arith.extui"(%cneg) : (i8) -> i32
-  "func.return"(%a, %b) : (i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %c255 = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
+    %cneg = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
+    %a = "arith.extui"(%c255) : (i8) -> i32
+    %b = "arith.extui"(%cneg) : (i8) -> i32
+    "func.return"(%a, %b) : (i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x000000ff#32, 0x000000ff#32]

--- a/Test/Interpreter/Arith/muli.mlir
+++ b/Test/Interpreter/Arith/muli.mlir
@@ -1,10 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %x = "arith.muli"(%lhs, %rhs) : (i32, i32) -> i32
-  "func.return"(%x) : (i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
+    %x = "arith.muli"(%lhs, %rhs) : (i32, i32) -> i32
+    "func.return"(%x) : (i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000006#32]

--- a/Test/Interpreter/Arith/or.mlir
+++ b/Test/Interpreter/Arith/or.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
-  %x = "arith.ori"(%three, %five) : (i32, i32) -> i32
-  %y = "arith.ori"(%eight, %negseven) : (i32, i32) -> i32
-  %z = "arith.ori"(%three, %eight) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %three = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+    %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
+    %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
+    %x = "arith.ori"(%three, %five) : (i32, i32) -> i32
+    %y = "arith.ori"(%eight, %negseven) : (i32, i32) -> i32
+    %z = "arith.ori"(%three, %eight) : (i32, i32) -> i32
+    "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output:  #[0x00000007#32, 0xfffffff9#32, 0x0000000b#32]

--- a/Test/Interpreter/Arith/remui.mlir
+++ b/Test/Interpreter/Arith/remui.mlir
@@ -1,13 +1,15 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
-  %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
-  %x = "arith.remui"(%lhs, %rhs) : (i32, i32) -> i32
-  %a = "arith.remui"(%negthree, %negtwo) : (i32, i32) -> i32
-  "func.return"(%x, %a) : (i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %lhs = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %negthree = "arith.constant"() <{ "value" = -3 : i32 }> : () -> i32
+    %negtwo = "arith.constant"() <{ "value" = -2 : i32 }> : () -> i32
+    %x = "arith.remui"(%lhs, %rhs) : (i32, i32) -> i32
+    %a = "arith.remui"(%negthree, %negtwo) : (i32, i32) -> i32
+    "func.return"(%x, %a) : (i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000001#32, 0xfffffffd#32]

--- a/Test/Interpreter/Arith/select.mlir
+++ b/Test/Interpreter/Arith/select.mlir
@@ -1,13 +1,15 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
-  %false = "arith.constant"() <{ "value" = 0 : i1 }> : () -> i1
-  %x = "arith.select"(%true, %lhs, %rhs) : (i1, i32, i32) -> i32
-  %y = "arith.select"(%false, %lhs, %rhs) : (i1, i32, i32) -> i32
-  "func.return"(%x, %y) : (i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+    %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
+    %false = "arith.constant"() <{ "value" = 0 : i1 }> : () -> i1
+    %x = "arith.select"(%true, %lhs, %rhs) : (i1, i32, i32) -> i32
+    %y = "arith.select"(%false, %lhs, %rhs) : (i1, i32, i32) -> i32
+    "func.return"(%x, %y) : (i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000003#32, 0x00000000#32]

--- a/Test/Interpreter/Arith/shli.mlir
+++ b/Test/Interpreter/Arith/shli.mlir
@@ -1,13 +1,15 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
-  %thirtytwo = "arith.constant"() <{ "value" = 32 : i32 }> : () -> i32
-  %x = "arith.shli"(%lhs, %rhs) : (i32, i32) -> i32
-  %p = "arith.shli"(%zero, %thirtytwo) : (i32, i32) -> i32
-  "func.return"(%x, %p) : (i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %zero = "arith.constant"() <{ "value" = 0 : i32 }> : () -> i32
+    %lhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
+    %thirtytwo = "arith.constant"() <{ "value" = 32 : i32 }> : () -> i32
+    %x = "arith.shli"(%lhs, %rhs) : (i32, i32) -> i32
+    %p = "arith.shli"(%zero, %thirtytwo) : (i32, i32) -> i32
+    "func.return"(%x, %p) : (i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x0000000c#32, poison]

--- a/Test/Interpreter/Arith/subi.mlir
+++ b/Test/Interpreter/Arith/subi.mlir
@@ -1,10 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %lhs = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %x = "arith.subi"(%lhs, %rhs) : (i32, i32) -> i32
-  "func.return"(%x) : (i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %lhs = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+    %rhs = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %x = "arith.subi"(%lhs, %rhs) : (i32, i32) -> i32
+    "func.return"(%x) : (i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000002#32]

--- a/Test/Interpreter/Arith/trunci.mlir
+++ b/Test/Interpreter/Arith/trunci.mlir
@@ -1,13 +1,15 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %c255 = "arith.constant"() <{ "value" = 255 : i32 }> : () -> i32
-  %c256 = "arith.constant"() <{ "value" = 256 : i32 }> : () -> i32
-  %cneg = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
-  %a = "arith.trunci"(%c255) : (i32) -> i8
-  %b = "arith.trunci"(%c256) : (i32) -> i8
-  %c = "arith.trunci"(%cneg) : (i32) -> i16
-  "func.return"(%a, %b, %c) : (i8, i8, i16) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %c255 = "arith.constant"() <{ "value" = 255 : i32 }> : () -> i32
+    %c256 = "arith.constant"() <{ "value" = 256 : i32 }> : () -> i32
+    %cneg = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
+    %a = "arith.trunci"(%c255) : (i32) -> i8
+    %b = "arith.trunci"(%c256) : (i32) -> i8
+    %c = "arith.trunci"(%cneg) : (i32) -> i16
+    "func.return"(%a, %b, %c) : (i8, i8, i16) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0xff#8, 0x00#8, 0xffff#16]

--- a/Test/Interpreter/Arith/xor.mlir
+++ b/Test/Interpreter/Arith/xor.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
-  %x = "arith.xori"(%three, %five) : (i32, i32) -> i32
-  %y = "arith.xori"(%eight, %negseven) : (i32, i32) -> i32
-  %z = "arith.xori"(%three, %eight) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %three = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+    %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
+    %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
+    %x = "arith.xori"(%three, %five) : (i32, i32) -> i32
+    %y = "arith.xori"(%eight, %negseven) : (i32, i32) -> i32
+    %z = "arith.xori"(%three, %eight) : (i32, i32) -> i32
+    "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000006#32, 0xfffffff1#32, 0x0000000b#32]

--- a/Test/Interpreter/Cf/br.mlir
+++ b/Test/Interpreter/Cf/br.mlir
@@ -1,12 +1,14 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  ^1():
-    %x1 = "arith.constant"() <{"value" = 8 : i32}> : () -> i32
-    %x2 = "arith.constant"() <{"value" = 11 : i32}> : () -> i32
-    "cf.br"(%x1, %x2) [^2] : (i32, i32) -> ()
-  ^2(%y1 : i32, %y2 : i32):
-    "func.return"(%y2) : (i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    ^1():
+      %x1 = "arith.constant"() <{"value" = 8 : i32}> : () -> i32
+      %x2 = "arith.constant"() <{"value" = 11 : i32}> : () -> i32
+      "cf.br"(%x1, %x2) [^2] : (i32, i32) -> ()
+    ^2(%y1 : i32, %y2 : i32):
+      "func.return"(%y2) : (i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x0000000b#32]

--- a/Test/Interpreter/Cf/cond_br.mlir
+++ b/Test/Interpreter/Cf/cond_br.mlir
@@ -1,20 +1,22 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  ^1():
-    %x1 = "arith.constant"() <{"value" = 8 : i32}> : () -> i32
-    %x2 = "arith.constant"() <{"value" = 11 : i32}> : () -> i32
-    %cond1 = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
-    "cf.cond_br"(%cond1, %x1, %x2) [^4,^3] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
-  ^2(%y : i32):
-    "func.return"(%y) : (i32) -> ()
-  ^3(%z1 : i32):
-    %z2 = "arith.constant"() <{"value" = 2 : i32}> : () -> i32
-    %cond3 = "arith.constant"() <{"value" = -1 : i1}> : () -> i1
-    "cf.cond_br"(%cond3, %z1, %z2) [^2,^4] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
-  ^4(%a1 : i32):
-    %a2 = "arith.constant"() <{"value" = 5 : i32}> : () -> i32
-    "func.return"(%a2) : (i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    ^1():
+      %x1 = "arith.constant"() <{"value" = 8 : i32}> : () -> i32
+      %x2 = "arith.constant"() <{"value" = 11 : i32}> : () -> i32
+      %cond1 = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
+      "cf.cond_br"(%cond1, %x1, %x2) [^4,^3] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+    ^2(%y : i32):
+      "func.return"(%y) : (i32) -> ()
+    ^3(%z1 : i32):
+      %z2 = "arith.constant"() <{"value" = 2 : i32}> : () -> i32
+      %cond3 = "arith.constant"() <{"value" = -1 : i1}> : () -> i1
+      "cf.cond_br"(%cond3, %z1, %z2) [^2,^4] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+    ^4(%a1 : i32):
+      %a2 = "arith.constant"() <{"value" = 5 : i32}> : () -> i32
+      "func.return"(%a2) : (i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x0000000b#32]

--- a/Test/Interpreter/HW/constant.mlir
+++ b/Test/Interpreter/HW/constant.mlir
@@ -1,10 +1,12 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %pos = "hw.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %zero = "hw.constant"() <{ "value" = 0 : i32 }> : () -> i32
-  %neg = "hw.constant"() <{ "value" = -4 : i32 }> : () -> i32
-  "func.return"(%pos, %zero, %neg) : (i32, i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %pos = "hw.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %zero = "hw.constant"() <{ "value" = 0 : i32 }> : () -> i32
+    %neg = "hw.constant"() <{ "value" = -4 : i32 }> : () -> i32
+    "func.return"(%pos, %zero, %neg) : (i32, i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000003#32, 0x00000000#32, 0xfffffffc#32]

--- a/Test/Interpreter/LLVM/and.mlir
+++ b/Test/Interpreter/LLVM/and.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  %three = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
-  %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
-  %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
-  %x = "llvm.and"(%three, %five) : (i32, i32) -> i32
-  %y = "llvm.and"(%eight, %negseven) : (i32, i32) -> i32
-  %z = "llvm.and"(%three, %eight) : (i32, i32) -> i32
-  "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  "func.func"() <{sym_name = "main"}> ({
+    %three = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
+    %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+    %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
+    %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
+    %x = "llvm.and"(%three, %five) : (i32, i32) -> i32
+    %y = "llvm.and"(%eight, %negseven) : (i32, i32) -> i32
+    %z = "llvm.and"(%three, %eight) : (i32, i32) -> i32
+    "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: Program output: #[0x00000001#32, 0x00000008#32, 0x00000000#32]


### PR DESCRIPTION
This is another step towards eliminating instructions at the top level of MLIR modules. I rewrote 16 test cases to do this.

Unfortunately it's a bit annoying to read the diffs since the instructions wanted to be re-indented. But the intent is that no changes have been made to the bodies of any of these tests, it's purely wrapping the existing instructions in a function.

There's a slight abuse here where one LLVM dialect test is rewritten to use a `func.func` instead of an `llvm.func` because the latter does not support multiple return values. This should be perfectly fine for purposes of testing using `veir-interpret` but the native MLIR tooling rejects this function as is. It will accept it if we add the `function_type` property, but we can just do that later on if we want to process these test cases using `mlir-translate`.

If people are happy with this patch, then I'll continue rewriting tests until we're able to disable interpreter support for module-level instructions.