### PR TITLE
Add support for LLVM array type

### DIFF
--- a/Test/LLVM/getelementptr.mlir
+++ b/Test/LLVM/getelementptr.mlir
@@ -15,10 +15,10 @@
       %g2 = "llvm.getelementptr"(%ptr, %i, %j) <{elem_type = !llvm.array<10 x i8>, rawConstantIndices = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
 
       // 3 dynamic indices: ptr[i][j][k]
-      %g3 = "llvm.getelementptr"(%ptr, %i, %j, %k) <{elem_type = !llvm.array<10 x array<10 x i8>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+      %g3 = "llvm.getelementptr"(%ptr, %i, %j, %k) <{elem_type = !llvm.array<10 x !llvm.array<10 x i8>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
 
       // 4 dynamic indices: ptr[i][j][k][l]
-      %g4 = "llvm.getelementptr"(%ptr, %i, %j, %k, %l) <{elem_type = !llvm.array<10 x array<10 x array<10 x i8>>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64, i64) -> !llvm.ptr
+      %g4 = "llvm.getelementptr"(%ptr, %i, %j, %k, %l) <{elem_type = !llvm.array<10 x !llvm.array<10 x !llvm.array<10 x i8>>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64, i64) -> !llvm.ptr
 
       // 2 dynamic indices with an interleaved constant index: ptr[i][0][j]
       %g5 = "llvm.getelementptr"(%ptr, %i, %j) <{elem_type = !llvm.array<10 x i8>, rawConstantIndices = array<i32: -2147483648, 0, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
@@ -33,8 +33,8 @@
 // CHECK-NEXT:        ^{{.*}}(%{{.*}} : !llvm.ptr, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64):
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = i8, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x i8>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x array<10 x i8>>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x array<10 x array<10 x i8>>>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64, i64) -> !llvm.ptr
+// CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x !llvm.array<10 x i8>>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+// CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x !llvm.array<10 x !llvm.array<10 x i8>>>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64, i64) -> !llvm.ptr
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x i8>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
 // CHECK-NEXT:          "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -182,6 +182,10 @@ macro "#assert " e:term : command =>
 /-! ## LLVM Pointer type -/
 #assert expectSuccessType "!llvm.ptr" (LLVM.PointerType.mk)
 
+/-! ## LLVM Array type -/
+#assert expectSuccessType "!llvm.array<2 x i32>" (LLVM.ArrayType.mk 2 $ IntegerType.mk 32)
+#assert expectSuccessAttr "!llvm.array<2 x !llvm.array<3x i64>>" (LLVM.ArrayType.mk 2 $ LLVM.ArrayType.mk 3 $ IntegerType.mk 64)
+
 /-! ## LLVM Function type -/
 #assert expectSuccessType "!llvm.func<i32 (i32)>"
   ⟨.llvmFunctionType (FunctionType.mk

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -221,6 +221,14 @@ structure DictionaryAttr where
 deriving Inhabited, Repr, Hashable
 
 /--
+  An attribute representing a fixed-sized array type
+-/
+structure LLVM.ArrayType where
+  size : Nat
+  type : Attribute
+deriving Repr, Hashable
+
+/--
   A data structure that represents compile-time information in the IR.
   Attributes are used either as type annotations for SSA values, or
   as extra information stored in operations.
@@ -258,6 +266,8 @@ inductive Attribute
 | modArithType (type : ModArithType)
 /-- LLVM pointer type -/
 | llvmPointerType (type : LLVM.PointerType)
+/-- LLVM array type -/
+| llvmArrayType (type : LLVM.ArrayType)
 /-- LLVM function type -/
 | llvmFunctionType (type : FunctionType)
 /-- Cuda Tile pointer type -/
@@ -267,6 +277,9 @@ inductive Attribute
 deriving Inhabited, Repr, Hashable
 
 end
+
+instance : Inhabited LLVM.ArrayType where
+  default := { size := 0, type := .llvmPointerType .mk }
 
 def ArrayAttr.empty : ArrayAttr := { value := #[] }
 
@@ -294,6 +307,10 @@ theorem ArrayAttr.sizeOf_elems_value {aa : ArrayAttr} (hx : x ∈ aa.value) :
 theorem DictionaryAttr.sizeOf_elems_entries {da : DictionaryAttr} (hx : x ∈ da.entries) :
     sizeOf x < sizeOf da := by
   grind [Array.sizeOf_lt_of_mem hx, cases DictionaryAttr]
+
+theorem LLVM.ArrayType.sizeOf_elems_type {t : ArrayType} :
+    sizeOf t.type < sizeOf t := by
+  grind [cases ArrayType]
 
 /-!
   ## DecidableEq instances
@@ -327,6 +344,22 @@ def ArrayAttr.decEq (arr1 arr2 : ArrayAttr) : Decidable (arr1 = arr2) :=
 termination_by sizeOf arr1
 decreasing_by
   have := @ArrayAttr.sizeOf_elems_value
+  grind
+
+def LLVM.ArrayType.decEq (arr1 arr2 : LLVM.ArrayType) : Decidable (arr1 = arr2) :=
+  let size1 := arr1.size
+  let size2 := arr2.size
+  let type1 := arr1.type
+  let type2 := arr2.type
+  match Int.instDecidableEq size1 size2 with
+  | isTrue _ =>
+    match Attribute.decEq type1 type2 with
+    | isTrue _ => isTrue (by grind [cases LLVM.ArrayType])
+    | isFalse _ => isFalse (by grind)
+  | isFalse _ => isFalse (by grind)
+termination_by sizeOf arr1
+decreasing_by
+  have := @LLVM.ArrayType.sizeOf_elems_type
   grind
 
 def DictionaryAttr.decEq (dict1 dict2 : DictionaryAttr) : Decidable (dict1 = dict2) :=
@@ -401,6 +434,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
       | isFalse hEq => isFalse (by grind))
   case llvmPointerType.llvmPointerType type1 type2 =>
     exact (isTrue (by grind))
+  case llvmArrayType.llvmArrayType type1 type2 =>
+    exact (match LLVM.ArrayType.decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case llvmFunctionType.llvmFunctionType type1 type2 =>
     exact (match FunctionType.decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
@@ -571,6 +608,12 @@ decreasing_by
   · apply FunctionType.sizeOf_elems_outputs
     grind
 
+def LLVM.ArrayType.toString (type : LLVM.ArrayType) : String :=
+  s!"!llvm.array<{type.size} x {Attribute.toString type.type}>"
+termination_by sizeOf type
+decreasing_by
+  apply LLVM.ArrayType.sizeOf_elems_type
+
 /--
   Convert an attribute to a string representation.
 -/
@@ -592,6 +635,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .functionType type => type.toString
   | .modArithType type => ToString.toString type
   | .llvmPointerType type => ToString.toString type
+  | .llvmArrayType type => type.toString
   | .llvmFunctionType type => type.toLLVMString
   | .cudaTilePointerType type => ToString.toString type
   | .hwModuleType type => ToString.toString type
@@ -610,6 +654,9 @@ instance : ToString ArrayAttr where
 
 instance : ToString DictionaryAttr where
   toString := DictionaryAttr.toString
+
+instance : ToString LLVM.ArrayType where
+  toString := LLVM.ArrayType.toString
 
 /-!
   ## Coercion instances to Attribute
@@ -658,6 +705,9 @@ instance : Coe ModArithType Attribute where
 instance : Coe LLVM.PointerType Attribute where
   coe type := .llvmPointerType type
 
+instance : Coe LLVM.ArrayType Attribute where
+  coe type := .llvmArrayType type
+
 instance : Coe CudaTile.PointerType Attribute where
   coe type := .cudaTilePointerType type
 
@@ -695,6 +745,7 @@ def isType (attr : Attribute) : Bool :=
   | .registerType _ => true
   | .registerAttr _ => true
   | .llvmPointerType _ => true
+  | .llvmArrayType _ => true
   | .llvmFunctionType _ => true
   | .cudaTilePointerType _ => true
   | .hwModuleType _ => true
@@ -767,6 +818,9 @@ instance : Coe RegisterType TypeAttr where
 
 instance : Coe LLVM.PointerType TypeAttr where
   coe type := ⟨.llvmPointerType type, by rfl⟩
+
+instance : Coe LLVM.ArrayType TypeAttr where
+  coe type := ⟨.llvmArrayType type, by rfl⟩
 
 instance : Coe CudaTile.PointerType TypeAttr where
   coe type := ⟨.cudaTilePointerType type, by rfl⟩

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -382,6 +382,24 @@ def parseOptionalHWModuleType : AttrParserM (Option HW.ModuleType) := do
 mutual
 
 /--
+  Parse an LLVM array type, if present.
+  Its syntax is `!llvm.array<size x type>`.
+-/
+partial def parseOptionalLLVMArrayType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "llvm.array".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let size ← parseInteger false false
+  parseKeyword "x".toByteArray
+  let ty ← parseType
+  parsePunctuation ">"
+  return some (LLVM.ArrayType.mk size.toNat ty)
+
+/--
   Parse a function type, if present.
   A function type has the form `(input1, input2, ...) -> (output1, output2, ...)` or
   `(input1, input2, ...) -> output`.
@@ -448,6 +466,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some modArithType
   if let some llvmPointerType := ← parseOptionalLLVMPointerType then
     return some llvmPointerType
+  if let some llvmArrayType := ← parseOptionalLLVMArrayType then
+    return some llvmArrayType
   if let some llvmFunctionType ← parseOptionalLLVMFunctionType then
     return some llvmFunctionType
   if let some cudaTilePointerType := ← parseOptionalCudaTilePointerType then


### PR DESCRIPTION
It consists of a size and a type.

Because of how attributes are mutually defined,
this inner type is an `Attribute`.
