### PR TITLE
Add properties to llvm.module_flags

### DIFF
--- a/Test/LLVM/fastntt.mlir
+++ b/Test/LLVM/fastntt.mlir
@@ -188,7 +188,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^[[BB_MOD:.*]]():
-// CHECK-NEXT:     "llvm.module_flags"() : () -> ()
+// CHECK-NEXT:     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
 // CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_L2FA_ENTRY:.*]]([[L2FA_ARG:%.*]] : i32):
 // CHECK-NEXT:         [[L2FA_C0:%.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -1,7 +1,7 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-  "llvm.module_flags"() : () -> ()
+  "llvm.module_flags"() <{flags = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
   "llvm.func"() ({
     ^bb0(%fcst : f64):
       %5 = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
@@ -78,7 +78,7 @@
 
 // CHECK:       "builtin.module"() ({
 // CHECK-NEXT:   ^4():
-// CHECK-NEXT:     "llvm.module_flags"() : () -> ()
+// CHECK-NEXT:     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
 // CHECK-NEXT:     "llvm.func"() ({
 // CHECK-NEXT:         ^7(%arg7_0 : f64):
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -31,6 +31,7 @@ match op with
 | .getelementptr => GetelementptrProperties
 | .fadd | .fsub | .fmul | .fdiv | .frem => FastMathFlagsProperties
 | .func => LLVMFuncProperties
+| .module_flags => LLVMModuleFlagsProperties
 | _ => Unit
 
 instance : HasDialectOpInfo Llvm where

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -110,6 +110,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case fdiv => exact (FastMathFlagsProperties.fromAttrDict attrDict)
     case frem => exact (FastMathFlagsProperties.fromAttrDict attrDict)
     case func => exact (LLVMFuncProperties.fromAttrDict attrDict)
+    case module_flags => exact (LLVMModuleFlagsProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case func op =>
     cases op
@@ -268,6 +269,10 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
       dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
     if let some function_type := props.function_type then
       dict := dict.insert "function_type".toUTF8 function_type
+    dict
+  | .llvm .module_flags => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 3
+    dict := dict.insert "flags".toUTF8 (Attribute.arrayAttr props.flags)
     dict
   | .func .func => Id.run do
     let mut dict := Std.HashMap.ofList props.extra.entries.toList

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -457,6 +457,18 @@ def LLVMFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
     (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8 && k ≠ "function_type".toUTF8)
   return { sym_name := symName, function_type := funcType, extra }
 
+structure LLVMModuleFlagsProperties where
+  flags : ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMModuleFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMModuleFlagsProperties := do
+  let flagsAttr ← match attrDict["flags".toUTF8]? with
+    | some (.arrayAttr flagsAttr) => .ok flagsAttr
+    | some attr => .error s!"expected 'flags' to be an array attribute, but got {attr}"
+    | none => .error "llvm.module_flags: missing 'flags' property"
+  return { flags := flagsAttr }
+
 /--
   Properties of `hw.module`.
 -/


### PR DESCRIPTION
These properties we previously silently discarded.