### PR TITLE
llvm: add required function properties

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   "llvm.module_flags"() <{flags = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
-  "llvm.func"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i32 (f64)>, linkage = #llvm.linkage<external>, sym_name = "myfunc", unnamed_addr = 0 : i64, visibility_ = 0 : i64}> ({
     ^bb0(%fcst : f64):
       %5 = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
       %6 = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i1
@@ -72,14 +72,14 @@
       %56 = "llvm.frem"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
       %57 = "llvm.frem"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
       %58 = "llvm.frem"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
-      "llvm.return"(%28, %29, %30, %31, %32) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+      "llvm.return"(%arg7_0) : (i32) -> ()
   }) : () -> ()
 }) : () -> ()
 
 // CHECK:       "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
 // CHECK-NEXT:     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
-// CHECK-NEXT:     "llvm.func"() ({
+// CHECK-NEXT:     "llvm.func"()  <{"CConv" = #llvm.cconv<ccc>, "function_type" = !llvm.func<i32 (f64)>, "linkage" = #llvm.linkage<external>, "sym_name" = "myfunc", "unnamed_addr" = 0 : i64, "visibility_" = 0 : i64}> ({
 // CHECK-NEXT:         ^{{.*}}(%arg7_0 : f64):
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i32}> : () -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i1
@@ -149,6 +149,6 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
-// CHECK-NEXT:       "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()


### PR DESCRIPTION
... and make return types consistent. This removes errors arising when trying to parse LLVM/identity.mlir with mlir-opt.