### PR TITLE
llvm: fix operand order for llvm.store

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -32,8 +32,8 @@
       %23 = "llvm.zext"(%6) : (i1) -> i32
       %24 = "llvm.alloca"(%5) <{elem_type = i32}> : (i32) -> !llvm.ptr
       %25 = "llvm.alloca"(%5) <{elem_type = i32, alignment = 4 : i32, inalloca}> : (i32) -> !llvm.ptr
-      "llvm.store"(%24, %5) : (!llvm.ptr, i32) -> ()
-      "llvm.store"(%24, %5) <{alignment = 1 : i32, volatile_, nontemporal, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr, i32) -> ()
+      "llvm.store"(%5, %24) : (i32, !llvm.ptr) -> ()
+      "llvm.store"(%5, %24) <{alignment = 1 : i32, volatile_, nontemporal, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (i32, !llvm.ptr) -> ()
       %26 = "llvm.load"(%24) : (!llvm.ptr) -> i32
       %27 = "llvm.load"(%24) <{alignment = 1 : i32, volatile_, nontemporal, invariant, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr) -> i32
       "llvm.cond_br"(%6, %5, %5) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
@@ -109,8 +109,8 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.zext"(%{{.*}}) : (i1) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 0 : i64, "elem_type" = i32}> : (i32) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 4 : i32, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr, i32) -> ()
-// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr, i32) -> ()
+// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
+// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariant, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr) -> i32
 // CHECK-NEXT:       "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[b1:.*]], ^[[b1]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()


### PR DESCRIPTION
The `llvm.store` instruction takes as a first argument the value to store and as the second the pointer to store to.

This removes an error that arises when trying to parse `LLVM/identity.mlir` with `mlir-opt`.