### PR TITLE
llvm and arith: make the high-level representation for icmp predicates first-class in our IR

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -49,7 +49,7 @@
 // CHECK-NEXT:     %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i1
+// CHECK-NEXT:     %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
 // CHECK-NEXT:     %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.divui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:     %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i64

--- a/Test/Arith/invalid_cmpi_predicate.mlir
+++ b/Test/Arith/invalid_cmpi_predicate.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+^bb0():
+  %a = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
+  %b = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
+  %r = "arith.cmpi"(%a, %b) <{"predicate" = 10 : i64}> : (i32, i32) -> i1
+}) : () -> ()
+
+// CHECK: arith.cmpi: invalid predicate 10

--- a/Test/LLVM/invalid_icmp_predicate.mlir
+++ b/Test/LLVM/invalid_icmp_predicate.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() ({
+    ^bb0(%a: i64, %b: i64):
+      %r = "llvm.icmp"(%a, %b) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.icmp: invalid predicate 11

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
@@ -9,8 +9,5 @@
         // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
         %r_6 = "llvm.icmp"(%c, %b) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
         // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i64, i32) -> i1
-        %r_11 = "llvm.icmp"(%c, %c) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
-        // CHECK-NEXT:      "llvm.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
   }) : () -> ()
 }) : () -> ()
-

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -27,7 +27,7 @@ inductive IntPred where
   | sge
   | slt
   | sle
-deriving DecidableEq, Inhabited
+deriving DecidableEq, Inhabited, Repr, Hashable
 
 /-- Mapped as in MLIR:
   https://github.com/llvm/llvm-project/blob/d3417c8bf35852af88f41aa721a719ea756fdd8c/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td#L571 -/
@@ -44,6 +44,25 @@ def IntPred.fromNat (s : Nat) : Option IntPred :=
   | 8 => some .ugt
   | 9 => some .uge
   | _ => none
+
+/-- Mapped as in MLIR. See `IntPred.fromNat`. -/
+def IntPred.toNat : IntPred → Nat
+  | .eq => 0
+  | .ne => 1
+  | .slt => 2
+  | .sle => 3
+  | .sgt => 4
+  | .sge => 5
+  | .ult => 6
+  | .ule => 7
+  | .ugt => 8
+  | .uge => 9
+
+/-- Sanity check: A numeric code parses to a predicate exactly when it
+    is that predicate's MLIR code. -/
+theorem IntPred.fromNat_eq_some_iff {n : Nat} {p : IntPred} :
+    IntPred.fromNat n = some p ↔ p.toNat = n := by
+  cases p <;> simp [IntPred.fromNat, IntPred.toNat] <;> split <;> simp_all <;> omega
 
 def IntPred.eval (p : IntPred) (x y : BitVec w) : Bool :=
   match p with

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -62,7 +62,7 @@ def IntPred.toNat : IntPred → Nat
     is that predicate's MLIR code. -/
 theorem IntPred.fromNat_eq_some_iff {n : Nat} {p : IntPred} :
     IntPred.fromNat n = some p ↔ p.toNat = n := by
-  cases p <;> simp [IntPred.fromNat, IntPred.toNat] <;> split <;> simp_all <;> omega
+  cases p <;> simp only [IntPred.fromNat, IntPred.toNat] <;> grind
 
 def IntPred.eval (p : IntPred) (x y : BitVec w) : Bool :=
   match p with

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -17,6 +17,7 @@ match op with
 | .muli => NswNuwProperties
 | .divsi => ExactProperties
 | .divui => ExactProperties
+| .cmpi => IcmpProperties
 | .shli => NswNuwProperties
 | .shrsi => ExactProperties
 | .shrui => ExactProperties

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -132,6 +132,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case muli => exact (NswNuwProperties.fromAttrDict attrDict)
     case divsi => exact (ExactProperties.fromAttrDict attrDict)
     case divui => exact (ExactProperties.fromAttrDict attrDict)
+    case cmpi => exact (IcmpProperties.fromAttrDictFor "arith.cmpi" attrDict)
     case shli => exact (NswNuwProperties.fromAttrDict attrDict)
     case shrsi => exact (ExactProperties.fromAttrDict attrDict)
     case shrui => exact (ExactProperties.fromAttrDict attrDict)
@@ -179,8 +180,9 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     if props.nsz then
       dict := dict.insert "nsz".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
-  | .llvm .icmp => Id.run do
-    (Std.HashMap.emptyWithCapacity 2).insert "predicate".toUTF8 (Attribute.integerAttr props.value)
+  | .arith .cmpi | .llvm .icmp => Id.run do
+    let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
+    (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr value)
   | .llvm .cond_br =>
     let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
     dict.insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -510,8 +510,7 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simpa using h)
-    let some p := LLVM.IntPred.fromNat properties.value.value.toNat | none
-    return (#[.int 1 (LLVM.Int.icmp lhs rhs p)], mem, none)
+    return (#[.int 1 (LLVM.Int.icmp lhs rhs properties.predicate)], mem, none)
   | .select => do
     let [.int 1 cond, .int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else

--- a/Veir/Passes/CSE.lean
+++ b/Veir/Passes/CSE.lean
@@ -94,8 +94,8 @@ def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
   | .llvm .add | .llvm .mul | .llvm .and | .llvm .or | .llvm .xor =>
       return commutativeBinopKey ctx op kind
   | .llvm .icmp =>
-      match Data.LLVM.IntPred.fromNat (op.getProperties! ctx (.llvm .icmp)).value.value.toNat with
-      | some .eq | some .ne =>
+      match (op.getProperties! ctx (.llvm .icmp)).predicate with
+      | .eq | .ne =>
         return commutativeBinopKey ctx op kind
       | _ =>
         return ordinaryKey ctx op kind

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -126,9 +126,6 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   if ltype.bitwidth ≠ 64 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
   if rtype.bitwidth ≠ 64 then return rewriter
-  /- Return if the predicate is invalid. -/
-  let p := property.value.value.toNat
-  if 10 ≤ p then return rewriter
   /- Casting is necessary regardless of the predicate. -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -138,8 +135,8 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
   /- Match depending on the predicate and build correct lowering. -/
-  let (rewriter, retOp) ← match p with
-    | 0 =>
+  let (rewriter, retOp) ← match property.predicate with
+    | .eq =>
       /- llvm.icmp eq lhs rhs  -> riscv.sltiu (riscv.xor lhs rhs) 1 -/
       let (rewriter, xorOp) ← rewriter.createOp (.riscv .xor) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -147,7 +144,7 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       let (rewriter, retOp) ← rewriter.createOp (.riscv .sltiu) #[RegisterType.mk] #[xorOp.getResult 0]
         #[] #[] c1 (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 1 =>
+    | .ne =>
       /- llvm.icmp ne lhs rhs  -> riscv.sltu 0 (riscv.xor lhs rhs) -/
       let (rewriter, xorOp) ← rewriter.createOp (.riscv .xor) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -157,12 +154,12 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       let (rewriter, retOp) ← rewriter.createOp (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, xorOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 2 =>
+    | .slt =>
       /- llvm.icmp slt lhs rhs -> riscv.slt lhs rhs  -/
       let (rewriter, retOp) ← rewriter.createOp (.riscv .slt) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 3 =>
+    | .sle =>
       /- llvm.icmp sle lhs rhs -> riscv.xori (riscv_slt rhs lhs) 1 -/
       let (rewriter, sltOp) ← rewriter.createOp (.riscv .slt) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -170,12 +167,12 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       let (rewriter, retOp) ← rewriter.createOp (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
         #[] #[] c1 (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 4 =>
+    | .sgt =>
       /- llvm.icmp sgt lhs rhs -> riscv.slt rhs lhs -/
       let (rewriter, retOp) ← rewriter.createOp (.riscv .slt) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 5 =>
+    | .sge =>
       /- llvm.icmp sge lhs rhs -> riscv.xori (riscv_slt lhs rhs) 1 -/
       let (rewriter, sltOp) ← rewriter.createOp (.riscv .slt) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -183,12 +180,12 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       let (rewriter, retOp) ← rewriter.createOp (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
         #[] #[] c1 (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 6 =>
+    | .ult =>
       /- llvm.icmp ult lhs rhs -> riscv.sltu lhs rhs -/
       let (rewriter, retOp) ← rewriter.createOp (.riscv .sltu) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 7 =>
+    | .ule =>
       /- llvm.icmp ule lhs rhs -> riscv.xori (riscv_sltu rhs lhs) 1 -/
       let (rewriter, sltuOp) ← rewriter.createOp (.riscv .sltu) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -196,12 +193,12 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       let (rewriter, retOp) ← rewriter.createOp (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
         #[] #[] c1 (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 8 =>
+    | .ugt =>
       /- llvm.icmp ugt lhs rhs -> riscv.sltu rhs lhs -/
       let (rewriter, retOp) ← rewriter.createOp (.riscv .sltu) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | 9 =>
+    | .uge =>
       /- llvm.icmp uge lhs rhs -> riscv.xori (riscv_sltu lhs rhs) 1 -/
       let (rewriter, sltuOp) ← rewriter.createOp (.riscv .sltu) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -209,8 +206,6 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       let (rewriter, retOp) ← rewriter.createOp (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
         #[] #[] c1 (some $ .before op) sorry (by simp) (by simp) sorry
       pure (rewriter, retOp)
-    | _ =>
-      return rewriter
   let (rewriter, castEqOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
         #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
   rewriter.replaceOp op castEqOp sorry sorry sorry sorry sorry

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -5,6 +5,7 @@ public import Veir.IR.Attribute
 public import Veir.IR.Simp
 public import Veir.ForLean
 public import Veir.IR.OpInfo
+public import Veir.Data.LLVM.Int.Basic
 
 /- This is needed as some properties have ByteArray and require Repr instances -/
 deriving instance Repr for ByteArray
@@ -136,22 +137,28 @@ def LLVMConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attrib
     | throw s!"llvm.constant: expected 'value' to be an integer attribute, but got {attr}"
   return { value := intAttr }
 
-/--
-  Properties of `llvm.icmp` operation, describing predicates for integer comparison.
--/
+/-- Properties of integer comparison operations in the LLVM and arith dialects. -/
 structure IcmpProperties where
-  value : IntegerAttr
+  predicate : Data.LLVM.IntPred
 deriving Inhabited, Repr, Hashable, DecidableEq
 
-def IcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+def IcmpProperties.fromAttrDictFor (opName : String) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String IcmpProperties := do
   if attrDict.size > 1 then
-    throw s!"llvm.icmp: expected only one property, but got {attrDict.size} properties"
+    throw s!"{opName}: expected only one property, but got {attrDict.size} properties"
   let some attr := attrDict["predicate".toUTF8]?
-    | throw "llvm.icmp: missing predicate"
+    | throw s!"{opName}: missing predicate"
   let .integerAttr intAttr := attr
-    | throw s!"llvm.icmp: expected predicate to be a string attribute, but got {attr}"
-  return { value := intAttr }
+    | throw s!"{opName}: expected predicate to be an integer attribute, but got {attr}"
+  if intAttr.value < 0 then
+    throw s!"{opName}: invalid predicate {intAttr.value}"
+  let some predicate := Data.LLVM.IntPred.fromNat intAttr.value.toNat
+    | throw s!"{opName}: invalid predicate {intAttr.value}"
+  return { predicate }
+
+def IcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String IcmpProperties :=
+  IcmpProperties.fromAttrDictFor "llvm.icmp" attrDict
 
 /--
   Properties of the RISC-V immediate operations.


### PR DESCRIPTION
I think that dealing with predicates represented as integers is awkward and error-prone, so let's not do that

for example, see the pleasing little cleanups this enables in CSE.lean and in RISCV64.lean, below
