### PR TITLE
Namespace List lemmas under Veir.List (followup to #626)

### DIFF
--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -115,25 +115,30 @@ theorem Array.reverse_singleton (a : α) :
 
 namespace ForLean.List
 
-theorem idxOf_getElem [DecidableEq α] {l : _root_.List α} (H : l.Nodup) (i : Nat) (h : i < l.length) :
-    _root_.List.idxOf l[i] l = i := by
+theorem idxOf_getElem [DecidableEq α] {l : List α} (H : l.Nodup) (i : Nat) (h : i < l.length) :
+    List.idxOf l[i] l = i := by
   induction l generalizing i <;> grind
 
-theorem getElem_idxOf [DecidableEq α] {l : _root_.List α} (h : l.idxOf x < l.length) :
+theorem getElem_idxOf [DecidableEq α] {l : List α} (h : l.idxOf x < l.length) :
     l[l.idxOf x] = x := by
   induction l <;> grind
 
 end ForLean.List
 
+section
+open ForLean
+
 @[simp, grind =]
 theorem Array.getElem?_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x]? = some x := by
-  rcases l; grind [ForLean.List.getElem_idxOf]
+  rcases l; grind [List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.getElem_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x] = x := by
-  rcases l; grind [ForLean.List.getElem_idxOf]
+  rcases l; grind [List.getElem_idxOf]
+
+end
 
 @[simp, grind =]
 theorem Array.toList_erase [BEq α] (l : Array α) (a : α) :

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -113,7 +113,7 @@ theorem Array.reverse_singleton (a : α) :
     #[a].reverse = #[a] := by
   simp
 
-namespace Veir.List
+namespace ForLean.List
 
 theorem idxOf_getElem [DecidableEq α] {l : _root_.List α} (H : l.Nodup) (i : Nat) (h : i < l.length) :
     _root_.List.idxOf l[i] l = i := by
@@ -123,17 +123,17 @@ theorem getElem_idxOf [DecidableEq α] {l : _root_.List α} (h : l.idxOf x < l.l
     l[l.idxOf x] = x := by
   induction l <;> grind
 
-end Veir.List
+end ForLean.List
 
 @[simp, grind =]
 theorem Array.getElem?_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x]? = some x := by
-  rcases l; grind [Veir.List.getElem_idxOf]
+  rcases l; grind [ForLean.List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.getElem_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x] = x := by
-  rcases l; grind [Veir.List.getElem_idxOf]
+  rcases l; grind [ForLean.List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.toList_erase [BEq α] (l : Array α) (a : α) :

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -113,23 +113,27 @@ theorem Array.reverse_singleton (a : α) :
     #[a].reverse = #[a] := by
   simp
 
-theorem List.idxOf_getElem [DecidableEq α] {l : List α} (H : Nodup l) (i : Nat) (h : i < l.length) :
-    idxOf l[i] l = i := by
+namespace Veir.List
+
+theorem idxOf_getElem [DecidableEq α] {l : _root_.List α} (H : l.Nodup) (i : Nat) (h : i < l.length) :
+    _root_.List.idxOf l[i] l = i := by
   induction l generalizing i <;> grind
 
-theorem List.getElem_idxOf [DecidableEq α] {l : List α} (h : l.idxOf x < l.length) :
+theorem getElem_idxOf [DecidableEq α] {l : _root_.List α} (h : l.idxOf x < l.length) :
     l[l.idxOf x] = x := by
   induction l <;> grind
+
+end Veir.List
 
 @[simp, grind =]
 theorem Array.getElem?_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x]? = some x := by
-  rcases l; grind [List.getElem_idxOf]
+  rcases l; grind [Veir.List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.getElem_idxOf [DecidableEq α] {l : Array α} (h : l.idxOf x < l.size) :
     l[l.idxOf x] = x := by
-  rcases l; grind [List.getElem_idxOf]
+  rcases l; grind [Veir.List.getElem_idxOf]
 
 @[simp, grind =]
 theorem Array.toList_erase [BEq α] (l : Array α) (a : α) :

--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -157,7 +157,7 @@ theorem ValuePtr.DefUse_array_erase_array_index
     array.idxOf array[i] = i := by
   have := ValuePtr.DefUse_array_toList_Nodup hWF
   rw [← Array.toArray_toList (xs := array)]
-  grind  [List.idxOf_getElem]
+  grind  [Veir.List.idxOf_getElem]
 
 @[grind .]
 theorem ValuePtr.DefUse.erase_getElem_array_eq_eraseIdx :
@@ -393,7 +393,7 @@ theorem BlockPtr.DefUse_array_erase_array_index
     array.idxOf array[i] = i := by
   have := DefUse_array_toList_Nodup hWF
   rw [← Array.toArray_toList (xs := array)]
-  grind [List.idxOf_getElem]
+  grind [Veir.List.idxOf_getElem]
 
 @[grind .]
 theorem BlockPtr.DefUse.erase_getElem_array_eq_eraseIdx :
@@ -738,7 +738,7 @@ theorem BlockPtr.OpChain.idxOf_getElem_array
     array.idxOf array[i] = i := by
   have := BlockPtr.OpChain_array_toList_Nodup hWF
   rw [← Array.toArray_toList (xs := array)]
-  grind  [List.idxOf_getElem]
+  grind  [Veir.List.idxOf_getElem]
 
 @[grind .]
 theorem BlockPtr.OpChain.erase_getElem_array_eq_eraseIdx

--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -12,6 +12,8 @@ public section
 
 namespace Veir
 
+open ForLean
+
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx ctx' : IRContext OpInfo}
 
@@ -157,7 +159,7 @@ theorem ValuePtr.DefUse_array_erase_array_index
     array.idxOf array[i] = i := by
   have := ValuePtr.DefUse_array_toList_Nodup hWF
   rw [← Array.toArray_toList (xs := array)]
-  grind  [Veir.List.idxOf_getElem]
+  grind  [List.idxOf_getElem]
 
 @[grind .]
 theorem ValuePtr.DefUse.erase_getElem_array_eq_eraseIdx :
@@ -393,7 +395,7 @@ theorem BlockPtr.DefUse_array_erase_array_index
     array.idxOf array[i] = i := by
   have := DefUse_array_toList_Nodup hWF
   rw [← Array.toArray_toList (xs := array)]
-  grind [Veir.List.idxOf_getElem]
+  grind [List.idxOf_getElem]
 
 @[grind .]
 theorem BlockPtr.DefUse.erase_getElem_array_eq_eraseIdx :
@@ -738,7 +740,7 @@ theorem BlockPtr.OpChain.idxOf_getElem_array
     array.idxOf array[i] = i := by
   have := BlockPtr.OpChain_array_toList_Nodup hWF
   rw [← Array.toArray_toList (xs := array)]
-  grind  [Veir.List.idxOf_getElem]
+  grind  [List.idxOf_getElem]
 
 @[grind .]
 theorem BlockPtr.OpChain.erase_getElem_array_eq_eraseIdx


### PR DESCRIPTION
## Summary

Followup to #626. After #626 renamed `List.getElem?_idxOf` to
`List.getElem_idxOf` (resolving the Mathlib `Data.List.Basic` collision),
downstream projects that import both Veir and Batteries/Mathlib still
hit collisions on related lemmas:

* **Batteries** (`Batteries.Data.List.Lemmas`) declares its own
  `List.getElem_idxOf` — same name as the post-#626 Veir version.
* **Mathlib** (`Mathlib.Data.List.Nodup`) declares `List.idxOf_getElem`
  — same name as Veir's adjacent lemma above the renamed one.

Both still hit:
```
import Mathlib.Data.List.Basic failed,
environment already contains 'List.getElem_idxOf' from Veir.ForLean
```
(or the analogous error from Batteries).

## Fix

Move both `List.idxOf_getElem` and `List.getElem_idxOf` into the
`Veir.List` namespace.  Update internal references in the Array
wrappers (`Veir/ForLean.lean`) and in `Veir/IR/WellFormed.lean`
(3 `grind [List.idxOf_getElem]` usages).

No semantic change.  Two single-block edits:

* `Veir/ForLean.lean` (~14 lines around the renamed lemmas): wrap in `namespace Veir.List ... end Veir.List`; explicit-namespace `_root_.List` references in statements.
* `Veir/IR/WellFormed.lean` (3 lines): `[List.idxOf_getElem]` → `[Veir.List.idxOf_getElem]`.

## Verification

Verified locally that a downstream consumer (CatCrypt) which imports
both Veir and Mathlib elaborates cleanly with the patch.  Without it,
the import sequence fails at the second collision after #626's first
fix resolved the original `getElem?` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)