### PR TITLE
fix inverted logic in DCE

### DIFF
--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -31,7 +31,7 @@ def reconcileRegistersPairingCast (rewriter : PatternRewriter OpCode) (op : Oper
   let rewriter ← rewriter.eraseOp op sorry sorry sorry
   /- If unused and side-effect-free, erase the parent cast operation as well.
     These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx.raw && hasSideEffects rewriter op'.op then
+  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ hasSideEffects rewriter op'.op then
     rewriter.eraseOp op'.op sorry sorry sorry
   else
     return rewriter
@@ -72,7 +72,7 @@ def reconcileIntegersPairingCast (rewriter : PatternRewriter OpCode) (op : Opera
   let rewriter ← rewriter.eraseOp op sorry sorry sorry
   /- If unused and side-effect-free, erase the parent cast operation as well.
     These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx.raw && hasSideEffects rewriter op'.op then
+  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ hasSideEffects rewriter op'.op then
     rewriter.eraseOp op'.op sorry sorry sorry
   else
     return rewriter

--- a/Veir/Passes/DCE/dce.lean
+++ b/Veir/Passes/DCE/dce.lean
@@ -12,13 +12,13 @@ namespace Veir
   TODO: replace this with a side-effect property on `OpCode`.
 -/
 def hasSideEffects (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Bool :=
-  0 < op.getNumResults! rewriter.ctx.raw
+  0 = op.getNumResults! rewriter.ctx.raw
 
 set_option warn.sorry false in
 def eliminateDeadOp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   /- delete operations that are not used and have no side effects -/
-  if ¬ op.hasUses! rewriter.ctx.raw && hasSideEffects rewriter op then
+  if ¬ op.hasUses! rewriter.ctx.raw && ¬ hasSideEffects rewriter op then
     rewriter.eraseOp op sorry sorry sorry
   else
     return rewriter


### PR DESCRIPTION
hasSideEffects was returning the opposite of what it should have returned. however, since all call sites also had the condition inverted, there was not an actual bug here, just a latent one. easy to fix.