### PR TITLE
ci: only run benchmarks on non-fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           .github/scripts/run_benchmarks.sh 1000 100 5
 
       - name: Store benchmark result
-        if: github.repository_owner == 'opencompl'
+        if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: VeIR Benchmarks


### PR DESCRIPTION
Previously we checked if the repo the PR was for was a 'fork', while this PR now checks if the branch that is PRs is from a 'fork', aka from a repository different to the repository it is PRed to.