### PR TITLE
Require `VariableState` to only contain values in bounds

### DIFF
--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -134,8 +134,8 @@ def InterpreterState.empty (ctx : WfIRContext OpInfo) : InterpreterState ctx :=
   Set the value of a variable.
 -/
 def VariableState.setVar? (state : VariableState ctx) (var : ValuePtr)
-    (val : RuntimeValue) (inBounds : var.InBounds ctx.raw := by grind)
-    : Option (VariableState ctx) :=
+    (val : RuntimeValue) (inBounds : var.InBounds ctx.raw := by grind) :
+    Option (VariableState ctx) :=
   if h : val.Conforms (var.getType! ctx.raw) then
     some ⟨state.variables.insert var val,
       by grind [VariableState.ValuesConform, cases VariableState],

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -113,6 +113,7 @@ def VariableState.ValuesConform (state : Std.ExtHashMap ValuePtr RuntimeValue)
 structure VariableState (ctx : WfIRContext OpInfo) where
   variables : Std.ExtHashMap ValuePtr RuntimeValue
   conforms : VariableState.ValuesConform variables ctx
+  variablesIn : ∀ val, val ∈ variables → val.InBounds ctx.raw
 
 /--
   The state of the interpreter at a given point in time.
@@ -127,15 +128,18 @@ structure InterpreterState (ctx : WfIRContext OpInfo) where
   Create an interpreter state with no variables defined.
 -/
 def InterpreterState.empty (ctx : WfIRContext OpInfo) : InterpreterState ctx :=
-  { variables := ⟨Std.ExtHashMap.emptyWithCapacity 8, by simp [VariableState.ValuesConform]⟩, memory := .empty }
+  { variables := ⟨Std.ExtHashMap.emptyWithCapacity 8, by simp [VariableState.ValuesConform], by simp⟩, memory := .empty }
 
 /--
   Set the value of a variable.
 -/
 def VariableState.setVar? (state : VariableState ctx) (var : ValuePtr)
-    (val : RuntimeValue) : Option (VariableState ctx) :=
+    (val : RuntimeValue) (inBounds : var.InBounds ctx.raw := by grind)
+    : Option (VariableState ctx) :=
   if h : val.Conforms (var.getType! ctx.raw) then
-    some ⟨state.variables.insert var val, by grind [VariableState.ValuesConform, cases VariableState]⟩
+    some ⟨state.variables.insert var val,
+      by grind [VariableState.ValuesConform, cases VariableState],
+      by grind [cases VariableState]⟩
   else
     none
 
@@ -163,7 +167,9 @@ def VariableState.getOperandValues (state : VariableState ctx)
   (op.getOperands! ctx.raw).mapM state.getVar?
 
 def VariableState.setResultValues?_loop (state : VariableState ctx)
-    (op : OperationPtr) (resultValues : Array RuntimeValue) (i : Nat) : Option (VariableState ctx) :=
+    (op : OperationPtr) (resultValues : Array RuntimeValue) (i : Nat)
+    (opInBounds : op.InBounds ctx.raw := by grind) (iInBounds : i ≤ op.getNumResults! ctx.raw := by grind)
+    : Option (VariableState ctx) :=
   match i with
   | 0 => state
   | i + 1 => do
@@ -176,15 +182,19 @@ def VariableState.setResultValues?_loop (state : VariableState ctx)
   Set the values of the results of an operation.
 -/
 def VariableState.setResultValues? (state : VariableState ctx)
-    (op : OperationPtr) (resultValues : Array RuntimeValue) : Option (VariableState ctx) :=
+    (op : OperationPtr) (resultValues : Array RuntimeValue) (opInBounds : op.InBounds ctx.raw := by grind)
+    : Option (VariableState ctx) :=
   VariableState.setResultValues?_loop state op resultValues (op.getNumResults! ctx.raw)
 
 /--
   Set the values of block arguments.
 -/
 def VariableState.setArgumentValues? (state : VariableState ctx)
-    (block : BlockPtr) (values : Array RuntimeValue) : Option (VariableState ctx) :=
-  let rec loop (state : VariableState ctx) (i : Nat) :=
+    (block : BlockPtr) (values : Array RuntimeValue)
+    (blockInBounds : block.InBounds ctx.raw := by grind)
+    : Option (VariableState ctx) :=
+  let rec loop (state : VariableState ctx) (i : Nat)
+      (iInBounds : i ≤ block.getNumArguments! ctx.raw := by grind) :=
     match i with
     | 0 => state
     | i + 1 => do
@@ -1076,6 +1086,7 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
   return `none`.
 -/
 def interpretOp (op : OperationPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+    (inBounds : op.InBounds ctx.raw := by grind)
     : Interp (InterpreterState ctx × Option ControlFlowAction) := do
   let some operands := state.variables.getOperandValues op | none
   let opType := op.getOpType! ctx

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -68,11 +68,12 @@ equivalent to saying that the results of interpreting `op` on the given `state` 
 `state` itself.
 -/
 def InterpreterState.EquationHolds {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
-    (op : OperationPtr) : Prop :=
+    (op : OperationPtr) (inBounds : op.InBounds ctx.raw := by grind) : Prop :=
   ∃ controlFlow, interpretOp op state = some (.ok (state, controlFlow))
 
 theorem interpretOp_equationHolds_self
-    {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom) :
+    {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom)
+    (inBounds : op.InBounds ctx.raw) :
     op.Pure ctx →
     interpretOp op state = some (.ok (state', controlFlow)) →
     state'.EquationHolds op := by
@@ -80,9 +81,10 @@ theorem interpretOp_equationHolds_self
   grind [OperationPtr.Pure.interpretOp'_eq_ok_implies_memory_eq, interpretOp_some_iff]
 
 theorem interpretOp_equationHolds_other
-    {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom) :
+    {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom)
+    {inBounds₁ : op₁.InBounds ctx.raw} {inBounds₂ : op₂.InBounds ctx.raw} :
     op₂.Pure ctx →
-    interpretOp op₁ state = some (.ok (state', cf₁)) →
+    interpretOp op₁ state inBounds₁ = some (.ok (state', cf₁)) →
     op₂.dominates op₁ ctx →
     state.EquationHolds op₂ →
     state'.EquationHolds op₂ := by
@@ -135,4 +137,5 @@ theorem interpretOp_equationLemmaAt {ctx : WfIRContext OpCode} {opInBounds} {sta
   · apply interpretOp_equationHolds_other ctxDom (by grind) hInterp
     · grind [OperationPtr.dominates_of_strictlyDominates]
     · grind [interpretOp_equationHolds_other]
+    · grind
   · grind [interpretOp_equationHolds_self]

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -11,12 +11,12 @@ variable {op op' : OperationPtr}
 
 theorem VariableState.setVar?_eq_none_iff_of_varState
     (varState₂ : VariableState ctx) :
-    varState.setVar? var' val = none ↔ varState₂.setVar? var' val = none := by
+    varState.setVar? var' val inBounds = none ↔ varState₂.setVar? var' val = none := by
   grind [VariableState.setVar?]
 
 theorem VariableState.setResultValues?_loop_eq_none_iff_of_varState
     (varState₂ : VariableState ctx) :
-    varState.setResultValues?_loop op resValues idx = none ↔
+    varState.setResultValues?_loop op resValues idx inBounds hi = none ↔
     varState₂.setResultValues?_loop op resValues idx = none := by
   induction idx generalizing varState varState₂ with
   | zero => grind [setResultValues?_loop]
@@ -26,20 +26,20 @@ theorem VariableState.setResultValues?_loop_eq_none_iff_of_varState
 
 theorem VariableState.setResultValues?_eq_none_iff_of_varState
     (varState₂ : VariableState ctx) :
-    varState.setResultValues? op resValues = none ↔
+    varState.setResultValues? op resValues inBounds = none ↔
     varState₂.setResultValues? op resValues = none := by
   simp only [setResultValues?]
   grind [VariableState.setResultValues?_loop_eq_none_iff_of_varState]
 
 theorem VariableState.setVar?_eq_some_of_varState
     (varState₂ : VariableState ctx) :
-    varState.setVar? var' val = some varStateA →
+    varState.setVar? var' val inBounds = some varStateA →
     ∃ varStateB, varState₂.setVar? var' val = some varStateB := by
   grind [VariableState.setVar?]
 
 theorem VariableState.setResultValues?_loop_eq_some_of_varState
     (varState₂ : VariableState ctx) :
-    varState.setResultValues?_loop op resValues idx = some varStateA →
+    varState.setResultValues?_loop op resValues idx inBounds hi = some varStateA →
     ∃ varStateB, varState₂.setResultValues?_loop op resValues idx = some varStateB := by
   cases hc : varState₂.setResultValues?_loop op resValues idx
   · grind [VariableState.setResultValues?_loop_eq_none_iff_of_varState]
@@ -47,7 +47,7 @@ theorem VariableState.setResultValues?_loop_eq_some_of_varState
 
 theorem VariableState.setResultValues?_eq_some_of_varState
     (varState₂ : VariableState ctx) :
-    varState.setResultValues? op resValues = some varStateA →
+    varState.setResultValues? op resValues inBounds = some varStateA →
     ∃ varStateB, varState₂.setResultValues? op resValues = some varStateB := by
   rcases hc : varState₂.setResultValues? op resValues
   · grind [VariableState.setResultValues?_eq_none_iff_of_varState]
@@ -55,13 +55,13 @@ theorem VariableState.setResultValues?_eq_some_of_varState
 
 @[grind =>]
 theorem VariableState.getVar?_of_setVar? :
-    VariableState.setVar? varState var' val = some varState' →
+    VariableState.setVar? varState var' val inBounds = some varState' →
     varState'.getVar? var =
     if var = var' then some val else varState.getVar? var := by
   grind [VariableState.setVar?, VariableState.getVar?]
 
 theorem VariableState.getVar?_setResultValues?_loop :
-    varState.setResultValues?_loop op resultValues idx = some varState' →
+    varState.setResultValues?_loop op resultValues idx inBounds hi = some varState' →
     varState'.getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
@@ -79,7 +79,7 @@ theorem VariableState.getVar?_setResultValues?_loop :
 
 @[grind =>]
 theorem VariableState.getVar?_setResultValues? :
-    varState.setResultValues? op resultValues = some varState' →
+    varState.setResultValues? op resultValues inBounds = some varState' →
     varState'.getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
@@ -94,7 +94,7 @@ theorem VariableState.getVar?_setResultValues? :
 @[grind =>]
 theorem VariableState.getVar?_setResultValues?_of_value_inBounds
     (valueInBounds : value.InBounds ctx.raw) :
-    varState.setResultValues? op resultValues = some varState' →
+    varState.setResultValues? op resultValues inBounds = some varState' →
     varState'.getVar? value =
     match value with
     | .opResult {op := op', index := index} =>
@@ -108,8 +108,9 @@ theorem VariableState.getVar?_setResultValues?_of_value_inBounds
   simp only [getVar?_setResultValues? h]
   cases value <;> grind
 
-theorem interpretOp_some_iff {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} :
-  interpretOp op state = some (.ok (state', cf)) ↔
+theorem interpretOp_some_iff {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx}
+  {inBounds : op.InBounds ctx.raw} :
+  interpretOp op state inBounds = some (.ok (state', cf)) ↔
   ∃ operandValues resValues mem' varState',
     (state.variables.getOperandValues op) = some operandValues ∧
     interpretOp' (op.getOpType! ctx.raw) (op.getProperties! ctx.raw (op.getOpType! ctx.raw))
@@ -132,10 +133,10 @@ theorem VariableState.getOperandValues_eq_of_getVar?_eq :
 
 theorem VariableState.setResultValues?_comm
     (hOp : op₁ ≠ op₂) :
-    varState.setResultValues? op₁ resValues₁ = some varState' →
-    varState'.setResultValues? op₂ resValues₂ = some varState'' →
-    ∃ varState₂, varState.setResultValues? op₂ resValues₂ = some varState₂ ∧
-    varState₂.setResultValues? op₁ resValues₁ = some varState'' := by
+    varState.setResultValues? op₁ resValues₁ inBounds₁ = some varState' →
+    varState'.setResultValues? op₂ resValues₂ inBounds₂ = some varState'' →
+    ∃ varState₂, varState.setResultValues? op₂ resValues₂ inBounds₂ = some varState₂ ∧
+    varState₂.setResultValues? op₁ resValues₁ inBounds₁ = some varState'' := by
   intros h₁ h₂
   have ⟨varState₂, hvs₂⟩ := setResultValues?_eq_some_of_varState varState h₂
   have ⟨varState₂', hvs₂'⟩ := setResultValues?_eq_some_of_varState varState₂ h₁
@@ -148,7 +149,7 @@ theorem VariableState.setResultValues?_comm
 theorem VariableState.getVar?_setResultValues?_operand_of_dominates
     (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
     value ∈ op'.getOperands! ctx.raw →
-    varState.setResultValues? op resValues = some varState' →
+    varState.setResultValues? op resValues inBounds = some varState' →
     varState'.getVar? value =
     varState.getVar? value := by
   intro valueInOperands h
@@ -165,7 +166,7 @@ theorem VariableState.getVar?_setResultValues?_operand_of_dominates
 @[grind =>]
 theorem VariableState.getOperandValues_setResultValues?_of_dominates
     (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
-    varState.setResultValues? op resValues = some varState' →
+    varState.setResultValues? op resValues inBounds = some varState' →
     varState'.getOperandValues op' = varState.getOperandValues op' := by
   intro h
   apply VariableState.getOperandValues_eq_of_getVar?_eq
@@ -174,15 +175,15 @@ theorem VariableState.getOperandValues_setResultValues?_of_dominates
 @[grind =>]
 theorem VariableState.getOperandValues_setResultValues?_self
     (ctxDom : ctx.Dom) :
-    (varState.setResultValues? op resValues) = varState' →
+    (varState.setResultValues? op resValues inBounds) = varState' →
     varState'.getOperandValues op = varState.getOperandValues op := by
   exact getOperandValues_setResultValues?_of_dominates ctxDom OperationPtr.dominates_refl
 
 @[grind =>]
 theorem VariableState.setResultValues?_setResultValues?_self :
-    varState.setResultValues? op resValues = some varState' →
-    varState'.setResultValues? op resValues' =
-    varState.setResultValues? op resValues' := by
+    varState.setResultValues? op resValues inBounds = some varState' →
+    varState'.setResultValues? op resValues' inBounds' =
+    varState.setResultValues? op resValues' inBounds' := by
   intro h
   rcases hopt : varState.setResultValues? op resValues' with _ | vs2
   · grind [VariableState.setResultValues?_eq_none_iff_of_varState]


### PR DESCRIPTION
The only meaningful change is in `VariableState`, where we add a new field.
All other changes is just adding missing `inBounds` to functions, or updating lemmas.