### PR TITLE
Add better error messages for values

### DIFF
--- a/Test/Parsing/already-defined.mlir
+++ b/Test/Parsing/already-defined.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a = "test.test"() <{first}> : () -> i32
+  %a = "test.test"() <{second}> : () -> i32
+}) : () -> ()
+
+// CHECK:already-defined.mlir:5:3: error: value %a has already been defined
+// CHECK-NEXT:  %a = "test.test"() <{second}> : () -> i32
+// CHECK-NEXT:  ^
+// CHECK-NEXT:already-defined.mlir:4:3: note: previously defined here
+// CHECK-NEXT:  %a = "test.test"() <{first}> : () -> i32
+// CHECK-NEXT:  ^

--- a/Test/Parsing/invalid-result-index.mlir
+++ b/Test/Parsing/invalid-result-index.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a:2 = "test.test"() : () -> (i32, i64)
+  %b = "test.test"(%a#2) : (i32) -> i1
+}) : () -> ()
+
+// CHECK:invalid-result-index.mlir:5:20: error: invalid result index 2 for %a
+// CHECK-NEXT:  %b = "test.test"(%a#2) : (i32) -> i1
+// CHECK-NEXT:                   ^
+// CHECK-NEXT:invalid-result-index.mlir:4:3: note: value defined here
+// CHECK-NEXT:  %a:2 = "test.test"() : () -> (i32, i64)
+// CHECK-NEXT:  ^

--- a/Test/Parsing/type-mismatch.mlir
+++ b/Test/Parsing/type-mismatch.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a:2 = "test.test"() : () -> (i32, i64)
+  %b = "test.test"(%a#1) : (i32) -> i1
+}) : () -> ()
+
+// CHECK:type-mismatch.mlir:5:20: error: type mismatch for value %a#1: expected i32, got i64
+// CHECK-NEXT:  %b = "test.test"(%a#1) : (i32) -> i1
+// CHECK-NEXT:                   ^
+// CHECK-NEXT:type-mismatch.mlir:4:3: note: value defined here
+// CHECK-NEXT:  %a:2 = "test.test"() : () -> (i32, i64)
+// CHECK-NEXT:  ^

--- a/UnitTest/Lexer.lean
+++ b/UnitTest/Lexer.lean
@@ -1,9 +1,10 @@
 import Veir.Parser.Lexer
 
 open Veir.Parser.Lexer
+open Veir.Parser
 
 def lexResult (s : String) : String :=
-  let res := lex (LexerState.mk (s.toByteArray) 0)
+  let res := lex (LexerState.mk (s.toByteArray) (Location.mk 0))
   match res with
   | .ok (tok, _) =>
     let value := String.fromUTF8! (tok.slice.of s.toByteArray)

--- a/UnitTest/Parser.lean
+++ b/UnitTest/Parser.lean
@@ -39,14 +39,14 @@ section throwAt
 foo bar
     ^ -/
 #guard_msgs (whitespace := exact) in
-#eval! testParser "foo bar" (throwAt 4 "oops" : EStateM ParserError ParserState Unit)
+#eval! testParser "foo bar" (throwAt (Location.mk 4) "oops" : EStateM ParserError ParserState Unit)
 
 -- throwAt uses the given position even after consuming a token (ignores current position).
 /-- info: <test>:1:1: error: oops
 foo bar
 ^ -/
 #guard_msgs (whitespace := exact) in
-#eval! testParser "foo bar" (do let _ ← consumeToken; throwAt 0 "oops" : EStateM ParserError ParserState Unit)
+#eval! testParser "foo bar" (do let _ ← consumeToken; throwAt (Location.mk 0) "oops" : EStateM ParserError ParserState Unit)
 
 end throwAt
 

--- a/UnitTest/ParserError.lean
+++ b/UnitTest/ParserError.lean
@@ -1,22 +1,23 @@
 module
 
 import all Veir.Parser.ParserError
+public meta import Veir.Parser.Location
 
 open Veir.Parser
 open Veir.Parser.ParserError
 
 /-- 1-based line:col for a byte offset into `s`. -/
 def test_byteOffsetToLineCol (s : String) (o : Nat) : String :=
-  let (line, col) := byteOffsetToLineCol s.toByteArray o
+  let (line, col) := byteOffsetToLineCol s.toByteArray (Location.mk o)
   s!"{line}:{col}"
 
 /-- The source line containing byte offset `o` of `s`. -/
 def test_lineContaining (s : String) (o : Nat) : Option String :=
-  lineContaining s.toByteArray o
+  lineContaining s.toByteArray (Location.mk o)
 
 def diag (filename s : String) (o : Option Nat) (msg : String)
     (notes : List (Nat × String)) : IO Unit :=
-  let e : ParserError := { msg, pos := o, notes := notes.map fun (pos, m) => { pos, msg := m } }
+  let e : ParserError := { msg, pos := o.map Location.mk, notes := notes.map fun (pos, m) => ParserErrorNote.mk m (Location.mk pos) }
   IO.print (e.format filename s.toByteArray)
 
 /-! ## `byteOffsetToLineCol` -/
@@ -76,5 +77,5 @@ hij
 #eval! do
   -- inject a 0xFF byte that makes the line non-UTF-8
   let src := "abc".toByteArray ++ ByteArray.mk #[0xFF] ++ "def".toByteArray
-  let e : ParserError := { msg := "bad byte", pos := some 0 }
+  let e : ParserError := { msg := "bad byte", pos := some (Location.mk 0) }
   IO.print (e.format "test.mlir" src)

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -41,7 +41,7 @@ def parseOptionalIntegerType : AttrParserM (Option IntegerType) := do
   | { kind := .bareIdent, slice := slice } =>
     if slice.size < 2 then
       return none
-    if (← (getThe ParserState)).input.getD slice.start 0 == 'i'.toUInt8 then
+    if (← (getThe ParserState)).input.getD slice.start.byteOffset 0 == 'i'.toUInt8 then
       let bitwidthSlice : Slice := {start := slice.start + 1, stop := slice.stop}
       let identifier := bitwidthSlice.of (← (getThe ParserState)).input
       let some bitwidth := (String.fromUTF8? identifier).bind String.toNat? | return none
@@ -59,7 +59,7 @@ def parseOptionalFloatType : AttrParserM (Option FloatType) := do
   | { kind := .bareIdent, slice := slice } =>
     if slice.size < 2 then
       return none
-    if (← (getThe ParserState)).input.getD slice.start 0 == 'f'.toUInt8 then
+    if (← (getThe ParserState)).input.getD slice.start.byteOffset 0 == 'f'.toUInt8 then
       let bitwidthSlice : Slice := {start := slice.start + 1, stop := slice.stop}
       let identifier := bitwidthSlice.of (← (getThe ParserState)).input
       let some bitwidth := (String.fromUTF8? identifier).bind String.toNat? | return none
@@ -183,12 +183,13 @@ def matchingBracket! (kind : TokenKind) : TokenKind :=
   The opening token is expected to have already been consumed when this function is called.
   The ending token (by default `>`) is not consumed by this function.
 -/
-private def parseUnregisteredAttrBody (endToken : TokenKind := .greater) (startPos : Option Nat := none) : AttrParserM String := do
+private def parseUnregisteredAttrBody (endToken : TokenKind := .greater)
+    (startPos : Option Parser.Location := none) : AttrParserM String := do
   let startPos := startPos.getD (← peekToken).slice.start
 
   /- This stack corresponds to the brackets that are still open. -/
   let mut bracketStack : Array TokenKind := #[]
-  let mut endPos : Nat := 0
+  let mut endPos : Parser.Location := { byteOffset := 0 }
 
   /- Read tokens one by one until we close the last `>` -/
   repeat

--- a/Veir/Parser/Lexer.lean
+++ b/Veir/Parser/Lexer.lean
@@ -12,15 +12,15 @@ namespace Lexer
   This class should be used to avoid unnecessary copies of ByteArrays.
 -/
 structure Slice where
-  start : Nat
-  stop : Nat
+  start : Location
+  stop : Location
 deriving Inhabited, Repr
 
 def Slice.size (slice : Slice) : Nat :=
-  slice.stop - slice.start
+  slice.stop.byteOffset - slice.start.byteOffset
 
 def Slice.of (slice : Slice) (array : ByteArray) : ByteArray :=
-  array.extract slice.start slice.stop
+  array.extract slice.start.byteOffset slice.stop.byteOffset
 
 /--
   Token kinds that can be produced by the lexer.
@@ -188,18 +188,18 @@ structure LexerState where
   input : ByteArray
 
   /-- The current position in the input file. -/
-  pos : Nat
+  pos : Location
 deriving Inhabited, Repr
 
 /-- Checks if the end of the file has been reached. -/
 def LexerState.isEof (state : LexerState) : Bool :=
-  state.pos >= state.input.size
+  state.pos.byteOffset >= state.input.size
 
 /--
   Forms a token from the current lexer state, given the token start position and kind.
   The end position is taken from the current lexer state.
 -/
-def LexerState.mkToken (state : LexerState) (kind : TokenKind) (startPos : Nat) : Token :=
+def LexerState.mkToken (state : LexerState) (kind : TokenKind) (startPos : Location) : Token :=
   let slice := Slice.mk startPos state.pos
   Token.mk kind slice
 
@@ -209,8 +209,8 @@ def LexerState.mkToken (state : LexerState) (kind : TokenKind) (startPos : Nat) 
 
   The first character is expected to have already been consumed at position `tokStart`.
 -/
-def lexBareIdentifier (state : LexerState) (tokStart : Nat) : Token × LexerState := Id.run do
-  let mut pos := state.pos
+def lexBareIdentifier (state : LexerState) (tokStart : Location) : Token × LexerState := Id.run do
+  let mut pos := state.pos.byteOffset
   let input := state.input
   while h: pos < input.size do
     let c := input[pos]
@@ -218,19 +218,19 @@ def lexBareIdentifier (state : LexerState) (tokStart : Nat) : Token × LexerStat
       pos := pos + 1
     else
       break
-  let newState := { state with pos := pos }
+  let newState := { state with pos := { byteOffset := pos } }
   (newState.mkToken .bareIdent tokStart, newState)
 
 def skipComments (state : LexerState) : LexerState :=
   if h: state.isEof then
     state
   else
-    let c := state.input[state.pos]'(by grind [LexerState.isEof])
+    let c := state.input[state.pos.byteOffset]'(by grind [LexerState.isEof])
     if c == '\n'.toUInt8 || c == '\r'.toUInt8 then
       {state with pos := state.pos + 1}
     else
       skipComments { state with pos := state.pos + 1 }
-termination_by state.input.size - state.pos
+termination_by state.input.size - state.pos.byteOffset
 decreasing_by
   grind [LexerState.isEof]
 
@@ -241,24 +241,24 @@ decreasing_by
 
   The opening `"` is expected to have already been consumed at position `tokStart`.
 -/
-def lexStringLiteral (state : LexerState) (tokStart : Nat) : Except ParserError (Token × LexerState) := do
+def lexStringLiteral (state : LexerState) (tokStart : Location) : Except ParserError (Token × LexerState) := do
   if h: state.isEof then
     .error { msg := "expected '\"' in string literal" }
   else
-    let c := state.input[state.pos]'(by grind [LexerState.isEof])
+    let c := state.input[state.pos.byteOffset]'(by grind [LexerState.isEof])
     if c == '"'.toUInt8 then
       let newState := { state with pos := state.pos + 1 }
       return (newState.mkToken .stringLit tokStart, newState)
     else if c == '\n'.toUInt8 then
       .error { msg := "expected '\"' in string literal" }
     else if c == '\\'.toUInt8 then
-      if h: state.pos + 1 < state.input.size then
-        let c1 := state.input[state.pos + 1]
+      if h: state.pos.byteOffset + 1 < state.input.size then
+        let c1 := state.input[state.pos.byteOffset + 1]
         if c1 == '"'.toUInt8 || c1 == '\\'.toUInt8 || c1 == 'n'.toUInt8 || c1 == 't'.toUInt8 then
           let nextState := { state with pos := state.pos + 2 }
           lexStringLiteral nextState tokStart
-        else if h: state.pos + 2 < state.input.size then
-          let c2 := state.input[state.pos + 2]
+        else if h: state.pos.byteOffset + 2 < state.input.size then
+          let c2 := state.input[state.pos.byteOffset + 2]
           if c1.isHexDigit && c2.isHexDigit then
             let nextState := { state with pos := state.pos + 3 }
             lexStringLiteral nextState tokStart
@@ -270,7 +270,7 @@ def lexStringLiteral (state : LexerState) (tokStart : Nat) : Except ParserError 
         .error { msg := "unknown escape in string literal" }
     else
       lexStringLiteral { state with pos := state.pos + 1 } tokStart
-termination_by state.input.size - state.pos
+termination_by state.input.size - state.pos.byteOffset
 decreasing_by
   all_goals grind [LexerState.isEof]
 
@@ -280,11 +280,11 @@ decreasing_by
 
   The first character `@` is expected to have already been parsed.
 -/
-def lexAtIdentifier (state : LexerState) (tokStart : Nat) : Except ParserError (Token × LexerState) := do
+def lexAtIdentifier (state : LexerState) (tokStart : Location) : Except ParserError (Token × LexerState) := do
   if h: state.isEof then
     .error { msg := "expected identifier or string literal after '@'" }
   else
-    let c := state.input[state.pos]'(by grind [LexerState.isEof])
+    let c := state.input[state.pos.byteOffset]'(by grind [LexerState.isEof])
     if UInt8.isAlphaOrUnderscore c then
       let (token, state) := lexBareIdentifier state tokStart
       return (LexerState.mkToken state .atIdent tokStart, state)
@@ -307,7 +307,7 @@ def lexAtIdentifier (state : LexerState) (tokStart : Nat) : Except ParserError (
   suffix-id     ::= digit+ | (letter|id-punct) (letter|id-punct|digit)*
   id-punct      ::= `$` | `.` | `_` | `-`
 -/
-def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
+def lexPrefixedIdentifier (state : LexerState) (tokStart : Location)
     (kind : TokenKind) : Except ParserError (Token × LexerState) := do
   let errorString := match kind with
     | .hashIdent => "invalid attribute name"
@@ -319,9 +319,9 @@ def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
   if h: state.isEof then
     .error { msg := errorString }
   else
-    let c := state.input[state.pos]'(by grind [LexerState.isEof])
+    let c := state.input[state.pos.byteOffset]'(by grind [LexerState.isEof])
     if UInt8.isDigit c then
-      let mut pos := state.pos + 1
+      let mut pos := state.pos.byteOffset + 1
       let input := state.input
       while h: pos < input.size do
         let c := input[pos]
@@ -329,10 +329,10 @@ def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
           pos := pos + 1
         else
           break
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken kind tokStart, newState)
     else if UInt8.isAlphaOrUnderscore c || c == '$'.toUInt8 || c == '.'.toUInt8 || c == '-'.toUInt8 then
-      let mut pos := state.pos + 1
+      let mut pos := state.pos.byteOffset + 1
       let input := state.input
       while h: pos < input.size do
         let c := input[pos]
@@ -340,7 +340,7 @@ def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
           pos := pos + 1
         else
           break
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken kind tokStart, newState)
     else
       .error { msg := errorString }
@@ -351,8 +351,8 @@ def lexPrefixedIdentifier (state : LexerState) (tokStart : Nat)
   integer-literal ::= digit+ | `0x` hex_digit+
   float-literal ::= [0-9]+[.][0-9]*([eE][-+]?[0-9]+)?
 -/
-def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Nat) : Token × LexerState := Id.run do
-  let mut pos := state.pos
+def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Location) : Token × LexerState := Id.run do
+  let mut pos := state.pos.byteOffset
   let input := state.input
 
   if h: state.isEof then
@@ -371,7 +371,7 @@ def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Nat) : Token 
           pos := pos + 1
         else
           break
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken .intLit tokStart, newState)
 
     -- Handle the normal decimal case, with the starting digits
@@ -384,7 +384,7 @@ def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Nat) : Token 
 
     -- Check for fractional part
     if input.getD pos 0 != '.'.toUInt8 then
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken .intLit tokStart, newState)
     pos := pos + 1
 
@@ -398,7 +398,7 @@ def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Nat) : Token 
 
     -- Check for exponent part
     if input.getD pos 0 != 'e'.toUInt8 && input.getD pos 0 != 'E'.toUInt8 then
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken .floatLit tokStart, newState)
     pos := pos + 1
 
@@ -412,10 +412,10 @@ def lexNumber (state : LexerState) (firstChar : UInt8) (tokStart : Nat) : Token 
           pos := pos + 1
         else
           break
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken .floatLit tokStart, newState)
     else
-      let newState := { state with pos := pos }
+      let newState := { state with pos := { byteOffset := pos } }
       return (newState.mkToken .floatLit tokStart, newState)
 
 
@@ -428,7 +428,7 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
   if h: state.isEof then
     return (state.mkToken .eof state.pos, state)
   else
-    let c := state.input[state.pos]'(by grind [LexerState.isEof])
+    let c := state.input[state.pos.byteOffset]'(by grind [LexerState.isEof])
     -- Skip whitespaces
     if c == ' '.toUInt8 || c == '\n'.toUInt8 || c == '\t'.toUInt8 || c == '\r'.toUInt8 || c == 0 then
       lex { state with pos := state.pos + 1 }
@@ -481,9 +481,9 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
       return (newState.mkToken .verticalBar tokStart, newState)
     -- Parse `...`
     else if c == '.'.toUInt8 then
-      if h: state.pos + 2 < state.input.size then
-        let c1 := state.input[state.pos + 1]
-        let c2 := state.input[state.pos + 2]
+      if h: state.pos.byteOffset + 2 < state.input.size then
+        let c1 := state.input[state.pos.byteOffset + 1]
+        let c2 := state.input[state.pos.byteOffset + 2]
         if c1 == '.'.toUInt8 && c2 == '.'.toUInt8 then
           let newState := { state with pos := state.pos + 3 }
           return (newState.mkToken .ellipsis tokStart, newState)
@@ -493,8 +493,8 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
         .error { msg := "expected three consecutive '.' for an ellipsis" }
     -- Parse `-` or `->`
     else if c == '-'.toUInt8 then
-      if h: state.pos + 1 < state.input.size then
-        let c1 := state.input[state.pos + 1]
+      if h: state.pos.byteOffset + 1 < state.input.size then
+        let c1 := state.input[state.pos.byteOffset + 1]
         if c1 == '>'.toUInt8 then
           let newState := { state with pos := state.pos + 2 }
           return (newState.mkToken .arrow tokStart, newState)
@@ -506,9 +506,9 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
         return (newState.mkToken .minus tokStart, newState)
     -- Parse `{` and `{-#`
     else if c == '{'.toUInt8 then
-      if h: state.pos + 2 < state.input.size then
-        let c1 := state.input[state.pos + 1]
-        let c2 := state.input[state.pos + 2]
+      if h: state.pos.byteOffset + 2 < state.input.size then
+        let c1 := state.input[state.pos.byteOffset + 1]
+        let c2 := state.input[state.pos.byteOffset + 2]
         if c1 == '-'.toUInt8 && c2 == '#'.toUInt8 then
           let newState := { state with pos := state.pos + 3 }
           return (newState.mkToken .fileMetadataBegin tokStart, newState)
@@ -519,14 +519,14 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
         let newState := { state with pos := state.pos + 1 }
         return (newState.mkToken .lBrace tokStart, newState)
     -- Parse `#-}`
-    else if c == '#'.toUInt8 && state.pos + 2 < state.input.size
-        && state.input[state.pos + 1]! == '-'.toUInt8 && state.input[state.pos + 2]! == '}'.toUInt8 then
+    else if c == '#'.toUInt8 && state.pos.byteOffset + 2 < state.input.size
+        && state.input[state.pos.byteOffset + 1]! == '-'.toUInt8 && state.input[state.pos.byteOffset + 2]! == '}'.toUInt8 then
       let newState := { state with pos := state.pos + 3 }
       return (newState.mkToken .fileMetadataEnd tokStart, newState)
     -- Parse `/` or a comment starting with `//`
     else if c == '/'.toUInt8 then
-      if h: state.pos + 1 < state.input.size then
-        let c1 := state.input[state.pos + 1]
+      if h: state.pos.byteOffset + 1 < state.input.size then
+        let c1 := state.input[state.pos.byteOffset + 1]
         if c1 == '/'.toUInt8 then
           lex (skipComments {state with pos := state.pos + 2 })
         else
@@ -558,7 +558,7 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
       let newState := { state with pos := state.pos + 1 }
       return lexNumber newState c tokStart
     else
-      .error { msg := s!"Unexpected character '{Char.ofUInt8 c}' at position {state.pos}" }
+      .error { msg := s!"Unexpected character '{Char.ofUInt8 c}' at position {state.pos.byteOffset}" }
 
 end Lexer
 

--- a/Veir/Parser/Location.lean
+++ b/Veir/Parser/Location.lean
@@ -1,0 +1,41 @@
+module
+
+/-
+  # Source locations in the parser.
+
+  A `Location` is a typed wrapper around a byte offset into the parser input.
+  Using a dedicated type instead of `Nat` prevents accidentally mixing
+  positions with sizes, counts, indices, or other numeric quantities.
+-/
+
+namespace Veir.Parser
+
+public section
+
+/-- A location into the parser input. -/
+structure Location where
+  /-- The byte offset in the parser input. -/
+  byteOffset : Nat
+deriving Inhabited, DecidableEq, Repr
+
+namespace Location
+
+instance : LT Location := ⟨fun a b => a.byteOffset < b.byteOffset⟩
+instance : LE Location := ⟨fun a b => a.byteOffset ≤ b.byteOffset⟩
+
+/-- Advance a location forward by `n` bytes. -/
+@[grind, expose]
+def advance (loc : Location) (n : Nat) : Location :=
+  { byteOffset := loc.byteOffset + n }
+
+/-- `loc + n` advances `loc` forward by `n` bytes. -/
+instance : HAdd Location Nat Location := ⟨Location.advance⟩
+
+@[grind =]
+theorem HAdd_eq_advance (loc : Location) (n : Nat) : loc + n = Location.advance loc n := rfl
+
+end Location
+
+end -- public section
+
+end Veir.Parser

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -23,8 +23,9 @@ variable {ctx : IRContext OpCode}
 structure MlirParserState where
   /-- The current IR context. -/
   ctx : WfIRContext OpCode
-  /-- The values that have been defined for a given name at that point in the parser. -/
-  values : Std.HashMap ByteArray (Array ValuePtr)
+  /-- The values that have been defined for a given name at that point in the parser,
+      along with the byte offset of where the value name token was parsed. -/
+  values : Std.HashMap ByteArray (Array ValuePtr × Location)
   /--
     The values defined in each currently active nested scope.
     Each scope sees all values defined in parent scopes (those that appear earlier in the array).
@@ -77,7 +78,7 @@ def getContext : MlirParserM (WfIRContext OpCode) := do
 /--
   Get the array of values associated with a previously parsed name.
 -/
-def getValues? (name : ByteArray) : MlirParserM (Option (Array ValuePtr)) := do
+def getValues? (name : ByteArray) : MlirParserM (Option (Array ValuePtr × Location)) := do
   return (← get).values[name]?
 
 /--
@@ -110,13 +111,14 @@ def inChildScope {α : Type} (m : MlirParserM α) : MlirParserM α := do
   Register an array of parsed values with the given name in the current scope.
   This is used to keep track of values that have been defined during parsing.
 -/
-def registerValueDefs (name : ByteArray) (values : Array ValuePtr) : MlirParserM Unit := do
-  if (← get).values.contains name then
-    throwString s!"value %{String.fromUTF8! name} has already been defined"
-
+def registerValueDefs (name : ByteArray) (pos : Location) (values : Array ValuePtr) : MlirParserM Unit := do
+  if let some (_, existingPos) := (← get).values[name]? then
+    let error := ParserError.mk s!"value %{String.fromUTF8! name} has already been defined" pos []
+    let error := error.addNote existingPos "previously defined here"
+    throw error
   modify fun s =>
     { s with
-      values := s.values.insert name values
+      values := s.values.insert name (values, pos)
       definitionsPerScope := s.definitionsPerScope.modify (s.definitionsPerScope.size - 1) (·.insert name)
     }
 
@@ -124,8 +126,8 @@ def registerValueDefs (name : ByteArray) (values : Array ValuePtr) : MlirParserM
   Register a single value with the given name in current scope.
   This is used to keep track of values that have been defined during parsing.
 -/
-def registerValueDef (name : ByteArray) (value : ValuePtr) : MlirParserM Unit :=
-  registerValueDefs name #[value]
+def registerValueDef (name : ByteArray) (pos : Location) (value : ValuePtr) : MlirParserM Unit :=
+  registerValueDefs name pos #[value]
 
 /--
   Set the current IR context.
@@ -225,26 +227,27 @@ def defineBlockUse (name : ByteArray) : MlirParserM BlockPtr := do
   Parse an operation result and the number of values it defines.
   This corresponds to the syntax `%name` and `%name:numberOfResults`.
 -/
-def parseOpResult : MlirParserM (ByteArray × Nat) := do
+def parseOpResult : MlirParserM (ByteArray × Nat × Location) := do
   let nameToken ← parseToken .percentIdent "operation result expected"
+  let tokenPos := nameToken.slice.start
   let slice := { nameToken.slice with start := nameToken.slice.start + 1 } -- skip % character
   let name := slice.of (← getInput)
 
   /- If the next token is ':', we parse the expected result count, otherwise we return the name. -/
   if !(← parseOptionalToken .colon).isSome then
-    return (name, 1)
+    return (name, 1, tokenPos)
 
   let count := (← parseInteger false false).toNat
   if count ≤ 1 then
     throwString "expected named operation to have at least 1 result"
 
-  return (name, count)
+  return (name, count, tokenPos)
 
 /--
   Parse the results before an operation definition,
   either as a list of values followed by '=', or nothing.
 -/
-def parseOpResults : MlirParserM (Array (ByteArray × Nat)) := do
+def parseOpResults : MlirParserM (Array (ByteArray × Nat × Location)) := do
   let .percentIdent := (← peekToken).kind | return #[]
   let results ← parseList parseOpResult
   parsePunctuation "=" "'=' expected after operation results"
@@ -262,6 +265,7 @@ def parseOpResults : MlirParserM (Array (ByteArray × Nat)) := do
 structure UnresolvedOperand where
   name : ByteArray
   index : Option Nat
+  pos : Location
 
 /--
   Get the name of an UnresolvedOperand as a String.
@@ -288,17 +292,18 @@ instance : ToString UnresolvedOperand where
 -/
 def parseOperand : MlirParserM UnresolvedOperand := do
   let nameToken ← parseToken .percentIdent "operand expected"
+  let tokenPos := nameToken.slice.start
   let name : ByteArray := { nameToken.slice with start := nameToken.slice.start + 1 }.of (← getInput)
 
   /- If no result number is specified, return without one. -/
   let some resultCount ← parseOptionalToken .hashIdent
-    | return UnresolvedOperand.mk name none
+    | return UnresolvedOperand.mk name none tokenPos
 
   /- Parse the result count as a Nat. -/
   let resultCount := { resultCount.slice with start := resultCount.slice.start + 1 }.of (← getInput) -- skip # character
   let some resultCount := String.fromUTF8? resultCount >>= String.toNat?
     | throwString "invalid SSA value result number"
-  return UnresolvedOperand.mk name resultCount
+  return UnresolvedOperand.mk name resultCount tokenPos
 
 /--
   Parse a list of operation operands delimited by parentheses.
@@ -327,12 +332,16 @@ def parseBlockOperands : MlirParserM (Array BlockPtr) := do
   Throw an error if the value is not defined or if the type does not match.
 -/
 def resolveOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) : MlirParserM ValuePtr := do
-  let some values := (← getValues? operand.name) | throwString s!"use of undefined value %{operand.nameString}"
-  let some value := values[operand.indexD]? | throwString s!"invalid result index {operand.indexD} for %{operand.nameString}"
+  let some (values, defPos) := (← getValues? operand.name)
+    | throwString s!"use of undefined value %{operand.nameString}"
+  let some value := values[operand.indexD]?
+    | throw (({ msg := s!"invalid result index {operand.indexD} for %{operand.nameString}",
+                pos := some operand.pos } : ParserError).addNote defPos "value defined here")
   let ⟨ctx, _⟩ ← getContext
   let parsedType := value.getType! ctx
   if parsedType ≠ expectedType then
-    throwString s!"type mismatch for value {operand}: expected {expectedType}, got {parsedType}"
+    throw (({ msg := s!"type mismatch for value {operand}: expected {expectedType}, got {parsedType}",
+              pos := some operand.pos } : ParserError).addNote defPos "value defined here")
   return value
 
 /--
@@ -369,14 +378,16 @@ def parseOperationType : MlirParserM (Array TypeAttr × Array TypeAttr) := do
 
 /--
   Parse an SSA value followed by a colon and a type, if present.
+  Also returns the location of the value definition.
 -/
-def parseTypedValue : MlirParserM (ByteArray × TypeAttr) := do
+def parseTypedValue : MlirParserM (ByteArray × TypeAttr × Location) := do
   let nameToken ← parseToken .percentIdent "value expected"
+  let tokenPos := nameToken.slice.start
   let slice := { nameToken.slice with start := nameToken.slice.start + 1 } -- skip % character
   let name := slice.of (← getInput)
   parsePunctuation ":"
   let ty ← parseType
-  return (name, ty)
+  return (name, ty, tokenPos)
 
 /--
   Parse the properties of an operation.
@@ -427,13 +438,13 @@ def parseOptionalBlockLabel (ip : BlockInsertPoint) : MlirParserM (Option BlockP
   let block ← defineBlock name ip
   /- Insert block arguments in the block. -/
   modifyContextM fun ctx => do
-    let argTypes := arguments.map (·.2)
+    let argTypes := arguments.map (·.2.1)
     let ⟨h_block_InBounds⟩ ← checkBlockInBounds block ctx.raw
     let ⟨h_block_NoArgs⟩ ← checkBlockHasNoArgs block ctx.raw
     pure (WfRewriter.setBlockArguments ctx block argTypes h_block_InBounds (by grind [BlockPtr.getArguments!.mem_iff_exists_index]))
   /- Register the block argument names in the parser state. -/
-  for ((argName, argType), index) in arguments.zipIdx do
-    registerValueDef argName (ValuePtr.blockArgument {block := block, index := index})
+  for ((argName, _argType, tokenPos), index) in arguments.zipIdx do
+    registerValueDef argName tokenPos (ValuePtr.blockArgument {block := block, index := index})
   return some block
 
 /--
@@ -482,7 +493,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   let (inputTypes, outputTypes) ← parseOperationType
 
   /- Results can have multiple parts so sum the sizes. -/
-  let numResults := results.foldl (· + ·.snd) 0
+  let numResults := results.foldl (· + ·.2.1) 0
 
   /- Check that the number of results matches with the operation type. -/
   if outputTypes.size ≠ numResults then
@@ -510,9 +521,9 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
 
   /- Register the values for each result name. -/
   let mut index := 0
-  for (name, count) in results do
+  for (name, count, tokenPos) in results do
     let values := .ofFn <| fun (i : Fin count) => op.getResult (index + i)
-    registerValueDefs name values
+    registerValueDefs name tokenPos values
     index := index + count
   return op
 

--- a/Veir/Parser/Parser.lean
+++ b/Veir/Parser/Parser.lean
@@ -19,7 +19,7 @@ structure ParserState where
   Create a new parser state at the beginning of the given input.
 -/
 def ParserState.fromInput (input : ByteArray) : Except ParserError ParserState := do
-  let lexerState := LexerState.mk input 0
+  let lexerState := LexerState.mk input { byteOffset := 0 }
   let (firstToken, lexerState) ← lex lexerState
   return ParserState.mk lexerState firstToken
 
@@ -27,7 +27,7 @@ def ParserState.fromInput (input : ByteArray) : Except ParserError ParserState :
   Get the current position in the input.
   This is the starting position of the current token.
 -/
-def ParserState.pos (state : ParserState) : Nat :=
+def ParserState.pos (state : ParserState) : Location :=
   state.currentToken.slice.start
 
 /--
@@ -47,7 +47,7 @@ variable [Monad M] [MonadExcept ParserError M] [MonadStateOf ParserState M]
   Get the current position in the input.
   This is the starting position of the current token.
 -/
-def getPos : M Nat := do
+def getPos : M Location := do
   return (←get).pos
 
 /--
@@ -60,7 +60,7 @@ def throwAtCurrentPos (msg : String) : M α := do
 /--
   Throw a `ParserError` whose location is the given byte offset.
 -/
-def throwAt (pos : Nat) (msg : String) : M α :=
+def throwAt (pos : Location) (msg : String) : M α :=
   throw { msg, pos := some pos }
 
 /--
@@ -246,7 +246,7 @@ private def processEscapes (input : ByteArray) (basePos : Nat) : Except ParserEr
       i := i + 1
       continue
     if i + 1 >= input.size then
-      throwAt (basePos + i) "unexpected end of string after '\\'"
+      throwAt { byteOffset := basePos + i } "unexpected end of string after '\\'"
     let next := input.getD (i + 1) 0
     if next == '\\'.toUInt8 then
       result := result.push '\\'.toUInt8
@@ -266,11 +266,11 @@ private def processEscapes (input : ByteArray) (basePos : Nat) : Except ParserEr
       continue
     -- Try \HH hex escape
     if i + 2 >= input.size then
-      throwAt (basePos + i) "unknown escape in string literal"
+      throwAt { byteOffset := basePos + i } "unknown escape in string literal"
     let hex1 := input.getD (i + 1) 0
     let hex2 := input.getD (i + 2) 0
     if !(hex1.isHexDigit && hex2.isHexDigit) then
-      throwAt (basePos + i) "unknown escape in string literal"
+      throwAt { byteOffset := basePos + i } "unknown escape in string literal"
     let high := if hex1 >= 'a'.toUInt8 then hex1 - 'a'.toUInt8 + 10
       else if hex1 >= 'A'.toUInt8 then hex1 - 'A'.toUInt8 + 10
       else hex1 - '0'.toUInt8
@@ -290,9 +290,9 @@ private def processEscapes (input : ByteArray) (basePos : Nat) : Except ParserEr
 def parseOptionalStringLiteral : M (Option String) := do
   match ← parseOptionalToken .stringLit with
   | some token =>
-    let slice : Slice := {start := token.slice.start + 1, stop := token.slice.stop - 1} -- remove quotes
+    let slice : Slice := {start := token.slice.start + 1, stop := { byteOffset := token.slice.stop.byteOffset - 1 }} -- remove quotes
     let raw := slice.of ((← get).input)
-    let processed ← ofExcept (processEscapes raw (token.slice.start + 1))
+    let processed ← ofExcept (processEscapes raw (token.slice.start.byteOffset + 1))
     match String.fromUTF8? processed with
     | some str => return some str
     | none => throwAt token.slice.start "internal error: failed converting string literal"

--- a/Veir/Parser/ParserError.lean
+++ b/Veir/Parser/ParserError.lean
@@ -8,6 +8,8 @@ module
   source line with a `^` pointing to the error column.
 -/
 
+public import Veir.Parser.Location
+
 namespace Veir.Parser
 
 public section
@@ -24,17 +26,17 @@ public section
 /-- A secondary diagnostic location attached to a `ParserError`. -/
 structure ParserErrorNote where
   msg : String
-  pos : Nat
+  pos : Location
 deriving Inhabited, DecidableEq, Repr
 
 /-- Structured parse error carrying an optional source location and notes. -/
 structure ParserError where
   msg : String
-  pos : Option Nat := none
+  pos : Option Location := none
   notes : List ParserErrorNote := []
 deriving Inhabited, DecidableEq, Repr
 
-def ParserError.addNote (e : ParserError) (pos : Nat) (msg : String) : ParserError :=
+def ParserError.addNote (e : ParserError) (pos : Location) (msg : String) : ParserError :=
   { e with notes := e.notes ++ [{ msg, pos }] }
 
 end
@@ -57,8 +59,8 @@ namespace ParserError
   The column is the byte distance from the start of the current line, plus one.
   This assumes that only ASCII characters are present.
 -/
-def byteOffsetToLineCol (input : ByteArray) (loc : Nat) : Nat × Nat := Id.run do
-  let offset := min loc input.size
+def byteOffsetToLineCol (input : ByteArray) (loc : Location) : Nat × Nat := Id.run do
+  let offset := min loc.byteOffset input.size
   let mut line := 1
   let mut lineStart := 0
   for i in [0:offset] do
@@ -72,8 +74,8 @@ def byteOffsetToLineCol (input : ByteArray) (loc : Nat) : Nat × Nat := Id.run d
   `\n` (or the start of input) up to the next `\n` (or end of input), decoded as
   UTF-8. Returns `none` if the bytes are not valid UTF-8.
 -/
-def lineContaining (input : ByteArray) (loc : Nat) : Option String := Id.run do
-  let offset := min loc input.size
+def lineContaining (input : ByteArray) (loc : Location) : Option String := Id.run do
+  let offset := min loc.byteOffset input.size
   let mut start := 0
   for i in [0:offset] do
     if input.get! i == '\n'.toUInt8 then
@@ -106,7 +108,7 @@ def lineContaining (input : ByteArray) (loc : Nat) : Option String := Id.run do
   When `loc` is `none`, the header uses `<unknown location>` and no source line
   is printed.
 -/
-def formatLabel (filename : String) (input : ByteArray) (severity : String) (loc : Option Nat)
+def formatLabel (filename : String) (input : ByteArray) (severity : String) (loc : Option Location)
     (msg : String) : String :=
   match loc with
   | none => s!"<unknown location>: {severity}: {msg}"


### PR DESCRIPTION
For this, we store value definition locations in the parser state.
We now get these errors:
```
already-defined.mlir:5:3: error: value %a has already been defined
  %a = "test.test"() <{second}> : () -> i32
  ^
already-defined.mlir:4:3: note: previously defined here
  %a = "test.test"() <{first}> : () -> i32
  ^
```