### PR TITLE
llvm: llvm.[load|store] alignment expects an i64 attribute

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -33,9 +33,9 @@
       %24 = "llvm.alloca"(%5) <{elem_type = i32}> : (i32) -> !llvm.ptr
       %25 = "llvm.alloca"(%5) <{elem_type = i32, alignment = 4 : i64, inalloca}> : (i32) -> !llvm.ptr
       "llvm.store"(%5, %24) : (i32, !llvm.ptr) -> ()
-      "llvm.store"(%5, %24) <{alignment = 1 : i32, volatile_, nontemporal, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (i32, !llvm.ptr) -> ()
+      "llvm.store"(%5, %24) <{alignment = 1 : i64, volatile_, nontemporal, invariantGroup, access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (i32, !llvm.ptr) -> ()
       %26 = "llvm.load"(%24) : (!llvm.ptr) -> i32
-      %27 = "llvm.load"(%24) <{alignment = 1 : i32, volatile_, nontemporal, invariant, invariantGroup, syncscope = "foo", access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr) -> i32
+      %27 = "llvm.load"(%24) <{alignment = 1 : i64, volatile_, nontemporal, invariant, invariantGroup, access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr) -> i32
       "llvm.cond_br"(%6, %5, %5) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
     ^7(%arg6_0 : i32):
       "llvm.br"(%arg6_0) [^8] : (i32) -> ()
@@ -110,9 +110,9 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 0 : i64, "elem_type" = i32}> : (i32) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 4 : i64, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
 // CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
-// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (i32, !llvm.ptr) -> ()
+// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i64, invariantGroup, "noalias_scopes" = [], nontemporal, "tbaa" = [], volatile_}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i32, invariant, invariantGroup, "noalias_scopes" = [], nontemporal, "syncscope" = "foo", "tbaa" = [], volatile_}> : (!llvm.ptr) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i64, invariant, invariantGroup, "noalias_scopes" = [], nontemporal, "tbaa" = [], volatile_}> : (!llvm.ptr) -> i32
 // CHECK-NEXT:       "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[b1:.*]], ^[[b1]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
 // CHECK-NEXT:     ^[[b1]](%{{.*}} : i32):
 // CHECK-NEXT:       "llvm.br"(%{{.*}}) [^[[b2:.*]]] : (i32) -> ()

--- a/Test/LLVM/invalid_alloca.mlir
+++ b/Test/LLVM/invalid_alloca.mlir
@@ -5,7 +5,7 @@
     ^bb0():
         %0 = "llvm.constant"() <{"value" = 13 : i32}> : () -> i32
         %1 = "llvm.alloca"(%0) <{"alignment" = 4 : i32, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
-        // CHECK: 'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute
+        // CHECK: 'llvm.alloca' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute
       "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/LLVM/invalid_alloca.mlir
+++ b/Test/LLVM/invalid_alloca.mlir
@@ -5,7 +5,7 @@
     ^bb0():
         %0 = "llvm.constant"() <{"value" = 13 : i32}> : () -> i32
         %1 = "llvm.alloca"(%0) <{"alignment" = 4 : i32, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
-        // CHECK: Expected alignment to be an i64 constant
+        // CHECK: 'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute
       "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -658,7 +658,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     let properties := (op.getProperties! ctx.raw (.llvm .alloca))
     if properties.alignment.type.bitwidth ≠ 64 then
-      throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
+      throw "'llvm.alloca' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
 
     pure ()
   | .llvm .load => do
@@ -672,7 +672,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     let properties := (op.getProperties! ctx.raw (.llvm .load))
     if properties.alignment.type.bitwidth ≠ 64 then
-      throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
+      throw "'llvm.load' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
 
     pure ()
   | .llvm .store => do

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -658,7 +658,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     let properties := (op.getProperties! ctx.raw (.llvm .alloca))
     if properties.alignment.type.bitwidth ≠ 64 then
-      throw "Expected alignment to be an i64 constant"
+      throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
 
     pure ()
   | .llvm .load => do
@@ -670,6 +670,10 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    let properties := (op.getProperties! ctx.raw (.llvm .load))
+    if properties.alignment.type.bitwidth ≠ 64 then
+      throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
+
     pure ()
   | .llvm .store => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -680,6 +684,9 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    let properties := (op.getProperties! ctx.raw (.llvm .store))
+    if properties.alignment.type.bitwidth ≠ 64 then
+      throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
     pure ()
   | .llvm .getelementptr => do
     let props := op.getProperties! ctx.raw (.llvm .getelementptr)


### PR DESCRIPTION
This removes an error that arises when trying to parse `LLVM/identity.mlir` with `mlir-opt`. To make `llvm.load` and `llvm.store` parse, we also drop `syncscope` which is only allowed for atomic load/stores.

Also match LLVM's error message for `llvm.alloc` with `mlir-opt`.