### PR TITLE
Dominance Public API

### DIFF
--- a/UnitTest/DataFlowFramework/Dominance.lean
+++ b/UnitTest/DataFlowFramework/Dominance.lean
@@ -1,6 +1,7 @@
 import UnitTest.DataFlowFramework.Helpers
 
 import Veir.Analysis.DataFlow.DominanceAnalysis
+import Veir.IR.Dominance
 
 open Std (HashMap HashSet)
 open Veir
@@ -9,7 +10,7 @@ open Veir
 Compare one expected dominator label against the observed dominance information.
 
 This checks `dominates`, `properlyDominates`, and membership in the dominator
-set returned by `BlockPtr.getDoms?`.
+set returned by `BlockPtr.dominators?`.
 -/
 private def compareExpectedDominator
     (name : String)
@@ -26,12 +27,12 @@ private def compareExpectedDominator
     Id.run do
       let shouldProperlyDom := expectedDom ≠ name
       let mut report := #[]
-      if !Veir.DominanceAnalysis.dominates expectedBlock block dfCtx irCtx then
+      if !expectedBlock.dominates block dfCtx irCtx then
         report := report.push s!"dominators {name}: missing expected dominator {expectedDom}"
       if !observedDoms.contains expectedBlock then
         report := report.push
-          s!"dominators {name}: BlockPtr.getDoms? missing expected dominator {expectedDom}"
-      if Veir.DominanceAnalysis.properlyDominates expectedBlock block dfCtx irCtx ≠ shouldProperlyDom then
+          s!"dominators {name}: BlockPtr.dominators? missing expected dominator {expectedDom}"
+      if expectedBlock.properlyDominates block dfCtx irCtx ≠ shouldProperlyDom then
         report := report.push
           s!"dominators {name}: unexpected properlyDominates result for {expectedDom}"
       report
@@ -40,7 +41,7 @@ private def compareExpectedDominator
 Compare one observed block label against the expected dominator list.
 
 This also cross checks the three ways of observing dominance for consistency:
-`dominates`, `properlyDominates`, and membership in `BlockPtr.getDoms?`.
+`dominates`, `properlyDominates`, and membership in `BlockPtr.dominators?`.
 -/
 private def compareObservedDominator
     (name : String)
@@ -52,18 +53,18 @@ private def compareObservedDominator
     (observedName : String)
     (observedBlock : BlockPtr) : MismatchReport :=
   Id.run do
-    let observedByRelation := Veir.DominanceAnalysis.dominates observedBlock block dfCtx irCtx
+    let observedByRelation := observedBlock.dominates block dfCtx irCtx
     let observedBySet := observedDoms.contains observedBlock
-    let observedProperly := Veir.DominanceAnalysis.properlyDominates observedBlock block dfCtx irCtx
+    let observedProperly := observedBlock.properlyDominates block dfCtx irCtx
     let mut report := #[]
     if observedByRelation ≠ observedBySet then
-      report := report.push s!"dominators {name}: dominates/getDoms? disagree on {observedName}"
+      report := report.push s!"dominators {name}: dominates/dominators? disagree on {observedName}"
     if observedProperly ≠ (observedByRelation && observedBlock ≠ block) then
       report := report.push s!"dominators {name}: dominates/properlyDominates disagree on {observedName}"
     if observedByRelation && !expectedDoms.contains observedName then
       report := report.push s!"dominators {name}: unexpected dominator {observedName}"
     if observedBySet && !expectedDoms.contains observedName then
-      report := report.push s!"dominators {name}: BlockPtr.getDoms? has unexpected dominator {observedName}"
+      report := report.push s!"dominators {name}: BlockPtr.dominators? has unexpected dominator {observedName}"
     if observedProperly && (!expectedDoms.contains observedName || observedName = name) then
       report := report.push s!"dominators {name}: unexpected proper dominator {observedName}"
     report
@@ -107,7 +108,7 @@ private def compareNamedBlockDominators
   | none =>
     #[s!"dominators {name}: missing block label"]
   | some block =>
-    let observedDoms? := block.getDoms? dfCtx irCtx
+    let observedDoms? := block.dominators? dfCtx irCtx
     match expectedDoms? with
     | none =>
       if observedDoms?.isSome then
@@ -249,7 +250,7 @@ def testDomLine : String :=
      ]
 
 /-
-  Test: entry branches to a while-loop or to an if-statement, then join.
+  Test: entry branches to a while loop or to an if statement, then join.
                       ┌───┐
                   ┌───┤ 0 ├───┐
                   │   └───┘   │
@@ -296,6 +297,36 @@ def testDomIfLoopIf : String :=
      , ("bb7", some #["bb0", "bb7"])
      ]
 
+/-
+  Test: nested sibling regions inside the same outer block.
+
+          ┌───────────────┐
+          │ ┌───┐   ┌───┐ │
+          │ │ 1 │ 0 │ 2 │ │
+          │ └───┘   └───┘ │
+          └───────────────┘
+
+  The outer block dominates both nested entry blocks, but sibling nested blocks
+  do not dominate each other.
+-/
+def testDomNestedRegions : String :=
+  run
+    "\"builtin.module\"() ({\n\
+    ^bb0:\n\
+      \"test.test\"() ({\n\
+      ^bb1:\n\
+        \"test.test\"() : () -> ()\n\
+      }) : () -> ()\n\
+      \"test.test\"() ({\n\
+      ^bb2:\n\
+        \"test.test\"() : () -> ()\n\
+      }) : () -> ()\n\
+    }) : () -> ()"
+    #[ ("bb0", some #["bb0"])
+     , ("bb1", some #["bb0", "bb1"])
+     , ("bb2", some #["bb0", "bb2"])
+     ]
+
 /--
 info: "ok"
 -/
@@ -319,5 +350,11 @@ info: "ok"
 -/
 #guard_msgs in
 #eval! testDomIfLoopIf
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDomNestedRegions
 
 end DominanceAnalysis

--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -62,28 +62,6 @@ def getIDom? [FactSpec .dominator] (block : BlockPtr) (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : Option BlockPtr :=
   block.getDominatorFact? dfCtx irCtx >>= (·.iDom)
 
-/--
-Collect the dominators currently reachable from `block` by following the `iDom`
-chain.
-
-The returned set always includes `block` itself. If `block` has no dominator
-fact, returns `none`. Otherwise, this walks the currently known immediate
-dominator chain until it reaches a root or a self-loop, so during analysis it
-may return only the known prefix of the full dominator set.
--/
-def getDoms? [FactSpec .dominator] (block : BlockPtr) (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode) : Option (HashSet BlockPtr) := do
-  let fact ← block.getDominatorFact? dfCtx irCtx
-  let mut doms := (∅ : HashSet BlockPtr).insert block
-  let mut current := fact.iDom
-  while let some dom := current do
-    doms := doms.insert dom
-    let next := dom.getIDom? dfCtx irCtx
-    if next = some dom then
-      return doms
-    current := next
-  doms
-
 end BlockPtr
 
 namespace RegionPtr

--- a/Veir/IR/Dominance.lean
+++ b/Veir/IR/Dominance.lean
@@ -1,0 +1,308 @@
+module
+
+public import Veir.Analysis.DataFlow.DominanceAnalysis
+
+public section
+
+namespace Veir
+
+open Std (HashSet)
+
+/--
+Normalize an insertion point into `region` by walking outward through enclosing
+operations until the point lies in a block directly contained in `region`.
+
+If `point` already lies in `region`, it is returned unchanged. If the walk
+escapes the IR hierarchy before reaching `region`, return `none`.
+-/
+private partial def normalizeInsertPoint?
+    (region : RegionPtr)
+    (point : InsertPoint)
+    (irCtx : IRContext OpCode) : Option InsertPoint := do
+  let block ← point.block! irCtx
+  if (block.get! irCtx).parent = some region then
+    return point
+  let parentRegion ← (block.get! irCtx).parent
+  let parentOp ← (parentRegion.get! irCtx).parent
+  normalizeInsertPoint? region (.before parentOp) irCtx
+
+/--
+Check dominance between two blocks that are already known to lie in the same
+region.
+
+This follows the immediate dominator chain from `block` upward until it either
+reaches `dominator` or the chain ends.
+-/
+private partial def dominatesWithinRegion
+    (dominator block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  if dominator = block then
+    true
+  else
+    match block.getIDom? dfCtx irCtx with
+    | some idom => idom ≠ block && dominatesWithinRegion dominator idom dfCtx irCtx
+    | none => false
+
+/--
+Check dominance between two operations that are already known to lie in the same block.
+
+Iterates from `dominator` down the block until it either reaches `op` or reaches the
+end of the block.
+-/
+private def dominatesWithinBlock
+    (dominator op : OperationPtr)
+    (irCtx : IRContext OpCode) : Bool := Id.run do
+  let mut current := some dominator
+  while let some operation := current do
+    if operation = op then
+      return true
+    current := (operation.get! irCtx).next
+  false
+
+
+/--
+Collect the dominators in `block`'s own region.
+
+The returned set contains `block` together with the blocks on its local
+immediate dominator chain. Enclosing region dominators are intentionally not
+included here; `BlockPtr.dominators?` adds those separately.
+-/
+private partial def localDominators?
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Option (HashSet BlockPtr) := do
+  let _ ← block.getDominatorFact? dfCtx irCtx
+  match block.getIDom? dfCtx irCtx with
+  | some idom =>
+      if idom = block then
+        return (∅ : HashSet BlockPtr).insert block
+      else
+        return (← localDominators? idom dfCtx irCtx).insert block
+  | none =>
+      return (∅ : HashSet BlockPtr).insert block
+
+/--
+Immediate dominator of a block start insertion point, if the block has
+initialized dominance information.
+
+For an entry block of a nested region, this is the insertion point immediately
+before the enclosing operation. For any other reachable block, this is the end
+of the immediate dominator block.
+-/
+private def blockStartImmediateDominator?
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Option InsertPoint := do
+  let _ ← block.getDominatorFact? dfCtx irCtx
+  let parentRegion ← (block.get! irCtx).parent
+  if (parentRegion.get! irCtx).firstBlock = some block then
+    let parentOp ← (parentRegion.get! irCtx).parent
+    let _ ← (parentOp.get! irCtx).parent
+    return .before parentOp
+  let iDomBlock ← block.getIDom? dfCtx irCtx
+  return .atEnd iDomBlock
+
+namespace InsertPoint
+
+/--
+Immediate dominator of an insertion point, if the enclosing block has
+dominance information.
+
+Within a block, the immediate dominator is the preceding insertion point. At a
+block start, the immediate dominator is inherited from control flow or, for a
+nested region entry, from the enclosing operation.
+-/
+def immediateDominator?
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Option InsertPoint := do
+  let block ← point.block! irCtx
+  match point with
+  | .before op =>
+      match (op.get! irCtx).prev with
+      | some prev =>
+          return .before prev
+      | none =>
+          blockStartImmediateDominator? block dfCtx irCtx
+  | .atEnd block =>
+      match (block.get! irCtx).lastOp with
+      | some lastOp =>
+          return .before lastOp
+      | none =>
+          blockStartImmediateDominator? block dfCtx irCtx
+
+/--
+All dominators of an insertion point, including the point itself.
+
+Returns `none` when the enclosing block has no dominance information.
+-/
+partial def dominators?
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Option (HashSet InsertPoint) := do
+  let block ← point.block! irCtx
+  let _ ← block.getDominatorFact? dfCtx irCtx
+  match point.immediateDominator? dfCtx irCtx with
+  | some idom =>
+      return (← idom.dominators? dfCtx irCtx).insert point
+  | none =>
+      return (∅ : HashSet InsertPoint).insert point
+
+/--
+Proper dominance query between two insertion points.
+
+If `point` lies in a nested region outside the region containing `dominator`, it
+is normalized into the dominator's region by replacing it with the enclosing
+operation position. Once both insertion points lie in the same region,
+dominance is decided by same block insertion point order or by block
+dominance.
+-/
+def properlyDominates
+    (dominator : InsertPoint)
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool := Id.run do
+  if dominator = point then
+    return false
+
+  let some dominatorBlock := dominator.block! irCtx
+    | return false
+  let some dominatorRegion := (dominatorBlock.get! irCtx).parent
+    | return false
+  let pointInRegion? :=
+    match point.block! irCtx with
+    | none => none
+    | some pointBlock =>
+        if (pointBlock.get! irCtx).parent = dominatorRegion then
+          point
+        else
+          -- Scoot up the point's region tree until we find a location in the
+          -- dominator's region that encloses it.  If this fails, then we know 
+          -- there is no dominance relation.
+          normalizeInsertPoint? dominatorRegion point irCtx
+  let some point := pointInRegion?
+    | return false
+  let some pointBlock := point.block! irCtx
+    | return false
+
+  if dominator = point then
+    return true
+  if dominatorBlock = pointBlock then
+    match dominator, point with
+    | .before dominatorOp, .before op =>
+        return dominatesWithinBlock dominatorOp op irCtx
+    | .before _, .atEnd _ =>
+        return true
+    | .atEnd _, _ =>
+        return false
+  return dominatesWithinRegion dominatorBlock pointBlock dfCtx irCtx
+
+/--
+Dominance query between two insertion points.
+
+An insertion point dominates itself. Otherwise this is the same query as
+`InsertPoint.properlyDominates`.
+-/
+def dominates
+    (dominator : InsertPoint)
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  dominator = point || dominator.properlyDominates point dfCtx irCtx
+
+end InsertPoint
+
+namespace BlockPtr
+
+/--
+Immediate dominator for the block entry, if the dominance analysis has
+initialized this block.
+-/
+def immediateDominator?
+    [FactSpec .dominator]
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Option BlockPtr :=
+  block.getIDom? dfCtx irCtx
+
+/--
+Dominance query between two insertion points.
+-/
+def dominates
+    [FactSpec .dominator]
+    (dominator block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  (InsertPoint.atStart! dominator irCtx).dominates (InsertPoint.atStart! block irCtx) dfCtx irCtx
+
+/--
+Proper version of `BlockPtr.dominates`.
+-/
+def properlyDominates
+    [FactSpec .dominator]
+    (dominator block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  (InsertPoint.atStart! dominator irCtx).properlyDominates
+    (InsertPoint.atStart! block irCtx) dfCtx irCtx
+
+/--
+All dominators of this block, including the block itself.
+
+Returns `none` when the block has no initialized dominator fact, which is how
+the dominance analysis represents unreachable blocks.
+
+Note that this returns enclosing blocks that dominate the block through
+nested regions as well.
+-/
+partial def dominators?
+    [FactSpec .dominator]
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Option (HashSet BlockPtr) := do
+  let mut doms ← localDominators? block dfCtx irCtx
+  let some parentRegion := (block.get! irCtx).parent
+    | return doms
+  let some parentOp := (parentRegion.get! irCtx).parent
+    | return doms
+  let some parentBlock := (parentOp.get! irCtx).parent
+    | return doms
+  if let some parentDoms := parentBlock.dominators? dfCtx irCtx then
+    doms := doms ∪ parentDoms
+  return doms
+
+end BlockPtr
+
+namespace OperationPtr
+
+/--
+Analysis-backed dominance query for operations.
+
+This follows MLIR's region-dominance behavior: if `op₂` is nested inside a
+region enclosed by `op₁`, the query normalizes `op₂` to the enclosing operation
+in `op₁`'s region before comparing block dominance or same-block order.
+-/
+def dominates
+    [FactSpec .dominator]
+    (dominator op : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  if dominator = op then
+    true
+  else
+    (InsertPoint.before dominator).properlyDominates (InsertPoint.before op) dfCtx irCtx
+
+/--
+Proper version of `OperationPtr.dominates`.
+-/
+def properlyDominates
+    [FactSpec .dominator]
+    (dominator op : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  dominator ≠ op && dominator.dominates op dfCtx irCtx
+
+end OperationPtr
+
+end Veir


### PR DESCRIPTION
Provides an API (which utilizes the dominance analysis) for querying dominance information in `IR/Dominance.lean`.