### PR TITLE
Implement `RuntimeValue.Conforms`

### DIFF
--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -65,8 +65,8 @@ instance : Decidable (Conforms val ty) := by
 
 @[grind <=]
 theorem Conforms.integerType :
-    Conforms runtimeValue (⟨.integerType intType, h⟩ : TypeAttr)
-    → ∃ val, runtimeValue = .int intType.bitwidth val := by
+    Conforms runtimeValue ⟨.integerType intType, h⟩ →
+    ∃ val, runtimeValue = .int intType.bitwidth val := by
   simp only [Conforms]
   cases runtimeValue
   case int bw val =>
@@ -77,15 +77,15 @@ theorem Conforms.integerType :
 
 @[grind <=]
 theorem Conforms.registerType :
-    Conforms runtimeValue (⟨.registerType regType, h⟩ : TypeAttr)
-    → ∃ val, runtimeValue = .reg val := by
+    Conforms runtimeValue ⟨.registerType regType, h⟩ →
+    ∃ val, runtimeValue = .reg val := by
   simp only [Conforms]
   cases runtimeValue <;> grind
 
 @[grind <=]
 theorem Conforms.llvmPointerType :
-    Conforms runtimeValue (⟨.llvmPointerType _, h⟩ : TypeAttr)
-    → ∃ val, runtimeValue = .addr val := by
+    Conforms runtimeValue ⟨.llvmPointerType _, h⟩ →
+    ∃ val, runtimeValue = .addr val := by
   simp only [Conforms]
   cases runtimeValue <;> grind
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -31,7 +31,7 @@ namespace Veir
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 
 /--
-  The representation of a value in the interpreter.
+  The type-erased representation of a value in the interpreter.
 -/
 inductive RuntimeValue where
 | int (bitwidth : Nat) (value : LLVM.Int bitwidth)
@@ -44,6 +44,52 @@ instance : ToString (RuntimeValue) where
     | .int _ val => ToString.toString val
     | .addr val => ToString.toString val
     | .reg val => ToString.toString val
+
+namespace RuntimeValue
+
+/--
+  A predicate indicating whether a `RuntimeValue` is a value that is a runtime value
+  of a given `TypeAttr`.
+-/
+@[grind]
+def Conforms (val : RuntimeValue) (ty : TypeAttr) : Prop :=
+  match val, ty with
+  | .int bw _, ⟨.integerType intType, _⟩ => intType.bitwidth = bw
+  | .reg _, ⟨.registerType _, _⟩ => True
+  | .addr _, ⟨.llvmPointerType _, _⟩ => True
+  | _, _ => False
+
+instance : Decidable (Conforms val ty) := by
+  unfold Conforms
+  split <;> infer_instance
+
+@[grind <=]
+theorem Conforms.integerType :
+    Conforms runtimeValue (⟨.integerType intType, h⟩ : TypeAttr)
+    → ∃ val, runtimeValue = .int intType.bitwidth val := by
+  simp only [Conforms]
+  cases runtimeValue
+  case int bw val =>
+    simp only [int.injEq, exists_and_left]
+    intro _; subst bw
+    grind
+  all_goals grind
+
+@[grind <=]
+theorem Conforms.registerType :
+    Conforms runtimeValue (⟨.registerType regType, h⟩ : TypeAttr)
+    → ∃ val, runtimeValue = .reg val := by
+  simp only [Conforms]
+  cases runtimeValue <;> grind
+
+@[grind <=]
+theorem Conforms.llvmPointerType :
+    Conforms runtimeValue (⟨.llvmPointerType _, h⟩ : TypeAttr)
+    → ∃ val, runtimeValue = .addr val := by
+  simp only [Conforms]
+  cases runtimeValue <;> grind
+
+end RuntimeValue
 
 /--
   Memory state during interpretation


### PR DESCRIPTION
This checks that a `RuntimeValue` in the interpreter represents a valid value of a `TypeAttr`.

This will be used in the interpreter state to check that dynamic values conform correctly to their MLIR types.