### PR TITLE
Improve lemma about verified add and constant operations

### DIFF
--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -359,6 +359,10 @@ def cast {w₁ w₂ : Nat} (x : Int w₁) (h : w₁ = w₂) : Int w₂ :=
   | .val v => .val (v.cast h)
   | .poison => .poison
 
+@[simp, grind =]
+theorem cast_self {w : Nat} (x : Int w) (h : w = w) : cast x h = x := by
+  cases x <;> simp [cast]
+
 /--
 The ‘and’ instruction returns the bitwise logical and of its two operands.
 

--- a/Veir/Data/LLVM/Int/Lemmas.lean
+++ b/Veir/Data/LLVM/Int/Lemmas.lean
@@ -1,9 +1,12 @@
 module
 
+public import Veir.Data.LLVM.Int.Basic
 import all Veir.Data.LLVM.Int.Basic
 import Veir.ForLean
 
 open Veir.Data.LLVM
+
+public section
 
 namespace Veir.Data.LLVM.Int
 

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -788,6 +788,11 @@ instance : Coe TypeAttr Attribute where
 instance : ToString TypeAttr where
   toString typeAttr := toString (typeAttr.val)
 
+theorem TypeAttr.inj {attr1 attr2 : TypeAttr} :
+  attr1 = attr2 ↔ (attr1 : Attribute) = (attr2 : Attribute) := by
+  unfold TypeAttr at *
+  grind
+
 /--
   Convert an attribute to a type attribute.
 -/

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1910,11 +1910,12 @@ theorem OperationPtr.Verified.arith_constant {op : OperationPtr} {opInBounds}
     op.getNumOperands! ctx.raw = 0 ∧
     op.getNumSuccessors! ctx.raw = 0 ∧
     op.getNumRegions! ctx.raw = 0 ∧
-    ((op.getResult 0).get! ctx.raw).type.val =
-      (op.getProperties! ctx.raw (.arith .constant)).value.type := by
+    ((op.getResult 0).get! ctx.raw).type =
+      ⟨(op.getProperties! ctx.raw (.arith .constant)).value.type, (by grind)⟩ := by
   simp only [Verified, verifyLocalInvariants, ← getOpType!_eq_getOpType, opType, ne_eq,
     bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure, Except.pure, dite_not,
     ite_not] at opVerify
+  simp only [TypeAttr.inj]
   grind
 
 theorem OperationPtr.Verified.arith_addi {op : OperationPtr} {opInBounds}
@@ -1924,12 +1925,13 @@ theorem OperationPtr.Verified.arith_addi {op : OperationPtr} {opInBounds}
     op.getNumSuccessors! ctx.raw = 0 ∧
     op.getNumRegions! ctx.raw = 0 ∧
     ∃ integerType,
-      ((op.getResult 0).get! ctx.raw).type.val = .integerType integerType ∧
-      ((op.getOperand! ctx.raw 0).getType! ctx.raw).val = .integerType integerType ∧
-      ((op.getOperand! ctx.raw 1).getType! ctx.raw).val = .integerType integerType := by
+      ((op.getResult 0).get! ctx.raw).type = ⟨.integerType integerType, (by grind)⟩ ∧
+      ((op.getOperand! ctx.raw 0).getType! ctx.raw) = ⟨.integerType integerType, (by grind)⟩ ∧
+      ((op.getOperand! ctx.raw 1).getType! ctx.raw) = ⟨.integerType integerType, (by grind)⟩ := by
   simp only [Verified, verifyLocalInvariants, ← getOpType!_eq_getOpType, opType, ne_eq,
     bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure, Except.pure, dite_not,
     ite_not] at opVerify
+  simp only [TypeAttr.inj]
   grind
 
 end


### PR DESCRIPTION
It is usually easier to reason about `typeattr = <_,_>` than `typeattr.val = _`.