### PR TITLE
Add `--allow-unregistered-dialect` flag

### DIFF
--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -10,42 +10,50 @@ open Veir.Attribute
 /--
   Run parseOptionalType on the given input string.
 -/
-def testOptionalType (s : String) : Except ParserError (Option TypeAttr) := do
+def testOptionalType (s : String) (allowUnregisteredDialect : Bool := false) :
+    Except ParserError (Option TypeAttr) := do
   let parser ← ParserState.fromInput (s.toByteArray)
-  parseOptionalType.run' AttrParserState.mk parser
+  parseOptionalType.run' { allowUnregisteredDialect } parser
 
 /--
   Run parseType on the given input string.
 -/
-def testType (s : String) : Except ParserError TypeAttr := do
+def testType (s : String) (allowUnregisteredDialect : Bool := false) :
+    Except ParserError TypeAttr := do
   let parser ← ParserState.fromInput (s.toByteArray)
-  parseType.run' AttrParserState.mk parser
+  parseType.run' { allowUnregisteredDialect } parser
 
 /--
   Run parseOptionalAttr on the given input string.
 -/
-def testOptionalAttr (s : String) : Except ParserError (Option Attribute) := do
+def testOptionalAttr (s : String) (allowUnregisteredDialect : Bool := false) :
+    Except ParserError (Option Attribute) := do
   let parser ← ParserState.fromInput (s.toByteArray)
-  parseOptionalAttribute.run' AttrParserState.mk parser
+  parseOptionalAttribute.run' { allowUnregisteredDialect } parser
 
 /--
   Run parseType on the given input string.
 -/
-def testAttr (s : String) : Except ParserError Attribute := do
+def testAttr (s : String) (allowUnregisteredDialect : Bool := false) :
+    Except ParserError Attribute := do
   let parser ← ParserState.fromInput (s.toByteArray)
-  parseAttribute.run' AttrParserState.mk parser
+  parseAttribute.run' { allowUnregisteredDialect } parser
 
 /--
   Test that parsing a type in the given string succeeds and matches the expected type.
 -/
-def expectSuccessType (s : String) (expected : TypeAttr) : Bool :=
-  testOptionalType s = .ok (some expected) ∧ testType s = .ok expected
+def expectSuccessType (s : String) (expected : TypeAttr)
+    (allowUnregisteredDialect : Bool := false) : Bool :=
+  testOptionalType s allowUnregisteredDialect = .ok (some expected) ∧
+  testType s allowUnregisteredDialect = .ok expected
 
 /--
   Test that parsing an attribute in the given string succeeds and matches the expected attribute.
 -/
-def expectSuccessAttr (s : String) (expected : Attribute) : Bool :=
-  testOptionalAttr s = .ok (some expected) ∧ testAttr s = .ok expected
+def expectSuccessAttr (s : String) (expected : Attribute)
+    (allowUnregisteredDialect : Bool := false) : Bool :=
+  testOptionalAttr s allowUnregisteredDialect = .ok (some expected) ∧
+  testAttr s allowUnregisteredDialect = .ok expected
 
 /--
   Test that parsing a type in the given string returns none in the parseOptional variant,
@@ -64,16 +72,18 @@ def expectMissingAttr (s : String) : Bool :=
 /--
   Test that parsing a type in the given string returns the expected error in both variants.
 -/
-def expectErrorType (s : String) (expected : String) : Bool :=
-  (testOptionalType s).mapError (·.msg) = .error expected
-    && (testType s).mapError (·.msg) = .error expected
+def expectErrorType (s : String) (expected : String)
+    (allowUnregisteredDialect : Bool := false) : Bool :=
+  (testOptionalType s allowUnregisteredDialect).mapError (·.msg) = .error expected
+    && (testType s allowUnregisteredDialect).mapError (·.msg) = .error expected
 
 /--
   Test that parsing an attribute in the given string returns the expected error in both variants.
 -/
-def expectErrorAttr (s : String) (expected : String) : Bool :=
-  (testOptionalAttr s).mapError (·.msg) = .error expected
-    && (testAttr s).mapError (·.msg) = .error expected
+def expectErrorAttr (s : String) (expected : String)
+    (allowUnregisteredDialect : Bool := false) : Bool :=
+  (testOptionalAttr s allowUnregisteredDialect).mapError (·.msg) = .error expected
+    && (testAttr s allowUnregisteredDialect).mapError (·.msg) = .error expected
 
 /--
   Macro to simplify test assertions. Wraps the test in #guard_msgs and #eval,
@@ -150,16 +160,25 @@ macro "#assert " e:term : command =>
 #assert expectSuccessAttr "array<i16: 0>" (DenseArrayAttr.mk (IntegerType.mk 16) #[0])
 #assert expectErrorAttr "array<>" "integer type expected in dense array attribute"
 
-/-! ## Dialect type -/
+/-! ## Unregistered dialect type -/
 
-#assert expectSuccessType "!foo.bar" ⟨UnregisteredAttr.mk "!foo.bar" true, by grind⟩
-#assert expectSuccessType "!foo<bar>" ⟨UnregisteredAttr.mk "!foo<bar>" true, by grind⟩
-#assert expectSuccessType "!test.test<bar>" ⟨UnregisteredAttr.mk "!test.test<bar>" true, by grind⟩
+#assert expectSuccessType "!foo.bar" ⟨UnregisteredAttr.mk "!foo.bar" true, by grind⟩ true
+#assert expectSuccessType "!foo<bar>" ⟨UnregisteredAttr.mk "!foo<bar>" true, by grind⟩ true
+#assert expectSuccessType "!test.test<bar>" ⟨UnregisteredAttr.mk "!test.test<bar>" true, by grind⟩ true
 
-/-! ## Dialect attribute -/
+#assert expectErrorType "!foo.bar" "type is not registered. Consider using --allow-unregistered-dialect." false
+#assert expectErrorType "!foo<bar>" "type is not registered. Consider using --allow-unregistered-dialect." false
+#assert expectErrorType "!test.test<bar>" "type is not registered. Consider using --allow-unregistered-dialect." false
 
-#assert expectSuccessAttr "#foo<bar>" (UnregisteredAttr.mk "#foo<bar>" false)
-#assert expectSuccessAttr "#test.test<bar>" (UnregisteredAttr.mk "#test.test<bar>" false)
+
+/-! ## Unregistered dialect attribute -/
+
+#assert expectSuccessAttr "#foo<bar>" (UnregisteredAttr.mk "#foo<bar>" false) true
+#assert expectSuccessAttr "#test.test<bar>" (UnregisteredAttr.mk "#test.test<bar>" false) true
+
+#assert expectErrorAttr "#foo<bar>" "attribute is not registered. Consider using --allow-unregistered-dialect." false
+#assert expectErrorAttr "#test.test<bar>" "attribute is not registered. Consider using --allow-unregistered-dialect." false
+
 
 /-! ## Location attribute -/
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -8,7 +8,8 @@ namespace Veir.AttrParser
 
 open Veir.Parser.ParserError
 
-structure AttrParserState
+structure AttrParserState where
+  allowUnregisteredDialect : Bool := false
 
 abbrev AttrParserM := StateT AttrParserState (EStateM ParserError ParserState)
 
@@ -240,6 +241,8 @@ partial def parseOptionalDialectType : AttrParserM (Option TypeAttr) := do
   let startPos ← getPos
   let dialectName ← parseOptionalPrefixedKeyword .exclamationIdent
   let some dialectName := dialectName | return none
+  if !(← getThe AttrParserState).allowUnregisteredDialect then
+    throwAt startPos s!"type is not registered. Consider using --allow-unregistered-dialect."
   if let true ← parseOptionalPunctuation "<" then
     let _ ← parseUnregisteredAttrBody
     let endPos := (← peekToken).slice.stop
@@ -257,6 +260,8 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   let startPos ← getPos
   let dialectName ← parseOptionalPrefixedKeyword .hashIdent
   let some dialectName := dialectName | return none
+  if !(← getThe AttrParserState).allowUnregisteredDialect then
+    throwAt startPos s!"attribute is not registered. Consider using --allow-unregistered-dialect."
   parsePunctuation "<"
   let _ ← parseUnregisteredAttrBody
   let endPos := (← peekToken).slice.stop

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -37,11 +37,15 @@ structure MlirParserState where
     (true), or has been forward declared (false).
   -/
   blocks : Std.HashMap ByteArray (BlockPtr × Bool)
+  /-- Whether to accept ops/types/attrs from unregistered dialects. -/
+  allowUnregisteredDialect : Bool := false
   deriving Inhabited
 
-def MlirParserState.fromContext (ctx : WfIRContext OpCode) : MlirParserState :=
+def MlirParserState.fromContext (ctx : WfIRContext OpCode)
+    (allowUnregisteredDialect : Bool := false) : MlirParserState :=
   {
     ctx
+    allowUnregisteredDialect
     values := Std.HashMap.emptyWithCapacity 128
     definitionsPerScope := #[Std.HashSet.emptyWithCapacity 2]
     blocks := Std.HashMap.emptyWithCapacity 1
@@ -348,7 +352,8 @@ def resolveOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) : Mli
   Parse a type, if present.
 -/
 def parseOptionalType : MlirParserM (Option TypeAttr) := do
-  match AttrParser.parseOptionalType.run AttrParserState.mk (← getThe ParserState) with
+  let allowUnregisteredDialect := (← get).allowUnregisteredDialect
+  match AttrParser.parseOptionalType.run { allowUnregisteredDialect } (← getThe ParserState) with
   | .ok (ty, _, parserState) =>
     set parserState
     return ty
@@ -399,7 +404,8 @@ def parseOpProperties (opCode : OpCode) : MlirParserM (propertiesOf opCode) := d
     match Properties.fromAttrDict opCode {} with
     | .ok properties => return properties
     | .error err => throwString err
-  match AttrParser.parseAttributeDictionary.run AttrParserState.mk (← getThe ParserState) with
+  let allowUnregisteredDialect := (← get).allowUnregisteredDialect
+  match AttrParser.parseAttributeDictionary.run { allowUnregisteredDialect } (← getThe ParserState) with
   | .ok (properties, _, parserState) =>
     set parserState
     parsePunctuation ">"
@@ -414,7 +420,7 @@ def parseOpProperties (opCode : OpCode) : MlirParserM (propertiesOf opCode) := d
   to parse valid MLIR syntax.
 -/
 def parseOpAttributes : MlirParserM DictionaryAttr := do
-  match AttrParser.parseOptionalAttributeDictionary.run AttrParserState.mk (← getThe ParserState) with
+  match AttrParser.parseOptionalAttributeDictionary.run { allowUnregisteredDialect := (← get).allowUnregisteredDialect } (← getThe ParserState) with
   | .ok (attrs, _, parserState) =>
     set parserState
     match attrs with
@@ -474,12 +480,18 @@ partial def parseOpRegions : MlirParserM (Array RegionPtr) := do
 partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option OperationPtr) := do
   /- Parse the operation. -/
   let results ← parseOpResults
+  let opNameStart ← getPos
   let some opName ← parseOptionalStringLiteral | return none
   let operands ← parseOperands
   let blockOperands ← parseBlockOperands
 
   /- Get the operation opcode. -/
   let opId := OpCode.fromName opName.toByteArray
+
+  if let .builtin .unregistered := opId then
+    if !(← get).allowUnregisteredDialect then
+      throwAt opNameStart
+        s!"op '{opName}' is not registered. Consider using --allow-unregistered-dialect."
 
   let properties ← parseOpProperties opId
   /- For `builtin.unregistered`, record the original op name in the properties so it can be

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -22,7 +22,8 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode Ã
     | throw "Failed to create IR context"
   match ParserState.fromInput fileContent with
   | .ok parser =>
-    match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+    let parserState := MlirParserState.fromContext ctx (allowUnregisteredDialect := true)
+    match (parseOp none).run parserState parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error errMsg =>

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -40,6 +40,8 @@ structure VeirOptArgs where
   filename : Option String
   /-- List of passes to run. -/
   passes : PassPipeline OpCode
+  /-- Whether to accept ops/types/attrs from unregistered dialects. -/
+  allowUnregisteredDialect : Bool
 
 /--
   Parse the `-p` flag to construct a pass pipeline.
@@ -63,17 +65,18 @@ def parseArgs (args : List String) : Except String VeirOptArgs := do
   let (flags, positional) := args.partition (·.startsWith "-")
   -- Parses the `-p` flag if present.
   let pipeline ← parsePipelineOption flags
+  let allowUnregisteredDialect := true
 
   if positional.length == 0 then -- read from stdin
-    return VeirOptArgs.mk none pipeline
+    return { filename := none, passes := pipeline, allowUnregisteredDialect }
 
   let [filename] := positional
     | .error "Expected exactly one positional argument for the input filename."
 
   if filename == "-" then
-    return VeirOptArgs.mk none pipeline
+    return { filename := none, passes := pipeline, allowUnregisteredDialect }
 
-  return VeirOptArgs.mk (some filename) pipeline
+  return { filename := some filename, passes := pipeline, allowUnregisteredDialect }
 
 def getFileContent (filename : Option String) : ExceptT String IO ByteArray := do
   if let some f := filename then
@@ -84,7 +87,8 @@ def getFileContent (filename : Option String) : ExceptT String IO ByteArray := d
 
   return ← IO.FS.Stream.readBinToEnd (←IO.getStdin)
 
-def parseOperation (filename : Option String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
+def parseOperation (filename : Option String) (allowUnregisteredDialect : Bool := false) :
+    ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
   let fileContent ← getFileContent filename
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "Failed to create IR context"
@@ -93,7 +97,8 @@ def parseOperation (filename : Option String) : ExceptT String IO (WfIRContext O
 
   match ParserState.fromInput fileContent with
   | .ok parser =>
-    match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+    let state := MlirParserState.fromContext ctx allowUnregisteredDialect
+    match (parseOp none).run state parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error err =>
@@ -106,10 +111,10 @@ def main (args : List String) : IO Unit := do
   match parseArgs args with
   | .error errMsg =>
     IO.eprintln s!"Error: {errMsg}"
-    IO.eprintln "Usage: veir-opt <filename> [-p=\"pass1,pass2,...\"]"
+    IO.eprintln "Usage: veir-opt <filename> [-p=\"pass1,pass2,...\"] [--allow-unregistered-dialect]"
     IO.Process.exit 1
-  | .ok { filename, passes } =>
-    match ← parseOperation filename with
+  | .ok { filename, passes, allowUnregisteredDialect } =>
+    match ← parseOperation filename allowUnregisteredDialect with
     | .error errMsg =>
       IO.eprintln errMsg
       IO.Process.exit 1


### PR DESCRIPTION
Without this flag, unregistered operations, attributes, or types are rejected.

By default, `veir-opt` and `veir-interpret` have this flag set to `false`.