### PR TITLE
chore(LLVM): use `IntegerAttr` to encode overflow flags

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -5,9 +5,9 @@
     ^4():
       %5 = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
       %addi = "arith.addi"(%5, %5) : (i32, i32) -> i32
-      %addi_nsw = "arith.addi"(%5, %5) <{nws}> : (i32, i32) -> i32
-      %addi_nuw = "arith.addi"(%5, %5) <{nuw}> : (i32, i32) -> i32
-      %addi_nsw_nuw = "arith.addi"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %addi_nsw = "arith.addi"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+      %addi_nuw = "arith.addi"(%5, %5) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+      %addi_nsw_nuw = "arith.addi"(%5, %5) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
       %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
       %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
       %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
@@ -22,9 +22,9 @@
       %18 = "arith.minsi"(%5, %5) : (i32, i32) -> i32
       %19 = "arith.minui"(%5, %5) : (i32, i32) -> i32
       %muli = "arith.muli"(%5, %5) : (i32, i32) -> i32
-      %muli_nsw = "arith.muli"(%5, %5) <{nws}> : (i32, i32) -> i32
-      %muli_nuw = "arith.muli"(%5, %5) <{nuw}> : (i32, i32) -> i32
-      %muli_nsw_nuw = "arith.muli"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %muli_nsw = "arith.muli"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+      %muli_nuw = "arith.muli"(%5, %5) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+      %muli_nsw_nuw = "arith.muli"(%5, %5) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
       %210, %211 = "arith.mulsi_extended"(%5, %5) : (i32, i32) -> (i32, i32)
       %220, %221 = "arith.mului_extended"(%5, %5) : (i32, i32) -> (i32, i32)
       %23 = "arith.ori"(%5, %5) : (i32, i32) -> i32
@@ -47,9 +47,9 @@
 // CHECK-NEXT:       ^{{.*}}():
 // CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
 // CHECK-NEXT:         %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
@@ -64,9 +64,9 @@
 // CHECK-NEXT:         %{{.*}} = "arith.minsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.minui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
 // CHECK-NEXT:         %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
 // CHECK-NEXT:         %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32

--- a/Test/Interpreter/Arith/addi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/addi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.addi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.addi"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/addi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.addi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.addi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.addi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.addi"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.addi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.addi"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.addi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.addi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/divsi_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/Arith/divsi_poison_dividend_neg1.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.divsi"(%poison, %neg1) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/divsi_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/divsi_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.divsi"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/divui_poison_dividend.mlir
+++ b/Test/Interpreter/Arith/divui_poison_dividend.mlir
@@ -7,7 +7,7 @@
     %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.divui"(%poison, %five) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/divui_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/divui_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.divui"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/muli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 13 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.muli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/muli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 13 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.muli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.muli"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/muli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.muli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.muli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.muli"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 2 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.muli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.muli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.muli"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/remsi_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/Arith/remsi_poison_dividend_neg1.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.remsi"(%poison, %neg1) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/remsi_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/remsi_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.remsi"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/remui_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/remui_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "arith.remui"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/shli_oversized_amount.mlir
+++ b/Test/Interpreter/Arith/shli_oversized_amount.mlir
@@ -5,8 +5,8 @@
     %c = "arith.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
     %none = "arith.shli"(%c, %c) : (i66, i66) -> i66
     %nsw = "arith.shli"(%c, %c) <{nsw}> : (i66, i66) -> i66
-    %nuw = "arith.shli"(%c, %c) <{nuw}> : (i66, i66) -> i66
-    %nsw_nuw = "arith.shli"(%c, %c) <{nsw, nuw}> : (i66, i66) -> i66
+    %nuw = "arith.shli"(%c, %c) <{"overflowFlags" = 2 : i32}> : (i66, i66) -> i66
+    %nsw_nuw = "arith.shli"(%c, %c) <{"overflowFlags" = 3 : i32}> : (i66, i66) -> i66
     "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_oversized_amount.mlir
+++ b/Test/Interpreter/Arith/shli_oversized_amount.mlir
@@ -4,7 +4,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %c = "arith.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
     %none = "arith.shli"(%c, %c) : (i66, i66) -> i66
-    %nsw = "arith.shli"(%c, %c) <{nsw}> : (i66, i66) -> i66
+    %nsw = "arith.shli"(%c, %c) <{"overflowFlags" = 1 : i32}> : (i66, i66) -> i66
     %nuw = "arith.shli"(%c, %c) <{"overflowFlags" = 2 : i32}> : (i66, i66) -> i66
     %nsw_nuw = "arith.shli"(%c, %c) <{"overflowFlags" = 3 : i32}> : (i66, i66) -> i66
     "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()

--- a/Test/Interpreter/Arith/shli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.shli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/shli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.shli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.shli"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/shli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 6 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.shli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.shli"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 6 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.shli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.shli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.shli"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.shli"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.shli"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/subi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 200 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 80 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.subi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/subi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/subi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 80 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.subi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.subi"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 220 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.subi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.subi"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 220 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.subi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "arith.constant"() <{ "value" = 127 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.subi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "arith.subi"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "arith.constant"() <{ "value" = -10 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 127 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.subi"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_signed_overflow.mlir
@@ -6,8 +6,8 @@
     %c127 = "arith.constant"() <{ "value" = 127 : i32 }> : () -> i32
     // 128 does not fit in i8 signed: sext(trunc(128)) == -128 != 128, poison
     %c128 = "arith.constant"() <{ "value" = 128 : i32 }> : () -> i32
-    %a = "arith.trunci"(%c127) <{nsw}> : (i32) -> i8
-    %b = "arith.trunci"(%c128) <{nsw}> : (i32) -> i8
+    %a = "arith.trunci"(%c127) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
+    %b = "arith.trunci"(%c128) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
     "func.return"(%a, %b) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
@@ -8,7 +8,7 @@
     %c384 = "arith.constant"() <{ "value" = 384 : i32 }> : () -> i32
     %none    = "arith.trunci"(%c384) : (i32) -> i8
     %nsw     = "arith.trunci"(%c384) <{nsw}> : (i32) -> i8
-    %nuw     = "arith.trunci"(%c384) <{nuw}> : (i32) -> i8
+    %nuw     = "arith.trunci"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
     %nuw_nsw = "arith.trunci"(%c384) <{nuw, nsw}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %c384 = "arith.constant"() <{ "value" = 384 : i32 }> : () -> i32
     %none    = "arith.trunci"(%c384) : (i32) -> i8
-    %nsw     = "arith.trunci"(%c384) <{nsw}> : (i32) -> i8
+    %nsw     = "arith.trunci"(%c384) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
     %nuw     = "arith.trunci"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
     %nuw_nsw = "arith.trunci"(%c384) <{nuw, nsw}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
@@ -9,7 +9,7 @@
     %none    = "arith.trunci"(%c384) : (i32) -> i8
     %nsw     = "arith.trunci"(%c384) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
     %nuw     = "arith.trunci"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
-    %nuw_nsw = "arith.trunci"(%c384) <{nuw, nsw}> : (i32) -> i8
+    %nuw_nsw = "arith.trunci"(%c384) <{"overflowFlags" = 3 : i32}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_unsigned_overflow.mlir
@@ -6,8 +6,8 @@
     %c255 = "arith.constant"() <{ "value" = 255 : i32 }> : () -> i32
     // 256 does not fit in i8 unsigned: zext(trunc(256)) == 0 != 256, poison
     %c256 = "arith.constant"() <{ "value" = 256 : i32 }> : () -> i32
-    %a = "arith.trunci"(%c255) <{nuw}> : (i32) -> i8
-    %b = "arith.trunci"(%c256) <{nuw}> : (i32) -> i8
+    %a = "arith.trunci"(%c255) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
+    %b = "arith.trunci"(%c256) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
     "func.return"(%a, %b) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Cf/cond_br_poison.mlir
+++ b/Test/Interpreter/Cf/cond_br_poison.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main"}> ({
     ^entry():
       %one    = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
-      %poison = "arith.addi"(%one, %one) <{nuw}> : (i1, i1) -> i1
+      %poison = "arith.addi"(%one, %one) <{"overflowFlags" = 2 : i32}> : (i1, i1) -> i1
       %tval   = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
       %fval   = "arith.constant"() <{"value" = 99 : i32}> : () -> i32
       "cf.cond_br"(%poison, %tval, %fval) [^t, ^f]

--- a/Test/Interpreter/Comb/add.mlir
+++ b/Test/Interpreter/Comb/add.mlir
@@ -10,7 +10,7 @@
     %z = "comb.add"(%c3, %c5, %c10) : (i8, i8, i8) -> i8
 
     %c255 = "hw.constant"() <{ "value" = 255 : i8 }> : () -> i8
-    %nuw_nsw = "llvm.add"(%c255, %c5) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.add"(%c255, %c5) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     %poison = "comb.add"(%nuw_nsw, %c5) : (i8, i8) -> i8
     "func.return"(%x, %y, %z, %poison) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/add_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/add_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/add_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/add_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 3 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/cond_br_poison.mlir
+++ b/Test/Interpreter/LLVM/cond_br_poison.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main"}> ({
     ^entry():
       %one    = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
-      %poison = "llvm.add"(%one, %one) <{nuw}> : (i1, i1) -> i1
+      %poison = "llvm.add"(%one, %one) <{"overflowFlags" = 2 : i32}> : (i1, i1) -> i1
       %tval   = "llvm.mlir.constant"() <{"value" = 42 : i32}> : () -> i32
       %fval   = "llvm.mlir.constant"() <{"value" = 99 : i32}> : () -> i32
       "llvm.cond_br"(%poison, %tval, %fval) [^t, ^f]

--- a/Test/Interpreter/LLVM/cond_br_poison_propagates.mlir
+++ b/Test/Interpreter/LLVM/cond_br_poison_propagates.mlir
@@ -9,7 +9,7 @@
       "llvm.br"() [^poison_block] : () -> ()
     ^poison_block():
       %one    = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
-      %poison = "llvm.add"(%one, %one) <{nuw}> : (i1, i1) -> i1
+      %poison = "llvm.add"(%one, %one) <{"overflowFlags" = 2 : i32}> : (i1, i1) -> i1
       %tval   = "llvm.mlir.constant"() <{"value" = 42 : i32}> : () -> i32
       %fval   = "llvm.mlir.constant"() <{"value" = 99 : i32}> : () -> i32
       "llvm.cond_br"(%poison, %tval, %fval) [^t, ^f]

--- a/Test/Interpreter/LLVM/mul_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 13 : i8 }> : () -> i8
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.mul"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 10 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 13 : i8 }> : () -> i8
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/mul_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.mul"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.mul"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/mul_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 2 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %none = "llvm.mul"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.mul"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.mul"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.mul"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/sdiv_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/LLVM/sdiv_poison_dividend_neg1.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.sdiv"(%poison, %neg1) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/sdiv_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/sdiv_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.sdiv"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/select.mlir
+++ b/Test/Interpreter/LLVM/select.mlir
@@ -12,10 +12,10 @@
     // Poison i32 via `llvm.add nuw` of -1 + 1 (unsigned overflow).
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %p32  = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %p32  = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
 
     // Poison i1 via `llvm.add nuw` of 1 + 1.
-    %p1 = "llvm.add"(%t, %t) <{nuw}> : (i1, i1) -> i1
+    %p1 = "llvm.add"(%t, %t) <{"overflowFlags" = 2 : i32}> : (i1, i1) -> i1
 
     // Concrete condition, concrete arms.
     %r1 = "llvm.select"(%t, %a, %b) : (i1, i32, i32) -> i32

--- a/Test/Interpreter/LLVM/shl_oversized_amount.mlir
+++ b/Test/Interpreter/LLVM/shl_oversized_amount.mlir
@@ -4,7 +4,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %c = "llvm.mlir.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
     %none = "llvm.shl"(%c, %c) : (i66, i66) -> i66
-    %nsw = "llvm.shl"(%c, %c) <{nsw}> : (i66, i66) -> i66
+    %nsw = "llvm.shl"(%c, %c) <{"overflowFlags" = 1 : i32}> : (i66, i66) -> i66
     %nuw = "llvm.shl"(%c, %c) <{"overflowFlags" = 2 : i32}> : (i66, i66) -> i66
     %nsw_nuw = "llvm.shl"(%c, %c) <{"overflowFlags" = 3 : i32}> : (i66, i66) -> i66
     "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()

--- a/Test/Interpreter/LLVM/shl_oversized_amount.mlir
+++ b/Test/Interpreter/LLVM/shl_oversized_amount.mlir
@@ -5,8 +5,8 @@
     %c = "llvm.mlir.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
     %none = "llvm.shl"(%c, %c) : (i66, i66) -> i66
     %nsw = "llvm.shl"(%c, %c) <{nsw}> : (i66, i66) -> i66
-    %nuw = "llvm.shl"(%c, %c) <{nuw}> : (i66, i66) -> i66
-    %nsw_nuw = "llvm.shl"(%c, %c) <{nsw, nuw}> : (i66, i66) -> i66
+    %nuw = "llvm.shl"(%c, %c) <{"overflowFlags" = 2 : i32}> : (i66, i66) -> i66
+    %nsw_nuw = "llvm.shl"(%c, %c) <{"overflowFlags" = 3 : i32}> : (i66, i66) -> i66
     "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/shl_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.shl"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/shl_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 10 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/shl_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 6 : i8 }> : () -> i8
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 6 : i8 }> : () -> i8
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.shl"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 5 : i8 }> : () -> i8
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/shl_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 5 : i8 }> : () -> i8
     %none = "llvm.shl"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.shl"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.shl"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.shl"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.shl"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/srem_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/LLVM/srem_poison_dividend_neg1.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.srem"(%poison, %neg1) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/srem_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/srem_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.srem"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 80 : i8 }> : () -> i8
     %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.sub"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 80 : i8 }> : () -> i8
     %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 220 : i8 }> : () -> i8
     %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.sub"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_signed_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 220 : i8 }> : () -> i8
     %none = "llvm.sub"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.sub"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.sub"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.sub"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
@@ -6,7 +6,7 @@
     %rhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
-    %nuw = "llvm.add"(%lhs, %rhs) <{nuw}> : (i8, i8) -> i8
+    %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
     %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
+    %nuw_nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/sub_unsigned_overflow.mlir
@@ -5,7 +5,7 @@
     %lhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
     %rhs = "llvm.mlir.constant"() <{ "value" = 200 : i8 }> : () -> i8
     %none = "llvm.add"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "llvm.add"(%lhs, %rhs) <{nsw}> : (i8, i8) -> i8
+    %nsw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
     %nuw = "llvm.add"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
     %nuw_nsw = "llvm.add"(%lhs, %rhs) <{nuw, nsw}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/trunc_signed_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_signed_overflow.mlir
@@ -6,8 +6,8 @@
     %c127 = "llvm.mlir.constant"() <{ "value" = 127 : i32 }> : () -> i32
     // 128 does not fit in i8 signed: sext(trunc(128)) == -128 != 128, poison
     %c128 = "llvm.mlir.constant"() <{ "value" = 128 : i32 }> : () -> i32
-    %a = "llvm.trunc"(%c127) <{nsw}> : (i32) -> i8
-    %b = "llvm.trunc"(%c128) <{nsw}> : (i32) -> i8
+    %a = "llvm.trunc"(%c127) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
+    %b = "llvm.trunc"(%c128) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
     "func.return"(%a, %b) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
@@ -8,7 +8,7 @@
     %c384 = "llvm.mlir.constant"() <{ "value" = 384 : i32 }> : () -> i32
     %none    = "llvm.trunc"(%c384) : (i32) -> i8
     %nsw     = "llvm.trunc"(%c384) <{nsw}> : (i32) -> i8
-    %nuw     = "llvm.trunc"(%c384) <{nuw}> : (i32) -> i8
+    %nuw     = "llvm.trunc"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
     %nuw_nsw = "llvm.trunc"(%c384) <{nuw, nsw}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
@@ -9,7 +9,7 @@
     %none    = "llvm.trunc"(%c384) : (i32) -> i8
     %nsw     = "llvm.trunc"(%c384) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
     %nuw     = "llvm.trunc"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
-    %nuw_nsw = "llvm.trunc"(%c384) <{nuw, nsw}> : (i32) -> i8
+    %nuw_nsw = "llvm.trunc"(%c384) <{"overflowFlags" = 3 : i32}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_signed_unsigned_overflow.mlir
@@ -7,7 +7,7 @@
   "func.func"() <{sym_name = "main"}> ({
     %c384 = "llvm.mlir.constant"() <{ "value" = 384 : i32 }> : () -> i32
     %none    = "llvm.trunc"(%c384) : (i32) -> i8
-    %nsw     = "llvm.trunc"(%c384) <{nsw}> : (i32) -> i8
+    %nsw     = "llvm.trunc"(%c384) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
     %nuw     = "llvm.trunc"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
     %nuw_nsw = "llvm.trunc"(%c384) <{nuw, nsw}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()

--- a/Test/Interpreter/LLVM/trunc_unsigned_overflow.mlir
+++ b/Test/Interpreter/LLVM/trunc_unsigned_overflow.mlir
@@ -6,8 +6,8 @@
     %c255 = "llvm.mlir.constant"() <{ "value" = 255 : i32 }> : () -> i32
     // 256 does not fit in i8 unsigned: zext(trunc(256)) == 0 != 256, poison
     %c256 = "llvm.mlir.constant"() <{ "value" = 256 : i32 }> : () -> i32
-    %a = "llvm.trunc"(%c255) <{nuw}> : (i32) -> i8
-    %b = "llvm.trunc"(%c256) <{nuw}> : (i32) -> i8
+    %a = "llvm.trunc"(%c255) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
+    %b = "llvm.trunc"(%c256) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
     "func.return"(%a, %b) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/udiv_poison_dividend.mlir
+++ b/Test/Interpreter/LLVM/udiv_poison_dividend.mlir
@@ -7,7 +7,7 @@
     %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.udiv"(%poison, %five) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/udiv_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/udiv_poison_divisor.mlir
@@ -8,7 +8,7 @@
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
     // -1 + 1 with `nuw` on i32 unsigned-overflows -> poison i32.
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.udiv"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/LLVM/urem_poison_divisor.mlir
+++ b/Test/Interpreter/LLVM/urem_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "llvm.mlir.constant"() <{ "value" = 130 : i32 }> : () -> i32
     %neg1 = "llvm.mlir.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "llvm.add"(%neg1, %one) <{nuw}> : (i32, i32) -> i32
+    %poison = "llvm.add"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %y = "llvm.urem"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/LLVM/fastntt.mlir
+++ b/Test/LLVM/fastntt.mlir
@@ -200,7 +200,7 @@
 // CHECK-NEXT:         "llvm.cond_br"([[L2FA_CMP]]) [^[[BB_L2FA_BODY:.*]], ^[[BB_L2FA_EXIT:.*]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
 // CHECK-NEXT:       ^[[BB_L2FA_BODY]]():
 // CHECK-NEXT:         [[L2FA_SHR:%.*]] = "llvm.ashr"([[L2FA_V1]], [[L2FA_C1]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[L2FA_ADD:%.*]] = "llvm.add"([[L2FA_V0]], [[L2FA_C1]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[L2FA_ADD:%.*]] = "llvm.add"([[L2FA_V0]], [[L2FA_C1]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.br"([[L2FA_ADD]], [[L2FA_SHR]]) [^[[BB_L2FA_COND]]] : (i32, i32) -> ()
 // CHECK-NEXT:       ^[[BB_L2FA_EXIT]]():
 // CHECK-NEXT:         "llvm.return"([[L2FA_V0]]) : (i32) -> ()
@@ -215,33 +215,33 @@
 // CHECK-NEXT:         "llvm.cond_br"([[L2F_CMP]]) [^[[BB_L2F_BODY:.*]], ^[[BB_L2F_EXIT:.*]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
 // CHECK-NEXT:       ^[[BB_L2F_BODY]]():
 // CHECK-NEXT:         [[L2F_SHR:%.*]] = "llvm.ashr"([[L2F_V1]], [[L2F_C1]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[L2F_ADD:%.*]] = "llvm.add"([[L2F_V0]], [[L2F_C1]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[L2F_ADD:%.*]] = "llvm.add"([[L2F_V0]], [[L2F_C1]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.br"([[L2F_ADD]], [[L2F_SHR]]) [^[[BB_L2F_COND]]] : (i32, i32) -> ()
 // CHECK-NEXT:       ^[[BB_L2F_EXIT]]():
 // CHECK-NEXT:         "llvm.return"([[L2F_V0]]) : (i32) -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_BCT:.*]]([[BCT_A0:%.*]] : i32, [[BCT_A1:%.*]] : i32, [[BCT_A2:%.*]] : i32, [[BCT_A3:%.*]] : i32, [[BCT_P0:%.*]] : !llvm.ptr, [[BCT_P1:%.*]] : !llvm.ptr):
-// CHECK-NEXT:         [[BCT_M0:%.*]] = "llvm.mul"([[BCT_A2]], [[BCT_A1]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[BCT_M0:%.*]] = "llvm.mul"([[BCT_A2]], [[BCT_A1]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         [[BCT_R0:%.*]] = "llvm.srem"([[BCT_M0]], [[BCT_A3]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[BCT_S0:%.*]] = "llvm.add"([[BCT_A0]], [[BCT_R0]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[BCT_S0:%.*]] = "llvm.add"([[BCT_A0]], [[BCT_R0]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         [[BCT_R1:%.*]] = "llvm.srem"([[BCT_S0]], [[BCT_A3]]) : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.store"([[BCT_R1]], [[BCT_P0]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
-// CHECK-NEXT:         [[BCT_M1:%.*]] = "llvm.mul"([[BCT_A2]], [[BCT_A1]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[BCT_M1:%.*]] = "llvm.mul"([[BCT_A2]], [[BCT_A1]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         [[BCT_R2:%.*]] = "llvm.srem"([[BCT_M1]], [[BCT_A3]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[BCT_SB:%.*]] = "llvm.sub"([[BCT_A0]], [[BCT_R2]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[BCT_AD:%.*]] = "llvm.add"([[BCT_SB]], [[BCT_A3]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[BCT_SB:%.*]] = "llvm.sub"([[BCT_A0]], [[BCT_R2]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         [[BCT_AD:%.*]] = "llvm.add"([[BCT_SB]], [[BCT_A3]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         [[BCT_R3:%.*]] = "llvm.srem"([[BCT_AD]], [[BCT_A3]]) : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.store"([[BCT_R3]], [[BCT_P1]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:         "llvm.return"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT:     "llvm.func"() <{{{.*}}}> ({
 // CHECK-NEXT:       ^[[BB_BGS:.*]]([[BGS_A0:%.*]] : i32, [[BGS_A1:%.*]] : i32, [[BGS_A2:%.*]] : i32, [[BGS_A3:%.*]] : i32, [[BGS_P0:%.*]] : !llvm.ptr, [[BGS_P1:%.*]] : !llvm.ptr):
-// CHECK-NEXT:         [[BGS_S0:%.*]] = "llvm.add"([[BGS_A0]], [[BGS_A1]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[BGS_S0:%.*]] = "llvm.add"([[BGS_A0]], [[BGS_A1]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         [[BGS_R0:%.*]] = "llvm.srem"([[BGS_S0]], [[BGS_A3]]) : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.store"([[BGS_R0]], [[BGS_P0]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
-// CHECK-NEXT:         [[BGS_SB:%.*]] = "llvm.sub"([[BGS_A0]], [[BGS_A1]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[BGS_M0:%.*]] = "llvm.mul"([[BGS_SB]], [[BGS_A2]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[BGS_SB:%.*]] = "llvm.sub"([[BGS_A0]], [[BGS_A1]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         [[BGS_M0:%.*]] = "llvm.mul"([[BGS_SB]], [[BGS_A2]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         [[BGS_R1:%.*]] = "llvm.srem"([[BGS_M0]], [[BGS_A3]]) : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.store"([[BGS_R1]], [[BGS_P1]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
 // CHECK-NEXT:         "llvm.return"() : () -> ()
@@ -275,7 +275,7 @@
 // CHECK-NEXT:         "llvm.cond_br"([[NTT_CMP2]]) [^[[BB_NTT_9:.*]], ^[[BB_NTT_10:.*]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
 // CHECK-NEXT:       ^[[BB_NTT_9]]():
 // CHECK-NEXT:         [[NTT_SHR0:%.*]] = "llvm.ashr"([[NTT_V7]], [[NTT_C2]]) : (i32, i32) -> i32
-// CHECK-NEXT:         [[NTT_ADD0:%.*]] = "llvm.add"([[NTT_V6]], [[NTT_C2]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[NTT_ADD0:%.*]] = "llvm.add"([[NTT_V6]], [[NTT_C2]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.br"([[NTT_ADD0]], [[NTT_SHR0]]) [^[[BB_NTT_8]]] : (i32, i32) -> ()
 // CHECK-NEXT:       ^[[BB_NTT_10]]():
 // CHECK-NEXT:         [[NTT_CMP3:%.*]] = "llvm.icmp"([[NTT_V5]], [[NTT_V6]]) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
@@ -295,17 +295,17 @@
 // CHECK-NEXT:       ^[[BB_NTT_17]]():
 // CHECK:              "llvm.br"() [^[[BB_NTT_19:.*]]] : () -> ()
 // CHECK-NEXT:       ^[[BB_NTT_19]]():
-// CHECK-NEXT:         [[NTT_ADD1:%.*]] = "llvm.add"([[NTT_V9]], [[NTT_C2]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[NTT_ADD1:%.*]] = "llvm.add"([[NTT_V9]], [[NTT_C2]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.br"([[NTT_ADD1]]) [^[[BB_NTT_16]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[BB_NTT_18]]():
 // CHECK-NEXT:         "llvm.br"() [^[[BB_NTT_20:.*]]] : () -> ()
 // CHECK-NEXT:       ^[[BB_NTT_20]]():
-// CHECK-NEXT:         [[NTT_ADD2:%.*]] = "llvm.add"([[NTT_V8]], [[NTT_C2]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[NTT_ADD2:%.*]] = "llvm.add"([[NTT_V8]], [[NTT_C2]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.br"([[NTT_ADD2]]) [^[[BB_NTT_13]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[BB_NTT_15]]():
 // CHECK:              "llvm.br"() [^[[BB_NTT_21:.*]]] : () -> ()
 // CHECK-NEXT:       ^[[BB_NTT_21]]():
-// CHECK-NEXT:         [[NTT_ADD3:%.*]] = "llvm.add"([[NTT_V5]], [[NTT_C2]]) : (i32, i32) -> i32
+// CHECK-NEXT:         [[NTT_ADD3:%.*]] = "llvm.add"([[NTT_V5]], [[NTT_C2]]) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:         "llvm.br"({{.*}}) [^[[BB_NTT_7]]] : (i32, i32, i32, i32) -> ()
 // CHECK-NEXT:       ^[[BB_NTT_12]]():
 // CHECK-NEXT:         "llvm.return"() : () -> ()

--- a/Test/LLVM/getelementptr.mlir
+++ b/Test/LLVM/getelementptr.mlir
@@ -25,6 +25,19 @@
 
       "llvm.return"(%g1, %g2, %g3, %g4, %g5) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   }) : () -> ()
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<void (ptr)>, linkage = #llvm.linkage<external>, sym_name = "gep_no_wrap_flags", visibility_ = 0 : i64}> ({
+  ^bb15(%arg0: !llvm.ptr):
+    %0 = "llvm.mlir.constant"() <{value = 7 : i32}> : () -> i32
+    // getelementptr inbounds float, ptr %ptr, i32 7
+    %1 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 3 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    // getelementptr nusw float, ptr %ptr, i32 7
+    %2 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 2 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    // getelementptr nuw float, ptr %ptr, i32 7
+    %3 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 4 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    // getelementptr nusw nuw float, ptr %ptr, i32 7
+    %4 = "llvm.getelementptr"(%arg0, %0) <{elem_type = f32, noWrapFlags = 6 : i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+    "llvm.return"() : () -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:       "builtin.module"() ({
@@ -38,4 +51,14 @@
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x i8>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
 // CHECK-NEXT:          "llvm.return"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      }) : () -> ()
+
+// CHECK-NEXT:  "llvm.func"()
+// CHECK-NEXT:  ^15(%{{.*}}: !llvm.ptr):
+// CHECK-NEXT:    %{{.*}} = "llvm.mlir.constant"() <{"value" = 7 : i32}> : () -> i32
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 2 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 4 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = f32, "noWrapFlags" = 6 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT:    "llvm.return"() : () -> ()
+// CHECK-NEXT:  }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -10,14 +10,14 @@
       %8 = "llvm.or"(%5, %5) : (i32, i32) -> i32
       %9 = "llvm.xor"(%5, %5) : (i32, i32) -> i32
       %add = "llvm.add"(%5, %5) : (i32, i32) -> i32
-      %add_nsw = "llvm.add"(%5, %5) <{nsw}> : (i32, i32) -> i32
-      %add_nuw = "llvm.add"(%5, %5) <{nuw}> : (i32, i32) -> i32
-      %add_nsw_nuw = "llvm.add"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %add_nsw = "llvm.add"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+      %add_nuw = "llvm.add"(%5, %5) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+      %add_nsw_nuw = "llvm.add"(%5, %5) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
       %11 = "llvm.sub"(%5, %5) : (i32, i32) -> i32
       %mul = "llvm.mul"(%5, %5) : (i32, i32) -> i32
-      %mul_nsw = "llvm.mul"(%5, %5) <{nsw}> : (i32, i32) -> i32
-      %mul_nuw = "llvm.mul"(%5, %5) <{nuw}> : (i32, i32) -> i32
-      %mul_nsw_nuw = "llvm.mul"(%5, %5) <{nsw, nuw}> : (i32, i32) -> i32
+      %mul_nsw = "llvm.mul"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+      %mul_nuw = "llvm.mul"(%5, %5) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+      %mul_nsw_nuw = "llvm.mul"(%5, %5) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
       %12 = "llvm.shl"(%5, %5) : (i32, i32) -> i32
       %13 = "llvm.lshr"(%5, %5) : (i32, i32) -> i32
       %14 = "llvm.ashr"(%5, %5) : (i32, i32) -> i32
@@ -83,14 +83,14 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.lshr"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.ashr"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -42,10 +42,6 @@
     ^8(%arg7_0 : i32):
       "llvm.return"(%arg7_0) : (i32) -> ()
     ^9(%ptr : !llvm.ptr):
-      %28 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 3 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-      %29 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 2 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-      %30 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 1 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-      %31 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, noWrapFlags = 0 : i32, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
       %32 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
       %34 = "llvm.fadd"(%fcst, %fcst) : (f64, f64) -> f64
       %35 = "llvm.fadd"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
@@ -119,10 +115,6 @@
 // CHECK-NEXT:     ^[[b2]](%{{.*}} : i32):
 // CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.ptr):
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 2 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 1 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.pt
-// CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64

--- a/Test/Passes/CSE/overflow_flags.mlir
+++ b/Test/Passes/CSE/overflow_flags.mlir
@@ -9,89 +9,89 @@
 
 // `add nsw` merges with `add nsw`; flagless `add` stays separate.
 ^add_nsw(%a : i32, %b : i32):
-    %add_nsw_1 = "llvm.add"(%a, %b) <{nsw}> : (i32, i32) -> i32
-    %add_nsw_2 = "llvm.add"(%a, %b) <{nsw}> : (i32, i32) -> i32
+    %add_nsw_1 = "llvm.add"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+    %add_nsw_2 = "llvm.add"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     %add_plain = "llvm.add"(%a, %b) : (i32, i32) -> i32
     "test.test"(%add_nsw_1, %add_nsw_2, %add_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[ADD_NSW:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[ADD_NSW:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[ADD_PLAIN:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[ADD_NSW]], %[[ADD_NSW]], %[[ADD_PLAIN]])
 
 // `add nsw`, `add nuw`, and `add nsw,nuw` all remain distinct; the duplicate
 // `add nsw,nuw` does merge with itself.
 ^add_flags(%c : i32, %d : i32):
-    %add_nsw_only = "llvm.add"(%c, %d) <{nsw}> : (i32, i32) -> i32
+    %add_nsw_only = "llvm.add"(%c, %d) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     %add_nuw_only = "llvm.add"(%c, %d) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %add_both_a   = "llvm.add"(%c, %d) <{nuw, nsw}> : (i32, i32) -> i32
     %add_both_b   = "llvm.add"(%c, %d) <{nuw, nsw}> : (i32, i32) -> i32
     "test.test"(%add_nsw_only, %add_nuw_only, %add_both_a, %add_both_b) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[ADD_NSW_ONLY:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[ADD_NSW_ONLY:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[ADD_NUW_ONLY:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[ADD_BOTH:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[ADD_NSW_ONLY]], %[[ADD_NUW_ONLY]], %[[ADD_BOTH]], %[[ADD_BOTH]])
 
 // Commutativity applies under matching flags: `add nsw a b` and `add nsw b a` merge.
 ^add_comm(%e : i32, %f : i32):
-    %add_comm_1 = "llvm.add"(%e, %f) <{nsw}> : (i32, i32) -> i32
-    %add_comm_2 = "llvm.add"(%f, %e) <{nsw}> : (i32, i32) -> i32
+    %add_comm_1 = "llvm.add"(%e, %f) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+    %add_comm_2 = "llvm.add"(%f, %e) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     "test.test"(%add_comm_1, %add_comm_2) : (i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[ADD_COMM:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[ADD_COMM:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[ADD_COMM]], %[[ADD_COMM]])
 
 // `mul nsw` vs `mul nuw` are distinct; `mul nsw` with commuted operands merges.
 ^mul_flags(%g : i32, %h : i32):
-    %mul_nsw = "llvm.mul"(%g, %h) <{nsw}> : (i32, i32) -> i32
+    %mul_nsw = "llvm.mul"(%g, %h) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     %mul_nuw = "llvm.mul"(%g, %h) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
-    %mul_nsw_dup = "llvm.mul"(%h, %g) <{nsw}> : (i32, i32) -> i32
+    %mul_nsw_dup = "llvm.mul"(%h, %g) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     "test.test"(%mul_nsw, %mul_nuw, %mul_nsw_dup) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[MUL_NSW:.*]] = "llvm.mul"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[MUL_NSW:.*]] = "llvm.mul"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[MUL_NUW:.*]] = "llvm.mul"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[MUL_NSW]], %[[MUL_NUW]], %[[MUL_NSW]])
 
 // `sub` is non-commutative; nsw still partitions identity.
 ^sub_flags(%i : i32, %j : i32):
-    %sub_nsw_1 = "llvm.sub"(%i, %j) <{nsw}> : (i32, i32) -> i32
-    %sub_nsw_2 = "llvm.sub"(%i, %j) <{nsw}> : (i32, i32) -> i32
+    %sub_nsw_1 = "llvm.sub"(%i, %j) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+    %sub_nsw_2 = "llvm.sub"(%i, %j) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     %sub_plain = "llvm.sub"(%i, %j) : (i32, i32) -> i32
     "test.test"(%sub_nsw_1, %sub_nsw_2, %sub_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[SUB_NSW:.*]] = "llvm.sub"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[SUB_NSW:.*]] = "llvm.sub"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[SUB_PLAIN:.*]] = "llvm.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[SUB_NSW]], %[[SUB_NSW]], %[[SUB_PLAIN]])
 
 // `shl` carries nsw/nuw; three flag combos must remain three ops.
 ^shl_flags(%k : i32, %l : i32):
-    %shl_nsw_1 = "llvm.shl"(%k, %l) <{nsw}> : (i32, i32) -> i32
-    %shl_nsw_2 = "llvm.shl"(%k, %l) <{nsw}> : (i32, i32) -> i32
+    %shl_nsw_1 = "llvm.shl"(%k, %l) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
+    %shl_nsw_2 = "llvm.shl"(%k, %l) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     %shl_nuw   = "llvm.shl"(%k, %l) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %shl_plain = "llvm.shl"(%k, %l) : (i32, i32) -> i32
     "test.test"(%shl_nsw_1, %shl_nsw_2, %shl_nuw, %shl_plain) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[SHL_NSW:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[SHL_NSW:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[SHL_NUW:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[SHL_PLAIN:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[SHL_NSW]], %[[SHL_NSW]], %[[SHL_NUW]], %[[SHL_PLAIN]])
 
 // `trunc` carries nsw/nuw; three flag combos remain three ops.
 ^trunc_flags(%t : i64):
-    %trunc_nsw  = "llvm.trunc"(%t) <{nsw}> : (i64) -> i32
+    %trunc_nsw  = "llvm.trunc"(%t) <{"overflowFlags" = 1 : i32}> : (i64) -> i32
     %trunc_nuw  = "llvm.trunc"(%t) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
     %trunc_both_1 = "llvm.trunc"(%t) <{nuw, nsw}> : (i64) -> i32
     %trunc_both_2 = "llvm.trunc"(%t) <{nuw, nsw}> : (i64) -> i32
     "test.test"(%trunc_nsw, %trunc_nuw, %trunc_both_1, %trunc_both_2) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i64):
-    // CHECK-NEXT: %[[TRUNC_NSW:.*]] = "llvm.trunc"(%{{.*}}) <{nsw}> : (i64) -> i32
+    // CHECK-NEXT: %[[TRUNC_NSW:.*]] = "llvm.trunc"(%{{.*}}) <{"overflowFlags" = 1 : i32}> : (i64) -> i32
     // CHECK-NEXT: %[[TRUNC_NUW:.*]] = "llvm.trunc"(%{{.*}}) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
     // CHECK-NEXT: %[[TRUNC_BOTH:.*]] = "llvm.trunc"(%{{.*}}) <{"overflowFlags" = 3 : i32}> : (i64) -> i32
     // CHECK-NEXT: "test.test"(%[[TRUNC_NSW]], %[[TRUNC_NUW]], %[[TRUNC_BOTH]], %[[TRUNC_BOTH]])

--- a/Test/Passes/CSE/overflow_flags.mlir
+++ b/Test/Passes/CSE/overflow_flags.mlir
@@ -24,8 +24,8 @@
 ^add_flags(%c : i32, %d : i32):
     %add_nsw_only = "llvm.add"(%c, %d) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
     %add_nuw_only = "llvm.add"(%c, %d) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
-    %add_both_a   = "llvm.add"(%c, %d) <{nuw, nsw}> : (i32, i32) -> i32
-    %add_both_b   = "llvm.add"(%c, %d) <{nuw, nsw}> : (i32, i32) -> i32
+    %add_both_a   = "llvm.add"(%c, %d) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
+    %add_both_b   = "llvm.add"(%c, %d) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
     "test.test"(%add_nsw_only, %add_nuw_only, %add_both_a, %add_both_b) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
@@ -86,8 +86,8 @@
 ^trunc_flags(%t : i64):
     %trunc_nsw  = "llvm.trunc"(%t) <{"overflowFlags" = 1 : i32}> : (i64) -> i32
     %trunc_nuw  = "llvm.trunc"(%t) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
-    %trunc_both_1 = "llvm.trunc"(%t) <{nuw, nsw}> : (i64) -> i32
-    %trunc_both_2 = "llvm.trunc"(%t) <{nuw, nsw}> : (i64) -> i32
+    %trunc_both_1 = "llvm.trunc"(%t) <{"overflowFlags" = 3 : i32}> : (i64) -> i32
+    %trunc_both_2 = "llvm.trunc"(%t) <{"overflowFlags" = 3 : i32}> : (i64) -> i32
     "test.test"(%trunc_nsw, %trunc_nuw, %trunc_both_1, %trunc_both_2) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i64):

--- a/Test/Passes/CSE/overflow_flags.mlir
+++ b/Test/Passes/CSE/overflow_flags.mlir
@@ -23,15 +23,15 @@
 // `add nsw,nuw` does merge with itself.
 ^add_flags(%c : i32, %d : i32):
     %add_nsw_only = "llvm.add"(%c, %d) <{nsw}> : (i32, i32) -> i32
-    %add_nuw_only = "llvm.add"(%c, %d) <{nuw}> : (i32, i32) -> i32
+    %add_nuw_only = "llvm.add"(%c, %d) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %add_both_a   = "llvm.add"(%c, %d) <{nuw, nsw}> : (i32, i32) -> i32
     %add_both_b   = "llvm.add"(%c, %d) <{nuw, nsw}> : (i32, i32) -> i32
     "test.test"(%add_nsw_only, %add_nuw_only, %add_both_a, %add_both_b) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
     // CHECK-NEXT: %[[ADD_NSW_ONLY:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
-    // CHECK-NEXT: %[[ADD_NUW_ONLY:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
-    // CHECK-NEXT: %[[ADD_BOTH:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{nsw, nuw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[ADD_NUW_ONLY:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[ADD_BOTH:.*]] = "llvm.add"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[ADD_NSW_ONLY]], %[[ADD_NUW_ONLY]], %[[ADD_BOTH]], %[[ADD_BOTH]])
 
 // Commutativity applies under matching flags: `add nsw a b` and `add nsw b a` merge.
@@ -47,13 +47,13 @@
 // `mul nsw` vs `mul nuw` are distinct; `mul nsw` with commuted operands merges.
 ^mul_flags(%g : i32, %h : i32):
     %mul_nsw = "llvm.mul"(%g, %h) <{nsw}> : (i32, i32) -> i32
-    %mul_nuw = "llvm.mul"(%g, %h) <{nuw}> : (i32, i32) -> i32
+    %mul_nuw = "llvm.mul"(%g, %h) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %mul_nsw_dup = "llvm.mul"(%h, %g) <{nsw}> : (i32, i32) -> i32
     "test.test"(%mul_nsw, %mul_nuw, %mul_nsw_dup) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
     // CHECK-NEXT: %[[MUL_NSW:.*]] = "llvm.mul"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
-    // CHECK-NEXT: %[[MUL_NUW:.*]] = "llvm.mul"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[MUL_NUW:.*]] = "llvm.mul"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[MUL_NSW]], %[[MUL_NUW]], %[[MUL_NSW]])
 
 // `sub` is non-commutative; nsw still partitions identity.
@@ -72,28 +72,28 @@
 ^shl_flags(%k : i32, %l : i32):
     %shl_nsw_1 = "llvm.shl"(%k, %l) <{nsw}> : (i32, i32) -> i32
     %shl_nsw_2 = "llvm.shl"(%k, %l) <{nsw}> : (i32, i32) -> i32
-    %shl_nuw   = "llvm.shl"(%k, %l) <{nuw}> : (i32, i32) -> i32
+    %shl_nuw   = "llvm.shl"(%k, %l) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     %shl_plain = "llvm.shl"(%k, %l) : (i32, i32) -> i32
     "test.test"(%shl_nsw_1, %shl_nsw_2, %shl_nuw, %shl_plain) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
     // CHECK-NEXT: %[[SHL_NSW:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) <{nsw}> : (i32, i32) -> i32
-    // CHECK-NEXT: %[[SHL_NUW:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) <{nuw}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[SHL_NUW:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[SHL_PLAIN:.*]] = "llvm.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[SHL_NSW]], %[[SHL_NSW]], %[[SHL_NUW]], %[[SHL_PLAIN]])
 
 // `trunc` carries nsw/nuw; three flag combos remain three ops.
 ^trunc_flags(%t : i64):
     %trunc_nsw  = "llvm.trunc"(%t) <{nsw}> : (i64) -> i32
-    %trunc_nuw  = "llvm.trunc"(%t) <{nuw}> : (i64) -> i32
+    %trunc_nuw  = "llvm.trunc"(%t) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
     %trunc_both_1 = "llvm.trunc"(%t) <{nuw, nsw}> : (i64) -> i32
     %trunc_both_2 = "llvm.trunc"(%t) <{nuw, nsw}> : (i64) -> i32
     "test.test"(%trunc_nsw, %trunc_nuw, %trunc_both_1, %trunc_both_2) : (i32, i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i64):
     // CHECK-NEXT: %[[TRUNC_NSW:.*]] = "llvm.trunc"(%{{.*}}) <{nsw}> : (i64) -> i32
-    // CHECK-NEXT: %[[TRUNC_NUW:.*]] = "llvm.trunc"(%{{.*}}) <{nuw}> : (i64) -> i32
-    // CHECK-NEXT: %[[TRUNC_BOTH:.*]] = "llvm.trunc"(%{{.*}}) <{nsw, nuw}> : (i64) -> i32
+    // CHECK-NEXT: %[[TRUNC_NUW:.*]] = "llvm.trunc"(%{{.*}}) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
+    // CHECK-NEXT: %[[TRUNC_BOTH:.*]] = "llvm.trunc"(%{{.*}}) <{"overflowFlags" = 3 : i32}> : (i64) -> i32
     // CHECK-NEXT: "test.test"(%[[TRUNC_NSW]], %[[TRUNC_NUW]], %[[TRUNC_BOTH]], %[[TRUNC_BOTH]])
   }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/add.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add.mlir
@@ -18,7 +18,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %add_nuw_nsw = "llvm.add"(%a, %b) <{nuw, nsw}>: (i64, i64) -> i64
+        %add_nuw_nsw = "llvm.add"(%a, %b) <{"overflowFlags" = 3 : i32}>: (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/add.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add.mlir
@@ -13,7 +13,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %add_nuw = "llvm.add"(%a, %b) <{nuw}>: (i64, i64) -> i64
+        %add_nuw = "llvm.add"(%a, %b) <{"overflowFlags" = 2 : i32}>: (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/add.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %add_nsw = "llvm.add"(%a, %b) <{nsw}> : (i64, i64) -> i64
+        %add_nsw = "llvm.add"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %lshr_nsw = "llvm.lshr"(%a, %b) <{nsw}> : (i64, i64) -> i64
+        %lshr_nsw = "llvm.lshr"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
@@ -13,7 +13,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %lshr_nuw = "llvm.lshr"(%a, %b) <{nuw}> : (i64, i64) -> i64
+        %lshr_nuw = "llvm.lshr"(%a, %b) <{"overflowFlags" = 2 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
@@ -18,7 +18,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %lshr_nuw_nsw = "llvm.lshr"(%a, %b) <{nuw, nsw}> : (i64, i64) -> i64
+        %lshr_nuw_nsw = "llvm.lshr"(%a, %b) <{"overflowFlags" = 3 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.srl"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/mul.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/mul.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %mul_nsw = "llvm.mul"(%a, %b) <{nsw}> : (i64, i64) -> i64
+        %mul_nsw = "llvm.mul"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/mul.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/mul.mlir
@@ -18,7 +18,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %mul_nuw_nsw = "llvm.mul"(%a, %b) <{nuw, nsw}> : (i64, i64) -> i64
+        %mul_nuw_nsw = "llvm.mul"(%a, %b) <{"overflowFlags" = 3 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/mul.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/mul.mlir
@@ -13,7 +13,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %mul_nuw = "llvm.mul"(%a, %b) <{nuw}> : (i64, i64) -> i64
+        %mul_nuw = "llvm.mul"(%a, %b) <{"overflowFlags" = 2 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/shl.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %shl_nsw = "llvm.shl"(%a, %b) <{nsw}> : (i64, i64) -> i64
+        %shl_nsw = "llvm.shl"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/shl.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl.mlir
@@ -18,7 +18,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %shl_nuw_nsw = "llvm.shl"(%a, %b) <{nuw, nsw}> : (i64, i64) -> i64
+        %shl_nuw_nsw = "llvm.shl"(%a, %b) <{"overflowFlags" = 3 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/shl.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl.mlir
@@ -13,7 +13,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %shl_nuw = "llvm.shl"(%a, %b) <{nuw}> : (i64, i64) -> i64
+        %shl_nuw = "llvm.shl"(%a, %b) <{"overflowFlags" = 2 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sll"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/sub.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %sub_nsw = "llvm.sub"(%a, %b) <{nsw}> : (i64, i64) -> i64
+        %sub_nsw = "llvm.sub"(%a, %b) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/sub.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub.mlir
@@ -13,7 +13,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %sub_nuw = "llvm.sub"(%a, %b) <{nuw}> : (i64, i64) -> i64
+        %sub_nuw = "llvm.sub"(%a, %b) <{"overflowFlags" = 2 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Test/Passes/InstructionSelection/RISCV64/sub.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub.mlir
@@ -18,7 +18,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!reg) -> i64
-        %sub_nuw_nsw = "llvm.sub"(%a, %b) <{nuw, nsw}> : (i64, i64) -> i64
+        %sub_nuw_nsw = "llvm.sub"(%a, %b) <{"overflowFlags" = 3 : i32}> : (i64, i64) -> i64
         // CHECK-NEXT:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!reg, !reg) -> !reg

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -163,11 +163,19 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
   | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci
   | .llvm .add | .llvm .sub | .llvm .mul | .llvm .shl | .llvm .trunc => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 2
+    let mut dict := Std.HashMap.emptyWithCapacity 1
+
+    let mut val := 0
     if props.nsw then
-      dict := dict.insert "nsw".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+      val := val + 1
+
     if props.nuw then
-      dict := dict.insert "nuw".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+      val := val + 2
+
+    if val > 0 then
+      let attr := IntegerAttr.mk (Int.ofNat val) (IntegerType.mk 32)
+      dict := dict.insert "overflowFlags".toUTF8 (Attribute.integerAttr attr)
+
     dict
   | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -63,8 +63,17 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 def NswNuwProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String NswNuwProperties := do
-  let nsw ← getUnitAttr "nsw" attrDict
-  let nuw ← getUnitAttr "nuw" attrDict
+  let value ← match attrDict["overflowFlags".toUTF8]? with
+    | some (.integerAttr flags) =>
+      if flags.type.bitwidth ≠ 32 then
+        .error s!"expected 'overflowFlags' to be an integer attribute of bitwidth 32, but got i{flags.type.bitwidth}"
+      else
+        .ok flags.value
+    | some attr => .error s!"expected 'overflowFlags' to be an optional integer attribute, but got {attr}"
+    | none => .ok 0
+
+  let nsw := (value.toNat &&& 1) ≠ 0
+  let nuw := (value.toNat &&& 2) ≠ 0
   return { nsw := nsw, nuw := nuw }
 
 /--


### PR DESCRIPTION
LLVM uses an `IntegerAttr` to encode its overflow flags, whereas we used two `UnitAttr`s to encode the `nsw` and `nuw` flags. Switch to `IntegerAttr` to be compatible with `mlir-opt`.

In particular, this change allows us to preserve the LLVM's (un)signed wrap flags through `mlir-opt`, preparing the file `Test/LLVM/identity.mlir` for testing with `MLIR_PASSTHROUGH`.