### PR TITLE
only run benchmarks on opencompl repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           .github/scripts/run_benchmarks.sh 1000 100 5
 
       - name: Store benchmark result
+        if: github.repository_owner == 'opencompl'
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: VeIR Benchmarks


### PR DESCRIPTION
This should avoid CI failures on forks.