### PR TITLE
chore: allow multiple MLIR versions

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -20,7 +20,7 @@ config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
 config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | lake exec veir-opt | filecheck %s"))
 
 mlir_opt = lit.util.which('mlir-opt')
-mlir_version_supported = '22.0.0git'
+mlir_versions_supported = ['22.0.0git', '23.0.0git']
 
 if mlir_opt:
   result = subprocess.run([mlir_opt, '--version'], capture_output=True, text=True)
@@ -29,12 +29,12 @@ if mlir_opt:
   if match:
     version = match.group(1)
 
-  if version == mlir_version_supported:
+  if version in mlir_versions_supported:
     print(f"'mlir-opt' version {version} detected. Running MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP",
      "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))
   else:
-    print(f"'mlir-opt' version {version} detected, but only {mlir_version_supported} supported. Skipping MLIR compatibility tests")
+    print(f"'mlir-opt' version {version} detected, but only {mlir_versions_supported} supported. Skipping MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP", "true"))
 else:
   config.substitutions.append(("MLIR_ROUNDTRIP", "true"))


### PR DESCRIPTION
I habitually keep a top-of-tree LLVM/MLIR in my PATH. 
ok for us to support this as well as 22.0.0?