### PR TITLE
llvm: llvm.alloc alignment expects an i64 attribute

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -31,7 +31,7 @@
       %22 = "llvm.sext"(%6) : (i1) -> i32
       %23 = "llvm.zext"(%6) : (i1) -> i32
       %24 = "llvm.alloca"(%5) <{elem_type = i32}> : (i32) -> !llvm.ptr
-      %25 = "llvm.alloca"(%5) <{elem_type = i32, alignment = 4 : i32, inalloca}> : (i32) -> !llvm.ptr
+      %25 = "llvm.alloca"(%5) <{elem_type = i32, alignment = 4 : i64, inalloca}> : (i32) -> !llvm.ptr
       "llvm.store"(%5, %24) : (i32, !llvm.ptr) -> ()
       "llvm.store"(%5, %24) <{alignment = 1 : i32, volatile_, nontemporal, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (i32, !llvm.ptr) -> ()
       %26 = "llvm.load"(%24) : (!llvm.ptr) -> i32
@@ -108,7 +108,7 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.sext"(%{{.*}}) : (i1) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.zext"(%{{.*}}) : (i1) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 0 : i64, "elem_type" = i32}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 4 : i32, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
+// CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 4 : i64, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
 // CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32

--- a/Test/LLVM/invalid_alloca.mlir
+++ b/Test/LLVM/invalid_alloca.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+        %0 = "llvm.constant"() <{"value" = 13 : i32}> : () -> i32
+        %1 = "llvm.alloca"(%0) <{"alignment" = 4 : i32, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
+        // CHECK: Expected alignment to be an i64 constant
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -656,6 +656,10 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    let properties := (op.getProperties! ctx.raw (.llvm .alloca))
+    if properties.alignment.type.bitwidth ≠ 64 then
+      throw "Expected alignment to be an i64 constant"
+
     pure ()
   | .llvm .load => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then


### PR DESCRIPTION
This removes an error that arises when trying to parse `LLVM/identity.mlir` with `mlir-opt`.