### PR TITLE
Minimal interpreter support for `llvm.getelementptr`

### DIFF
--- a/Test/Interpreter/LLVM/getelementptr.mlir
+++ b/Test/Interpreter/LLVM/getelementptr.mlir
@@ -1,0 +1,19 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main"}> ({
+    ^bb0():
+      %size = "llvm.mlir.constant"() <{ "value" = 4 : i64 }> : () -> i64
+      %array = "llvm.alloca"(%size) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr
+      %off1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
+      %ptr1 = "llvm.getelementptr"(%array, %off1) <{ elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+      %val1 = "llvm.mlir.constant"() <{ "value" = 256 : i64 }> : () -> i64
+      "llvm.store"(%ptr1, %val1) : (!llvm.ptr, i64) -> ()
+      %off2 = "llvm.mlir.constant"() <{ "value" = 9 : i64 }> : () -> i64
+      %ptr2 = "llvm.getelementptr"(%array, %off2) <{ elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+      %val2 = "llvm.load"(%ptr2) : (!llvm.ptr) -> i8
+      "llvm.return"(%val2) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x01#8]

--- a/Test/Interpreter/LLVM/getelementptr_array.mlir
+++ b/Test/Interpreter/LLVM/getelementptr_array.mlir
@@ -1,0 +1,19 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main"}> ({
+    ^bb0():
+      %size = "llvm.mlir.constant"() <{ "value" = 4 : i64 }> : () -> i64
+      %array = "llvm.alloca"(%size) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr
+      %off1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
+      %ptr1 = "llvm.getelementptr"(%array, %off1) <{ elem_type = !llvm.array<8 x i8>, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+      %val1 = "llvm.mlir.constant"() <{ "value" = 256 : i64 }> : () -> i64
+      "llvm.store"(%ptr1, %val1) : (!llvm.ptr, i64) -> ()
+      %off2 = "llvm.mlir.constant"() <{ "value" = 9 : i64 }> : () -> i64
+      %ptr2 = "llvm.getelementptr"(%array, %off2) <{ elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+      %val2 = "llvm.load"(%ptr2) : (!llvm.ptr) -> i8
+      "llvm.return"(%val2) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x01#8]

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -248,6 +248,18 @@ def MemoryState.loadValue (state : MemoryState) (addr : UInt64) (type : TypeAttr
       return .addr ba.toUInt64LE!
   | _ => none
 
+/--
+  Returns the size of an LLVM type, in bytes.
+-/
+def sizeOfType (type : Attribute) : Option Nat :=
+  match type with
+  | .integerType { bitwidth } | .floatType { bitwidth } => some $ (bitwidth + 7) / 8
+  | .llvmPointerType _ => some 8
+  | .llvmArrayType { size, type } => do
+      let inner ← sizeOfType type
+      some (inner * size)
+  | _ => none
+
 
 def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
@@ -552,6 +564,13 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     let [.addr addr, val] := operands.toList | none
     let mem ← mem.storeValue addr val
     return (#[], mem, none)
+  | .getelementptr => do
+    /- only supports exactly one dynamic index for now -/
+    let [.addr ptr, .int _ idx] := operands.toList | none
+    let size ← sizeOfType properties.elem_type.val
+    match idx with
+    | .val idx => return (#[.addr (ptr.toNat + idx.toNat * size).toUInt64], mem, none)
+    | .poison => Interp.ub
   | _ => none
 
 def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasDialectOpInfo.propertiesOf opType)


### PR DESCRIPTION
For now, it is restricted to exactly one dynamic index
