### PR TITLE
Rename `List.getElem?_idxOf` → `List.getElem_idxOf` (resolves name collision with Mathlib)

### DIFF
--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -117,19 +117,19 @@ theorem List.idxOf_getElem [DecidableEq α] {l : List α} (H : Nodup l) (i : Nat
     idxOf l[i] l = i := by
   induction l generalizing i <;> grind
 
-theorem List.getElem?_idxOf [DecidableEq α] {l : List α} (h : l.idxOf x < l.length) :
+theorem List.getElem_idxOf [DecidableEq α] {l : List α} (h : l.idxOf x < l.length) :
     l[l.idxOf x] = x := by
   induction l <;> grind
 
 @[simp, grind =]
 theorem Array.getElem?_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x]? = some x := by
-  rcases l; grind [List.getElem?_idxOf]
+  rcases l; grind [List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.getElem_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x] = x := by
-  rcases l; grind [List.getElem?_idxOf]
+  rcases l; grind [List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.toList_erase [BEq α] (l : Array α) (a : α) :


### PR DESCRIPTION
## Summary

`Veir/ForLean.lean:120` declares a theorem named `List.getElem?_idxOf` whose
statement does NOT use `getElem?` (the `Option`-returning variant):

```lean
theorem List.getElem?_idxOf [DecidableEq α] {l : List α} (h : l.idxOf x < l.length) :
    l[l.idxOf x] = x := by
  induction l <;> grind
```

The trailing `?` in the name is therefore inaccurate.

Independently, **Mathlib** (`Mathlib/Data/List/Basic.lean:654-657`) declares a
*different* theorem under the **same** global name `List.getElem?_idxOf`,
which does use `getElem?`:

```lean
@[simp]
theorem getElem?_idxOf [BEq α] [LawfulBEq α] {a : α} {l : List α} (h : a ∈ l) :
    l[idxOf a l]? = some a := by ...
```

Any downstream project that imports both Veir and Mathlib (transitively via,
e.g., a typed-SSA front-end like `opencompl/lean-mlir` or third-party
crypto/compiler projects) currently fails to elaborate with:

```
import Mathlib.Data.List.Basic failed,
environment already contains 'List.getElem?_idxOf' from Veir.ForLean
```

## Fix

Rename Veir's theorem to `List.getElem_idxOf` — matching its actual statement
(no `?`), and aligning with the sibling `Array.getElem_idxOf` (line 130) which
is already correctly named. Update the two internal callers.

No semantic change. Three single-token renames in `Veir/ForLean.lean`:

* Line 120: declaration
* Line 127: caller inside `Array.getElem?_idxOf`'s proof
* Line 132: caller inside `Array.getElem_idxOf`'s proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)