### PR TITLE
chore(LLVM): polish `getelementptr` flag tests cases

### DIFF
--- a/Test/LLVM/getelementptr.mlir
+++ b/Test/LLVM/getelementptr.mlir
@@ -25,6 +25,19 @@
 
       "llvm.return"(%g1, %g2, %g3, %g4, %g5) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   }) : () -> ()
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<void (ptr)>, linkage = #llvm.linkage<external>, sym_name = "gep_no_wrap_flags", visibility_ = 0 : i64}> ({
+  ^bb15(%arg0: !llvm.ptr):
+    %0 = "llvm.mlir.constant"() <{value = 7 : i32}> : () -> i32
+    // getelementptr inbounds float, ptr %ptr, i32 7
+    %1 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 3 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    // getelementptr nusw float, ptr %ptr, i32 7
+    %2 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 2 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    // getelementptr nuw float, ptr %ptr, i32 7
+    %3 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 4 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    // getelementptr nusw nuw float, ptr %ptr, i32 7
+    %4 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 6 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    "llvm.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:       "builtin.module"() ({
@@ -38,4 +51,14 @@
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x i8>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
 // CHECK-NEXT:          "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      }) : () -> ()
+
+// CHECK-NEXT:  "llvm.func"()
+// CHECK-NEXT:  ^15(%{{.*}}: !llvm.ptr):
+// CHECK-NEXT:    %{{.*}} = "llvm.mlir.constant"() <{"value" = 7 : i32}> : () -> i32
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 2 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 4 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 6 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    "llvm.return"() : () -> ()
+// CHECK-NEXT:  }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -42,10 +42,6 @@
     ^8(%arg7_0 : i32):
       "llvm.return"(%arg7_0) : (i32) -> ()
     ^9(%ptr : !llvm.ptr):
-      %28 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 3 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-      %29 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 2 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-      %30 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 1 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-      %31 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
       %32 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
       %34 = "llvm.fadd"(%fcst, %fcst) : (f64, f64) -> f64
       %35 = "llvm.fadd"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
@@ -119,10 +115,6 @@
 // CHECK-NEXT:     ^[[b2]](%{{.*}} : i32):
 // CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.ptr):
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 2 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 1 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.pt
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64


### PR DESCRIPTION
The getelementptr instruction supports the flags `inbounds`, `nusw`, and `nuw`, for which the LLVM repository offered a test case:

```
  define void @gep_no_wrap_flags(ptr %ptr) {
    %1 = getelementptr inbounds float, ptr %ptr, i32 7
    %2 = getelementptr nusw float, ptr %ptr, i32 7
    %3 = getelementptr nuw float, ptr %ptr, i32 7
    %4 = getelementptr nusw nuw float, ptr %ptr, i32 7
    ret void
  }
```

We translate this test case to MLIR and add the corresponding tests to `Test/LLVM/getelementptr.mlir`. This replaces the getelementptr flag test cases that were present in `Test/LLVM/identity.mlir`.

As a side effect, we do not test anymore for the flag `noWrapFlags = 1`, which is invalid and triggers in MLIR the error `'inbounds_flag' cannot be used directly`.

This change helps on our quest to parse `test/LLVM/identity.mlir` with `mlir-opt` without triggering verification errors, as it removes the gep verification error.

This fixes #678.