### PR TITLE
test: Make sure all tests are in top-level `func.func`

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -1,77 +1,84 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^4():
-  %5 = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
-  %addi = "arith.addi"(%5, %5) : (i32, i32) -> i32
-  %addi_nsw = "arith.addi"(%5, %5) <{nws}> : (i32, i32) -> i32
-  %addi_nuw = "arith.addi"(%5, %5) <{nuw}> : (i32, i32) -> i32
-  %addi_nsw_nuw = "arith.addi"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
-  %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
-  %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
-  %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
-  %10 = "arith.ceildivui"(%5, %5) : (i32, i32) -> i32
-  %11 = "arith.cmpi"(%5, %5) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
-  %12 = "arith.divsi"(%5, %5) : (i32, i32) -> i32
-  %13 = "arith.divui"(%5, %5) : (i32, i32) -> i32
-  %14 = "arith.extui"(%5) : (i32) -> i64
-  %15 = "arith.floordivsi"(%5, %5) : (i32, i32) -> i32
-  %16 = "arith.maxsi"(%5, %5) : (i32, i32) -> i32
-  %17 = "arith.maxui"(%5, %5) : (i32, i32) -> i32
-  %18 = "arith.minsi"(%5, %5) : (i32, i32) -> i32
-  %19 = "arith.minui"(%5, %5) : (i32, i32) -> i32
-  %muli = "arith.muli"(%5, %5) : (i32, i32) -> i32
-  %muli_nsw = "arith.muli"(%5, %5) <{nws}> : (i32, i32) -> i32
-  %muli_nuw = "arith.muli"(%5, %5) <{nuw}> : (i32, i32) -> i32
-  %muli_nsw_nuw = "arith.muli"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
-  %210, %211 = "arith.mulsi_extended"(%5, %5) : (i32, i32) -> (i32, i32)
-  %220, %221 = "arith.mului_extended"(%5, %5) : (i32, i32) -> (i32, i32)
-  %23 = "arith.ori"(%5, %5) : (i32, i32) -> i32
-  %24 = "arith.remsi"(%5, %5) : (i32, i32) -> i32
-  %25 = "arith.remui"(%5, %5) : (i32, i32) -> i32
-  %26 = "arith.select"(%11, %5, %5) : (i1, i32, i32) -> i32
-  %27 = "arith.shli"(%5, %5) : (i32, i32) -> i32
-  %28 = "arith.shrsi"(%5, %5) : (i32, i32) -> i32
-  %29 = "arith.shrui"(%5, %5) : (i32, i32) -> i32
-  %30 = "arith.subi"(%5, %5) : (i32, i32) -> i32
-  %31 = "arith.trunci"(%5) : (i32) -> i16
-  %32 = "arith.xori"(%5, %5) : (i32, i32) -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^4():
+      %5 = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
+      %addi = "arith.addi"(%5, %5) : (i32, i32) -> i32
+      %addi_nsw = "arith.addi"(%5, %5) <{nws}> : (i32, i32) -> i32
+      %addi_nuw = "arith.addi"(%5, %5) <{nuw}> : (i32, i32) -> i32
+      %addi_nsw_nuw = "arith.addi"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
+      %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
+      %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
+      %10 = "arith.ceildivui"(%5, %5) : (i32, i32) -> i32
+      %11 = "arith.cmpi"(%5, %5) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
+      %12 = "arith.divsi"(%5, %5) : (i32, i32) -> i32
+      %13 = "arith.divui"(%5, %5) : (i32, i32) -> i32
+      %14 = "arith.extui"(%5) : (i32) -> i64
+      %15 = "arith.floordivsi"(%5, %5) : (i32, i32) -> i32
+      %16 = "arith.maxsi"(%5, %5) : (i32, i32) -> i32
+      %17 = "arith.maxui"(%5, %5) : (i32, i32) -> i32
+      %18 = "arith.minsi"(%5, %5) : (i32, i32) -> i32
+      %19 = "arith.minui"(%5, %5) : (i32, i32) -> i32
+      %muli = "arith.muli"(%5, %5) : (i32, i32) -> i32
+      %muli_nsw = "arith.muli"(%5, %5) <{nws}> : (i32, i32) -> i32
+      %muli_nuw = "arith.muli"(%5, %5) <{nuw}> : (i32, i32) -> i32
+      %muli_nsw_nuw = "arith.muli"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %210, %211 = "arith.mulsi_extended"(%5, %5) : (i32, i32) -> (i32, i32)
+      %220, %221 = "arith.mului_extended"(%5, %5) : (i32, i32) -> (i32, i32)
+      %23 = "arith.ori"(%5, %5) : (i32, i32) -> i32
+      %24 = "arith.remsi"(%5, %5) : (i32, i32) -> i32
+      %25 = "arith.remui"(%5, %5) : (i32, i32) -> i32
+      %26 = "arith.select"(%11, %5, %5) : (i1, i32, i32) -> i32
+      %27 = "arith.shli"(%5, %5) : (i32, i32) -> i32
+      %28 = "arith.shrsi"(%5, %5) : (i32, i32) -> i32
+      %29 = "arith.shrui"(%5, %5) : (i32, i32) -> i32
+      %30 = "arith.subi"(%5, %5) : (i32, i32) -> i32
+      %31 = "arith.trunci"(%5) : (i32) -> i16
+      %32 = "arith.xori"(%5, %5) : (i32, i32) -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
-// CHECK-NEXT:     %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.divui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i64
-// CHECK-NEXT:     %{{.*}} = "arith.floordivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.maxsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.maxui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.minsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.minui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
-// CHECK-NEXT:     %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
-// CHECK-NEXT:     %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.remsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.remui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.shli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.shrui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.trunci"(%{{.*}}) : (i32) -> i16
-// CHECK-NEXT:     %{{.*}} = "arith.xori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
+// CHECK-NEXT:         %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.ceildivui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.divui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.extui"(%{{.*}}) : (i32) -> i64
+// CHECK-NEXT:         %{{.*}} = "arith.floordivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.maxsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.maxui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.minsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.minui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:         %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
+// CHECK-NEXT:         %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.remsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.remui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.shli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.shrui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.subi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.trunci"(%{{.*}}) : (i32) -> i16
+// CHECK-NEXT:         %{{.*}} = "arith.xori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/attributes.mlir
+++ b/Test/Builtin/attributes.mlir
@@ -1,41 +1,48 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %3 = "test.test"() {str = "hello world"} : () -> i32
-  %4 = "test.test"() {empty = ""} : () -> i32
-  %5 = "test.test"() {escaped = "line1\nline2\ttab"} : () -> i32
-  %6 = "test.test"() {unregistered = #unregistered.dialect<foo 3 + 2>} : () -> i32
-  %7 = "test.test"() {u = unit} : () -> i32
-  %8 = "test.test"() {u} : () -> i32
-  %9 = "test.test"() {dict = {a = 0 : i32, b = "hello"}} : () -> i32
-  %10 = "test.test"() {empty_dict = {}} : () -> i32
-  %11 = "test.test"() {dict_unit = {x, y}} : () -> i32
-  %12 = "test.test"() {arr = []} : () -> i32
-  %13 = "test.test"() {arr = [unit]} : () -> i32
-  %14 = "test.test"() {arr = [0 : i32, "hello"]} : () -> i32
-  %15 = "test.test"() {da = array<i8>} : () -> i32
-  %16 = "test.test"() {da = array<i32: 10, 42>} : () -> i32
-  %17 = "test.test"() {sym = @foo} : () -> i32
-  %18 = "test.test"() {sym = @"my.func"} : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %3 = "test.test"() {str = "hello world"} : () -> i32
+      %4 = "test.test"() {empty = ""} : () -> i32
+      %5 = "test.test"() {escaped = "line1\nline2\ttab"} : () -> i32
+      %6 = "test.test"() {unregistered = #unregistered.dialect<foo 3 + 2>} : () -> i32
+      %7 = "test.test"() {u = unit} : () -> i32
+      %8 = "test.test"() {u} : () -> i32
+      %9 = "test.test"() {dict = {a = 0 : i32, b = "hello"}} : () -> i32
+      %10 = "test.test"() {empty_dict = {}} : () -> i32
+      %11 = "test.test"() {dict_unit = {x, y}} : () -> i32
+      %12 = "test.test"() {arr = []} : () -> i32
+      %13 = "test.test"() {arr = [unit]} : () -> i32
+      %14 = "test.test"() {arr = [0 : i32, "hello"]} : () -> i32
+      %15 = "test.test"() {da = array<i8>} : () -> i32
+      %16 = "test.test"() {da = array<i32: 10, 42>} : () -> i32
+      %17 = "test.test"() {sym = @foo} : () -> i32
+      %18 = "test.test"() {sym = @"my.func"} : () -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"str" = "hello world"} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"empty" = ""} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"escaped" = "line1\nline2\ttab"} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"unregistered" = #unregistered.dialect<foo 3 + 2>} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {u} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {u} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"dict" = {"a" = 0 : i32, "b" = "hello"}} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"empty_dict" = {}} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"dict_unit" = {x, y}} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = []} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [unit]} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"arr" = [0 : i32, "hello"]} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i8>} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"da" = array<i32: 10, 42>} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"sym" = @foo} : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() {"sym" = @"my.func"} : () -> i32
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"str" = "hello world"} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"empty" = ""} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"escaped" = "line1\nline2\ttab"} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"unregistered" = #unregistered.dialect<foo 3 + 2>} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {u} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {u} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"dict" = {"a" = 0 : i32, "b" = "hello"}} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"empty_dict" = {}} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"dict_unit" = {x, y}} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"arr" = []} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"arr" = [unit]} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"arr" = [0 : i32, "hello"]} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"da" = array<i8>} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"da" = array<i32: 10, 42>} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"sym" = @foo} : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() {"sym" = @"my.func"} : () -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/types.mlir
+++ b/Test/Builtin/types.mlir
@@ -1,17 +1,24 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %0 = "test.test"() : () -> i32
-  %1 = "test.test"() : () -> ((i32) -> (i32))
-  %2 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
-  %3 = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "test.test"() : () -> i32
+      %1 = "test.test"() : () -> ((i32) -> (i32))
+      %2 = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+      %3 = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> i32
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> ((i32) -> i32)
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> ((i32) -> ((i32) -> i32))
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> i32
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> ((i32) -> i32)
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> ((i32) -> ((i32) -> i32))
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> !unregistered.dialect<foo 3 + 2 - 4>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Builtin/unrealized_conversion_cast.mlir
+++ b/Test/Builtin/unrealized_conversion_cast.mlir
@@ -1,12 +1,15 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %0 = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
-  %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> !reg
-  %2 = "builtin.unrealized_conversion_cast"(%1) : (!reg) -> i32
-  // CHECK:          %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
-  // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !reg
-  // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
+      %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> !reg
+      %2 = "builtin.unrealized_conversion_cast"(%1) : (!reg) -> i32
+      // CHECK:          %{{.*}} = "llvm.mlir.constant"() <{"value" = 13 : i8}> : () -> i8
+      // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !reg
+      // CHECK-NEXT:     %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 

--- a/Test/Comb/identity.mlir
+++ b/Test/Comb/identity.mlir
@@ -1,109 +1,116 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^4():
-  %a = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
-  %b = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
-  %c = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
-  %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
-  %add1 = "comb.add"(%a) : (i32) -> i32
-  %add2 = "comb.add"(%a, %b) : (i32, i32) -> i32
-  %add3 = "comb.add"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %and1 = "comb.and"(%a) : (i32) -> i32
-  %and2 = "comb.and"(%a, %b) : (i32, i32) -> i32
-  %and3 = "comb.and"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %concat0 = "comb.concat"() : () -> i0
-  %concat1 = "comb.concat"(%a) : (i32) -> i32
-  %concat2 = "comb.concat"(%a, %b) : (i32, i32) -> i64
-  %concat3 = "comb.concat"(%a, %b, %c) : (i32, i32, i32) -> i96
-  %divs = "comb.divs"(%a, %b) : (i32, i32) -> i32
-  %divu = "comb.divu"(%a, %b) : (i32, i32) -> i32
-  %extract = "comb.extract"(%a) <{ "lowBit" = 2 : i32 }> : (i32) -> i8
-  %icmp0 = "comb.icmp"(%a, %b) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
-  %icmp1 = "comb.icmp"(%a, %b) <{ "predicate" = 1 : i64 }> : (i32, i32) -> i1
-  %icmp2 = "comb.icmp"(%a, %b) <{ "predicate" = 2 : i64 }> : (i32, i32) -> i1
-  %icmp3 = "comb.icmp"(%a, %b) <{ "predicate" = 3 : i64 }> : (i32, i32) -> i1
-  %icmp4 = "comb.icmp"(%a, %b) <{ "predicate" = 4 : i64 }> : (i32, i32) -> i1
-  %icmp5 = "comb.icmp"(%a, %b) <{ "predicate" = 5 : i64 }> : (i32, i32) -> i1
-  %icmp6 = "comb.icmp"(%a, %b) <{ "predicate" = 6 : i64 }> : (i32, i32) -> i1
-  %icmp7 = "comb.icmp"(%a, %b) <{ "predicate" = 7 : i64 }> : (i32, i32) -> i1
-  %icmp8 = "comb.icmp"(%a, %b) <{ "predicate" = 8 : i64 }> : (i32, i32) -> i1
-  %icmp9 = "comb.icmp"(%a, %b) <{ "predicate" = 9 : i64 }> : (i32, i32) -> i1
-  %icmp10 = "comb.icmp"(%a, %b) <{ "predicate" = 10 : i64 }> : (i32, i32) -> i1
-  %icmp11 = "comb.icmp"(%a, %b) <{ "predicate" = 11 : i64 }> : (i32, i32) -> i1
-  %icmp12 = "comb.icmp"(%a, %b) <{ "predicate" = 12 : i64 }> : (i32, i32) -> i1
-  %icmp13 = "comb.icmp"(%a, %b) <{ "predicate" = 13 : i64 }> : (i32, i32) -> i1
-  %mods = "comb.mods"(%a, %b) : (i32, i32) -> i32
-  %modu = "comb.modu"(%a, %b) : (i32, i32) -> i32
-  %mul1 = "comb.mul"(%a) : (i32) -> i32
-  %mul2 = "comb.mul"(%a, %b) : (i32, i32) -> i32
-  %mul3 = "comb.mul"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %mux = "comb.mux"(%true, %a, %b) : (i1, i32, i32) -> i32
-  %or1 = "comb.or"(%a) : (i32) -> i32
-  %or2 = "comb.or"(%a, %b) : (i32, i32) -> i32
-  %or3 = "comb.or"(%a, %b, %c) : (i32, i32, i32) -> i32
-  %parity = "comb.parity"(%a) : (i32) -> i1
-  %replicate = "comb.replicate"(%a) : (i32) -> i64
-  %reverse = "comb.reverse"(%a) : (i32) -> i32
-  %shl = "comb.shl"(%a, %b) : (i32, i32) -> i32
-  %shrs = "comb.shrs"(%a, %b) : (i32, i32) -> i32
-  %shru = "comb.shru"(%a, %b) : (i32, i32) -> i32
-  %sub = "comb.sub"(%a, %b) : (i32, i32) -> i32
-  %xor1 = "comb.xor"(%a) : (i32) -> i32
-  %xor2 = "comb.xor"(%a, %b) : (i32, i32) -> i32
-  %xor3 = "comb.xor"(%a, %b, %c) : (i32, i32, i32) -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^4():
+      %a = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
+      %b = "arith.constant"() <{ "value" = 3 : i32 }> : () -> i32
+      %c = "arith.constant"() <{ "value" = 42 : i32 }> : () -> i32
+      %true = "arith.constant"() <{ "value" = 1 : i1 }> : () -> i1
+      %add1 = "comb.add"(%a) : (i32) -> i32
+      %add2 = "comb.add"(%a, %b) : (i32, i32) -> i32
+      %add3 = "comb.add"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %and1 = "comb.and"(%a) : (i32) -> i32
+      %and2 = "comb.and"(%a, %b) : (i32, i32) -> i32
+      %and3 = "comb.and"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %concat0 = "comb.concat"() : () -> i0
+      %concat1 = "comb.concat"(%a) : (i32) -> i32
+      %concat2 = "comb.concat"(%a, %b) : (i32, i32) -> i64
+      %concat3 = "comb.concat"(%a, %b, %c) : (i32, i32, i32) -> i96
+      %divs = "comb.divs"(%a, %b) : (i32, i32) -> i32
+      %divu = "comb.divu"(%a, %b) : (i32, i32) -> i32
+      %extract = "comb.extract"(%a) <{ "lowBit" = 2 : i32 }> : (i32) -> i8
+      %icmp0 = "comb.icmp"(%a, %b) <{ "predicate" = 0 : i64 }> : (i32, i32) -> i1
+      %icmp1 = "comb.icmp"(%a, %b) <{ "predicate" = 1 : i64 }> : (i32, i32) -> i1
+      %icmp2 = "comb.icmp"(%a, %b) <{ "predicate" = 2 : i64 }> : (i32, i32) -> i1
+      %icmp3 = "comb.icmp"(%a, %b) <{ "predicate" = 3 : i64 }> : (i32, i32) -> i1
+      %icmp4 = "comb.icmp"(%a, %b) <{ "predicate" = 4 : i64 }> : (i32, i32) -> i1
+      %icmp5 = "comb.icmp"(%a, %b) <{ "predicate" = 5 : i64 }> : (i32, i32) -> i1
+      %icmp6 = "comb.icmp"(%a, %b) <{ "predicate" = 6 : i64 }> : (i32, i32) -> i1
+      %icmp7 = "comb.icmp"(%a, %b) <{ "predicate" = 7 : i64 }> : (i32, i32) -> i1
+      %icmp8 = "comb.icmp"(%a, %b) <{ "predicate" = 8 : i64 }> : (i32, i32) -> i1
+      %icmp9 = "comb.icmp"(%a, %b) <{ "predicate" = 9 : i64 }> : (i32, i32) -> i1
+      %icmp10 = "comb.icmp"(%a, %b) <{ "predicate" = 10 : i64 }> : (i32, i32) -> i1
+      %icmp11 = "comb.icmp"(%a, %b) <{ "predicate" = 11 : i64 }> : (i32, i32) -> i1
+      %icmp12 = "comb.icmp"(%a, %b) <{ "predicate" = 12 : i64 }> : (i32, i32) -> i1
+      %icmp13 = "comb.icmp"(%a, %b) <{ "predicate" = 13 : i64 }> : (i32, i32) -> i1
+      %mods = "comb.mods"(%a, %b) : (i32, i32) -> i32
+      %modu = "comb.modu"(%a, %b) : (i32, i32) -> i32
+      %mul1 = "comb.mul"(%a) : (i32) -> i32
+      %mul2 = "comb.mul"(%a, %b) : (i32, i32) -> i32
+      %mul3 = "comb.mul"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %mux = "comb.mux"(%true, %a, %b) : (i1, i32, i32) -> i32
+      %or1 = "comb.or"(%a) : (i32) -> i32
+      %or2 = "comb.or"(%a, %b) : (i32, i32) -> i32
+      %or3 = "comb.or"(%a, %b, %c) : (i32, i32, i32) -> i32
+      %parity = "comb.parity"(%a) : (i32) -> i1
+      %replicate = "comb.replicate"(%a) : (i32) -> i64
+      %reverse = "comb.reverse"(%a) : (i32) -> i32
+      %shl = "comb.shl"(%a, %b) : (i32, i32) -> i32
+      %shrs = "comb.shrs"(%a, %b) : (i32, i32) -> i32
+      %shru = "comb.shru"(%a, %b) : (i32, i32) -> i32
+      %sub = "comb.sub"(%a, %b) : (i32, i32) -> i32
+      %xor1 = "comb.xor"(%a) : (i32) -> i32
+      %xor2 = "comb.xor"(%a, %b) : (i32, i32) -> i32
+      %xor3 = "comb.xor"(%a, %b, %c) : (i32, i32, i32) -> i32
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
-// CHECK-NEXT:     %{{.*}} = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.concat"() : () -> i0
-// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}) : (i32, i32) -> i64
-// CHECK-NEXT:     %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i96
-// CHECK-NEXT:     %{{.*}} = "comb.divs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.divu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.extract"(%{{.*}}) <{"lowBit" = 2 : i32}> : (i32) -> i8
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 3 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 5 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 7 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 8 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 9 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 10 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 12 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 13 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.mods"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.modu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.mux"(%8, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.parity"(%{{.*}}) : (i32) -> i1
-// CHECK-NEXT:     %{{.*}} = "comb.replicate"(%{{.*}}) : (i32) -> i64
-// CHECK-NEXT:     %{{.*}} = "comb.reverse"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.shrs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.shru"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}) : (i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:     %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.and"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.and"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.concat"() : () -> i0
+// CHECK-NEXT:         %{{.*}} = "comb.concat"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}) : (i32, i32) -> i64
+// CHECK-NEXT:         %{{.*}} = "comb.concat"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i96
+// CHECK-NEXT:         %{{.*}} = "comb.divs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.divu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.extract"(%{{.*}}) <{"lowBit" = 2 : i32}> : (i32) -> i8
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 3 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 4 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 5 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 6 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 7 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 8 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 9 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 10 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 11 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 12 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.icmp"(%{{.*}}, %{{.*}}) <{"predicate" = 13 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.mods"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.modu"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mul"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mul"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.mux"(%10, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.or"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.or"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.parity"(%{{.*}}) : (i32) -> i1
+// CHECK-NEXT:         %{{.*}} = "comb.replicate"(%{{.*}}) : (i32) -> i64
+// CHECK-NEXT:         %{{.*}} = "comb.reverse"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.shrs"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.shru"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.xor"(%{{.*}}) : (i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "comb.xor"(%{{.*}}, %{{.*}}, %{{.*}}) : (i32, i32, i32) -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/CudaTile/types.mlir
+++ b/Test/CudaTile/types.mlir
@@ -1,10 +1,20 @@
 // RUN: VEIR_ROUNDTRIP
 "builtin.module"() ({
-^bb0(%arg0: !cuda_tile.ptr<i1>):
-    %0 = "test.test"() : () -> !cuda_tile.ptr<i1>
+  // TODO(#675): the proper type should be without quotes, i.e.
+  // `!cuda_tile.ptr<i1> -> ()`. Our parser cannot handle this right now, it's a
+  // bug that should be fixed.
+  "func.func"() <{function_type = "!cuda_tile.ptr<i1> -> ()", sym_name = "main"}> ({
+    ^bb0(%arg0: !cuda_tile.ptr<i1>):
+      %0 = "test.test"() : () -> !cuda_tile.ptr<i1>
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK-NEXT: "builtin.module"() ({
-// CHECK-NEXT:   ^{{.*}}(%{{.*}} : !cuda_tile.ptr<i1>):
-// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !cuda_tile.ptr<i1>
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = "!cuda_tile.ptr<i1> -> ()", "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : !cuda_tile.ptr<i1>):
+// CHECK-NEXT:         %{{.*}} = "test.test"() : () -> !cuda_tile.ptr<i1>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Datapath/identity.mlir
+++ b/Test/Datapath/identity.mlir
@@ -1,15 +1,22 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0(%arg0: i3, %arg1: i3, %arg2: i3):
-  %0, %1 = "datapath.compress"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3)
-  %2, %3, %4 = "datapath.partial_product"(%arg0, %arg1) : (i3, i3) -> (i3, i3, i3)
-  %5, %6, %7 = "datapath.pos_partial_product"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3, i3)
+  "func.func"() <{function_type = (i3, i3, i3) -> (), sym_name = "main"}> ({
+    ^bb0(%arg0: i3, %arg1: i3, %arg2: i3):
+      %0, %1 = "datapath.compress"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3)
+      %2, %3, %4 = "datapath.partial_product"(%arg0, %arg1) : (i3, i3) -> (i3, i3, i3)
+      %5, %6, %7 = "datapath.pos_partial_product"(%arg0, %arg1, %arg2) : (i3, i3, i3) -> (i3, i3, i3)
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4(%{{.*}} : i3, %{{.*}} : i3, %{{.*}} : i3):
-// CHECK-NEXT:     %{{.*}}:2 = "datapath.compress"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3)
-// CHECK-NEXT:     %{{.*}}:3 = "datapath.partial_product"(%{{.*}}, %{{.*}}) : (i3, i3) -> (i3, i3, i3)
-// CHECK-NEXT:     %{{.*}}:3 = "datapath.pos_partial_product"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i3, i3, i3) -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i3, %{{.*}} : i3, %{{.*}} : i3):
+// CHECK-NEXT:         %{{.*}}:2 = "datapath.compress"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3)
+// CHECK-NEXT:         %{{.*}}:3 = "datapath.partial_product"(%{{.*}}, %{{.*}}) : (i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:         %{{.*}}:3 = "datapath.pos_partial_product"(%{{.*}}, %{{.*}}, %{{.*}}) : (i3, i3, i3) -> (i3, i3, i3)
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/HW/identity.mlir
+++ b/Test/HW/identity.mlir
@@ -1,27 +1,34 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^4():
-  %1 = "hw.constant"() <{value = 13 : i10}> : () -> i10
-  "hw.module"() <{module_type = !hw.modty<output a : i10, input b : i10>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "bar"}> ({
-  ^bb0(%b: i10):
-    "hw.output"(%b) : (i10) -> ()
-  }) {sym_visibility = "public"} : () -> ()
-  "hw.module"() <{module_type = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "foo"}> ({
-  ^bb0(%arg5: i3, %arg6: i1):
-    "hw.output"(%arg5, %arg6) : (i3, i1) -> ()
-  }) {sym_visibility = "private"} : () -> ()
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^4():
+      %1 = "hw.constant"() <{value = 13 : i10}> : () -> i10
+      "hw.module"() <{module_type = !hw.modty<output a : i10, input b : i10>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "bar"}> ({
+      ^bb0(%b: i10):
+        "hw.output"(%b) : (i10) -> ()
+      }) {sym_visibility = "public"} : () -> ()
+      "hw.module"() <{module_type = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, parameters = [], result_locs = [loc("source.mlir":2:61), loc("source.mlir":2:73)], sym_name = "foo"}> ({
+      ^bb0(%arg5: i3, %arg6: i1):
+        "hw.output"(%arg5, %arg6) : (i3, i1) -> ()
+      }) {sym_visibility = "private"} : () -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "hw.constant"() <{"value" = 13 : i10}> : () -> i10
-// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<output a : i10, input b : i10>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "bar"}> ({
-// CHECK-NEXT:       ^{{.*}}(%{{.*}}: i10):
-// CHECK-NEXT:         "hw.output"(%{{.*}}) : (i10) -> ()
-// CHECK-NEXT:     }) {"sym_visibility" = "public"} : () -> ()
-// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "foo"}> ({
-// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i3, %{{.*}}: i1):
-// CHECK-NEXT:         "hw.output"(%{{.*}}, %{{.*}}) : (i3, i1) -> ()
-// CHECK-NEXT:     }) {"sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "hw.constant"() <{"value" = 13 : i10}> : () -> i10
+// CHECK-NEXT:         "hw.module"() <{"module_type" = !hw.modty<output a : i10, input b : i10>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "bar"}> ({
+// CHECK-NEXT:           ^{{.*}}(%{{.*}}: i10):
+// CHECK-NEXT:             "hw.output"(%{{.*}}) : (i10) -> ()
+// CHECK-NEXT:         }) {"sym_visibility" = "public"} : () -> ()
+// CHECK-NEXT:         "hw.module"() <{"module_type" = !hw.modty<input a : i3, input b : i1, output c : i3, output d : i1>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "foo"}> ({
+// CHECK-NEXT:           ^{{.*}}(%{{.*}} : i3, %{{.*}}: i1):
+// CHECK-NEXT:             "hw.output"(%{{.*}}, %{{.*}}) : (i3, i1) -> ()
+// CHECK-NEXT:         }) {"sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/invalid.mlir
+++ b/Test/LLVM/invalid.mlir
@@ -1,8 +1,11 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  ^bb0(%a: i32, %b : i16):
-      %sexta = "llvm.sext"(%a) : (i32) -> i16
-      // CHECK: Error verifying input program: Operand's width must be smaller than result's width
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0(%a: i32, %b : i16):
+        %sexta = "llvm.sext"(%a) : (i32) -> i16
+        // CHECK: Error verifying input program: Operand's width must be smaller than result's width
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 

--- a/Test/ModArith/identity.mlir
+++ b/Test/ModArith/identity.mlir
@@ -1,20 +1,27 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-^bb0():
-  %0 = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
-  %1 = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
-  %2 = "mod_arith.add"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-  %3 = "mod_arith.sub"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-  %4 = "mod_arith.mul"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
+      %1 = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
+      %2 = "mod_arith.add"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+      %3 = "mod_arith.sub"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+      %4 = "mod_arith.mul"(%0, %1) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 
-// CHECK:       "builtin.module"() ({
-// CHECK-NEXT:   ^4():
-// CHECK-NEXT:     %{{.*}} = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.add"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.sub"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
-// CHECK-NEXT:     %{{.*}} = "mod_arith.mul"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "mod_arith.constant"() <{"value" = 13 : i32}> : () -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.constant"() <{"value" = 7 : i32}> : () -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.add"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.sub"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         %{{.*}} = "mod_arith.mul"(%{{.*}}, %{{.*}}) : (!mod_arith.int<17 : i32>, !mod_arith.int<17 : i32>) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Parsing/scopes.mlir
+++ b/Test/Parsing/scopes.mlir
@@ -1,58 +1,63 @@
 // RUN: veir-opt %s | filecheck %s
 
-"test.test"() ({
-    %a = "test.test"() : () -> i1
-
-    "test.test"() ({
-        "test.test"(%a) : (i1) -> ()
-        %b = "test.test"() : () -> i2
-
-        "test.test"() ({
-        ^bb0:
-            %c = "test.test"() : () -> i3
-        ^bb1:
-            "test.test"(%a, %b, %c) : (i1, i2, i3) -> ()
-        }) : () -> ()
-
-        "test.test"() ({
-        ^bb0:
-            %c = "test.test"() : () -> i4
-        ^bb1:
-            "test.test"(%a, %b, %c) : (i1, i2, i4) -> ()
-        }) : () -> ()
-
-        %c = "test.test"() : () -> i5
-        "test.test"(%a, %b, %c) : (i1, i2, i5) -> ()
-    }) : () -> ()
-
-^bb1:
-    %b, %c = "test.test"() : () -> (i6, i7)
-    "test.test"(%a, %b, %c) : (i1, i6, i7) -> ()
+"builtin.module"() ({
+  "test.test"() ({
+      %a = "test.test"() : () -> i1
+  
+      "test.test"() ({
+          "test.test"(%a) : (i1) -> ()
+          %b = "test.test"() : () -> i2
+  
+          "test.test"() ({
+          ^bb0:
+              %c = "test.test"() : () -> i3
+          ^bb1:
+              "test.test"(%a, %b, %c) : (i1, i2, i3) -> ()
+          }) : () -> ()
+  
+          "test.test"() ({
+          ^bb0:
+              %c = "test.test"() : () -> i4
+          ^bb1:
+              "test.test"(%a, %b, %c) : (i1, i2, i4) -> ()
+          }) : () -> ()
+  
+          %c = "test.test"() : () -> i5
+          "test.test"(%a, %b, %c) : (i1, i2, i5) -> ()
+      }) : () -> ()
+  
+  ^bb1:
+      %b, %c = "test.test"() : () -> (i6, i7)
+      "test.test"(%a, %b, %c) : (i1, i6, i7) -> ()
+  }) : () -> ()
 }) : () -> ()
 
-// CHECK:      "test.test"() ({
+// CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %[[A:.*]] = "test.test"() : () -> i1
 // CHECK-NEXT:     "test.test"() ({
 // CHECK-NEXT:       ^{{.*}}():
-// CHECK-NEXT:         "test.test"(%[[A]]) : (i1) -> ()
-// CHECK-NEXT:         %[[B:.*]] = "test.test"() : () -> i2
+// CHECK-NEXT:         %[[A:.*]] = "test.test"() : () -> i1
 // CHECK-NEXT:         "test.test"() ({
 // CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             %[[C3:.*]] = "test.test"() : () -> i3
-// CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C3]]) : (i1, i2, i3) -> ()
+// CHECK-NEXT:             "test.test"(%[[A]]) : (i1) -> ()
+// CHECK-NEXT:             %[[B:.*]] = "test.test"() : () -> i2
+// CHECK-NEXT:             "test.test"() ({
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 %[[C3:.*]] = "test.test"() : () -> i3
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 "test.test"(%[[A]], %[[B]], %[[C3]]) : (i1, i2, i3) -> ()
+// CHECK-NEXT:             }) : () -> ()
+// CHECK-NEXT:             "test.test"() ({
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 %[[C4:.*]] = "test.test"() : () -> i4
+// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 "test.test"(%[[A]], %[[B]], %[[C4]]) : (i1, i2, i4) -> ()
+// CHECK-NEXT:             }) : () -> ()
+// CHECK-NEXT:             %[[C5:.*]] = "test.test"() : () -> i5
+// CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C5]]) : (i1, i2, i5) -> ()
 // CHECK-NEXT:         }) : () -> ()
-// CHECK-NEXT:         "test.test"() ({
-// CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             %[[C4:.*]] = "test.test"() : () -> i4
-// CHECK-NEXT:           ^{{.*}}():
-// CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C4]]) : (i1, i2, i4) -> ()
-// CHECK-NEXT:         }) : () -> ()
-// CHECK-NEXT:         %[[C5:.*]] = "test.test"() : () -> i5
-// CHECK-NEXT:         "test.test"(%[[A]], %[[B]], %[[C5]]) : (i1, i2, i5) -> ()
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %[[B6C7:.*]]:2 = "test.test"() : () -> (i6, i7)
+// CHECK-NEXT:         "test.test"(%[[A]], %[[B6C7]]#0, %[[B6C7]]#1) : (i1, i6, i7) -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %[[B6C7:.*]]:2 = "test.test"() : () -> (i6, i7)
-// CHECK-NEXT:     "test.test"(%[[A]], %[[B6C7]]#0, %[[B6C7]]#1) : (i1, i6, i7) -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Parsing/unregistered_ops.mlir
+++ b/Test/Parsing/unregistered_ops.mlir
@@ -1,6 +1,7 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
     "unregistered.op_one"() : () -> ()
     %1 = "unregistered.op_two"() : () -> !foo.bar
     %2 = "unregistered.op_three"() : () -> !foo.bar<baz>
@@ -9,4 +10,6 @@
     // CHECK-NEXT: %{{.*}} = "unregistered.op_two"() : () -> !foo.bar
     // CHECK-NEXT: %{{.*}} = "unregistered.op_three"() : () -> !foo.bar<baz>
     // CHECK-NEXT: "unregistered.op_four"() <{"foo" = 1 : i32}> : () -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/add_zero.mlir
+++ b/Test/Passes/InstCombine/add_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // add x + 0 => x
-    %add_zero = "llvm.add"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%add_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // add x + 0 => x
+      %add_zero = "llvm.add"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%add_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/and_x_x.mlir
+++ b/Test/Passes/InstCombine/and_x_x.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %x = "test.test"() : () -> i32
-    // CHECK: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %x = "test.test"() : () -> i32
+      // CHECK: %[[X:.*]] = "test.test"() : () -> i32
 
-    // and x & x => x
-    %and_self = "llvm.and"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%and_self) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // and x & x => x
+      %and_self = "llvm.and"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%and_self) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "function.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/and_zero.mlir
+++ b/Test/Passes/InstCombine/and_zero.mlir
@@ -1,17 +1,19 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-   // and x & 0 => 0
-    %and_zero = "llvm.and"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%and_zero) : (i32) -> ()
-    // CHECK-NEXT: %[[AND_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: "test.test"(%[[AND_ZERO]]) : (i32) -> ()
-
+     // and x & 0 => 0
+      %and_zero = "llvm.and"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%and_zero) : (i32) -> ()
+      // CHECK-NEXT: %[[AND_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: "test.test"(%[[AND_ZERO]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_notand_or.mlir
+++ b/Test/Passes/InstCombine/de_morgan_notand_or.mlir
@@ -1,25 +1,27 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    %b = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
-    // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      %b = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+      // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
 
-    // ~(~a & ~b) => a | b
-    %na1 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %nb1 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
-    %and1 = "llvm.and"(%na1, %nb1) : (i32, i32) -> i32
-    %demorgan_or = "llvm.xor"(%and1, %m1) : (i32, i32) -> i32
-    "test.test"(%demorgan_or) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[OR:.*]] = "llvm.or"(%[[A]], %[[B]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[OR]]) : (i32) -> ()
-
+      // ~(~a & ~b) => a | b
+      %na1 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %nb1 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
+      %and1 = "llvm.and"(%na1, %nb1) : (i32, i32) -> i32
+      %demorgan_or = "llvm.xor"(%and1, %m1) : (i32, i32) -> i32
+      "test.test"(%demorgan_or) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[OR:.*]] = "llvm.or"(%[[A]], %[[B]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[OR]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_notnot.mlir
+++ b/Test/Passes/InstCombine/de_morgan_notnot.mlir
@@ -1,18 +1,20 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
 
-    // ~~a => a
-    %na0 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %nna = "llvm.xor"(%na0, %m1) : (i32, i32) -> i32
-    "test.test"(%nna) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[A]]) : (i32) -> ()
-
+      // ~~a => a
+      %na0 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %nna = "llvm.xor"(%na0, %m1) : (i32, i32) -> i32
+      "test.test"(%nna) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[A]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_notor_and.mlir
+++ b/Test/Passes/InstCombine/de_morgan_notor_and.mlir
@@ -1,25 +1,27 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    %b = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
-    // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      %b = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+      // CHECK-NEXT: %[[B:.*]] = "test.test"() : () -> i32
 
-    // ~(~a | ~b) => a & b
-    %na2 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %nb2 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
-    %or2 = "llvm.or"(%na2, %nb2) : (i32, i32) -> i32
-    %demorgan_and = "llvm.xor"(%or2, %m1) : (i32, i32) -> i32
-    "test.test"(%demorgan_and) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[AND:.*]] = "llvm.and"(%[[A]], %[[B]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[AND]]) : (i32) -> ()
-
+      // ~(~a | ~b) => a & b
+      %na2 = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %nb2 = "llvm.xor"(%b, %m1) : (i32, i32) -> i32
+      %or2 = "llvm.or"(%na2, %nb2) : (i32, i32) -> i32
+      %demorgan_and = "llvm.xor"(%or2, %m1) : (i32, i32) -> i32
+      "test.test"(%demorgan_and) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.xor"(%[[B]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[AND:.*]] = "llvm.and"(%[[A]], %[[B]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[AND]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/de_morgan_xorxor.mlir
+++ b/Test/Passes/InstCombine/de_morgan_xorxor.mlir
@@ -1,21 +1,23 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- DeMorgan patterns ---
-    %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- DeMorgan patterns ---
+      %m1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK:      %[[M1:.*]] = "llvm.mlir.constant"() <{"value" = -1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[A:.*]] = "test.test"() : () -> i32
 
-    // Negative: xor(xor(a, -1), -7) is not ~~a -- outer constant is not -1.
-    %m7 = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
-    %na_neg = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
-    %not_nna = "llvm.xor"(%na_neg, %m7) : (i32, i32) -> i32
-    "test.test"(%not_nna) : (i32) -> ()
-    // CHECK-NEXT: %[[M7:.*]] = "llvm.mlir.constant"() <{"value" = -7 : i32}> : () -> i32
-    // CHECK-NEXT: %[[NA_NEG:.*]] = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[NEG_RES:.*]] = "llvm.xor"(%[[NA_NEG]], %[[M7]]) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%[[NEG_RES]]) : (i32) -> ()
-
+      // Negative: xor(xor(a, -1), -7) is not ~~a -- outer constant is not -1.
+      %m7 = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
+      %na_neg = "llvm.xor"(%a, %m1) : (i32, i32) -> i32
+      %not_nna = "llvm.xor"(%na_neg, %m7) : (i32, i32) -> i32
+      "test.test"(%not_nna) : (i32) -> ()
+      // CHECK-NEXT: %[[M7:.*]] = "llvm.mlir.constant"() <{"value" = -7 : i32}> : () -> i32
+      // CHECK-NEXT: %[[NA_NEG:.*]] = "llvm.xor"(%[[A]], %[[M1]]) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[NEG_RES:.*]] = "llvm.xor"(%[[NA_NEG]], %[[M7]]) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%[[NEG_RES]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/mult_one.mlir
+++ b/Test/Passes/InstCombine/mult_one.mlir
@@ -1,15 +1,17 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK: %[[ONE:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK: %[[ONE:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // mul x * 1 => x
-    %mul_one = "llvm.mul"(%x, %one) : (i32, i32) -> i32
-    "test.test"(%mul_one) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // mul x * 1 => x
+      %mul_one = "llvm.mul"(%x, %one) : (i32, i32) -> i32
+      "test.test"(%mul_one) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/mult_two.mlir
+++ b/Test/Passes/InstCombine/mult_two.mlir
@@ -1,15 +1,17 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
 
-    %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
-    "test.test"(%mul_two) : (i32) -> ()
-    // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: "test.test"(%{{.*}}) : (i32) -> ()
-
+      %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
+      "test.test"(%mul_two) : (i32) -> ()
+      // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      // CHECK-NEXT: "test.test"(%{{.*}}) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/multzero_multtwo.mlir
+++ b/Test/Passes/InstCombine/multzero_multtwo.mlir
@@ -1,20 +1,22 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %a = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+      %a = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "test.test"() : () -> i32
 
-    %mul_zero = "llvm.mul"(%a, %zero) : (i32, i32) -> i32
-    %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+      %mul_zero = "llvm.mul"(%a, %zero) : (i32, i32) -> i32
+      %mul_two = "llvm.mul"(%a, %two) : (i32, i32) -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 
-    "test.test"(%mul_zero, %mul_two) : (i32, i32) -> ()
-    // CHECK-NEXT: "test.test"(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
-
+      "test.test"(%mul_zero, %mul_two) : (i32, i32) -> ()
+      // CHECK-NEXT: "test.test"(%{{.*}}, %{{.*}}) : (i32, i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/or_x_x.mlir
+++ b/Test/Passes/InstCombine/or_x_x.mlir
@@ -1,14 +1,16 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %x = "test.test"() : () -> i32
-    // CHECK: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %x = "test.test"() : () -> i32
+      // CHECK: %[[X:.*]] = "test.test"() : () -> i32
 
-    // or x | x => x
-    %or_self = "llvm.or"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%or_self) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // or x | x => x
+      %or_self = "llvm.or"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%or_self) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/or_zero.mlir
+++ b/Test/Passes/InstCombine/or_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // or x | 0 => x
-    %or_zero = "llvm.or"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%or_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // or x | 0 => x
+      %or_zero = "llvm.or"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%or_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/sub_x_x.mlir
+++ b/Test/Passes/InstCombine/sub_x_x.mlir
@@ -1,17 +1,19 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // sub x - x => 0
-    %sub_self = "llvm.sub"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%sub_self) : (i32) -> ()
-    // CHECK-NEXT: %[[SUB_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: "test.test"(%[[SUB_ZERO]]) : (i32) -> ()
-
+      // sub x - x => 0
+      %sub_self = "llvm.sub"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%sub_self) : (i32) -> ()
+      // CHECK-NEXT: %[[SUB_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: "test.test"(%[[SUB_ZERO]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/sub_zero.mlir
+++ b/Test/Passes/InstCombine/sub_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
-
-    // sub x - 0 => x
-    %sub_zero = "llvm.sub"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%sub_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  
+      // sub x - 0 => x
+      %sub_zero = "llvm.sub"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%sub_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/xor_x_x.mlir
+++ b/Test/Passes/InstCombine/xor_x_x.mlir
@@ -1,17 +1,19 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // xor x ^ x => 0
-    %xor_self = "llvm.xor"(%x, %x) : (i32, i32) -> i32
-    "test.test"(%xor_self) : (i32) -> ()
-    // CHECK-NEXT: %[[XOR_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: "test.test"(%[[XOR_ZERO]]) : (i32) -> ()
-
+      // xor x ^ x => 0
+      %xor_self = "llvm.xor"(%x, %x) : (i32, i32) -> i32
+      "test.test"(%xor_self) : (i32) -> ()
+      // CHECK-NEXT: %[[XOR_ZERO:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: "test.test"(%[[XOR_ZERO]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstCombine/xor_zero.mlir
+++ b/Test/Passes/InstCombine/xor_zero.mlir
@@ -1,16 +1,18 @@
 // RUN: veir-opt %s -p=instcombine | filecheck %s
 
 "builtin.module"() ({
-^bb0():
-    // --- Identity and annihilation patterns ---
-    %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
-    %x = "test.test"() : () -> i32
-    // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-    // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // --- Identity and annihilation patterns ---
+      %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
+      // CHECK-NEXT: %[[X:.*]] = "test.test"() : () -> i32
 
-    // xor x ^ 0 => x
-    %xor_zero = "llvm.xor"(%x, %zero) : (i32, i32) -> i32
-    "test.test"(%xor_zero) : (i32) -> ()
-    // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
-
+      // xor x ^ 0 => x
+      %xor_zero = "llvm.xor"(%x, %zero) : (i32, i32) -> i32
+      "test.test"(%xor_zero) : (i32) -> ()
+      // CHECK-NEXT: "test.test"(%[[X]]) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()


### PR DESCRIPTION
Stemmed out of #636. Per discussion on Zulip, we probably don't want to encode into the parser the restriction that only functions are allowed at the top-level of a module, since spec-wise MLIR doesn't care what you put at the top-level of a `builtin.module`. However, that is still non-standard behavior and our tests should be as close to real-world MLIR as possible. This PR moves all tests that originally look like this:
```mlir
"builtin.module"() ({
^4():
  "foo.bar"() : () -> ()
}) : () -> ()
```
and wrap that top-level basic block inside a `main` function:
```mlir
"builtin.module"() ({
  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
    ^4():
      "foo.bar"() : () -> ()
      "func.return"() : () -> ()
  }) : () -> ()
}) : () -> ()
```
All changes are hand-crafted so there can be no copy-and-pasting errors caused by those ~~pesky stochastic machines~~ LLMs.