### PR TITLE
Clean up control-flow-related parsing tests

### DIFF
--- a/Test/Cf/identity.mlir
+++ b/Test/Cf/identity.mlir
@@ -12,12 +12,12 @@
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
+// CHECK-NEXT:   ^{{.*}}():
 // CHECK-NEXT:     "func.func"() ({
-// CHECK-NEXT:       ^6(%arg6_0 : i32):
-// CHECK-NEXT:         "cf.br"(%arg6_0) [^7] : (i32) -> ()
-// CHECK-NEXT:       ^7(%arg7_0 : i32):
-// CHECK-NEXT:         %9 = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
-// CHECK-NEXT:         "cf.cond_br"(%9, %arg7_0, %arg7_0) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT:         "cf.br"(%{{.*}}) [^[[tgt:.*]]] : (i32) -> ()
+// CHECK-NEXT:       ^[[tgt]](%{{.*}} : i32):
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
+// CHECK-NEXT:         "cf.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[tgt]], ^[[tgt]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -77,10 +77,10 @@
 }) : () -> ()
 
 // CHECK:       "builtin.module"() ({
-// CHECK-NEXT:   ^4():
+// CHECK-NEXT:   ^{{.*}}():
 // CHECK-NEXT:     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
 // CHECK-NEXT:     "llvm.func"() ({
-// CHECK-NEXT:         ^7(%arg7_0 : f64):
+// CHECK-NEXT:         ^{{.*}}(%arg7_0 : f64):
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i1
 // CHECK-NEXT:       %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
@@ -113,10 +113,10 @@
 // CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr, i32) -> ()
 // CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariant, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr) -> i32
-// CHECK-NEXT:       "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
-// CHECK-NEXT:     ^{{.*}}(%{{.*}} : i32):
-// CHECK-NEXT:       "llvm.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()
-// CHECK-NEXT:     ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT:       "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[b1:.*]], ^[[b1]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+// CHECK-NEXT:     ^[[b1]](%{{.*}} : i32):
+// CHECK-NEXT:       "llvm.br"(%{{.*}}) [^[[b2:.*]]] : (i32) -> ()
+// CHECK-NEXT:     ^[[b2]](%{{.*}} : i32):
 // CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.ptr):
 // CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr

--- a/Test/RISCV_Cf/identity.mlir
+++ b/Test/RISCV_Cf/identity.mlir
@@ -14,14 +14,14 @@
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
+// CHECK-NEXT:   ^{{.*}}():
 // CHECK-NEXT:     "func.func"() ({
-// CHECK-NEXT:       ^6(%arg6_0 : i32):
-// CHECK-NEXT:         "riscv_cf.branch"(%arg6_0) [^7] : (i32) -> ()
-// CHECK-NEXT:       ^7(%arg7_0 : i32):
-// CHECK-NEXT:         "riscv_cf.beq"(%arg7_0, %arg7_0, %arg7_0, %arg7_0) [^9, ^10] <{"operandSegmentSizes" = array<i32: 1, 1, 1, 1>}> : (i32, i32, i32, i32) -> ()
-// CHECK-NEXT:       ^10(%arg10_0 : i32):
-// CHECK-NEXT:         "riscv_cf.bne"(%arg10_0, %arg10_0, %arg10_0, %arg10_0) [^10, ^9] <{"operandSegmentSizes" = array<i32: 1, 1, 1, 1>}> : (i32, i32, i32, i32) -> ()
-// CHECK-NEXT:       ^9(%arg9_0 : i32):
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT:         "riscv_cf.branch"(%{{.*}}) [^[[b1:.*]]] : (i32) -> ()
+// CHECK-NEXT:       ^[[b1]](%{{.*}} : i32):
+// CHECK-NEXT:         "riscv_cf.beq"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) [^[[b3:.*]], ^[[b2:.*]]] <{"operandSegmentSizes" = array<i32: 1, 1, 1, 1>}> : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT:       ^[[b2]](%{{.*}} : i32):
+// CHECK-NEXT:         "riscv_cf.bne"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) [^[[b2]], ^[[b3]]] <{"operandSegmentSizes" = array<i32: 1, 1, 1, 1>}> : (i32, i32, i32, i32) -> ()
+// CHECK-NEXT:       ^[[b3]](%{{.*}} : i32):
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
by using string substitution blocks
