### PR TITLE
Expose `LLVM.Int` lemmas

### DIFF
--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -359,6 +359,10 @@ def cast {w₁ w₂ : Nat} (x : Int w₁) (h : w₁ = w₂) : Int w₂ :=
   | .val v => .val (v.cast h)
   | .poison => .poison
 
+@[simp, grind =]
+theorem cast_self {w : Nat} (x : Int w) (h : w = w) : cast x h = x := by
+  cases x <;> simp [cast]
+
 /--
 The ‘and’ instruction returns the bitwise logical and of its two operands.
 

--- a/Veir/Data/LLVM/Int/Lemmas.lean
+++ b/Veir/Data/LLVM/Int/Lemmas.lean
@@ -1,9 +1,12 @@
 module
 
+public import Veir.Data.LLVM.Int.Basic
 import all Veir.Data.LLVM.Int.Basic
 import Veir.ForLean
 
 open Veir.Data.LLVM
+
+public section
 
 namespace Veir.Data.LLVM.Int
 


### PR DESCRIPTION
Previously, a lot of the lemmas were just in a module without a public section