### PR TITLE
Test `mlir-opt` compatibility in CI

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: gerlero/apt-install@v1
         with:
-          packages: mlir-opt-22
+          packages: mlir-tools-22
 
       - name: Rename MLIR-opt
         run: |

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -16,14 +16,16 @@ jobs:
       - name: Source environment variables
         run: source .envrc
 
-      - uses: gerlero/add-apt-repository@v1
+      - name: Add LLVM apt repository
+        uses: gerlero/add-apt-repository@v1
         with:
           uri: http://apt.llvm.org/noble/ 
           key: https://apt.llvm.org/llvm-snapshot.gpg.key
           component: main
           suite: llvm-toolchain-noble-22
 
-      - uses: gerlero/apt-install@v1
+      - name: Install mlir-opt
+        uses: gerlero/apt-install@v1
         with:
           packages: mlir-22-tools
 

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -21,6 +21,7 @@ jobs:
           uri: http://apt.llvm.org/noble/ 
           key: https://apt.llvm.org/llvm-snapshot.gpg.key
           component: main
+          suite: llvm-toolchain-noble
 
       - uses: gerlero/apt-install@v1
         with:

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -60,7 +60,7 @@ jobs:
         run: uv sync
 
       - name: Run filecheck tests
-        run: uv run lit Test/ -v --param TEST_MLIR
+        run: uv run lit Test/ -v
 
       - name: Build the ExArray package
         uses: leanprover/lean-action@v1

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -19,7 +19,8 @@ jobs:
       - name: Install mlir-opt
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: mlir-22-tools
+          packages: "mlir-22-tools"
+          add-repository: "http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-22 main"
 
       - name: Rename MLIR-opt
         run: |

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -25,7 +25,7 @@ jobs:
 
       - uses: gerlero/apt-install@v1
         with:
-          packages: mlir-tools-22
+          packages: mlir-22-tools
 
       - name: Rename MLIR-opt
         run: |

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -20,7 +20,6 @@ jobs:
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: mlir-22-tools
-          add-repository: "http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-22 main"
 
       - name: Rename MLIR-opt
         run: |

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -21,7 +21,7 @@ jobs:
           uri: http://apt.llvm.org/noble/ 
           key: https://apt.llvm.org/llvm-snapshot.gpg.key
           component: main
-          suite: llvm-toolchain-noble
+          suite: llvm-toolchain-noble-22
 
       - uses: gerlero/apt-install@v1
         with:

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -18,8 +18,9 @@ jobs:
 
       - uses: gerlero/add-apt-repository@v1
         with:
-          uri: http://apt.llvm.org/noble/
+          uri: http://apt.llvm.org/noble/ 
           key: https://apt.llvm.org/llvm-snapshot.gpg.key
+          component: main
 
       - uses: gerlero/apt-install@v1
         with:

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -16,6 +16,14 @@ jobs:
       - name: Source environment variables
         run: source .envrc
 
+      - name: Install mlir-opt
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 22
+          sudo apt-get install mlir-22-tools
+          sudo ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt
+
       - name: Build the project
         uses: leanprover/lean-action@v1
         with:
@@ -43,7 +51,7 @@ jobs:
         run: uv sync
 
       - name: Run filecheck tests
-        run: uv run lit Test/ -v
+        run: uv run lit Test/ -v --param TEST_MLIR
 
       - name: Build the ExArray package
         uses: leanprover/lean-action@v1

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -16,11 +16,14 @@ jobs:
       - name: Source environment variables
         run: source .envrc
 
-      - name: Install mlir-opt
-        uses: awalsh128/cache-apt-pkgs-action@latest
+      - uses: gerlero/add-apt-repository@v1
         with:
-          packages: "mlir-22-tools"
-          add-repository: "http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-22 main"
+          uri: http://apt.llvm.org/noble/
+          key: https://apt.llvm.org/llvm-snapshot.gpg.key
+
+      - uses: gerlero/apt-install@v1
+        with:
+          packages: mlir-opt-22
 
       - name: Rename MLIR-opt
         run: |

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -17,11 +17,13 @@ jobs:
         run: source .envrc
 
       - name: Install mlir-opt
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: mlir-22-tools
+          add-repository: "http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-22 main"
+
+      - name: Rename MLIR-opt
         run: |
-          wget https://apt.llvm.org/llvm.sh
-          chmod +x llvm.sh
-          sudo ./llvm.sh 22
-          sudo apt-get install mlir-22-tools
           sudo ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt
 
       - name: Build the project

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ First, install dependencies:
 uv sync
 ```
 
-Then run the tests:
+Then run the tests (if you have `mlir-opt` in your path you can add `--param TEST_MLIR`):
 
 ```bash
 uv run lit Test/ -v

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ First, install dependencies:
 uv sync
 ```
 
-Then run the tests (if you have `mlir-opt` in your path you can add `--param TEST_MLIR`):
+Then run the tests:
 
 ```bash
 uv run lit Test/ -v

--- a/Test/LLVM/fastntt.mlir
+++ b/Test/LLVM/fastntt.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 // This test results from the lowering of a C implementation of the FastNTT algorithm, based on the Heir 
 // pseudocode: https://github.com/google/heir/blob/1210ad37dc9531d6e60d8ddbce81dbd79f7626a6/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp#L1060. 

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -20,6 +20,7 @@ config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
 config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | lake exec veir-opt | filecheck %s"))
 
 mlir_opt = lit.util.which('mlir-opt')
+mlir_version_supported = '22.0.0git'
 
 if mlir_opt:
   result = subprocess.run([mlir_opt, '--version'], capture_output=True, text=True)
@@ -28,12 +29,12 @@ if mlir_opt:
   if match:
     version = match.group(1)
 
-  if version == '22.0.0git':
+  if version == mlir_version_supported::
     print(f"'mlir-opt' version {version} detected. Running MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP",
      "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))
   else:
-    print(f"'mlir-opt' version {version} detected. Skipping MLIR compatibility tests")
+    print(f"'mlir-opt' version {version} detected, but only {mlir_version_supported} supported. Skipping MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP", "true"))
 else:
   config.substitutions.append(("MLIR_ROUNDTRIP", "true"))

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -29,7 +29,7 @@ if mlir_opt:
   if match:
     version = match.group(1)
 
-  if version == mlir_version_supported::
+  if version == mlir_version_supported:
     print(f"'mlir-opt' version {version} detected. Running MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP",
      "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -16,3 +16,12 @@ config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {veir_root}"])
 config.substitutions.append(('veir-opt', "lake exec veir-opt"))
 config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
 config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | lake exec veir-opt | filecheck %s"))
+
+test_MLIR = 'TEST_MLIR' in lit_config.params
+
+if test_MLIR:
+  assert lit.util.which('mlir-opt'), "mlir-opt not found, but TEST_MLIR parameter given"
+  config.substitutions.append(("MLIR_ROUNDTRIP",
+    "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))
+else:
+  config.substitutions.append(("MLIR_ROUNDTRIP", "true"))

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -1,6 +1,8 @@
 import lit.formats
+import subprocess
 import lit.util
 import os
+import re
 from pathlib import Path
 
 config.test_source_root = os.path.dirname(__file__)
@@ -17,11 +19,21 @@ config.substitutions.append(('veir-opt', "lake exec veir-opt"))
 config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
 config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | lake exec veir-opt | filecheck %s"))
 
-test_MLIR = 'TEST_MLIR' in lit_config.params
+mlir_opt = lit.util.which('mlir-opt')
 
-if test_MLIR:
-  assert lit.util.which('mlir-opt'), "mlir-opt not found, but TEST_MLIR parameter given"
-  config.substitutions.append(("MLIR_ROUNDTRIP",
-    "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))
+if mlir_opt:
+  result = subprocess.run([mlir_opt, '--version'], capture_output=True, text=True)
+  version = "unknown"
+  match = re.search(r'version\s+([a-zA-Z0-9\.]+)', str(result))
+  if match:
+    version = match.group(1)
+
+  if version == '22.0.0git':
+    print(f"'mlir-opt' version {version} detected. Running MLIR compatibility tests")
+    config.substitutions.append(("MLIR_ROUNDTRIP",
+     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))
+  else:
+    print(f"'mlir-opt' version {version} detected. Skipping MLIR compatibility tests")
+    config.substitutions.append(("MLIR_ROUNDTRIP", "true"))
 else:
   config.substitutions.append(("MLIR_ROUNDTRIP", "true"))


### PR DESCRIPTION
Add a lit abbreviation `MLIR_ROUNDTRIP` which passes the input file to`mlir-opt` to check that the input is accepted by MLIR. It then passes the output to `veir-opt` and subsequently to `mlir-opt` again, to check that the output of `mlir-opt` is accepted by `veir-opt`, and that the output of `veir-opt` is accepted by `mlir-opt`. Finally, we use `veir-opt` once more to ensure the textual output is identical between `VEIR_ROUNDTRIP` and `MLIR_ROUNDTRIP`.

We enable a single file and will add other files as they are `MLIR_ROUNDTRIP`-clean.