### PR TITLE
Fix riscv interpreter tests that were using `i64` instead of `!reg`

### DIFF
--- a/Test/Interpreter/RISCV/add.mlir
+++ b/Test/Interpreter/RISCV/add.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %x = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %y = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %z = "riscv.add"(%x, %y) : (i64, i64) -> i64
-    "func.return"(%z) : (i64) -> ()
+    %x = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %y = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %z = "riscv.add"(%x, %y) : (!reg, !reg) -> !reg
+    "func.return"(%z) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/addi.mlir
+++ b/Test/Interpreter/RISCV/addi.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.addi"(%a) <{ value = 5 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %d = "riscv.addi"(%c) <{ value = -5 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.addi"(%a) <{ value = 5 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %d = "riscv.addi"(%c) <{ value = -5 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/addiw.mlir
+++ b/Test/Interpreter/RISCV/addiw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.addiw"(%a) <{ value = 3 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %d = "riscv.addiw"(%c) <{ value = -31 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.addiw"(%a) <{ value = 3 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %d = "riscv.addiw"(%c) <{ value = -31 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/adduw.mlir
+++ b/Test/Interpreter/RISCV/adduw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.adduw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.adduw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.adduw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.adduw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/adduw_overflow.mlir
+++ b/Test/Interpreter/RISCV/adduw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.adduw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.adduw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/addw.mlir
+++ b/Test/Interpreter/RISCV/addw.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %x = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %y = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %z = "riscv.addw"(%x, %y) : (i64, i64) -> i64
-    "func.return"(%z) : (i64) -> ()
+    %x = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %y = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %z = "riscv.addw"(%x, %y) : (!reg, !reg) -> !reg
+    "func.return"(%z) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/addw_overflow.mlir
+++ b/Test/Interpreter/RISCV/addw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.addw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.addw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/and.mlir
+++ b/Test/Interpreter/RISCV/and.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %x = "riscv.li"() <{ value = 6 : i64 }> : () -> i64
-    %y = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %z = "riscv.and"(%x, %y) : (i64, i64) -> i64
-    "func.return"(%z) : (i64) -> ()
+    %x = "riscv.li"() <{ value = 6 : i64 }> : () -> !reg
+    %y = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %z = "riscv.and"(%x, %y) : (!reg, !reg) -> !reg
+    "func.return"(%z) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/andi.mlir
+++ b/Test/Interpreter/RISCV/andi.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 23 : i64 }> : () -> i64
-    %b = "riscv.andi"(%a) <{ value = 3 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 23 : i64 }> : () -> i64
-    %d = "riscv.andi"(%c) <{ value = -3 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 23 : i64 }> : () -> !reg
+    %b = "riscv.andi"(%a) <{ value = 3 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 23 : i64 }> : () -> !reg
+    %d = "riscv.andi"(%c) <{ value = -3 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/andn.mlir
+++ b/Test/Interpreter/RISCV/andn.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %x = "riscv.li"() <{ value = 6 : i64 }> : () -> i64
-    %y = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %z = "riscv.andn"(%x, %y) : (i64, i64) -> i64
-    "func.return"(%z) : (i64) -> ()
+    %x = "riscv.li"() <{ value = 6 : i64 }> : () -> !reg
+    %y = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %z = "riscv.andn"(%x, %y) : (!reg, !reg) -> !reg
+    "func.return"(%z) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/auipc.mlir
+++ b/Test/Interpreter/RISCV/auipc.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.auipc"(%a) <{ value = 3 : i20 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %d = "riscv.auipc"(%c) <{ value = -3 : i20 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.auipc"(%a) <{ value = 3 : i20 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %d = "riscv.auipc"(%c) <{ value = -3 : i20 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/bclr.mlir
+++ b/Test/Interpreter/RISCV/bclr.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.bclr"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.bclr"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.bclr"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.bclr"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/bclri.mlir
+++ b/Test/Interpreter/RISCV/bclri.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.bclri"(%a) <{ value = 2 : i12 }> : (i64) -> i64
-    %d = "riscv.bclri"(%b) <{ value = 5 : i12 }> : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.bclri"(%a) <{ value = 2 : i12 }> : (!reg) -> !reg
+    %d = "riscv.bclri"(%b) <{ value = 5 : i12 }> : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/bext.mlir
+++ b/Test/Interpreter/RISCV/bext.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.bext"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.bext"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.bext"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.bext"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/bexti.mlir
+++ b/Test/Interpreter/RISCV/bexti.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.bexti"(%a) <{ value = 2 : i12 }> : (i64) -> i64
-    %d = "riscv.bexti"(%b) <{ value = 5 : i12 }> : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.bexti"(%a) <{ value = 2 : i12 }> : (!reg) -> !reg
+    %d = "riscv.bexti"(%b) <{ value = 5 : i12 }> : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/binv.mlir
+++ b/Test/Interpreter/RISCV/binv.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.binv"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.binv"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.binv"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.binv"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/binvi.mlir
+++ b/Test/Interpreter/RISCV/binvi.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.binvi"(%a) <{ value = 2 : i12 }> : (i64) -> i64
-    %d = "riscv.binvi"(%b) <{ value = 5 : i12 }> : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.binvi"(%a) <{ value = 2 : i12 }> : (!reg) -> !reg
+    %d = "riscv.binvi"(%b) <{ value = 5 : i12 }> : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/bset.mlir
+++ b/Test/Interpreter/RISCV/bset.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.bset"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.bset"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.bset"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.bset"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/bseti.mlir
+++ b/Test/Interpreter/RISCV/bseti.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.bseti"(%a) <{ value = 2 : i12 }> : (i64) -> i64
-    %d = "riscv.bseti"(%b) <{ value = 5 : i12 }> : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.bseti"(%a) <{ value = 2 : i12 }> : (!reg) -> !reg
+    %d = "riscv.bseti"(%b) <{ value = 5 : i12 }> : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/clz.mlir
+++ b/Test/Interpreter/RISCV/clz.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> i64
-    %d = "riscv.clz"(%a) : (i64) -> i64
-    %e = "riscv.clz"(%b) : (i64) -> i64
-    %f = "riscv.clz"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> !reg
+    %d = "riscv.clz"(%a) : (!reg) -> !reg
+    %e = "riscv.clz"(%b) : (!reg) -> !reg
+    %f = "riscv.clz"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/clzw.mlir
+++ b/Test/Interpreter/RISCV/clzw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.clzw"(%a) : (i64) -> i64
-    %d = "riscv.clzw"(%b) : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.clzw"(%a) : (!reg) -> !reg
+    %d = "riscv.clzw"(%b) : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/clzw_overflow.mlir
+++ b/Test/Interpreter/RISCV/clzw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> i64
-    %b = "riscv.clzw"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> !reg
+    %b = "riscv.clzw"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/cpop.mlir
+++ b/Test/Interpreter/RISCV/cpop.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.cpop"(%a) : (i64) -> i64
-    %e = "riscv.cpop"(%b) : (i64) -> i64
-    %f = "riscv.cpop"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.cpop"(%a) : (!reg) -> !reg
+    %e = "riscv.cpop"(%b) : (!reg) -> !reg
+    %f = "riscv.cpop"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/cpopw.mlir
+++ b/Test/Interpreter/RISCV/cpopw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.cpopw"(%a) : (i64) -> i64
-    %d = "riscv.cpopw"(%b) : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.cpopw"(%a) : (!reg) -> !reg
+    %d = "riscv.cpopw"(%b) : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/cpopw_overflow.mlir
+++ b/Test/Interpreter/RISCV/cpopw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.cpopw"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.cpopw"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/ctz.mlir
+++ b/Test/Interpreter/RISCV/ctz.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.ctz"(%a) : (i64) -> i64
-    %e = "riscv.ctz"(%b) : (i64) -> i64
-    %f = "riscv.ctz"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.ctz"(%a) : (!reg) -> !reg
+    %e = "riscv.ctz"(%b) : (!reg) -> !reg
+    %f = "riscv.ctz"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/ctzw.mlir
+++ b/Test/Interpreter/RISCV/ctzw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.ctzw"(%a) : (i64) -> i64
-    %d = "riscv.ctzw"(%b) : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.ctzw"(%a) : (!reg) -> !reg
+    %d = "riscv.ctzw"(%b) : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/ctzw_overflow.mlir
+++ b/Test/Interpreter/RISCV/ctzw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.ctzw"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.ctzw"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/div.mlir
+++ b/Test/Interpreter/RISCV/div.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %f = "riscv.div"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.div"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.div"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %f = "riscv.div"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.div"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.div"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/divu.mlir
+++ b/Test/Interpreter/RISCV/divu.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %f = "riscv.divu"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.divu"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.divu"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %f = "riscv.divu"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.divu"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.divu"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/divuw.mlir
+++ b/Test/Interpreter/RISCV/divuw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %d = "riscv.divuw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.divuw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %d = "riscv.divuw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.divuw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/divuw_overflow.mlir
+++ b/Test/Interpreter/RISCV/divuw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %c = "riscv.divuw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %c = "riscv.divuw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/divw.mlir
+++ b/Test/Interpreter/RISCV/divw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %d = "riscv.divw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.divw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %d = "riscv.divw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.divw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/divw_overflow.mlir
+++ b/Test/Interpreter/RISCV/divw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %c = "riscv.divw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %c = "riscv.divw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/li.mlir
+++ b/Test/Interpreter/RISCV/li.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %x = "riscv.li"() <{ "value" = 3 : i64 }> : () -> i64
-    %y = "riscv.li"() <{ "value" = -2 : i64 }> : () -> i64
-    "func.return"(%x, %y) : (i64, i64) -> ()
+    %x = "riscv.li"() <{ "value" = 3 : i64 }> : () -> !reg
+    %y = "riscv.li"() <{ "value" = -2 : i64 }> : () -> !reg
+    "func.return"(%x, %y) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/lui.mlir
+++ b/Test/Interpreter/RISCV/lui.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %x = "riscv.lui"() <{ value = -5 : i20 }> : () -> i64
-    %y = "riscv.lui"() <{ value = 3 : i20 }> : () -> i64
-    "func.return"(%x, %y) : (i64, i64) -> ()
+    %x = "riscv.lui"() <{ value = -5 : i20 }> : () -> !reg
+    %y = "riscv.lui"() <{ value = 3 : i20 }> : () -> !reg
+    "func.return"(%x, %y) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/max.mlir
+++ b/Test/Interpreter/RISCV/max.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.max"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.max"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.max"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.max"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/maxu.mlir
+++ b/Test/Interpreter/RISCV/maxu.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.maxu"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.maxu"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.maxu"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.maxu"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/min.mlir
+++ b/Test/Interpreter/RISCV/min.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.min"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.min"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.min"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.min"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/minu.mlir
+++ b/Test/Interpreter/RISCV/minu.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.minu"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.minu"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.minu"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.minu"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mul.mlir
+++ b/Test/Interpreter/RISCV/mul.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %f = "riscv.mul"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.mul"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.mul"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %f = "riscv.mul"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.mul"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.mul"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mulh.mlir
+++ b/Test/Interpreter/RISCV/mulh.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %f = "riscv.mulh"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.mulh"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.mulh"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %f = "riscv.mulh"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.mulh"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.mulh"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mulhsu.mlir
+++ b/Test/Interpreter/RISCV/mulhsu.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = -4294967288 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %f = "riscv.mulhsu"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.mulhsu"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.mulhsu"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = -4294967288 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %f = "riscv.mulhsu"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.mulhsu"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.mulhsu"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mulhu.mlir
+++ b/Test/Interpreter/RISCV/mulhu.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = -4294967288 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %f = "riscv.mulhu"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.mulhu"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.mulhu"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = -4294967288 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %f = "riscv.mulhu"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.mulhu"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.mulhu"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mulw.mlir
+++ b/Test/Interpreter/RISCV/mulw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.mulw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.mulw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.mulw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.mulw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mulw_overflow.mlir
+++ b/Test/Interpreter/RISCV/mulw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %c = "riscv.mulw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %c = "riscv.mulw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/mv.mlir
+++ b/Test/Interpreter/RISCV/mv.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.mv"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.mv"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/neg.mlir
+++ b/Test/Interpreter/RISCV/neg.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.neg"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.neg"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/negw.mlir
+++ b/Test/Interpreter/RISCV/negw.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.negw"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.negw"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/not.mlir
+++ b/Test/Interpreter/RISCV/not.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.not"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.not"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/or.mlir
+++ b/Test/Interpreter/RISCV/or.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 53 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %d = "riscv.or"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.or"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 53 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %d = "riscv.or"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.or"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/ori.mlir
+++ b/Test/Interpreter/RISCV/ori.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.ori"(%a) <{ value = 3 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %d = "riscv.ori"(%c) <{ value = -3 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.ori"(%a) <{ value = 3 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %d = "riscv.ori"(%c) <{ value = -3 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/orn.mlir
+++ b/Test/Interpreter/RISCV/orn.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 53 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %d = "riscv.orn"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.orn"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 53 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %d = "riscv.orn"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.orn"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/pack.mlir
+++ b/Test/Interpreter/RISCV/pack.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> i64
-    %e = "riscv.pack"(%a, %b) : (i64, i64) -> i64
-    %f = "riscv.pack"(%a, %c) : (i64, i64) -> i64
-    %g = "riscv.pack"(%a, %d) : (i64, i64) -> i64
-    "func.return"(%e, %f, %g) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> !reg
+    %e = "riscv.pack"(%a, %b) : (!reg, !reg) -> !reg
+    %f = "riscv.pack"(%a, %c) : (!reg, !reg) -> !reg
+    %g = "riscv.pack"(%a, %d) : (!reg, !reg) -> !reg
+    "func.return"(%e, %f, %g) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/packh.mlir
+++ b/Test/Interpreter/RISCV/packh.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> i64
-    %e = "riscv.packh"(%a, %b) : (i64, i64) -> i64
-    %f = "riscv.packh"(%a, %c) : (i64, i64) -> i64
-    %g = "riscv.packh"(%a, %d) : (i64, i64) -> i64
-    "func.return"(%e, %f, %g) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> !reg
+    %e = "riscv.packh"(%a, %b) : (!reg, !reg) -> !reg
+    %f = "riscv.packh"(%a, %c) : (!reg, !reg) -> !reg
+    %g = "riscv.packh"(%a, %d) : (!reg, !reg) -> !reg
+    "func.return"(%e, %f, %g) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/packw.mlir
+++ b/Test/Interpreter/RISCV/packw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.packw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.packw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.packw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.packw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/packw_overflow.mlir
+++ b/Test/Interpreter/RISCV/packw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> i64
-    %c = "riscv.packw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 4294967297 : i64 }> : () -> !reg
+    %c = "riscv.packw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rem.mlir
+++ b/Test/Interpreter/RISCV/rem.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %f = "riscv.remu"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.remu"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.remu"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %f = "riscv.remu"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.remu"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.remu"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/remu.mlir
+++ b/Test/Interpreter/RISCV/remu.mlir
@@ -2,15 +2,15 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %f = "riscv.remu"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.remu"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.remu"(%d, %e) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %e = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %f = "riscv.remu"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.remu"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.remu"(%d, %e) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/remuw.mlir
+++ b/Test/Interpreter/RISCV/remuw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.remuw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.remuw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.remuw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.remuw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/remuw_overflow.mlir
+++ b/Test/Interpreter/RISCV/remuw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %c = "riscv.remuw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %c = "riscv.remuw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/remw.mlir
+++ b/Test/Interpreter/RISCV/remw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.remw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.remw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.remw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.remw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/remw_overflow.mlir
+++ b/Test/Interpreter/RISCV/remw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %c = "riscv.remw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %c = "riscv.remw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rol.mlir
+++ b/Test/Interpreter/RISCV/rol.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %e = "riscv.rol"(%a, %b) : (i64, i64) -> i64
-    %f = "riscv.rol"(%a, %d) : (i64, i64) -> i64
-    %g = "riscv.rol"(%c, %b) : (i64, i64) -> i64
-    "func.return"(%e, %f, %g) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %e = "riscv.rol"(%a, %b) : (!reg, !reg) -> !reg
+    %f = "riscv.rol"(%a, %d) : (!reg, !reg) -> !reg
+    %g = "riscv.rol"(%c, %b) : (!reg, !reg) -> !reg
+    "func.return"(%e, %f, %g) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rolw.mlir
+++ b/Test/Interpreter/RISCV/rolw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.rolw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.rolw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.rolw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.rolw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rolw_overflow.mlir
+++ b/Test/Interpreter/RISCV/rolw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.rolw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.rolw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/ror.mlir
+++ b/Test/Interpreter/RISCV/ror.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %e = "riscv.ror"(%a, %b) : (i64, i64) -> i64
-    %f = "riscv.ror"(%a, %d) : (i64, i64) -> i64
-    %g = "riscv.ror"(%c, %b) : (i64, i64) -> i64
-    "func.return"(%e, %f, %g) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %e = "riscv.ror"(%a, %b) : (!reg, !reg) -> !reg
+    %f = "riscv.ror"(%a, %d) : (!reg, !reg) -> !reg
+    %g = "riscv.ror"(%c, %b) : (!reg, !reg) -> !reg
+    "func.return"(%e, %f, %g) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rori.mlir
+++ b/Test/Interpreter/RISCV/rori.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.rori"(%a) <{ value = 3 : i6 }> : (i64) -> i64
-    %e = "riscv.rori"(%b) <{ value = -3 : i6 }> : (i64) -> i64
-    %f = "riscv.rori"(%c) <{ value = -3 : i6 }> : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.rori"(%a) <{ value = 3 : i6 }> : (!reg) -> !reg
+    %e = "riscv.rori"(%b) <{ value = -3 : i6 }> : (!reg) -> !reg
+    %f = "riscv.rori"(%c) <{ value = -3 : i6 }> : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/roriw.mlir
+++ b/Test/Interpreter/RISCV/roriw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.roriw"(%a) <{ value = 3 : i6 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %d = "riscv.roriw"(%c) <{ value = -3 : i6 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.roriw"(%a) <{ value = 3 : i6 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %d = "riscv.roriw"(%c) <{ value = -3 : i6 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/roriw_overflow.mlir
+++ b/Test/Interpreter/RISCV/roriw_overflow.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.roriw"(%a) <{ value = 3 : i6 }> : (i64) -> i64
-    %e = "riscv.roriw"(%b) <{ value = -3 : i6 }> : (i64) -> i64
-    %f = "riscv.roriw"(%c) <{ value = -3 : i6 }> : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.roriw"(%a) <{ value = 3 : i6 }> : (!reg) -> !reg
+    %e = "riscv.roriw"(%b) <{ value = -3 : i6 }> : (!reg) -> !reg
+    %f = "riscv.roriw"(%c) <{ value = -3 : i6 }> : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rorw.mlir
+++ b/Test/Interpreter/RISCV/rorw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.rorw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.rorw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.rorw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.rorw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/rorw_overflow.mlir
+++ b/Test/Interpreter/RISCV/rorw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.rorw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.rorw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/seqz.mlir
+++ b/Test/Interpreter/RISCV/seqz.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> i64
-    %c = "riscv.seqz"(%a) : (i64) -> i64
-    %d = "riscv.seqz"(%b) : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> !reg
+    %c = "riscv.seqz"(%a) : (!reg) -> !reg
+    %d = "riscv.seqz"(%b) : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sextb.mlir
+++ b/Test/Interpreter/RISCV/sextb.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.sextb"(%a) : (i64) -> i64
-    %e = "riscv.sextb"(%b) : (i64) -> i64
-    %f = "riscv.sextb"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.sextb"(%a) : (!reg) -> !reg
+    %e = "riscv.sextb"(%b) : (!reg) -> !reg
+    %f = "riscv.sextb"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sexth.mlir
+++ b/Test/Interpreter/RISCV/sexth.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.sexth"(%a) : (i64) -> i64
-    %e = "riscv.sexth"(%b) : (i64) -> i64
-    %f = "riscv.sexth"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.sexth"(%a) : (!reg) -> !reg
+    %e = "riscv.sexth"(%b) : (!reg) -> !reg
+    %f = "riscv.sexth"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sextw.mlir
+++ b/Test/Interpreter/RISCV/sextw.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %b = "riscv.sextw"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %b = "riscv.sextw"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sgtz.mlir
+++ b/Test/Interpreter/RISCV/sgtz.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -1 : i64 }> : () -> i64
-    %d = "riscv.sgtz"(%a) : (i64) -> i64
-    %e = "riscv.sgtz"(%b) : (i64) -> i64
-    %f = "riscv.sgtz"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -1 : i64 }> : () -> !reg
+    %d = "riscv.sgtz"(%a) : (!reg) -> !reg
+    %e = "riscv.sgtz"(%b) : (!reg) -> !reg
+    %f = "riscv.sgtz"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh1add.mlir
+++ b/Test/Interpreter/RISCV/sh1add.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %f = "riscv.sh1add"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.sh1add"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.sh1add"(%d, %a) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %f = "riscv.sh1add"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.sh1add"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.sh1add"(%d, %a) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh1adduw.mlir
+++ b/Test/Interpreter/RISCV/sh1adduw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.sh1adduw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sh1adduw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.sh1adduw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sh1adduw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh1adduw_overflow.mlir
+++ b/Test/Interpreter/RISCV/sh1adduw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.sh1adduw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.sh1adduw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh2add.mlir
+++ b/Test/Interpreter/RISCV/sh2add.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %f = "riscv.sh2add"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.sh2add"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.sh2add"(%d, %a) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %f = "riscv.sh2add"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.sh2add"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.sh2add"(%d, %a) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh2adduw.mlir
+++ b/Test/Interpreter/RISCV/sh2adduw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.sh2adduw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sh2adduw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.sh2adduw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sh2adduw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh2adduw_overflow.mlir
+++ b/Test/Interpreter/RISCV/sh2adduw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.sh2adduw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.sh2adduw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh3add.mlir
+++ b/Test/Interpreter/RISCV/sh3add.mlir
@@ -2,14 +2,14 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %f = "riscv.sh3add"(%a, %b) : (i64, i64) -> i64
-    %g = "riscv.sh3add"(%a, %c) : (i64, i64) -> i64
-    %h = "riscv.sh3add"(%d, %a) : (i64, i64) -> i64
-    "func.return"(%f, %g, %h) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %f = "riscv.sh3add"(%a, %b) : (!reg, !reg) -> !reg
+    %g = "riscv.sh3add"(%a, %c) : (!reg, !reg) -> !reg
+    %h = "riscv.sh3add"(%d, %a) : (!reg, !reg) -> !reg
+    "func.return"(%f, %g, %h) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh3adduw.mlir
+++ b/Test/Interpreter/RISCV/sh3adduw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.sh3adduw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sh3adduw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.sh3adduw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sh3adduw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sh3adduw_overflow.mlir
+++ b/Test/Interpreter/RISCV/sh3adduw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %c = "riscv.sh2adduw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %c = "riscv.sh2adduw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sll.mlir
+++ b/Test/Interpreter/RISCV/sll.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 21 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.sll"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sll"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 21 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.sll"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sll"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slli.mlir
+++ b/Test/Interpreter/RISCV/slli.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.slli"(%a) <{ value = 3 : i6 }> : (i64) -> i64
-    %e = "riscv.slli"(%b) <{ value = -3 : i6 }> : (i64) -> i64
-    %f = "riscv.slli"(%c) <{ value = -3 : i5 }> : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.slli"(%a) <{ value = 3 : i6 }> : (!reg) -> !reg
+    %e = "riscv.slli"(%b) <{ value = -3 : i6 }> : (!reg) -> !reg
+    %f = "riscv.slli"(%c) <{ value = -3 : i5 }> : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slliuw.mlir
+++ b/Test/Interpreter/RISCV/slliuw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.slliuw"(%a) <{ value = 3 : i5 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %d = "riscv.slliuw"(%c) <{ value = -3 : i5 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.slliuw"(%a) <{ value = 3 : i5 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %d = "riscv.slliuw"(%c) <{ value = -3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slliuw_overflow.mlir
+++ b/Test/Interpreter/RISCV/slliuw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.slliuw"(%a) <{ value = -3 : i5 }> : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.slliuw"(%a) <{ value = -3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slliw.mlir
+++ b/Test/Interpreter/RISCV/slliw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.slliw"(%a) <{ value = 3 : i5 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %d = "riscv.slliw"(%c) <{ value = -3 : i5 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.slliw"(%a) <{ value = 3 : i5 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %d = "riscv.slliw"(%c) <{ value = -3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slliw_overflow.mlir
+++ b/Test/Interpreter/RISCV/slliw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %b = "riscv.slliw"(%a) <{ value = 3 : i5 }> : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %b = "riscv.slliw"(%a) <{ value = 3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sllw.mlir
+++ b/Test/Interpreter/RISCV/sllw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 21 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.sllw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sllw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 21 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.sllw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sllw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sllw_overflow.mlir
+++ b/Test/Interpreter/RISCV/sllw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.sllw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.sllw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slt.mlir
+++ b/Test/Interpreter/RISCV/slt.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.slt"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.slt"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.slt"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.slt"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/slti.mlir
+++ b/Test/Interpreter/RISCV/slti.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.slti"(%a) <{ value = 33 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %d = "riscv.slti"(%c) <{ value = -33 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.slti"(%a) <{ value = 33 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %d = "riscv.slti"(%c) <{ value = -33 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sltiu.mlir
+++ b/Test/Interpreter/RISCV/sltiu.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.sltiu"(%a) <{ value = 33 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %d = "riscv.sltiu"(%c) <{ value = -33 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.sltiu"(%a) <{ value = 33 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %d = "riscv.sltiu"(%c) <{ value = -33 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sltu.mlir
+++ b/Test/Interpreter/RISCV/sltu.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -13 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 7 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -7 : i64 }> : () -> i64
-    %d = "riscv.sltu"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sltu"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = -13 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 7 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -7 : i64 }> : () -> !reg
+    %d = "riscv.sltu"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sltu"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sltz.mlir
+++ b/Test/Interpreter/RISCV/sltz.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -1 : i64 }> : () -> i64
-    %d = "riscv.sltz"(%a) : (i64) -> i64
-    %e = "riscv.sltz"(%b) : (i64) -> i64
-    %f = "riscv.sltz"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -1 : i64 }> : () -> !reg
+    %d = "riscv.sltz"(%a) : (!reg) -> !reg
+    %e = "riscv.sltz"(%b) : (!reg) -> !reg
+    %f = "riscv.sltz"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/snez.mlir
+++ b/Test/Interpreter/RISCV/snez.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> i64
-    %c = "riscv.snez"(%a) : (i64) -> i64
-    %d = "riscv.snez"(%b) : (i64) -> i64
-    "func.return"(%c, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 0 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> !reg
+    %c = "riscv.snez"(%a) : (!reg) -> !reg
+    %d = "riscv.snez"(%b) : (!reg) -> !reg
+    "func.return"(%c, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sra.mlir
+++ b/Test/Interpreter/RISCV/sra.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %d = "riscv.sra"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sra"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %d = "riscv.sra"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sra"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srai.mlir
+++ b/Test/Interpreter/RISCV/srai.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 23 : i64 }> : () -> i64
-    %b = "riscv.srai"(%a) <{ value = 1 : i6 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 23 : i64 }> : () -> i64
-    %d = "riscv.srai"(%c) <{ value = -1 : i6 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 23 : i64 }> : () -> !reg
+    %b = "riscv.srai"(%a) <{ value = 1 : i6 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 23 : i64 }> : () -> !reg
+    %d = "riscv.srai"(%c) <{ value = -1 : i6 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sraiw.mlir
+++ b/Test/Interpreter/RISCV/sraiw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 23 : i64 }> : () -> i64
-    %b = "riscv.sraiw"(%a) <{ value = 1 : i6 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 23 : i64 }> : () -> i64
-    %d = "riscv.sraiw"(%c) <{ value = -1 : i6 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 23 : i64 }> : () -> !reg
+    %b = "riscv.sraiw"(%a) <{ value = 1 : i6 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 23 : i64 }> : () -> !reg
+    %d = "riscv.sraiw"(%c) <{ value = -1 : i6 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sraiw_overflow.mlir
+++ b/Test/Interpreter/RISCV/sraiw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %b = "riscv.sraiw"(%a) <{ value = 3 : i5 }> : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %b = "riscv.sraiw"(%a) <{ value = 3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sraw.mlir
+++ b/Test/Interpreter/RISCV/sraw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %d = "riscv.sraw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sraw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %d = "riscv.sraw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sraw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sraw_overflow.mlir
+++ b/Test/Interpreter/RISCV/sraw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> i64
-    %c = "riscv.sraw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> !reg
+    %c = "riscv.sraw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srl.mlir
+++ b/Test/Interpreter/RISCV/srl.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %d = "riscv.srl"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.srl"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %d = "riscv.srl"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.srl"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srli.mlir
+++ b/Test/Interpreter/RISCV/srli.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 11 : i64 }> : () -> i64
-    %b = "riscv.srli"(%a) <{ value = 3 : i6 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 11 : i64 }> : () -> i64
-    %d = "riscv.srli"(%c) <{ value = -3 : i6 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 11 : i64 }> : () -> !reg
+    %b = "riscv.srli"(%a) <{ value = 3 : i6 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 11 : i64 }> : () -> !reg
+    %d = "riscv.srli"(%c) <{ value = -3 : i6 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srliw.mlir
+++ b/Test/Interpreter/RISCV/srliw.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %b = "riscv.srliw"(%a) <{ value = 3 : i5 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> i64
-    %d = "riscv.srliw"(%c) <{ value = -3 : i5 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %b = "riscv.srliw"(%a) <{ value = 3 : i5 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !reg
+    %d = "riscv.srliw"(%c) <{ value = -3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srliw_overflow.mlir
+++ b/Test/Interpreter/RISCV/srliw_overflow.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %b = "riscv.srliw"(%a) <{ value = 3 : i5 }> : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %b = "riscv.srliw"(%a) <{ value = 3 : i5 }> : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srlw.mlir
+++ b/Test/Interpreter/RISCV/srlw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> i64
-    %d = "riscv.srlw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.srlw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = -2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 3 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -3 : i64 }> : () -> !reg
+    %d = "riscv.srlw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.srlw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/srlw_overflow.mlir
+++ b/Test/Interpreter/RISCV/srlw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> i64
-    %c = "riscv.srlw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 1 : i64 }> : () -> !reg
+    %c = "riscv.srlw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/sub.mlir
+++ b/Test/Interpreter/RISCV/sub.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.sub"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.sub"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.sub"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.sub"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/subw.mlir
+++ b/Test/Interpreter/RISCV/subw.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %d = "riscv.subw"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.subw"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %d = "riscv.subw"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.subw"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/subw_overflow.mlir
+++ b/Test/Interpreter/RISCV/subw_overflow.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %c = "riscv.subw"(%a, %b) : (i64, i64) -> i64
-    "func.return"(%c) : (i64) -> ()
+    %a = "riscv.li"() <{ value = 4294967296 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %c = "riscv.subw"(%a, %b) : (!reg, !reg) -> !reg
+    "func.return"(%c) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/xnor.mlir
+++ b/Test/Interpreter/RISCV/xnor.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 7 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 7 : i64 }> : () -> i64
-    %d = "riscv.xnor"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.xnor"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 7 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 7 : i64 }> : () -> !reg
+    %d = "riscv.xnor"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.xnor"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/xor.mlir
+++ b/Test/Interpreter/RISCV/xor.mlir
@@ -2,12 +2,12 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = 7 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 7 : i64 }> : () -> i64
-    %d = "riscv.xor"(%a, %b) : (i64, i64) -> i64
-    %e = "riscv.xor"(%a, %c) : (i64, i64) -> i64
-    "func.return"(%d, %e) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 5 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = 7 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 7 : i64 }> : () -> !reg
+    %d = "riscv.xor"(%a, %b) : (!reg, !reg) -> !reg
+    %e = "riscv.xor"(%a, %c) : (!reg, !reg) -> !reg
+    "func.return"(%d, %e) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/xori.mlir
+++ b/Test/Interpreter/RISCV/xori.mlir
@@ -2,11 +2,11 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.xori"(%a) <{ value = 3 : i12 }> : (i64) -> i64
-    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %d = "riscv.xori"(%c) <{ value = -3 : i12 }> : (i64) -> i64
-    "func.return"(%b, %d) : (i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.xori"(%a) <{ value = 3 : i12 }> : (!reg) -> !reg
+    %c = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %d = "riscv.xori"(%c) <{ value = -3 : i12 }> : (!reg) -> !reg
+    "func.return"(%b, %d) : (!reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/zextb.mlir
+++ b/Test/Interpreter/RISCV/zextb.mlir
@@ -2,9 +2,9 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %b = "riscv.zextb"(%a) : (i64) -> i64
-    "func.return"(%b) : (i64) -> ()
+    %a = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %b = "riscv.zextb"(%a) : (!reg) -> !reg
+    "func.return"(%b) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV/zexth.mlir
+++ b/Test/Interpreter/RISCV/zexth.mlir
@@ -2,13 +2,13 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
-    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> i64
-    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> i64
-    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> i64
-    %d = "riscv.zexth"(%a) : (i64) -> i64
-    %e = "riscv.zexth"(%b) : (i64) -> i64
-    %f = "riscv.zexth"(%c) : (i64) -> i64
-    "func.return"(%d, %e, %f) : (i64, i64, i64) -> ()
+    %a = "riscv.li"() <{ value = 2 : i64 }> : () -> !reg
+    %b = "riscv.li"() <{ value = -5 : i64 }> : () -> !reg
+    %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !reg
+    %d = "riscv.zexth"(%a) : (!reg) -> !reg
+    %e = "riscv.zexth"(%b) : (!reg) -> !reg
+    %f = "riscv.zexth"(%c) : (!reg) -> !reg
+    "func.return"(%d, %e, %f) : (!reg, !reg, !reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV_Cf/beq.mlir
+++ b/Test/Interpreter/RISCV_Cf/beq.mlir
@@ -3,17 +3,17 @@
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
     ^1():
-      %x1 = "riscv.li"() <{"value" = 8 : i64}> : () -> i64
-      %x2 = "riscv.li"() <{"value" = 11 : i64}> : () -> i64
-      "riscv_cf.beq"(%x1, %x2, %x1, %x2) [^4,^3] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (i64, i64, i64, i64) -> ()
-    ^3(%z1 : i64):
-      %z2 = "riscv.li"() <{"value" = 11 : i64}> : () -> i64
-      "riscv_cf.beq"(%z1, %z2, %z1, %z2) [^2,^4] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (i64, i64, i64, i64) -> ()
-    ^4(%a1 : i64):
-      %a2 = "riscv.li"() <{"value" = 5 : i64}> : () -> i64
-      "func.return"(%a2) : (i64) -> ()
-    ^2(%y : i64):
-      "func.return"(%y) : (i64) -> ()
+      %x1 = "riscv.li"() <{"value" = 8 : i64}> : () -> !reg
+      %x2 = "riscv.li"() <{"value" = 11 : i64}> : () -> !reg
+      "riscv_cf.beq"(%x1, %x2, %x1, %x2) [^4,^3] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (!reg, !reg, !reg, !reg) -> ()
+    ^3(%z1 : !reg):
+      %z2 = "riscv.li"() <{"value" = 11 : i64}> : () -> !reg
+      "riscv_cf.beq"(%z1, %z2, %z1, %z2) [^2,^4] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (!reg, !reg, !reg, !reg) -> ()
+    ^4(%a1 : !reg):
+      %a2 = "riscv.li"() <{"value" = 5 : i64}> : () -> !reg
+      "func.return"(%a2) : (!reg) -> ()
+    ^2(%y : !reg):
+      "func.return"(%y) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV_Cf/bne.mlir
+++ b/Test/Interpreter/RISCV_Cf/bne.mlir
@@ -3,17 +3,17 @@
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
     ^1():
-      %x1 = "riscv.li"() <{"value" = 8 : i64}> : () -> i64
-      %x2 = "riscv.li"() <{"value" = 11 : i64}> : () -> i64
-      "riscv_cf.bne"(%x1, %x2, %x2, %x1) [^3, ^4] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (i64, i64, i64, i64) -> ()
-    ^4(%a1 : i64):
-      %a2 = "riscv.li"() <{"value" = 5 : i64}> : () -> i64
-      "func.return"(%a2) : (i64) -> ()
-    ^3(%z1 : i64):
-      %z2 = "riscv.li"() <{"value" = 11 : i64}> : () -> i64
-      "riscv_cf.bne"(%z1, %z2, %z2, %z1) [^4, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (i64, i64, i64, i64) -> ()
-    ^2(%y : i64):
-      "func.return"(%y) : (i64) -> ()
+      %x1 = "riscv.li"() <{"value" = 8 : i64}> : () -> !reg
+      %x2 = "riscv.li"() <{"value" = 11 : i64}> : () -> !reg
+      "riscv_cf.bne"(%x1, %x2, %x2, %x1) [^3, ^4] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (!reg, !reg, !reg, !reg) -> ()
+    ^4(%a1 : !reg):
+      %a2 = "riscv.li"() <{"value" = 5 : i64}> : () -> !reg
+      "func.return"(%a2) : (!reg) -> ()
+    ^3(%z1 : !reg):
+      %z2 = "riscv.li"() <{"value" = 11 : i64}> : () -> !reg
+      "riscv_cf.bne"(%z1, %z2, %z2, %z1) [^4, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}> : (!reg, !reg, !reg, !reg) -> ()
+    ^2(%y : !reg):
+      "func.return"(%y) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 

--- a/Test/Interpreter/RISCV_Cf/branch.mlir
+++ b/Test/Interpreter/RISCV_Cf/branch.mlir
@@ -3,10 +3,10 @@
 "builtin.module"() ({
   "func.func"() <{sym_name = "main"}> ({
     ^1():
-      %x = "riscv.li"() <{ "value" = 9 : i64 }> : () -> i64
-      "riscv_cf.branch"(%x) [^2] : (i64) -> ()
-    ^2(%y : i64):
-      "func.return"(%y) : (i64) -> ()
+      %x = "riscv.li"() <{ "value" = 9 : i64 }> : () -> !reg
+      "riscv_cf.branch"(%x) [^2] : (!reg) -> ()
+    ^2(%y : !reg):
+      "func.return"(%y) : (!reg) -> ()
   }) : () -> ()
 }) : () -> ()
 


### PR DESCRIPTION
Our verifier does not check types of input and outputs.