### PR TITLE
Remove parsing support for top-level operations

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -1,77 +1,84 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^4():
-  %5 = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
-  %addi = "arith.addi"(%5, %5) : (i32, i32) -> i32
-  %addi_nsw = "arith.addi"(%5, %5) <{nws}> : (i32, i32) -> i32
-  %addi_nuw = "arith.addi"(%5, %5) <{nuw}> : (i32, i32) -> i32
-  %addi_nsw_nuw = "arith.addi"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
-  %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
-  %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
-  %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
-  %10 = "arith.ceildivui"(%5, %5) : (i32, i32) -> i32
-  %11 = "arith.cmpi"(%5, %5) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
-  %12 = "arith.divsi"(%5, %5) : (i32, i32) -> i32
-  %13 = "arith.divui"(%5, %5) : (i32, i32) -> i32
-  %14 = "arith.extui"(%5) : (i32) -> i64
-  %15 = "arith.floordivsi"(%5, %5) : (i32, i32) -> i32
-  %16 = "arith.maxsi"(%5, %5) : (i32, i32) -> i32
-  %17 = "arith.maxui"(%5, %5) : (i32, i32) -> i32
-  %18 = "arith.minsi"(%5, %5) : (i32, i32) -> i32
-  %19 = "arith.minui"(%5, %5) : (i32, i32) -> i32
-  %muli = "arith.muli"(%5, %5) : (i32, i32) -> i32
-  %muli_nsw = "arith.muli"(%5, %5) <{nws}> : (i32, i32) -> i32
-  %muli_nuw = "arith.muli"(%5, %5) <{nuw}> : (i32, i32) -> i32
-  %muli_nsw_nuw = "arith.muli"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
-  %210, %211 = "arith.mulsi_extended"(%5, %5) : (i32, i32) -> (i32, i32)
-  %220, %221 = "arith.mului_extended"(%5, %5) : (i32, i32) -> (i32, i32)
-  %23 = "arith.ori"(%5, %5) : (i32, i32) -> i32
-  %24 = "arith.remsi"(%5, %5) : (i32, i32) -> i32
-  %25 = "arith.remui"(%5, %5) : (i32, i32) -> i32
-  %26 = "arith.select"(%11, %5, %5) : (i1, i32, i32) -> i32
-  %27 = "arith.shli"(%5, %5) : (i32, i32) -> i32
-  %28 = "arith.shrsi"(%5, %5) : (i32, i32) -> i32
-  %29 = "arith.shrui"(%5, %5) : (i32, i32) -> i32
-  %30 = "arith.subi"(%5, %5) : (i32, i32) -> i32
-  %31 = "arith.trunci"(%5) : (i32) -> i16
-  %32 = "arith.xori"(%5, %5) : (i32, i32) -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^4():
+      %5 = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
+      %addi = "arith.addi"(%5, %5) : (i32, i32) -> i32
+      %addi_nsw = "arith.addi"(%5, %5) <{nws}> : (i32, i32) -> i32
+      %addi_nuw = "arith.addi"(%5, %5) <{nuw}> : (i32, i32) -> i32
+      %addi_nsw_nuw = "arith.addi"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
+      %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
+      %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
+      %10 = "arith.ceildivui"(%5, %5) : (i32, i32) -> i32
+      %11 = "arith.cmpi"(%5, %5) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
+      %12 = "arith.divsi"(%5, %5) : (i32, i32) -> i32
+      %13 = "arith.divui"(%5, %5) : (i32, i32) -> i32
+      %14 = "arith.extui"(%5) : (i32) -> i64
+      %15 = "arith.floordivsi"(%5, %5) : (i32, i32) -> i32
+      %16 = "arith.maxsi"(%5, %5) : (i32, i32) -> i32
+      %17 = "arith.maxui"(%5, %5) : (i32, i32) -> i32
+      %18 = "arith.minsi"(%5, %5) : (i32, i32) -> i32
+      %19 = "arith.minui"(%5, %5) : (i32, i32) -> i32
+      %muli = "arith.muli"(%5, %5) : (i32, i32) -> i32
+      %muli_nsw = "arith.muli"(%5, %5) <{nws}> : (i32, i32) -> i32
+      %muli_nuw = "arith.muli"(%5, %5) <{nuw}> : (i32, i32) -> i32
+      %muli_nsw_nuw = "arith.muli"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %210, %211 = "arith.mulsi_extended"(%5, %5) : (i32, i32) -> (i32, i32)
+      %220, %221 = "arith.mului_extended"(%5, %5) : (i32, i32) -> (i32, i32)
+      %23 = "arith.ori"(%5, %5) : (i32, i32) -> i32
+      %24 = "arith.remsi"(%5, %5) : (i32, i32) -> i32
+      %25 = "arith.remui"(%5, %5) : (i32, i32) -> i32
+      %26 = "arith.select"(%11, %5, %5) : (i1, i32, i32) -> i32
+      %27 = "arith.shli"(%5, %5) : (i32, i32) -> i32
+      %28 = "arith.shrsi"(%5, %5) : (i32, i32) -> i32
+      %29 = "arith.shrui"(%5, %5) : (i32, i32) -> i32
+      %30 = "arith.subi"(%5, %5) : (i32, i32) -> i32
+      %31 = "arith.trunci"(%5) : (i32) -> i16
+      %32 = "arith.xori"(%5, %5) : (i32, i32) -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
-// CHECK-NEXT:     %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.divui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i64
-// CHECK-NEXT:     %{{.*}} = "arith.floordivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.maxsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.maxui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.minsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.minui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
-// CHECK-NEXT:     %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
-// CHECK-NEXT:     %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.remsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.remui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.shli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.shrui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.trunci"(%{{.*}}) : (i32) -> i16
-// CHECK-NEXT:     %{{.*}} = "arith.xori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
+// CHECK-NEXT:         %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.divui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i64
+// CHECK-NEXT:         %{{.*}} = "arith.floordivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.maxsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.maxui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.minsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.minui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:         %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:         %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.remsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.remui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.shli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.shrui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.trunci"(%{{.*}}) : (i32) -> i16
+// CHECK-NEXT:         %{{.*}} = "arith.xori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/attributes.mlir
+++ b/Test/Builtin/attributes.mlir
@@ -1,41 +1,48 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %3 = "test.test"() {str = "hello world"} : () -> i32
-  %4 = "test.test"() {empty = ""} : () -> i32
-  %5 = "test.test"() {escaped = "line1\nline2\ttab"} : () -> i32
-  %6 = "test.test"() {unregistered = #unregistered.dialect<foo 3 + 2>} : () -> i32
-  %7 = "test.test"() {u = unit} : () -> i32
-  %8 = "test.test"() {u} : () -> i32
-  %9 = "test.test"() {dict = {a = 0 : i32, b = "hello"}} : () -> i32
-  %10 = "test.test"() {empty_dict = {}} : () -> i32
-  %11 = "test.test"() {dict_unit = {x, y}} : () -> i32
-  %12 = "test.test"() {arr = []} : () -> i32
-  %13 = "test.test"() {arr = [unit]} : () -> i32
-  %14 = "test.test"() {arr = [0 : i32, "hello"]} : () -> i32
-  %15 = "test.test"() {da = array<i8>} : () -> i32
-  %16 = "test.test"() {da = array<i32: 10, 42>} : () -> i32
-  %17 = "test.test"() {sym = @foo} : () -> i32
-  %18 = "test.test"() {sym = @"my.func"} : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %3 = "test.test"() {str = "hello world"} : () -> i32
+      %4 = "test.test"() {empty = ""} : () -> i32
+      %5 = "test.test"() {escaped = "line1\nline2\ttab"} : () -> i32
+      %6 = "test.test"() {unregistered = #unregistered.dialect<foo 3 + 2>} : () -> i32
+      %7 = "test.test"() {u = unit} : () -> i32
+      %8 = "test.test"() {u} : () -> i32
+      %9 = "test.test"() {dict = {a = 0 : i32, b = "hello"}} : () -> i32
+      %10 = "test.test"() {empty_dict = {}} : () -> i32
+      %11 = "test.test"() {dict_unit = {x, y}} : () -> i32
+      %12 = "test.test"() {arr = []} : () -> i32
+      %13 = "test.test"() {arr = [unit]} : () -> i32
+      %14 = "test.test"() {arr = [0 : i32, "hello"]} : () -> i32
+      %15 = "test.test"() {da = array<i8>} : () -> i32
+      %16 = "test.test"() {da = array<i32: 10, 42>} : () -> i32
+      %17 = "test.test"() {sym = @foo} : () -> i32
+      %18 = "test.test"() {sym = @"my.func"} : () -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"str" = "hello world"} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"empty" = ""} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"escaped" = "line1\nline2\ttab"} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"unregistered" = #unregistered.dialect<foo 3 + 2>} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {u} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {u} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"dict" = {"a" = 0 : i32, "b" = "hello"}} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"empty_dict" = {}} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"dict_unit" = {x, y}} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = []} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [unit]} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [0 : i32, "hello"]} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i8>} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i32: 10, 42>} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"sym" = @foo} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"sym" = @"my.func"} : () -> i32
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"str" = "hello world"} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"empty" = ""} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"escaped" = "line1\nline2\ttab"} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"unregistered" = #unregistered.dialect<foo 3 + 2>} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {u} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {u} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"dict" = {"a" = 0 : i32, "b" = "hello"}} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"empty_dict" = {}} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"dict_unit" = {x, y}} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"arr" = []} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"arr" = [unit]} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"arr" = [0 : i32, "hello"]} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"da" = array<i8>} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"da" = array<i32: 10, 42>} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"sym" = @foo} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"sym" = @"my.func"} : () -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/types.mlir
+++ b/Test/Builtin/types.mlir
@@ -1,17 +1,24 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %0 = "test.test"() : () -> i32
-  %1 = "test.test"() : () -> ((i32) -> (i32))
-  %2 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
-  %3 = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "test.test"() : () -> i32
+      %1 = "test.test"() : () -> ((i32) -> (i32))
+      %2 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+      %3 = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> ((i32) -> i32)
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> ((i32) -> ((i32) -> i32))
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> ((i32) -> i32)
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/unrealized_conversion_cast.mlir
+++ b/Test/Builtin/unrealized_conversion_cast.mlir
@@ -1,12 +1,15 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %0 = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
-  %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> !reg
-  %2 = "builtin.unrealized_conversion_cast"(%1) : (!reg) -> i32
-  // CHECK:          %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
-  // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !reg
-  // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
+      %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> !reg
+      %2 = "builtin.unrealized_conversion_cast"(%1) : (!reg) -> i32
+      // CHECK:          %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
+      // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !reg
+      // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 

--- a/Test/Comb/identity.mlir
+++ b/Test/Comb/identity.mlir
@@ -1,109 +1,116 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^4():
-  %a = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
-  %b = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %c = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
-  %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
-  %add1 = "comb.add"(%a) : (i32) -> i32
-  %add2 = "comb.add"(%a, %b) : (i32, i32) -> i32
-  %add3 = "comb.add"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %and1 = "comb.and"(%a) : (i32) -> i32
-  %and2 = "comb.and"(%a, %b) : (i32, i32) -> i32
-  %and3 = "comb.and"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %concat0 = "comb.concat"() : () -> i0
-  %concat1 = "comb.concat"(%a) : (i32) -> i32
-  %concat2 = "comb.concat"(%a, %b) : (i32, i32) -> i64
-  %concat3 = "comb.concat"(%a, %b, %c) : (i32, i32, i32) -> i96
-  %divs = "comb.divs"(%a, %b) : (i32, i32) -> i32
-  %divu = "comb.divu"(%a, %b) : (i32, i32) -> i32
-  %extract = "comb.extract"(%a) <{ "lowBit" = 2 : i32 }> : (i32) -> i8
-  %icmp0 = "comb.icmp"(%a, %b) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
-  %icmp1 = "comb.icmp"(%a, %b) <{ "predicate" = 1 : i64 }> : (i32, i32) -> i1
-  %icmp2 = "comb.icmp"(%a, %b) <{ "predicate" = 2 : i64 }> : (i32, i32) -> i1
-  %icmp3 = "comb.icmp"(%a, %b) <{ "predicate" = 3 : i64 }> : (i32, i32) -> i1
-  %icmp4 = "comb.icmp"(%a, %b) <{ "predicate" = 4 : i64 }> : (i32, i32) -> i1
-  %icmp5 = "comb.icmp"(%a, %b) <{ "predicate" = 5 : i64 }> : (i32, i32) -> i1
-  %icmp6 = "comb.icmp"(%a, %b) <{ "predicate" = 6 : i64 }> : (i32, i32) -> i1
-  %icmp7 = "comb.icmp"(%a, %b) <{ "predicate" = 7 : i64 }> : (i32, i32) -> i1
-  %icmp8 = "comb.icmp"(%a, %b) <{ "predicate" = 8 : i64 }> : (i32, i32) -> i1
-  %icmp9 = "comb.icmp"(%a, %b) <{ "predicate" = 9 : i64 }> : (i32, i32) -> i1
-  %icmp10 = "comb.icmp"(%a, %b) <{ "predicate" = 10 : i64 }> : (i32, i32) -> i1
-  %icmp11 = "comb.icmp"(%a, %b) <{ "predicate" = 11 : i64 }> : (i32, i32) -> i1
-  %icmp12 = "comb.icmp"(%a, %b) <{ "predicate" = 12 : i64 }> : (i32, i32) -> i1
-  %icmp13 = "comb.icmp"(%a, %b) <{ "predicate" = 13 : i64 }> : (i32, i32) -> i1
-  %mods = "comb.mods"(%a, %b) : (i32, i32) -> i32
-  %modu = "comb.modu"(%a, %b) : (i32, i32) -> i32
-  %mul1 = "comb.mul"(%a) : (i32) -> i32
-  %mul2 = "comb.mul"(%a, %b) : (i32, i32) -> i32
-  %mul3 = "comb.mul"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %mux = "comb.mux"(%true, %a, %b) : (i1, i32, i32) -> i32
-  %or1 = "comb.or"(%a) : (i32) -> i32
-  %or2 = "comb.or"(%a, %b) : (i32, i32) -> i32
-  %or3 = "comb.or"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %parity = "comb.parity"(%a) : (i32) -> i1
-  %replicate = "comb.replicate"(%a) : (i32) -> i64
-  %reverse = "comb.reverse"(%a) : (i32) -> i32
-  %shl = "comb.shl"(%a, %b) : (i32, i32) -> i32
-  %shrs = "comb.shrs"(%a, %b) : (i32, i32) -> i32
-  %shru = "comb.shru"(%a, %b) : (i32, i32) -> i32
-  %sub = "comb.sub"(%a, %b) : (i32, i32) -> i32
-  %xor1 = "comb.xor"(%a) : (i32) -> i32
-  %xor2 = "comb.xor"(%a, %b) : (i32, i32) -> i32
-  %xor3 = "comb.xor"(%a, %b, %c) : (i32, i32, i32) -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^4():
+      %a = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
+      %b = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+      %c = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
+      %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
+      %add1 = "comb.add"(%a) : (i32) -> i32
+      %add2 = "comb.add"(%a, %b) : (i32, i32) -> i32
+      %add3 = "comb.add"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %and1 = "comb.and"(%a) : (i32) -> i32
+      %and2 = "comb.and"(%a, %b) : (i32, i32) -> i32
+      %and3 = "comb.and"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %concat0 = "comb.concat"() : () -> i0
+      %concat1 = "comb.concat"(%a) : (i32) -> i32
+      %concat2 = "comb.concat"(%a, %b) : (i32, i32) -> i64
+      %concat3 = "comb.concat"(%a, %b, %c) : (i32, i32, i32) -> i96
+      %divs = "comb.divs"(%a, %b) : (i32, i32) -> i32
+      %divu = "comb.divu"(%a, %b) : (i32, i32) -> i32
+      %extract = "comb.extract"(%a) <{ "lowBit" = 2 : i32 }> : (i32) -> i8
+      %icmp0 = "comb.icmp"(%a, %b) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
+      %icmp1 = "comb.icmp"(%a, %b) <{ "predicate" = 1 : i64 }> : (i32, i32) -> i1
+      %icmp2 = "comb.icmp"(%a, %b) <{ "predicate" = 2 : i64 }> : (i32, i32) -> i1
+      %icmp3 = "comb.icmp"(%a, %b) <{ "predicate" = 3 : i64 }> : (i32, i32) -> i1
+      %icmp4 = "comb.icmp"(%a, %b) <{ "predicate" = 4 : i64 }> : (i32, i32) -> i1
+      %icmp5 = "comb.icmp"(%a, %b) <{ "predicate" = 5 : i64 }> : (i32, i32) -> i1
+      %icmp6 = "comb.icmp"(%a, %b) <{ "predicate" = 6 : i64 }> : (i32, i32) -> i1
+      %icmp7 = "comb.icmp"(%a, %b) <{ "predicate" = 7 : i64 }> : (i32, i32) -> i1
+      %icmp8 = "comb.icmp"(%a, %b) <{ "predicate" = 8 : i64 }> : (i32, i32) -> i1
+      %icmp9 = "comb.icmp"(%a, %b) <{ "predicate" = 9 : i64 }> : (i32, i32) -> i1
+      %icmp10 = "comb.icmp"(%a, %b) <{ "predicate" = 10 : i64 }> : (i32, i32) -> i1
+      %icmp11 = "comb.icmp"(%a, %b) <{ "predicate" = 11 : i64 }> : (i32, i32) -> i1
+      %icmp12 = "comb.icmp"(%a, %b) <{ "predicate" = 12 : i64 }> : (i32, i32) -> i1
+      %icmp13 = "comb.icmp"(%a, %b) <{ "predicate" = 13 : i64 }> : (i32, i32) -> i1
+      %mods = "comb.mods"(%a, %b) : (i32, i32) -> i32
+      %modu = "comb.modu"(%a, %b) : (i32, i32) -> i32
+      %mul1 = "comb.mul"(%a) : (i32) -> i32
+      %mul2 = "comb.mul"(%a, %b) : (i32, i32) -> i32
+      %mul3 = "comb.mul"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %mux = "comb.mux"(%true, %a, %b) : (i1, i32, i32) -> i32
+      %or1 = "comb.or"(%a) : (i32) -> i32
+      %or2 = "comb.or"(%a, %b) : (i32, i32) -> i32
+      %or3 = "comb.or"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %parity = "comb.parity"(%a) : (i32) -> i1
+      %replicate = "comb.replicate"(%a) : (i32) -> i64
+      %reverse = "comb.reverse"(%a) : (i32) -> i32
+      %shl = "comb.shl"(%a, %b) : (i32, i32) -> i32
+      %shrs = "comb.shrs"(%a, %b) : (i32, i32) -> i32
+      %shru = "comb.shru"(%a, %b) : (i32, i32) -> i32
+      %sub = "comb.sub"(%a, %b) : (i32, i32) -> i32
+      %xor1 = "comb.xor"(%a) : (i32) -> i32
+      %xor2 = "comb.xor"(%a, %b) : (i32, i32) -> i32
+      %xor3 = "comb.xor"(%a, %b, %c) : (i32, i32, i32) -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.concat"() : () -> i0
-// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}) : (i32, i32) -> i64
-// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i96
-// CHECK-NEXT:     %{{.*}} = "comb.divs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.divu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.extract"(%{{.*}}) <{"lowBit" = 2 : i32}> : (i32) -> i8
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 3 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 5 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 7 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 8 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 9 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 10 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 12 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 13 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.mods"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.modu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mux"(%8, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.parity"(%{{.*}}) : (i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.replicate"(%{{.*}}) : (i32) -> i64
-// CHECK-NEXT:     %{{.*}} = "comb.reverse"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.shrs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.shru"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.and"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.concat"() : () -> i0
+// CHECK-NEXT:         %{{.*}} = "comb.concat"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}) : (i32, i32) -> i64
+// CHECK-NEXT:         %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i96
+// CHECK-NEXT:         %{{.*}} = "comb.divs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.divu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.extract"(%{{.*}}) <{"lowBit" = 2 : i32}> : (i32) -> i8
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 3 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 5 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 7 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 8 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 9 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 10 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 12 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 13 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.mods"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.modu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mul"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mux"(%10, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.or"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.parity"(%{{.*}}) : (i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.replicate"(%{{.*}}) : (i32) -> i64
+// CHECK-NEXT:         %{{.*}} = "comb.reverse"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.shrs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.shru"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.xor"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/CudaTile/types.mlir
+++ b/Test/CudaTile/types.mlir
@@ -1,10 +1,20 @@
 // RUN: VEIR_ROUNDTRIP
 "builtin.module"() ({
-^bb0(%arg0: !cuda_tile.ptr<i1>):
-    %0 = "test.test"() : () -> !cuda_tile.ptr<i1>
+  // Note: the proper type should be without quotes, i.e.
+  // `!cuda_tile.ptr<i1> -> ()`. Our parser cannot handle this right now, it's a
+  // bug that should be fixed.
+  "func.func"() <{function_type = "!cuda_tile.ptr<i1> -> ()", sym_name = "main"}> ({
+    ^bb0(%arg0: !cuda_tile.ptr<i1>):
+      %0 = "test.test"() : () -> !cuda_tile.ptr<i1>
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !cuda_tile.ptr<i1>):
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !cuda_tile.ptr<i1>
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = "!cuda_tile.ptr<i1> -> ()", "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : !cuda_tile.ptr<i1>):
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> !cuda_tile.ptr<i1>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Datapath/identity.mlir
+++ b/Test/Datapath/identity.mlir
@@ -1,15 +1,22 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0(%arg0: i3, %arg1: i3, %arg2: i3):
-  %0, %1 = "datapath.compress"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3)
-  %2, %3, %4 = "datapath.partial_product"(%arg0, %arg1) : (i3, i3) -> (i3, i3, i3)
-  %5, %6, %7 = "datapath.pos_partial_product"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3, i3)
+  "func.func"() <{function_type = (i3, i3, i3) -> (), sym_name = "main"}> ({
+    ^bb0(%arg0: i3, %arg1: i3, %arg2: i3):
+      %0, %1 = "datapath.compress"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3)
+      %2, %3, %4 = "datapath.partial_product"(%arg0, %arg1) : (i3, i3) -> (i3, i3, i3)
+      %5, %6, %7 = "datapath.pos_partial_product"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3, i3)
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4(%{{.*}} : i3, %{{.*}} : i3, %{{.*}} : i3):
-// CHECK-NEXT:     %{{.*}}:2 = "datapath.compress"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3)
-// CHECK-NEXT:     %{{.*}}:3 = "datapath.partial_product"(%{{.*}}, %{{.*}}) : (i3, i3) -> (i3, i3, i3)
-// CHECK-NEXT:     %{{.*}}:3 = "datapath.pos_partial_product"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i3, i3, i3) -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i3, %{{.*}} : i3, %{{.*}} : i3):
+// CHECK-NEXT:         %{{.*}}:2 = "datapath.compress"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3)
+// CHECK-NEXT:         %{{.*}}:3 = "datapath.partial_product"(%{{.*}}, %{{.*}}) : (i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:         %{{.*}}:3 = "datapath.pos_partial_product"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/HW/identity.mlir
+++ b/Test/HW/identity.mlir
@@ -1,27 +1,34 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^4():
-  %1 = "hw.constant"() <{value = 13 : i10}> : () -> i10
-  "hw.module"() <{module_type = !hw.modty<output a : i10, input b : i10>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "bar"}> ({
-  ^bb0(%b: i10):
-    "hw.output"(%b) : (i10) -> ()
-  }) {sym_visibility = "public"} : () -> ()
-  "hw.module"() <{module_type = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "foo"}> ({
-  ^bb0(%arg5: i3, %arg6: i1):
-    "hw.output"(%arg5, %arg6) : (i3, i1) -> ()
-  }) {sym_visibility = "private"} : () -> ()
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^4():
+      %1 = "hw.constant"() <{value = 13 : i10}> : () -> i10
+      "hw.module"() <{module_type = !hw.modty<output a : i10, input b : i10>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "bar"}> ({
+      ^bb0(%b: i10):
+        "hw.output"(%b) : (i10) -> ()
+      }) {sym_visibility = "public"} : () -> ()
+      "hw.module"() <{module_type = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "foo"}> ({
+      ^bb0(%arg5: i3, %arg6: i1):
+        "hw.output"(%arg5, %arg6) : (i3, i1) -> ()
+      }) {sym_visibility = "private"} : () -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "hw.constant"() <{"value" = 13 : i10}> : () -> i10
-// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<output a : i10, input b : i10>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "bar"}> ({
-// CHECK-NEXT:       ^{{.*}}(%{{.*}}: i10):
-// CHECK-NEXT:         "hw.output"(%{{.*}}) : (i10) -> ()
-// CHECK-NEXT:     }) {"sym_visibility" = "public"} : () -> ()
-// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "foo"}> ({
-// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i3, %{{.*}}: i1):
-// CHECK-NEXT:         "hw.output"(%{{.*}}, %{{.*}}) : (i3, i1) -> ()
-// CHECK-NEXT:     }) {"sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "hw.constant"() <{"value" = 13 : i10}> : () -> i10
+// CHECK-NEXT:         "hw.module"() <{"module_type" = !hw.modty<output a : i10, input b : i10>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "bar"}> ({
+// CHECK-NEXT:           ^{{.*}}(%{{.*}}: i10):
+// CHECK-NEXT:             "hw.output"(%{{.*}}) : (i10) -> ()
+// CHECK-NEXT:         }) {"sym_visibility" = "public"} : () -> ()
+// CHECK-NEXT:         "hw.module"() <{"module_type" = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "foo"}> ({
+// CHECK-NEXT:           ^{{.*}}(%{{.*}} : i3, %{{.*}}: i1):
+// CHECK-NEXT:             "hw.output"(%{{.*}}, %{{.*}}) : (i3, i1) -> ()
+// CHECK-NEXT:         }) {"sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Interpreter/main_and_top_level.mlir
+++ b/Test/Interpreter/main_and_top_level.mlir
@@ -9,4 +9,4 @@
   "func.return"(%0) : (i32) -> ()
 }) : () -> ()
 
-// CHECK: Error: Top-level operations are disallowed; define a zero-argument function named 'main'
+// CHECK: Error: Error parsing module: top-level operation with operands or results is not allowed; only function and module definitions may appear at the module level

--- a/Test/LLVM/invalid.mlir
+++ b/Test/LLVM/invalid.mlir
@@ -1,8 +1,11 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  ^bb0(%a: i32, %b : i16):
-      %sexta = "llvm.sext"(%a) : (i32) -> i16
-      // CHECK: Error verifying input program: Operand's width must be smaller than result's width
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0(%a: i32, %b : i16):
+        %sexta = "llvm.sext"(%a) : (i32) -> i16
+        // CHECK: Error verifying input program: Operand's width must be smaller than result's width
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 

--- a/Test/ModArith/identity.mlir
+++ b/Test/ModArith/identity.mlir
@@ -1,20 +1,27 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %0 = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
-  %1 = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
-  %2 = "mod_arith.add"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-  %3 = "mod_arith.sub"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-  %4 = "mod_arith.mul"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
+      %1 = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
+      %2 = "mod_arith.add"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+      %3 = "mod_arith.sub"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+      %4 = "mod_arith.mul"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 
-// CHECK:       "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.add"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.sub"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.mul"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.add"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.sub"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.mul"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Parsing/scopes.mlir
+++ b/Test/Parsing/scopes.mlir
@@ -1,58 +1,63 @@
 // RUN: veir-opt %s | filecheck %s
 
-"test.test"() ({
-    %a = "test.test"() : () -> i1
-
-    "test.test"() ({
-        "test.test"(%a) : (i1) -> ()
-        %b = "test.test"() : () -> i2
-
-        "test.test"() ({
-        ^bb0:
-            %c = "test.test"() : () -> i3
-        ^bb1:
-            "test.test"(%a, %b, %c) : (i1, i2, i3) -> ()
-        }) : () -> ()
-
-        "test.test"() ({
-        ^bb0:
-            %c = "test.test"() : () -> i4
-        ^bb1:
-            "test.test"(%a, %b, %c) : (i1, i2, i4) -> ()
-        }) : () -> ()
-
-        %c = "test.test"() : () -> i5
-        "test.test"(%a, %b, %c) : (i1, i2, i5) -> ()
-    }) : () -> ()
-
-^bb1:
-    %b, %c = "test.test"() : () -> (i6, i7)
-    "test.test"(%a, %b, %c) : (i1, i6, i7) -> ()
+"builtin.module"() ({
+  "test.test"() ({
+      %a = "test.test"() : () -> i1
+  
+      "test.test"() ({
+          "test.test"(%a) : (i1) -> ()
+          %b = "test.test"() : () -> i2
+  
+          "test.test"() ({
+          ^bb0:
+              %c = "test.test"() : () -> i3
+          ^bb1:
+              "test.test"(%a, %b, %c) : (i1, i2, i3) -> ()
+          }) : () -> ()
+  
+          "test.test"() ({
+          ^bb0:
+              %c = "test.test"() : () -> i4
+          ^bb1:
+              "test.test"(%a, %b, %c) : (i1, i2, i4) -> ()
+          }) : () -> ()
+  
+          %c = "test.test"() : () -> i5
+          "test.test"(%a, %b, %c) : (i1, i2, i5) -> ()
+      }) : () -> ()
+  
+  ^bb1:
+      %b, %c = "test.test"() : () -> (i6, i7)
+      "test.test"(%a, %b, %c) : (i1, i6, i7) -> ()
+  }) : () -> ()
 }) : () -> ()
 
-// CHECK:      "test.test"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %[[A:.*]] = "test.test"() : () -> i1
 // CHECK-NEXT:     "test.test"() ({
 // CHECK-NEXT:       ^{{.*}}():
-// CHECK-NEXT:         "test.test"(%[[A]]) : (i1) -> ()
-// CHECK-NEXT:         %[[B:.*]] = "test.test"() : () -> i2
+// CHECK-NEXT:         %[[A:.*]] = "test.test"() : () -> i1
 // CHECK-NEXT:         "test.test"() ({
 // CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             %[[C3:.*]] = "test.test"() : () -> i3
-// CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C3]]) : (i1, i2, i3) -> ()
+// CHECK-NEXT:             "test.test"(%[[A]]) : (i1) -> ()
+// CHECK-NEXT:             %[[B:.*]] = "test.test"() : () -> i2
+// CHECK-NEXT:             "test.test"() ({
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 %[[C3:.*]] = "test.test"() : () -> i3
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 "test.test"(%[[A]], %[[B]], %[[C3]]) : (i1, i2, i3) -> ()
+// CHECK-NEXT:             }) : () -> ()
+// CHECK-NEXT:             "test.test"() ({
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 %[[C4:.*]] = "test.test"() : () -> i4
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 "test.test"(%[[A]], %[[B]], %[[C4]]) : (i1, i2, i4) -> ()
+// CHECK-NEXT:             }) : () -> ()
+// CHECK-NEXT:             %[[C5:.*]] = "test.test"() : () -> i5
+// CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C5]]) : (i1, i2, i5) -> ()
 // CHECK-NEXT:         }) : () -> ()
-// CHECK-NEXT:         "test.test"() ({
-// CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             %[[C4:.*]] = "test.test"() : () -> i4
-// CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C4]]) : (i1, i2, i4) -> ()
-// CHECK-NEXT:         }) : () -> ()
-// CHECK-NEXT:         %[[C5:.*]] = "test.test"() : () -> i5
-// CHECK-NEXT:         "test.test"(%[[A]], %[[B]], %[[C5]]) : (i1, i2, i5) -> ()
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %[[B6C7:.*]]:2 = "test.test"() : () -> (i6, i7)
+// CHECK-NEXT:         "test.test"(%[[A]], %[[B6C7]]#0, %[[B6C7]]#1) : (i1, i6, i7) -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %[[B6C7:.*]]:2 = "test.test"() : () -> (i6, i7)
-// CHECK-NEXT:     "test.test"(%[[A]], %[[B6C7]]#0, %[[B6C7]]#1) : (i1, i6, i7) -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Parsing/unregistered_ops.mlir
+++ b/Test/Parsing/unregistered_ops.mlir
@@ -1,6 +1,7 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
     "unregistered.op_one"() : () -> ()
     %1 = "unregistered.op_two"() : () -> !foo.bar
     %2 = "unregistered.op_three"() : () -> !foo.bar<baz>
@@ -9,4 +10,6 @@
     // CHECK-NEXT: %{{.*}} = "unregistered.op_two"() : () -> !foo.bar
     // CHECK-NEXT: %{{.*}} = "unregistered.op_three"() : () -> !foo.bar<baz>
     // CHECK-NEXT: "unregistered.op_four"() <{"foo" = 1 : i32}> : () -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/add_zero.mlir
+++ b/Test/Passes/InstCombine/add_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // add x + 0 => x
-    %add_zero = "llvm.add"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%add_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // add x + 0 => x
+      %add_zero = "llvm.add"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%add_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/and_x_x.mlir
+++ b/Test/Passes/InstCombine/and_x_x.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %x = "test.test"() : () -> i32
-    // CHECK: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %x = "test.test"() : () -> i32
+      // CHECK: %[[X:.*]] = "test.test"() : () -> i32
 
-    // and x & x => x
-    %and_self = "llvm.and"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%and_self) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // and x & x => x
+      %and_self = "llvm.and"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%and_self) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "function.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/and_zero.mlir
+++ b/Test/Passes/InstCombine/and_zero.mlir
@@ -1,17 +1,19 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-   // and x & 0 => 0
-    %and_zero = "llvm.and"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%and_zero) : (i32) -> ()
-    // CHECK-NEXT: %[[AND_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: "test.test"(%[[AND_ZERO]]) : (i32) -> ()
-
+     // and x & 0 => 0
+      %and_zero = "llvm.and"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%and_zero) : (i32) -> ()
+      // CHECK-NEXT: %[[AND_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: "test.test"(%[[AND_ZERO]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_notand_or.mlir
+++ b/Test/Passes/InstCombine/de_morgan_notand_or.mlir
@@ -1,25 +1,27 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    %b = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
-    // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      %b = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+      // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
 
-    // ~(~a & ~b) => a | b
-    %na1 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %nb1 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
-    %and1 = "llvm.and"(%na1, %nb1) : (i32, i32) -> i32
-    %demorgan_or = "llvm.xor"(%and1, %m1) : (i32, i32) -> i32
-    "test.test"(%demorgan_or) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[OR:.*]] = "llvm.or"(%[[A]], %[[B]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[OR]]) : (i32) -> ()
-
+      // ~(~a & ~b) => a | b
+      %na1 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %nb1 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
+      %and1 = "llvm.and"(%na1, %nb1) : (i32, i32) -> i32
+      %demorgan_or = "llvm.xor"(%and1, %m1) : (i32, i32) -> i32
+      "test.test"(%demorgan_or) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[OR:.*]] = "llvm.or"(%[[A]], %[[B]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[OR]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_notnot.mlir
+++ b/Test/Passes/InstCombine/de_morgan_notnot.mlir
@@ -1,18 +1,20 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
 
-    // ~~a => a
-    %na0 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %nna = "llvm.xor"(%na0, %m1) : (i32, i32) -> i32
-    "test.test"(%nna) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[A]]) : (i32) -> ()
-
+      // ~~a => a
+      %na0 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %nna = "llvm.xor"(%na0, %m1) : (i32, i32) -> i32
+      "test.test"(%nna) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[A]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_notor_and.mlir
+++ b/Test/Passes/InstCombine/de_morgan_notor_and.mlir
@@ -1,25 +1,27 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    %b = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
-    // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      %b = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+      // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
 
-    // ~(~a | ~b) => a & b
-    %na2 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %nb2 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
-    %or2 = "llvm.or"(%na2, %nb2) : (i32, i32) -> i32
-    %demorgan_and = "llvm.xor"(%or2, %m1) : (i32, i32) -> i32
-    "test.test"(%demorgan_and) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[AND:.*]] = "llvm.and"(%[[A]], %[[B]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[AND]]) : (i32) -> ()
-
+      // ~(~a | ~b) => a & b
+      %na2 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %nb2 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
+      %or2 = "llvm.or"(%na2, %nb2) : (i32, i32) -> i32
+      %demorgan_and = "llvm.xor"(%or2, %m1) : (i32, i32) -> i32
+      "test.test"(%demorgan_and) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[AND:.*]] = "llvm.and"(%[[A]], %[[B]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[AND]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_xorxor.mlir
+++ b/Test/Passes/InstCombine/de_morgan_xorxor.mlir
@@ -1,21 +1,23 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
 
-    // Negative: xor(xor(a, -1), -7) is not ~~a -- outer constant is not -1.
-    %m7 = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
-    %na_neg = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %not_nna = "llvm.xor"(%na_neg, %m7) : (i32, i32) -> i32
-    "test.test"(%not_nna) : (i32) -> ()
-    // CHECK-NEXT: %[[M7:.*]] = "llvm.mlir.constant"() <{"value" = -7 : i32}> : () -> i32
-    // CHECK-NEXT: %[[NA_NEG:.*]] = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[NEG_RES:.*]] = "llvm.xor"(%[[NA_NEG]], %[[M7]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[NEG_RES]]) : (i32) -> ()
-
+      // Negative: xor(xor(a, -1), -7) is not ~~a -- outer constant is not -1.
+      %m7 = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
+      %na_neg = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %not_nna = "llvm.xor"(%na_neg, %m7) : (i32, i32) -> i32
+      "test.test"(%not_nna) : (i32) -> ()
+      // CHECK-NEXT: %[[M7:.*]] = "llvm.mlir.constant"() <{"value" = -7 : i32}> : () -> i32
+      // CHECK-NEXT: %[[NA_NEG:.*]] = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[NEG_RES:.*]] = "llvm.xor"(%[[NA_NEG]], %[[M7]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[NEG_RES]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/mult_one.mlir
+++ b/Test/Passes/InstCombine/mult_one.mlir
@@ -1,15 +1,17 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK: %[[ONE:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK: %[[ONE:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // mul x * 1 => x
-    %mul_one = "llvm.mul"(%x, %one) : (i32, i32) -> i32
-    "test.test"(%mul_one) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // mul x * 1 => x
+      %mul_one = "llvm.mul"(%x, %one) : (i32, i32) -> i32
+      "test.test"(%mul_one) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/mult_two.mlir
+++ b/Test/Passes/InstCombine/mult_two.mlir
@@ -1,15 +1,17 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
 
-    %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
-    "test.test"(%mul_two) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%{{.*}}) : (i32) -> ()
-
+      %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
+      "test.test"(%mul_two) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%{{.*}}) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/multzero_multtwo.mlir
+++ b/Test/Passes/InstCombine/multzero_multtwo.mlir
@@ -1,20 +1,22 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
 
-    %mul_zero = "llvm.mul"(%a, %zero) : (i32, i32) -> i32
-    %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      %mul_zero = "llvm.mul"(%a, %zero) : (i32, i32) -> i32
+      %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 
-    "test.test"(%mul_zero, %mul_two) : (i32, i32) -> ()
-    // CHECK-NEXT: "test.test"(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
-
+      "test.test"(%mul_zero, %mul_two) : (i32, i32) -> ()
+      // CHECK-NEXT: "test.test"(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/or_x_x.mlir
+++ b/Test/Passes/InstCombine/or_x_x.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %x = "test.test"() : () -> i32
-    // CHECK: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %x = "test.test"() : () -> i32
+      // CHECK: %[[X:.*]] = "test.test"() : () -> i32
 
-    // or x | x => x
-    %or_self = "llvm.or"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%or_self) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // or x | x => x
+      %or_self = "llvm.or"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%or_self) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/or_zero.mlir
+++ b/Test/Passes/InstCombine/or_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // or x | 0 => x
-    %or_zero = "llvm.or"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%or_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // or x | 0 => x
+      %or_zero = "llvm.or"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%or_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/sub_x_x.mlir
+++ b/Test/Passes/InstCombine/sub_x_x.mlir
@@ -1,17 +1,19 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // sub x - x => 0
-    %sub_self = "llvm.sub"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%sub_self) : (i32) -> ()
-    // CHECK-NEXT: %[[SUB_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: "test.test"(%[[SUB_ZERO]]) : (i32) -> ()
-
+      // sub x - x => 0
+      %sub_self = "llvm.sub"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%sub_self) : (i32) -> ()
+      // CHECK-NEXT: %[[SUB_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: "test.test"(%[[SUB_ZERO]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/sub_zero.mlir
+++ b/Test/Passes/InstCombine/sub_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
-
-    // sub x - 0 => x
-    %sub_zero = "llvm.sub"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%sub_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  
+      // sub x - 0 => x
+      %sub_zero = "llvm.sub"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%sub_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/xor_x_x.mlir
+++ b/Test/Passes/InstCombine/xor_x_x.mlir
@@ -1,17 +1,19 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // xor x ^ x => 0
-    %xor_self = "llvm.xor"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%xor_self) : (i32) -> ()
-    // CHECK-NEXT: %[[XOR_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: "test.test"(%[[XOR_ZERO]]) : (i32) -> ()
-
+      // xor x ^ x => 0
+      %xor_self = "llvm.xor"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%xor_self) : (i32) -> ()
+      // CHECK-NEXT: %[[XOR_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: "test.test"(%[[XOR_ZERO]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/xor_zero.mlir
+++ b/Test/Passes/InstCombine/xor_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // xor x ^ 0 => x
-    %xor_zero = "llvm.xor"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%xor_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // xor x ^ 0 => x
+      %xor_zero = "llvm.xor"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%xor_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/RISCV/identity.mlir
+++ b/Test/RISCV/identity.mlir
@@ -1,213 +1,220 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-  ^bb0():
-    %0 = "riscv.li"() <{ "value" = 13 : i64 }>  : () -> !reg
-    %1 = "riscv.li"() <{ "value" = 17 : i64 }> : () -> !reg
-    // Immediate load 
-    %2 = "riscv.lui"() <{"value" = 13 : i20}> : () -> !reg
-    %3 = "riscv.auipc"(%0) <{"value" = 13 : i20}> : (!reg) -> !reg
-    // Immediate operations 
-    %4 = "riscv.addi"(%0) <{"value" = 5 : i12}> : (!reg) -> !reg
-    %5 = "riscv.slti"(%0) <{"value" = 7 : i12}> : (!reg) -> !reg
-    %6 = "riscv.sltiu"(%0) <{"value" = 11 : i12}> : (!reg) -> !reg
-    %7 = "riscv.andi"(%0) <{"value" = 13 : i12}> : (!reg) -> !reg
-    %8 = "riscv.ori"(%0) <{"value" = 17 : i12}> : (!reg) -> !reg
-    %9 = "riscv.xori"(%0) <{"value" = 23 : i12}> : (!reg) -> !reg
-    %10 = "riscv.addiw"(%0) <{"value" = 29 : i12}> : (!reg) -> !reg
-    %11 = "riscv.slli"(%0) <{"value" = 31 : i6}> : (!reg) -> !reg
-    %12 = "riscv.srli"(%0) <{"value" = 33 : i6}> : (!reg) -> !reg
-    %13 = "riscv.srai"(%0) <{"value" = 37 : i6}> : (!reg) -> !reg
-    %14 = "riscv.slliw"(%0) <{ "value" = 13 : i5 }> : (!reg) -> !reg
-    %15 = "riscv.srliw"(%0) <{ "value" = 17 : i5 }> : (!reg) -> !reg
-    %16 = "riscv.sraiw"(%0) <{ "value" = 19 : i5 }> : (!reg) -> !reg
-    %17 = "riscv.slliuw"(%0) <{"value" = 13 : i6 }> : (!reg) -> !reg
-    %18 = "riscv.roriw"(%0) <{"value" = 13 : i5 }> : (!reg) -> !reg
-    %19 = "riscv.rori"(%0) <{"value" = 13 : i6 }> : (!reg) -> !reg
-    %20 = "riscv.bclri"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
-    %21 = "riscv.bexti"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
-    %22 = "riscv.binvi"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
-    %23 = "riscv.bseti"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
-    // Unary operations 
-    %24 = "riscv.sextb"(%0) : (!reg) -> !reg
-    %25 = "riscv.sexth"(%0) : (!reg) -> !reg
-    %26 = "riscv.zexth"(%0) : (!reg) -> !reg
-    %27 = "riscv.clz"(%0) : (!reg) -> !reg
-    %28 = "riscv.clzw"(%0) : (!reg) -> !reg
-    %29 = "riscv.ctz"(%0) : (!reg) -> !reg
-    %30 = "riscv.ctzw"(%0) : (!reg) -> !reg
-    %cpop = "riscv.cpop"(%0) : (!reg) -> !reg
-    %cpopw = "riscv.cpopw"(%0) : (!reg) -> !reg
-    // Binary operations 
-    %31 = "riscv.add"(%0, %1) : (!reg, !reg) -> !reg
-    %32 = "riscv.sub"(%0, %1) : (!reg, !reg) -> !reg
-    %33 = "riscv.sll"(%0, %1) : (!reg, !reg) -> !reg
-    %34 = "riscv.slt"(%0, %1) : (!reg, !reg) -> !reg
-    %35 = "riscv.sltu"(%0, %1) : (!reg, !reg) -> !reg
-    %36 = "riscv.xor"(%0, %1) : (!reg, !reg) -> !reg
-    %37 = "riscv.srl"(%0, %1) : (!reg, !reg) -> !reg
-    %38 = "riscv.sra"(%0, %1) : (!reg, !reg) -> !reg
-    %39 = "riscv.or"(%0, %1) : (!reg, !reg) -> !reg
-    %40 = "riscv.and"(%0, %1) : (!reg, !reg) -> !reg
-    %41 = "riscv.addw"(%0, %1) : (!reg, !reg) -> !reg
-    %42 = "riscv.subw"(%0, %1) : (!reg, !reg) -> !reg
-    %43 = "riscv.sllw"(%0, %1) : (!reg, !reg) -> !reg
-    %44 = "riscv.srlw"(%0, %1) : (!reg, !reg) -> !reg
-    %45 = "riscv.sraw"(%0, %1) : (!reg, !reg) -> !reg
-    %46 = "riscv.rem"(%0, %1) : (!reg, !reg) -> !reg
-    %47 = "riscv.remu"(%0, %1) : (!reg, !reg) -> !reg
-    %48 = "riscv.remw"(%0, %1) : (!reg, !reg) -> !reg
-    %49 = "riscv.remuw"(%0, %1) : (!reg, !reg) -> !reg
-    %50 = "riscv.mul"(%0, %1) : (!reg, !reg) -> !reg
-    %51 = "riscv.mulh"(%0, %1) : (!reg, !reg) -> !reg
-    %52 = "riscv.mulhu"(%0, %1) : (!reg, !reg) -> !reg
-    %53 = "riscv.mulhsu"(%0, %1) : (!reg, !reg) -> !reg
-    %54 = "riscv.mulw"(%0, %1) : (!reg, !reg) -> !reg
-    %55 = "riscv.div"(%0, %1) : (!reg, !reg) -> !reg
-    %56 = "riscv.divw"(%0, %1) : (!reg, !reg) -> !reg
-    %57 = "riscv.divu"(%0, %1) : (!reg, !reg) -> !reg
-    %58 = "riscv.divuw"(%0, %1) : (!reg, !reg) -> !reg
-    %59 = "riscv.adduw"(%0, %1) : (!reg, !reg) -> !reg
-    %60 = "riscv.sh1adduw"(%0, %1) : (!reg, !reg) -> !reg
-    %61 = "riscv.sh2adduw"(%0, %1) : (!reg, !reg) -> !reg
-    %62 = "riscv.sh3adduw"(%0, %1) : (!reg, !reg) -> !reg
-    %63 = "riscv.sh1add"(%0, %1) : (!reg, !reg) -> !reg
-    %64 = "riscv.sh2add"(%0, %1) : (!reg, !reg) -> !reg
-    %65 = "riscv.sh3add"(%0, %1) : (!reg, !reg) -> !reg
-    %66 = "riscv.andn"(%0, %1) : (!reg, !reg) -> !reg
-    %67 = "riscv.orn"(%0, %1) : (!reg, !reg) -> !reg
-    %68 = "riscv.xnor"(%0, %1) : (!reg, !reg) -> !reg
-    %69 = "riscv.max"(%0, %1) : (!reg, !reg) -> !reg
-    %70 = "riscv.maxu"(%0, %1) : (!reg, !reg) -> !reg
-    %71 = "riscv.min"(%0, %1) : (!reg, !reg) -> !reg
-    %72 = "riscv.minu"(%0, %1) : (!reg, !reg) -> !reg
-    %73 = "riscv.rol"(%0, %1) : (!reg, !reg) -> !reg
-    %74 = "riscv.ror"(%0, %1) : (!reg, !reg) -> !reg
-    %75 = "riscv.rolw"(%0, %1) : (!reg, !reg) -> !reg
-    %76 = "riscv.rorw"(%0, %1) : (!reg, !reg) -> !reg
-    %77 = "riscv.bclr"(%0, %1) : (!reg, !reg) -> !reg
-    %78 = "riscv.bext"(%0, %1) : (!reg, !reg) -> !reg
-    %79 = "riscv.binv"(%0, %1) : (!reg, !reg) -> !reg
-    %80 = "riscv.bset"(%0, %1) : (!reg, !reg) -> !reg
-    %81 = "riscv.pack"(%0, %1) : (!reg, !reg) -> !reg
-    %82 = "riscv.packh"(%0, %1) : (!reg, !reg) -> !reg
-    %83 = "riscv.packw"(%0, %1) : (!reg, !reg) -> !reg
-    // pseudo instructions
-    %84 = "riscv.mv"(%83) : (!reg) -> !reg
-    %85 = "riscv.not"(%83) : (!reg) -> !reg
-    %86 = "riscv.neg"(%83) : (!reg) -> !reg
-    %87 = "riscv.negw"(%83) : (!reg) -> !reg
-    %88 = "riscv.sextw"(%83) : (!reg) -> !reg
-    %89 = "riscv.zextb"(%83) : (!reg) -> !reg
-    %90 = "riscv.zextw"(%83) : (!reg) -> !reg
-    %91 = "riscv.seqz"(%83) : (!reg) -> !reg
-    %92 = "riscv.snez"(%83) : (!reg) -> !reg
-    %93 = "riscv.sltz"(%83) : (!reg) -> !reg
-    %94 = "riscv.sgtz"(%83) : (!reg) -> !reg
-    // Memory operations
-    %95 = "riscv.ld"(%0) <{"value" = 5 : i12}> : (!reg) -> !reg
-    "riscv.sd"(%0, %1) <{"value" = 5 : i12}> : (!reg, !reg) -> ()
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "riscv.li"() <{ "value" = 13 : i64 }>  : () -> !reg
+      %1 = "riscv.li"() <{ "value" = 17 : i64 }> : () -> !reg
+      // Immediate load 
+      %2 = "riscv.lui"() <{"value" = 13 : i20}> : () -> !reg
+      %3 = "riscv.auipc"(%0) <{"value" = 13 : i20}> : (!reg) -> !reg
+      // Immediate operations 
+      %4 = "riscv.addi"(%0) <{"value" = 5 : i12}> : (!reg) -> !reg
+      %5 = "riscv.slti"(%0) <{"value" = 7 : i12}> : (!reg) -> !reg
+      %6 = "riscv.sltiu"(%0) <{"value" = 11 : i12}> : (!reg) -> !reg
+      %7 = "riscv.andi"(%0) <{"value" = 13 : i12}> : (!reg) -> !reg
+      %8 = "riscv.ori"(%0) <{"value" = 17 : i12}> : (!reg) -> !reg
+      %9 = "riscv.xori"(%0) <{"value" = 23 : i12}> : (!reg) -> !reg
+      %10 = "riscv.addiw"(%0) <{"value" = 29 : i12}> : (!reg) -> !reg
+      %11 = "riscv.slli"(%0) <{"value" = 31 : i6}> : (!reg) -> !reg
+      %12 = "riscv.srli"(%0) <{"value" = 33 : i6}> : (!reg) -> !reg
+      %13 = "riscv.srai"(%0) <{"value" = 37 : i6}> : (!reg) -> !reg
+      %14 = "riscv.slliw"(%0) <{ "value" = 13 : i5 }> : (!reg) -> !reg
+      %15 = "riscv.srliw"(%0) <{ "value" = 17 : i5 }> : (!reg) -> !reg
+      %16 = "riscv.sraiw"(%0) <{ "value" = 19 : i5 }> : (!reg) -> !reg
+      %17 = "riscv.slliuw"(%0) <{"value" = 13 : i6 }> : (!reg) -> !reg
+      %18 = "riscv.roriw"(%0) <{"value" = 13 : i5 }> : (!reg) -> !reg
+      %19 = "riscv.rori"(%0) <{"value" = 13 : i6 }> : (!reg) -> !reg
+      %20 = "riscv.bclri"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
+      %21 = "riscv.bexti"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
+      %22 = "riscv.binvi"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
+      %23 = "riscv.bseti"(%0) <{"value" = 13 : i6}> : (!reg) -> !reg
+      // Unary operations 
+      %24 = "riscv.sextb"(%0) : (!reg) -> !reg
+      %25 = "riscv.sexth"(%0) : (!reg) -> !reg
+      %26 = "riscv.zexth"(%0) : (!reg) -> !reg
+      %27 = "riscv.clz"(%0) : (!reg) -> !reg
+      %28 = "riscv.clzw"(%0) : (!reg) -> !reg
+      %29 = "riscv.ctz"(%0) : (!reg) -> !reg
+      %30 = "riscv.ctzw"(%0) : (!reg) -> !reg
+      %cpop = "riscv.cpop"(%0) : (!reg) -> !reg
+      %cpopw = "riscv.cpopw"(%0) : (!reg) -> !reg
+      // Binary operations 
+      %31 = "riscv.add"(%0, %1) : (!reg, !reg) -> !reg
+      %32 = "riscv.sub"(%0, %1) : (!reg, !reg) -> !reg
+      %33 = "riscv.sll"(%0, %1) : (!reg, !reg) -> !reg
+      %34 = "riscv.slt"(%0, %1) : (!reg, !reg) -> !reg
+      %35 = "riscv.sltu"(%0, %1) : (!reg, !reg) -> !reg
+      %36 = "riscv.xor"(%0, %1) : (!reg, !reg) -> !reg
+      %37 = "riscv.srl"(%0, %1) : (!reg, !reg) -> !reg
+      %38 = "riscv.sra"(%0, %1) : (!reg, !reg) -> !reg
+      %39 = "riscv.or"(%0, %1) : (!reg, !reg) -> !reg
+      %40 = "riscv.and"(%0, %1) : (!reg, !reg) -> !reg
+      %41 = "riscv.addw"(%0, %1) : (!reg, !reg) -> !reg
+      %42 = "riscv.subw"(%0, %1) : (!reg, !reg) -> !reg
+      %43 = "riscv.sllw"(%0, %1) : (!reg, !reg) -> !reg
+      %44 = "riscv.srlw"(%0, %1) : (!reg, !reg) -> !reg
+      %45 = "riscv.sraw"(%0, %1) : (!reg, !reg) -> !reg
+      %46 = "riscv.rem"(%0, %1) : (!reg, !reg) -> !reg
+      %47 = "riscv.remu"(%0, %1) : (!reg, !reg) -> !reg
+      %48 = "riscv.remw"(%0, %1) : (!reg, !reg) -> !reg
+      %49 = "riscv.remuw"(%0, %1) : (!reg, !reg) -> !reg
+      %50 = "riscv.mul"(%0, %1) : (!reg, !reg) -> !reg
+      %51 = "riscv.mulh"(%0, %1) : (!reg, !reg) -> !reg
+      %52 = "riscv.mulhu"(%0, %1) : (!reg, !reg) -> !reg
+      %53 = "riscv.mulhsu"(%0, %1) : (!reg, !reg) -> !reg
+      %54 = "riscv.mulw"(%0, %1) : (!reg, !reg) -> !reg
+      %55 = "riscv.div"(%0, %1) : (!reg, !reg) -> !reg
+      %56 = "riscv.divw"(%0, %1) : (!reg, !reg) -> !reg
+      %57 = "riscv.divu"(%0, %1) : (!reg, !reg) -> !reg
+      %58 = "riscv.divuw"(%0, %1) : (!reg, !reg) -> !reg
+      %59 = "riscv.adduw"(%0, %1) : (!reg, !reg) -> !reg
+      %60 = "riscv.sh1adduw"(%0, %1) : (!reg, !reg) -> !reg
+      %61 = "riscv.sh2adduw"(%0, %1) : (!reg, !reg) -> !reg
+      %62 = "riscv.sh3adduw"(%0, %1) : (!reg, !reg) -> !reg
+      %63 = "riscv.sh1add"(%0, %1) : (!reg, !reg) -> !reg
+      %64 = "riscv.sh2add"(%0, %1) : (!reg, !reg) -> !reg
+      %65 = "riscv.sh3add"(%0, %1) : (!reg, !reg) -> !reg
+      %66 = "riscv.andn"(%0, %1) : (!reg, !reg) -> !reg
+      %67 = "riscv.orn"(%0, %1) : (!reg, !reg) -> !reg
+      %68 = "riscv.xnor"(%0, %1) : (!reg, !reg) -> !reg
+      %69 = "riscv.max"(%0, %1) : (!reg, !reg) -> !reg
+      %70 = "riscv.maxu"(%0, %1) : (!reg, !reg) -> !reg
+      %71 = "riscv.min"(%0, %1) : (!reg, !reg) -> !reg
+      %72 = "riscv.minu"(%0, %1) : (!reg, !reg) -> !reg
+      %73 = "riscv.rol"(%0, %1) : (!reg, !reg) -> !reg
+      %74 = "riscv.ror"(%0, %1) : (!reg, !reg) -> !reg
+      %75 = "riscv.rolw"(%0, %1) : (!reg, !reg) -> !reg
+      %76 = "riscv.rorw"(%0, %1) : (!reg, !reg) -> !reg
+      %77 = "riscv.bclr"(%0, %1) : (!reg, !reg) -> !reg
+      %78 = "riscv.bext"(%0, %1) : (!reg, !reg) -> !reg
+      %79 = "riscv.binv"(%0, %1) : (!reg, !reg) -> !reg
+      %80 = "riscv.bset"(%0, %1) : (!reg, !reg) -> !reg
+      %81 = "riscv.pack"(%0, %1) : (!reg, !reg) -> !reg
+      %82 = "riscv.packh"(%0, %1) : (!reg, !reg) -> !reg
+      %83 = "riscv.packw"(%0, %1) : (!reg, !reg) -> !reg
+      // pseudo instructions
+      %84 = "riscv.mv"(%83) : (!reg) -> !reg
+      %85 = "riscv.not"(%83) : (!reg) -> !reg
+      %86 = "riscv.neg"(%83) : (!reg) -> !reg
+      %87 = "riscv.negw"(%83) : (!reg) -> !reg
+      %88 = "riscv.sextw"(%83) : (!reg) -> !reg
+      %89 = "riscv.zextb"(%83) : (!reg) -> !reg
+      %90 = "riscv.zextw"(%83) : (!reg) -> !reg
+      %91 = "riscv.seqz"(%83) : (!reg) -> !reg
+      %92 = "riscv.snez"(%83) : (!reg) -> !reg
+      %93 = "riscv.sltz"(%83) : (!reg) -> !reg
+      %94 = "riscv.sgtz"(%83) : (!reg) -> !reg
+      // Memory operations
+      %95 = "riscv.ld"(%0) <{"value" = 5 : i12}> : (!reg) -> !reg
+      "riscv.sd"(%0, %1) <{"value" = 5 : i12}> : (!reg, !reg) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK: "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "riscv.li"() <{"value" = 13 : i64}> : () -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.li"() <{"value" = 17 : i64}> : () -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.lui"() <{"value" = 13 : i20}> : () -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.auipc"(%{{.*}}) <{"value" = 13 : i20}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.addi"(%{{.*}}) <{"value" = 5 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.slti"(%{{.*}}) <{"value" = 7 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sltiu"(%{{.*}}) <{"value" = 11 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.andi"(%{{.*}}) <{"value" = 13 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.ori"(%{{.*}}) <{"value" = 17 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.xori"(%{{.*}}) <{"value" = 23 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.addiw"(%{{.*}}) <{"value" = 29 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.slli"(%{{.*}}) <{"value" = 31 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 33 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 37 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.slliw"(%{{.*}}) <{"value" = 13 : i5}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.srliw"(%{{.*}}) <{"value" = 17 : i5}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 19 : i5}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.slliuw"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.roriw"(%{{.*}}) <{"value" = 13 : i5}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.rori"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.bclri"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.bexti"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.binvi"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.bseti"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sextb"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sexth"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.zexth"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.clz"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.clzw"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.ctz"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.ctzw"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.cpop"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.cpopw"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.slt"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sltu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sra"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.and"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.addw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.subw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sllw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.srlw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sraw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.rem"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.remu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.remw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.remuw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.mulh"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.mulhu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.mulhsu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.mulw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.div"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.divw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.divu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.divuw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sh1adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sh2adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sh3adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sh1add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sh2add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sh3add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.andn"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.orn"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.xnor"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.max"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.maxu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.min"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.minu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.rol"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.ror"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.rolw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.rorw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.bclr"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.bext"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.binv"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.bset"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.pack"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.packh"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.packw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.mv"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.not"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.neg"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.negw"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sextw"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.zextb"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.zextw"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.seqz"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.snez"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.sltz"(%{{.*}}) : (!reg) -> !reg 
-// CHECK-NEXT:     %{{.*}} = "riscv.sgtz"(%{{.*}}) : (!reg) -> !reg
-// CHECK-NEXT:     %{{.*}} = "riscv.ld"(%{{.*}}) <{"value" = 5 : i12}> : (!reg) -> !reg
-// CHECK-NEXT:     "riscv.sd"(%{{.*}}, %{{.*}}) <{"value" = 5 : i12}> : (!reg, !reg) -> ()
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "riscv.li"() <{"value" = 13 : i64}> : () -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.li"() <{"value" = 17 : i64}> : () -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.lui"() <{"value" = 13 : i20}> : () -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.auipc"(%{{.*}}) <{"value" = 13 : i20}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.addi"(%{{.*}}) <{"value" = 5 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.slti"(%{{.*}}) <{"value" = 7 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sltiu"(%{{.*}}) <{"value" = 11 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.andi"(%{{.*}}) <{"value" = 13 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.ori"(%{{.*}}) <{"value" = 17 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.xori"(%{{.*}}) <{"value" = 23 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.addiw"(%{{.*}}) <{"value" = 29 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.slli"(%{{.*}}) <{"value" = 31 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 33 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 37 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.slliw"(%{{.*}}) <{"value" = 13 : i5}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.srliw"(%{{.*}}) <{"value" = 17 : i5}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 19 : i5}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.slliuw"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.roriw"(%{{.*}}) <{"value" = 13 : i5}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.rori"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.bclri"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.bexti"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.binvi"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.bseti"(%{{.*}}) <{"value" = 13 : i6}> : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sextb"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sexth"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.zexth"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.clz"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.clzw"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.ctz"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.ctzw"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.cpop"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.cpopw"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.slt"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sltu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sra"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.and"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.addw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.subw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sllw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.srlw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sraw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.rem"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.remu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.remw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.remuw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.mulh"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.mulhu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.mulhsu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.mulw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.div"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.divw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.divu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.divuw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sh1adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sh2adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sh3adduw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sh1add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sh2add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sh3add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.andn"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.orn"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.xnor"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.max"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.maxu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.min"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.minu"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.rol"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.ror"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.rolw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.rorw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.bclr"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.bext"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.binv"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.bset"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.pack"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.packh"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.packw"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.mv"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.not"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.neg"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.negw"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sextw"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.zextb"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.zextw"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.seqz"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.snez"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.sltz"(%{{.*}}) : (!reg) -> !reg 
+// CHECK-NEXT:         %{{.*}} = "riscv.sgtz"(%{{.*}}) : (!reg) -> !reg
+// CHECK-NEXT:         %{{.*}} = "riscv.ld"(%{{.*}}) <{"value" = 5 : i12}> : (!reg) -> !reg
+// CHECK-NEXT:         "riscv.sd"(%{{.*}}, %{{.*}}) <{"value" = 5 : i12}> : (!reg, !reg) -> ()
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -599,4 +599,40 @@ partial def parseOptionalBlock (ip : BlockInsertPoint) : MlirParserM (Option Blo
 
 end
 
+/--
+  Recursively walk the linked list of operations in a block and validate
+  that top-level operations do not have operands or results
+  (i.e., that they are definitions such as func.func, llvm.func, not instructions).
+-/
+partial def validateBodyOps (ctx : IRContext OpCode) : Option OperationPtr → MlirParserM Unit
+  | none => return ()
+  | some op => do
+    if op.getNumResults! ctx > 0 || op.getNumOperands! ctx > 0 then
+      throwString "top-level operation with operands or results is not allowed; only function and module definitions may appear at the module level"
+    validateBodyOps ctx ((op.get! ctx).next)
+
+/--
+  Validate that the body of a builtin.module only contains definition operations
+  (operations without operands or results at the operation level).
+  Requires that `moduleOp` is actually a builtin.module operation.
+-/
+def validateModuleBody (moduleOp : OperationPtr) : MlirParserM Unit := do
+  let wfCtx ← getContext
+  let ctx := wfCtx.raw
+  let opType := moduleOp.getOpType! ctx
+  if opType != .builtin .module then
+    throwString "top-level operation must be a builtin.module"
+  let region := moduleOp.getRegion! ctx 0
+  let some firstBlock := (region.get! ctx).firstBlock | return ()
+  validateBodyOps ctx (firstBlock.get! ctx).firstOp
+
+/--
+  Parse a complete MLIR module (builtin.module) and validate its body, ensuring
+  that only definition operations appear at the top level.
+-/
+def parseModule : MlirParserM OperationPtr := do
+  let op ← parseOp none
+  validateModuleBody op
+  return op
+
 end Veir.Parser

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -22,11 +22,11 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode Ã
     | throw "Failed to create IR context"
   match ParserState.fromInput fileContent with
   | .ok parser =>
-    match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+    match (parseModule).run (MlirParserState.fromContext ctx) parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error errMsg =>
-      throw s!"Error parsing operation: {errMsg}"
+      throw s!"Error parsing module: {errMsg}"
   | .error errMsg =>
     throw s!"Error reading file: {errMsg}"
 

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -93,7 +93,7 @@ def parseOperation (filename : Option String) : ExceptT String IO (WfIRContext O
 
   match ParserState.fromInput fileContent with
   | .ok parser =>
-    match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+    match (parseModule).run (MlirParserState.fromContext ctx) parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error err =>


### PR DESCRIPTION
Fixes #636.

~~I haven't manually reviewed the test case changes, they're coded by DeepSeek.~~ All tests have been updated by hand, AI was unwieldy for this type of mostly but not always copy-and-paste tasks.