### PR TITLE
Ensure all values in the interpreter state conforms to their types

### DIFF
--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -65,8 +65,8 @@ instance : Decidable (Conforms val ty) := by
 
 @[grind <=]
 theorem Conforms.integerType :
-    Conforms runtimeValue (⟨.integerType intType, h⟩ : TypeAttr)
-    → ∃ val, runtimeValue = .int intType.bitwidth val := by
+    Conforms runtimeValue ⟨.integerType intType, h⟩ →
+    ∃ val, runtimeValue = .int intType.bitwidth val := by
   simp only [Conforms]
   cases runtimeValue
   case int bw val =>
@@ -77,15 +77,15 @@ theorem Conforms.integerType :
 
 @[grind <=]
 theorem Conforms.registerType :
-    Conforms runtimeValue (⟨.registerType regType, h⟩ : TypeAttr)
-    → ∃ val, runtimeValue = .reg val := by
+    Conforms runtimeValue ⟨.registerType regType, h⟩ →
+    ∃ val, runtimeValue = .reg val := by
   simp only [Conforms]
   cases runtimeValue <;> grind
 
 @[grind <=]
 theorem Conforms.llvmPointerType :
-    Conforms runtimeValue (⟨.llvmPointerType _, h⟩ : TypeAttr)
-    → ∃ val, runtimeValue = .addr val := by
+    Conforms runtimeValue ⟨.llvmPointerType _, h⟩ →
+    ∃ val, runtimeValue = .addr val := by
   simp only [Conforms]
   cases runtimeValue <;> grind
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -31,7 +31,7 @@ namespace Veir
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 
 /--
-  The representation of a value in the interpreter.
+  The type-erased representation of a value in the interpreter.
 -/
 inductive RuntimeValue where
 | int (bitwidth : Nat) (value : LLVM.Int bitwidth)
@@ -44,6 +44,52 @@ instance : ToString (RuntimeValue) where
     | .int _ val => ToString.toString val
     | .addr val => ToString.toString val
     | .reg val => ToString.toString val
+
+namespace RuntimeValue
+
+/--
+  A predicate indicating whether a `RuntimeValue` is a value that is a runtime value
+  of a given `TypeAttr`.
+-/
+@[grind]
+def Conforms (val : RuntimeValue) (ty : TypeAttr) : Prop :=
+  match val, ty with
+  | .int bw _, ⟨.integerType intType, _⟩ => intType.bitwidth = bw
+  | .reg _, ⟨.registerType _, _⟩ => True
+  | .addr _, ⟨.llvmPointerType _, _⟩ => True
+  | _, _ => False
+
+instance : Decidable (Conforms val ty) := by
+  unfold Conforms
+  split <;> infer_instance
+
+@[grind <=]
+theorem Conforms.integerType :
+    Conforms runtimeValue (⟨.integerType intType, h⟩ : TypeAttr)
+    → ∃ val, runtimeValue = .int intType.bitwidth val := by
+  simp only [Conforms]
+  cases runtimeValue
+  case int bw val =>
+    simp only [int.injEq, exists_and_left]
+    intro _; subst bw
+    grind
+  all_goals grind
+
+@[grind <=]
+theorem Conforms.registerType :
+    Conforms runtimeValue (⟨.registerType regType, h⟩ : TypeAttr)
+    → ∃ val, runtimeValue = .reg val := by
+  simp only [Conforms]
+  cases runtimeValue <;> grind
+
+@[grind <=]
+theorem Conforms.llvmPointerType :
+    Conforms runtimeValue (⟨.llvmPointerType _, h⟩ : TypeAttr)
+    → ∃ val, runtimeValue = .addr val := by
+  simp only [Conforms]
+  cases runtimeValue <;> grind
+
+end RuntimeValue
 
 /--
   Memory state during interpretation

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -29,6 +29,7 @@ open Veir.Data
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {ctx : WfIRContext OpInfo}
 
 /--
   The type-erased representation of a value in the interpreter.
@@ -101,34 +102,52 @@ structure MemoryState where
 def MemoryState.empty : MemoryState :=
   { contents := (ByteArray.emptyWithCapacity 1024).extend 8 0xff }
 
-structure VariableState where
+/--
+  Property that a hash map from `ValuePtr` to `RuntimeValue` conforms to the value types in the
+  IR context. This is an invariant that must be maintained by the variable state of the interpreter.
+-/
+def VariableState.ValuesConform (state : Std.ExtHashMap ValuePtr RuntimeValue)
+    (ctx : WfIRContext OpInfo) : Prop :=
+  ∀ val var, (h : val ∈ state) → state[val] = var → var.Conforms (val.getType! ctx.raw)
+
+structure VariableState (ctx : WfIRContext OpInfo) where
   variables : Std.ExtHashMap ValuePtr RuntimeValue
+  conforms : VariableState.ValuesConform variables ctx
 
 /--
   The state of the interpreter at a given point in time.
   It includes a mapping from IR values to their runtime values.
 -/
 @[ext]
-structure InterpreterState where
-  variables : VariableState
+structure InterpreterState (ctx : WfIRContext OpInfo) where
+  variables : VariableState ctx
   memory : MemoryState
+
+/--
+  Create an interpreter state with no variables defined.
+-/
+def InterpreterState.empty (ctx : WfIRContext OpInfo) : InterpreterState ctx :=
+  { variables := ⟨Std.ExtHashMap.emptyWithCapacity 8, by simp [VariableState.ValuesConform]⟩, memory := .empty }
 
 /--
   Set the value of a variable.
 -/
-def VariableState.setVar (state : VariableState) (var : ValuePtr) (val : RuntimeValue) :
-    VariableState :=
-  ⟨state.variables.insert var val⟩
+def VariableState.setVar? (state : VariableState ctx) (var : ValuePtr)
+    (val : RuntimeValue) : Option (VariableState ctx) :=
+  if h : val.Conforms (var.getType! ctx.raw) then
+    some ⟨state.variables.insert var val, by grind [VariableState.ValuesConform, cases VariableState]⟩
+  else
+    none
 
 /--
   Get the value of a variable, if the variable exists.
 -/
-def VariableState.getVar? (state : VariableState) (var : ValuePtr)
+def VariableState.getVar? (state : VariableState ctx) (var : ValuePtr)
     : Option RuntimeValue :=
   state.variables[var]?
 
 @[ext]
-theorem VariableState.ext {s₁ s₂ : VariableState} :
+theorem VariableState.ext {s₁ s₂ : VariableState ctx} :
     (∀ var, s₁.getVar? var = s₂.getVar? var) →
     s₁ = s₂ := by
   rcases s₁; rcases s₂
@@ -139,47 +158,41 @@ theorem VariableState.ext {s₁ s₂ : VariableState} :
   Get the value of the operands of an operation.
   If any operand is not in the state, return `none`.
 -/
-def VariableState.getOperandValues (state : VariableState)
-    (ctx : IRContext OpInfo) (op : OperationPtr) : Option (Array RuntimeValue) := do
-  (op.getOperands! ctx).mapM state.getVar?
+def VariableState.getOperandValues (state : VariableState ctx)
+    (op : OperationPtr) : Option (Array RuntimeValue) := do
+  (op.getOperands! ctx.raw).mapM state.getVar?
 
-def VariableState.setResultValues_loop (state : VariableState)
-    (ctx : IRContext OpInfo) (op : OperationPtr) (resultValues : Array RuntimeValue) (i : Nat) : VariableState :=
+def VariableState.setResultValues?_loop (state : VariableState ctx)
+    (op : OperationPtr) (resultValues : Array RuntimeValue) (i : Nat) : Option (VariableState ctx) :=
   match i with
   | 0 => state
-  | i + 1 =>
+  | i + 1 => do
     let result := op.getResult i
     let value := resultValues[i]!
-    let newState := state.setVar result value
-    VariableState.setResultValues_loop newState ctx op resultValues i
+    let newState ← state.setVar? result value
+    VariableState.setResultValues?_loop newState op resultValues i
 
 /--
   Set the values of the results of an operation.
 -/
-def VariableState.setResultValues (state : VariableState) (ctx : IRContext OpInfo)
-    (op : OperationPtr) (resultValues : Array RuntimeValue) : VariableState :=
-  VariableState.setResultValues_loop state ctx op resultValues (op.getNumResults! ctx)
+def VariableState.setResultValues? (state : VariableState ctx)
+    (op : OperationPtr) (resultValues : Array RuntimeValue) : Option (VariableState ctx) :=
+  VariableState.setResultValues?_loop state op resultValues (op.getNumResults! ctx.raw)
 
 /--
   Set the values of block arguments.
 -/
-def VariableState.setArgumentValues (state : VariableState) (ctx : IRContext OpInfo)
-    (block : BlockPtr) (values : Array RuntimeValue) : VariableState :=
-  let rec loop (state : VariableState) (i : Nat) :=
+def VariableState.setArgumentValues? (state : VariableState ctx)
+    (block : BlockPtr) (values : Array RuntimeValue) : Option (VariableState ctx) :=
+  let rec loop (state : VariableState ctx) (i : Nat) :=
     match i with
     | 0 => state
-    | i + 1 =>
+    | i + 1 => do
       let arg := block.getArgument i
       let value := values[i]!
-      let newState := state.setVar arg value
+      let newState ← state.setVar? arg value
       loop newState i
-  loop state (block.getNumArguments! ctx)
-
-/--
-  Create an interpreter state with no variables defined.
--/
-def InterpreterState.empty : InterpreterState :=
-  { variables := ⟨Std.ExtHashMap.emptyWithCapacity 8⟩, memory := .empty }
+  loop state (block.getNumArguments! ctx.raw)
 
 /--
   How the control flow should proceed after interpreting a terminator.
@@ -1062,12 +1075,14 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
   If any error occurs during interpretation (e.g., unknown operation, missing variable),
   return `none`.
 -/
-def interpretOp (ctx : IRContext OpCode) (op : OperationPtr) (state : InterpreterState)
-    : Interp (InterpreterState × Option ControlFlowAction) := do
-  let some operands := state.variables.getOperandValues ctx op | none
+def interpretOp (op : OperationPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+    : Interp (InterpreterState ctx × Option ControlFlowAction) := do
+  let some operands := state.variables.getOperandValues op | none
   let opType := op.getOpType! ctx
-  let (resultValues, mem, action) ← interpretOp' opType (op.getProperties! ctx opType) (op.getResultTypes! ctx) operands (op.getSuccessors! ctx) state.memory
-  let newState := ⟨state.variables.setResultValues ctx op resultValues, mem⟩
+  let (resultValues, mem, action) ← interpretOp' opType (op.getProperties! ctx opType)
+    (op.getResultTypes! ctx.raw) operands (op.getSuccessors! ctx.raw) state.memory
+  let newVars ← state.variables.setResultValues? op resultValues
+  let newState := ⟨newVars, mem⟩
   return (newState, action)
 
 /--
@@ -1077,17 +1092,17 @@ def interpretOp (ctx : IRContext OpCode) (op : OperationPtr) (state : Interprete
   Return a ControlFlowAction indicating how to continue the interpretation.
   Return `none` if any errors occur during interpretation.
 -/
-def interpretOpList (ctx : IRContext OpCode) (op : OperationPtr) (state : InterpreterState)
-    (opInBounds : op.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind)
-    : Interp (InterpreterState × ControlFlowAction) := do
-  let (state, action) ← interpretOp ctx op state
+def interpretOpList (op : OperationPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+    (opInBounds : op.InBounds ctx.raw := by grind)
+    : Interp (InterpreterState ctx × ControlFlowAction) := do
+  let (state, action) ← interpretOp op state
   match action with
   | none =>
-    rlet next ← (op.get ctx).next
-    interpretOpList ctx next state
+    rlet next ← (op.get ctx.raw).next
+    interpretOpList next state
   | some action =>
     return (state, action)
-termination_by op.idxInParentFromTail ctx
+termination_by op.idxInParentFromTail ctx.raw
 decreasing_by grind
 
 /--
@@ -1096,22 +1111,29 @@ decreasing_by grind
   to continue the interpretation.
   Return `none` if any errors occur during interpretation.
 -/
-def interpretBlock (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : InterpreterState) (blockInBounds : blockPtr.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Interp (InterpreterState × ControlFlowAction) := do
-  rlet firstOp ← (blockPtr.get ctx).firstOp
-  interpretOpList ctx firstOp state
+def interpretBlock (blockPtr : BlockPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+    (blockInBounds : blockPtr.InBounds ctx.raw := by grind) :
+  Interp (InterpreterState ctx × ControlFlowAction) := do
+  rlet firstOp ← (blockPtr.get ctx.raw).firstOp
+  interpretOpList firstOp state
 
 /--
   Interpret a CFG, starting from the given block.
   Return the resulting interpreter state and values eventually returned, if any.
   Return `none` if any errors occur during interpretation.
 -/
-def interpretBlockCFG (ctx : IRContext OpCode) (blockPtr : BlockPtr) (state : InterpreterState) (blockInBounds : blockPtr.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Interp (InterpreterState × Array RuntimeValue) := do
-  match interpretBlock ctx blockPtr state blockInBounds wf with
+def interpretBlockCFG (blockPtr : BlockPtr) {ctx : WfIRContext OpCode}
+    (state : InterpreterState ctx) (blockInBounds : blockPtr.InBounds ctx.raw := by grind) :
+    Interp (InterpreterState ctx × Array RuntimeValue) := do
+  match interpretBlock blockPtr state blockInBounds with
   | some (.ok (state, .return res)) => some (.ok (state, res))
   | some (.ok (state, .branch res succ)) =>
-    if h : succ.InBounds ctx then
-      let state := ⟨state.variables.setArgumentValues ctx succ res, state.memory⟩
-      interpretBlockCFG ctx succ state h wf else none
+    if h : succ.InBounds ctx.raw then
+      rlet newVars ← state.variables.setArgumentValues? succ res
+      let state := ⟨newVars, state.memory⟩
+      interpretBlockCFG succ state h
+    else
+      none
   | some .ub => Interp.ub
   | none => none
 partial_fixpoint
@@ -1121,22 +1143,23 @@ partial_fixpoint
   Return the resulting interpreter state and values eventually returned, or `none`
   if any errors occur during interpretation.
 -/
-def interpretRegion (ctx : IRContext OpCode) (region : RegionPtr) (state : InterpreterState) (regionIn : region.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind) : Interp (InterpreterState × Array RuntimeValue) := do
-  rlet block ← (region.get ctx).firstBlock
-  interpretBlockCFG ctx block state
+def interpretRegion (region : RegionPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+    (regionIn : region.InBounds ctx.raw := by grind) :
+    Interp (InterpreterState ctx × Array RuntimeValue) := do
+  rlet block ← (region.get ctx.raw).firstBlock
+  interpretBlockCFG block state
 
 /--
   Interpret a builtin.module operation.
   This is done by interpreting the unique region of the operation.
   Return the values eventually returned, or `none` if any errors occur during interpretation.
 -/
-def interpretModule (ctx : IRContext OpCode) (op : OperationPtr)
-    (opIn : op.InBounds ctx := by grind) (wf : ctx.WellFormed := by grind)
-    : Interp (Array RuntimeValue) := do
-  if h: op.getNumRegions ctx ≠ 1 then
+def interpretModule (ctx : WfIRContext OpCode) (op : OperationPtr)
+    (opIn : op.InBounds ctx.raw := by grind) : Interp (Array RuntimeValue) := do
+  if h: op.getNumRegions ctx.raw ≠ 1 then
     none
   else
-    let (_state, results) ← interpretRegion ctx (op.getRegion ctx 0) InterpreterState.empty
+    let (_state, results) ← interpretRegion (op.getRegion ctx.raw 0) (InterpreterState.empty ctx)
     return results
 
 end Veir

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1113,7 +1113,7 @@ decreasing_by grind
 -/
 def interpretBlock (blockPtr : BlockPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
     (blockInBounds : blockPtr.InBounds ctx.raw := by grind) :
-  Interp (InterpreterState ctx × ControlFlowAction) := do
+    Interp (InterpreterState ctx × ControlFlowAction) := do
   rlet firstOp ← (blockPtr.get ctx.raw).firstOp
   interpretOpList firstOp state
 

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -16,7 +16,6 @@ CompCertSSA semantics are based on small-step operational semantics.
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {state : InterpreterState}
 
 /-!
 ## Equation Lemma
@@ -68,41 +67,41 @@ This is encoded by stating that interpreting `op` in `state` produces `state` it
 equivalent to saying that the results of interpreting `op` on the given `state` are present in
 `state` itself.
 -/
-def InterpreterState.EquationHolds (state : InterpreterState) (ctx : WfIRContext OpCode)
+def InterpreterState.EquationHolds {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
     (op : OperationPtr) : Prop :=
-  ∃ controlFlow, interpretOp ctx op state = some (.ok (state, controlFlow))
+  ∃ controlFlow, interpretOp op state = some (.ok (state, controlFlow))
 
 theorem interpretOp_equationHolds_self
-    {ctx : WfIRContext OpCode} (ctxDom : ctx.Dom) :
+    {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom) :
     op.Pure ctx →
-    interpretOp ctx op state = some (.ok (state', controlFlow)) →
-    state'.EquationHolds ctx op := by
+    interpretOp op state = some (.ok (state', controlFlow)) →
+    state'.EquationHolds op := by
   simp only [InterpreterState.EquationHolds]
-  grind [interpretOp_some_iff, OperationPtr.Pure.interpretOp'_eq_ok_implies_memory_eq]
+  grind [OperationPtr.Pure.interpretOp'_eq_ok_implies_memory_eq, interpretOp_some_iff]
 
 theorem interpretOp_equationHolds_other
-    {ctx : WfIRContext OpCode} (ctxDom : ctx.Dom) :
+    {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom) :
     op₂.Pure ctx →
-    interpretOp ctx op₁ state = some (.ok (state', cf₁)) →
+    interpretOp op₁ state = some (.ok (state', cf₁)) →
     op₂.dominates op₁ ctx →
-    state.EquationHolds ctx op₂ →
-    state'.EquationHolds ctx op₂ := by
+    state.EquationHolds op₂ →
+    state'.EquationHolds op₂ := by
   intro op₂Pure hInterp₁ hDom
   simp only [InterpreterState.EquationHolds]
   rintro ⟨cf₂, hInterp₂⟩
   exists cf₂
-  have ⟨operandValues₁, resValues₁, memory₁, hOperandValues₁, hInterp₁', hResValues₁⟩ := interpretOp_some_iff.mp hInterp₁
-  have ⟨operandValues₂, resValues₂, memory₂, hOperandValues₂, hInterp₂', hResValues₂⟩ := interpretOp_some_iff.mp hInterp₂
-  subst state'
-  simp only [interpretOp, bind, pure]
-  simp only [VariableState.getOperandValues_setResultValues_of_dominates ctxDom hDom]
+  have ⟨operandValues₁, resValues₁, memory₁, resState₂, hOperandValues₁, hInterp₁', hResValues₁, hState'⟩ := interpretOp_some_iff.mp hInterp₁
+  have ⟨operandValues₂, resValues₂, memory₂, resState₁, hOperandValues₂, hInterp₂', hResValues₂, hState⟩ := interpretOp_some_iff.mp hInterp₂
+  subst state state'; simp_all only
+  simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]
+  simp only [VariableState.getOperandValues_setResultValues?_of_dominates ctxDom hDom hResValues₁]
   simp only [hOperandValues₂]
-  rw [OperationPtr.Pure.interpretOp'_eq_interpretOp'_other_memory op₂Pure state.memory]
-  simp only [Interp.map, Option.map, hInterp₂', UBOr.map]
-  by_cases hOp : op₁ = op₂
+  rw [OperationPtr.Pure.interpretOp'_eq_interpretOp'_other_memory op₂Pure memory₂]
+  simp only [hInterp₂', Interp.map, Option.map, UBOr.map]
+  by_cases hOp : op₂ = op₁
   · grind
-  · simp only [VariableState.setResultValues_comm hOp]
-    cases state; grind
+  · have := VariableState.setResultValues?_comm hOp hResValues₂ hResValues₁
+    grind
 
 /-!
 ## SSA Invariant at a Program Point
@@ -114,18 +113,19 @@ lemma for all operations that dominate that program point.
 In other words, all operations that dominate the given location have already been interpreted and
 their results are present in the state.
 -/
-def InterpreterState.EquationLemmaAt (state : InterpreterState) (ctx : WfIRContext OpCode)
+def InterpreterState.EquationLemmaAt {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
     (location : InsertPoint) (_locInBounds : location.InBounds ctx.raw := by grind) : Prop :=
   ∀ (op : OperationPtr) (_opInBounds : op.InBounds ctx.raw),
   op.Pure ctx →
   op.dominatesIp location ctx →
-  state.EquationHolds ctx op
+  state.EquationHolds op
 
-theorem interpretOp_equationLemmaAt (ctxDom : ctx.Dom)
-    (stateWf : state.EquationLemmaAt ctx (InsertPoint.before op) opInBounds)
+theorem interpretOp_equationLemmaAt {ctx : WfIRContext OpCode} {opInBounds} {state state' : InterpreterState ctx}
+    (ctxDom : ctx.Dom)
+    (stateWf : state.EquationLemmaAt (InsertPoint.before op) opInBounds)
     (opHasParent : (op.get! ctx.raw).parent = some block) :
-    interpretOp ctx op state = some (.ok (state', controlFlow)) →
-    state'.EquationLemmaAt ctx (InsertPoint.after op ctx.raw block) := by
+    interpretOp op state = some (.ok (state', controlFlow)) →
+    state'.EquationLemmaAt (InsertPoint.after op ctx.raw block) := by
   intro hInterp
   simp only [InterpreterState.EquationLemmaAt] at stateWf ⊢
   intro op' op'InBounds hPure hDom

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -4,47 +4,98 @@ import Veir.Dominance
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {varState varState' : VariableState}
-variable {state state' : InterpreterState}
+variable {ctx : WfIRContext OpInfo}
+variable {varState varState' : VariableState ctx}
+variable {state state' : InterpreterState ctx}
 variable {op op' : OperationPtr}
 
-@[grind =]
-theorem VariableState.getVar?_setVar :
-    (VariableState.setVar varState var' val).getVar? var =
-    if var = var' then some val else varState.getVar? var := by
-  grind [VariableState.setVar, VariableState.getVar?]
+theorem VariableState.setVar?_eq_none_iff_of_varState
+    (varState₂ : VariableState ctx) :
+    varState.setVar? var' val = none ↔ varState₂.setVar? var' val = none := by
+  grind [VariableState.setVar?]
 
-theorem VariableState.getVar?_setResultValues_loop {ctx : IRContext OpInfo} :
-    (varState.setResultValues_loop ctx op resultValues idx).getVar? value =
+theorem VariableState.setResultValues?_loop_eq_none_iff_of_varState
+    (varState₂ : VariableState ctx) :
+    varState.setResultValues?_loop op resValues idx = none ↔
+    varState₂.setResultValues?_loop op resValues idx = none := by
+  induction idx generalizing varState varState₂ with
+  | zero => grind [setResultValues?_loop]
+  | succ i ih =>
+    simp [setResultValues?_loop, Option.bind]
+    grind [VariableState.setVar?_eq_none_iff_of_varState]
+
+theorem VariableState.setResultValues?_eq_none_iff_of_varState
+    (varState₂ : VariableState ctx) :
+    varState.setResultValues? op resValues = none ↔
+    varState₂.setResultValues? op resValues = none := by
+  simp only [setResultValues?]
+  grind [VariableState.setResultValues?_loop_eq_none_iff_of_varState]
+
+theorem VariableState.setVar?_eq_some_of_varState
+    (varState₂ : VariableState ctx) :
+    varState.setVar? var' val = some varStateA →
+    ∃ varStateB, varState₂.setVar? var' val = some varStateB := by
+  grind [VariableState.setVar?]
+
+theorem VariableState.setResultValues?_loop_eq_some_of_varState
+    (varState₂ : VariableState ctx) :
+    varState.setResultValues?_loop op resValues idx = some varStateA →
+    ∃ varStateB, varState₂.setResultValues?_loop op resValues idx = some varStateB := by
+  cases hc : varState₂.setResultValues?_loop op resValues idx
+  · grind [VariableState.setResultValues?_loop_eq_none_iff_of_varState]
+  · grind
+
+theorem VariableState.setResultValues?_eq_some_of_varState
+    (varState₂ : VariableState ctx) :
+    varState.setResultValues? op resValues = some varStateA →
+    ∃ varStateB, varState₂.setResultValues? op resValues = some varStateB := by
+  rcases hc : varState₂.setResultValues? op resValues
+  · grind [VariableState.setResultValues?_eq_none_iff_of_varState]
+  · grind
+
+@[grind =>]
+theorem VariableState.getVar?_of_setVar? :
+    VariableState.setVar? varState var' val = some varState' →
+    varState'.getVar? var =
+    if var = var' then some val else varState.getVar? var := by
+  grind [VariableState.setVar?, VariableState.getVar?]
+
+theorem VariableState.getVar?_setResultValues?_loop :
+    varState.setResultValues?_loop op resultValues idx = some varState' →
+    varState'.getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
       if op' = op ∧ index < idx then
         some resultValues[index]!
        else
-         varState.getVar? value
+        varState.getVar? value
     | _ =>
       varState.getVar? value := by
-  fun_induction VariableState.setResultValues_loop
+  fun_induction VariableState.setResultValues?_loop
   next => grind
-  next => grind [cases OpResultPtr, OperationPtr.getResult_def, cases ValuePtr]
+  next =>
+    simp only [Option.bind_eq_bind, Nat.succ_eq_add_one, Option.bind]
+    grind [cases OpResultPtr, OperationPtr.getResult_def, cases ValuePtr]
 
-@[grind =]
-theorem VariableState.getVar?_setResultValues {ctx : IRContext OpInfo} :
-    (varState.setResultValues ctx op resultValues).getVar? value =
+@[grind =>]
+theorem VariableState.getVar?_setResultValues? :
+    varState.setResultValues? op resultValues = some varState' →
+    varState'.getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
-      if op' = op ∧ index < op.getNumResults! ctx then
+      if op' = op ∧ index < op.getNumResults! ctx.raw then
         some resultValues[index]!
        else
          varState.getVar? value
     | _ =>
       varState.getVar? value := by
-  simp [VariableState.setResultValues, VariableState.getVar?_setResultValues_loop]
+  grind [VariableState.setResultValues?, VariableState.getVar?_setResultValues?_loop]
 
-@[grind =]
-theorem VariableState.getVar?_setResultValues_of_value_inBounds
-    {ctx : IRContext OpInfo} (valueInBounds : value.InBounds ctx) :
-    (varState.setResultValues ctx op resultValues).getVar? value =
+@[grind =>]
+theorem VariableState.getVar?_setResultValues?_of_value_inBounds
+    (valueInBounds : value.InBounds ctx.raw) :
+    varState.setResultValues? op resultValues = some varState' →
+    varState'.getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
       if op' = op then
@@ -53,22 +104,25 @@ theorem VariableState.getVar?_setResultValues_of_value_inBounds
          varState.getVar? value
     | _ =>
       varState.getVar? value := by
-  simp only [getVar?_setResultValues]
+  intro h
+  simp only [getVar?_setResultValues? h]
   cases value <;> grind
 
-theorem interpretOp_some_iff :
-  interpretOp ctx op state = some (.ok (state', cf)) ↔
-  ∃ operandValues resValues mem',
-    (state.variables.getOperandValues ctx op) = some operandValues ∧
-    interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
-      (op.getResultTypes! ctx) operandValues (op.getSuccessors! ctx) state.memory = some (.ok (resValues, mem', cf)) ∧
-    state' = ⟨state.variables.setResultValues ctx op resValues, mem'⟩ := by
-  simp only [interpretOp, bind, pure]
+theorem interpretOp_some_iff {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} :
+  interpretOp op state = some (.ok (state', cf)) ↔
+  ∃ operandValues resValues mem' varState',
+    (state.variables.getOperandValues op) = some operandValues ∧
+    interpretOp' (op.getOpType! ctx.raw) (op.getProperties! ctx.raw (op.getOpType! ctx.raw))
+      (op.getResultTypes! ctx.raw) operandValues (op.getSuccessors! ctx.raw) state.memory =
+      some (.ok (resValues, mem', cf)) ∧
+    state.variables.setResultValues? op resValues = some varState' ∧
+    state' = ⟨varState', mem'⟩ := by
+  simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]
   grind
 
-theorem VariableState.getOperandValues_eq_of_getVar?_eq {ctx : IRContext OpInfo} :
-    (∀ val, val ∈ op.getOperands! ctx → varState.getVar? val = varState'.getVar? val) →
-    varState.getOperandValues ctx op = varState'.getOperandValues ctx op := by
+theorem VariableState.getOperandValues_eq_of_getVar?_eq :
+    (∀ val, val ∈ op.getOperands! ctx.raw → varState.getVar? val = varState'.getVar? val) →
+    varState.getOperandValues op = varState'.getOperandValues op := by
   intro h
   simp only [getOperandValues, Array.mapM_eq_mapM_toList]
   suffices H : ∀ (l : List _), (∀ val ∈ l, varState.getVar? val = varState'.getVar? val) →
@@ -76,20 +130,29 @@ theorem VariableState.getOperandValues_eq_of_getVar?_eq {ctx : IRContext OpInfo}
   intro l hl
   induction l <;> grind
 
-theorem VariableState.setResultValues_comm {ctx : WfIRContext OpInfo}
+theorem VariableState.setResultValues?_comm
     (hOp : op₁ ≠ op₂) :
-    (varState.setResultValues ctx.raw op₁ resValues₁).setResultValues ctx.raw op₂ resValues₂ =
-    (varState.setResultValues ctx.raw op₂ resValues₂).setResultValues ctx.raw op₁ resValues₁ := by
-  ext val runtimeVal
-  cases val <;> grind
+    varState.setResultValues? op₁ resValues₁ = some varState' →
+    varState'.setResultValues? op₂ resValues₂ = some varState'' →
+    ∃ varState₂, varState.setResultValues? op₂ resValues₂ = some varState₂ ∧
+    varState₂.setResultValues? op₁ resValues₁ = some varState'' := by
+  intros h₁ h₂
+  have ⟨varState₂, hvs₂⟩ := setResultValues?_eq_some_of_varState varState h₂
+  have ⟨varState₂', hvs₂'⟩ := setResultValues?_eq_some_of_varState varState₂ h₁
+  exists varState₂
+  constructor; grind
+  simp only [hvs₂', Option.some.injEq]
+  ext val value
+  cases val <;> grind [getVar?_setResultValues?]
 
-theorem VariableState.getVar?_setResultValues_operand_of_dominates {ctx : WfIRContext OpInfo}
+theorem VariableState.getVar?_setResultValues?_operand_of_dominates
     (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
     value ∈ op'.getOperands! ctx.raw →
-    (varState.setResultValues ctx.raw op resValues).getVar? value =
+    varState.setResultValues? op resValues = some varState' →
+    varState'.getVar? value =
     varState.getVar? value := by
-  intro valueInOperands
-  simp only [VariableState.getVar?_setResultValues]
+  intro valueInOperands h
+  simp only [VariableState.getVar?_setResultValues? h]
   have := IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom hdom value valueInOperands
   cases value
   case blockArgument blockArg => grind
@@ -100,24 +163,30 @@ theorem VariableState.getVar?_setResultValues_operand_of_dominates {ctx : WfIRCo
     grind [OperationPtr.getResult_def, cases OpResultPtr]
 
 @[grind =>]
-theorem VariableState.getOperandValues_setResultValues_of_dominates {ctx : WfIRContext OpInfo}
+theorem VariableState.getOperandValues_setResultValues?_of_dominates
     (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
-    (varState.setResultValues ctx.raw op resValues).getOperandValues ctx.raw op' =
-    varState.getOperandValues ctx.raw op' := by
+    varState.setResultValues? op resValues = some varState' →
+    varState'.getOperandValues op' = varState.getOperandValues op' := by
+  intro h
   apply VariableState.getOperandValues_eq_of_getVar?_eq
-  grind [VariableState.getVar?_setResultValues_operand_of_dominates]
+  grind [VariableState.getVar?_setResultValues?_operand_of_dominates]
 
 @[grind =>]
-theorem VariableState.getOperandValues_setResultValues_self {ctx : WfIRContext OpInfo}
+theorem VariableState.getOperandValues_setResultValues?_self
     (ctxDom : ctx.Dom) :
-    (varState.setResultValues ctx.raw op resValues).getOperandValues ctx.raw op =
-    varState.getOperandValues ctx.raw op := by
-  exact getOperandValues_setResultValues_of_dominates ctxDom OperationPtr.dominates_refl
+    (varState.setResultValues? op resValues) = varState' →
+    varState'.getOperandValues op = varState.getOperandValues op := by
+  exact getOperandValues_setResultValues?_of_dominates ctxDom OperationPtr.dominates_refl
 
-@[grind = ]
-theorem VariableState.setResultValues_setResultValues_self {ctx : WfIRContext OpCode} :
-    (varState.setResultValues ctx.raw op resValues).setResultValues ctx.raw op resValues' =
-    varState.setResultValues ctx.raw op resValues' := by
-  ext val runtimeVal
-  simp only [VariableState.getVar?_setResultValues]
-  grind
+@[grind =>]
+theorem VariableState.setResultValues?_setResultValues?_self :
+    varState.setResultValues? op resValues = some varState' →
+    varState'.setResultValues? op resValues' =
+    varState.setResultValues? op resValues' := by
+  intro h
+  rcases hopt : varState.setResultValues? op resValues' with _ | vs2
+  · grind [VariableState.setResultValues?_eq_none_iff_of_varState]
+  · have ⟨varState₂, hvs₂⟩ := setResultValues?_eq_some_of_varState varState' hopt
+    simp only [hvs₂, Option.some.injEq]
+    ext
+    grind [VariableState.getVar?_setResultValues?]

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -97,7 +97,7 @@ def main (args : List String) : IO Unit := do
       | .ok _ =>
         let rawCtx : IRContext OpCode := ctx
         let mainOp ← resolveEntryPoint rawCtx op
-        let result := bind (interpretRegion rawCtx (mainOp.getRegion! rawCtx 0) InterpreterState.empty (by sorry) (by sorry))
+        let result := bind (interpretRegion (mainOp.getRegion! rawCtx 0) (InterpreterState.empty ctx) (by sorry))
                            (fun (_, r) => pure r)
         match result with
         | some (.ok results) => IO.println s!"Program output: {results}"


### PR DESCRIPTION
In `VariableState`, we now add a field that asserts that all runtime values in the hashmap actually correspond to their associated MLIR types.
This means that `VariableState` and `InterpreterState` now have an WfIRContext parameter.
Additionally, `VariableState.setVar` and `VariableState.setResultVars` now return an optional, as we need to check wether or not the values correctly conforms to their respective types. This required to update a lot of our proofs.