### PR TITLE
return non-zero to the OS on errors

### DIFF
--- a/RunBenchmarks.lean
+++ b/RunBenchmarks.lean
@@ -33,4 +33,4 @@ def main (args : List String) : IO Unit := do
   | some bench => Veir.Benchmarks.runBenchmark bench count (getPCFrom args[2]?)
   | _ =>
     IO.eprintln "Please provide a benchmark name"
-    IO.Process.exit 1
+    IO.Process.exit 2

--- a/RunBenchmarks.lean
+++ b/RunBenchmarks.lean
@@ -31,4 +31,6 @@ def main (args : List String) : IO Unit := do
   let count := getCountFrom args[1]?
   match args[0]? with
   | some bench => Veir.Benchmarks.runBenchmark bench count (getPCFrom args[2]?)
-  | _ => IO.println "Please provide a benchmark name"
+  | _ =>
+    IO.eprintln "Please provide a benchmark name"
+    IO.Process.exit 1

--- a/Test/Interpreter/Func/main_with_args_no_entry.mlir
+++ b/Test/Interpreter/Func/main_with_args_no_entry.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-interpret %s 2>&1 | filecheck %s
+// RUN: not veir-interpret %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({

--- a/Test/Interpreter/main_and_top_level.mlir
+++ b/Test/Interpreter/main_and_top_level.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-interpret %s 2>&1 | filecheck %s
+// RUN: not veir-interpret %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   %0 = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32

--- a/Test/Interpreter/main_with_args_no_entry.mlir
+++ b/Test/Interpreter/main_with_args_no_entry.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-interpret %s 2>&1 | filecheck %s
+// RUN: not veir-interpret %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 (i16)>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({

--- a/Test/Interpreter/mixed_mains.mlir
+++ b/Test/Interpreter/mixed_mains.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-interpret %s 2>&1 | filecheck %s
+// RUN: not veir-interpret %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({

--- a/Test/Interpreter/multiple_mains.mlir
+++ b/Test/Interpreter/multiple_mains.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-interpret %s 2>&1 | filecheck %s
+// RUN: not veir-interpret %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "main", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({

--- a/Test/Interpreter/no_entry.mlir
+++ b/Test/Interpreter/no_entry.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-interpret %s 2>&1 | filecheck %s
+// RUN: not veir-interpret %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i16 ()>, linkage = #llvm.linkage<external>, sym_name = "myfunc", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({

--- a/Test/LLVM/invalid.mlir
+++ b/Test/LLVM/invalid.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s 2>&1 | filecheck %s
+// RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
   ^bb0(%a: i32, %b : i16):

--- a/Test/Parsing/invalid-syntax.mlir
+++ b/Test/Parsing/invalid-syntax.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
 
 // Verify that parse errors go through ParserError.format.
 

--- a/Test/test-verifier.mlir
+++ b/Test/test-verifier.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s 2>&1 | filecheck %s
+// RUN: not veir-opt %s 2>&1 | filecheck %s
 
 // CHECK: Error verifying input program: Expected 1 region
 "builtin.module"() ({

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -110,11 +110,13 @@ def resolveEntryPoint (ctx : IRContext OpCode) (moduleOp : OperationPtr) : Excep
       | _, _ => .error .none
 
 /-- Report an interpreter result to the CLI. Hard failures (`none`) use a generic error. -/
-def reportInterpResult (result : Interp (Array RuntimeValue)) : IO Unit :=
+def reportInterpResult (result : Interp (Array RuntimeValue)) : IO Unit := do
   match result with
   | some (.ok results) => IO.println s!"Program output: {results}"
   | some .ub => IO.println "Undefined behavior"
-  | none => IO.eprintln "Error while interpreting module"
+  | none =>
+    IO.eprintln "Error while interpreting module"
+    IO.Process.exit 1
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
@@ -134,11 +136,17 @@ def main (args : List String) : IO Unit := do
           reportInterpResult (interpretModule rawCtx op (by sorry) (by sorry))
         | .error .none =>
           IO.eprintln "Error: No entry point: define a zero-argument function named 'main' or use top-level executable ops"
+          IO.Process.exit 1
         | .error .multiple =>
           IO.eprintln "Error: Multiple entry points: define exactly one zero-argument function named 'main' or use only top-level executable ops"
-      | .error errMsg => IO.eprintln s!"Error verifying input program: {errMsg}"
+          IO.Process.exit 1
+      | .error errMsg =>
+        IO.eprintln s!"Error verifying input program: {errMsg}"
+        IO.Process.exit 1
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"
+      IO.Process.exit 1
   | _ =>
     IO.eprintln "Wrong number of arguments."
     IO.eprintln "Usage: veir-interpret <filename>"
+    IO.Process.exit 1

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -149,4 +149,4 @@ def main (args : List String) : IO Unit := do
   | _ =>
     IO.eprintln "Wrong number of arguments."
     IO.eprintln "Usage: veir-interpret <filename>"
-    IO.Process.exit 1
+    IO.Process.exit 2

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -105,16 +105,21 @@ def main (args : List String) : IO Unit := do
   | .error errMsg =>
     IO.eprintln s!"Error: {errMsg}"
     IO.eprintln "Usage: veir-opt <filename> [-p=\"pass1,pass2,...\"]"
+    IO.Process.exit 1
   | .ok { filename, passes } =>
     match ← parseOperation filename with
-    | .error errMsg => IO.eprintln errMsg
+    | .error errMsg =>
+      IO.eprintln errMsg
+      IO.Process.exit 1
     | .ok (ctx, op) =>
       match ctx.verify with
       | .error errMsg =>
         IO.eprintln s!"Error verifying input program: {errMsg}"
+        IO.Process.exit 1
       | .ok _ =>
         match ← passes.run ⟨ctx, by sorry⟩ op with
         | .error errMsg =>
           IO.eprintln s!"Error: {errMsg}"
+          IO.Process.exit 1
         | .ok finalCtx =>
           Veir.Printer.printOperation finalCtx op


### PR DESCRIPTION
`vcc` is having trouble figuring out when `veir-opt` has failed, because `veir-opt` is terminating with exit code 0 even when it runs into an error.

I have no idea if this specific code is the right way to do it, but: all command line tools need to return non-zero to the OS when they terminate with an error. so if we don't accept this patch, let's hopefully have someone else do this the right way! but this seems to work.