### PR TITLE
fix(LLVM): parse and print support for C-style variadic function arguments

### DIFF
--- a/Test/LLVM/variadic.mlir
+++ b/Test/LLVM/variadic.mlir
@@ -1,0 +1,9 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{sym_name = "with_fixed", function_type = !llvm.func<i32 (ptr, ...)>}> ({}) : () -> ()
+  "llvm.func"() <{sym_name = "only_varargs", function_type = !llvm.func<i32 (...)>}> ({}) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.func"() <{"function_type" = !llvm.func<i32 (!llvm.ptr, ...)>, "sym_name" = "with_fixed"}> ({{.*}}) : () -> ()
+// CHECK: "llvm.func"() <{"function_type" = !llvm.func<i32 (...)>, "sym_name" = "only_varargs"}> ({{.*}}) : () -> ()

--- a/Test/Parsing/invalid-variadic.mlir
+++ b/Test/Parsing/invalid-variadic.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  "llvm.func"() <{sym_name = "bad", function_type = !llvm.func<i32 (..., ptr)>}> ({}) : () -> ()
+}) : () -> ()
+
+// CHECK:invalid-variadic.mlir:4:79: error: '...' is only valid as the last parameter of an LLVM function type
+// CHECK-NEXT:  "llvm.func"() <{sym_name = "bad", function_type = !llvm.func<i32 (..., ptr)>}> ({}) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -219,36 +219,42 @@ macro "#assert " e:term : command =>
 /-! ## LLVM Function type -/
 #assert expectSuccessType "!llvm.func<i32 (i32)>"
   ⟨.llvmFunctionType (FunctionType.mk
-    #[(IntegerType.mk 32 : Attribute)] #[(IntegerType.mk 32 : Attribute)]), by rfl⟩
+    #[(IntegerType.mk 32 : Attribute)] #[(IntegerType.mk 32 : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<i64 ()>"
-  ⟨.llvmFunctionType (FunctionType.mk #[] #[(IntegerType.mk 64 : Attribute)]), by rfl⟩
+  ⟨.llvmFunctionType (FunctionType.mk #[] #[(IntegerType.mk 64 : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<i32 (i32, i64)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(IntegerType.mk 32 : Attribute), (IntegerType.mk 64 : Attribute)]
-    #[(IntegerType.mk 32 : Attribute)]), by rfl⟩
+    #[(IntegerType.mk 32 : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<!llvm.ptr (!llvm.ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
-    #[(LLVM.PointerType.mk : Attribute)] #[(LLVM.PointerType.mk : Attribute)]), by rfl⟩
+    #[(LLVM.PointerType.mk : Attribute)] #[(LLVM.PointerType.mk : Attribute)] (isVarArg := false)), by rfl⟩
 -- LLVM pretty-print sugar: bare `void` and `ptr` keywords inside `!llvm.func<...>`.
 #assert expectSuccessType "!llvm.func<void ()>"
   ⟨.llvmFunctionType (FunctionType.mk #[]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)]), by rfl⟩
+    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<void (i32)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(IntegerType.mk 32 : Attribute)]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)]), by rfl⟩
+    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<i32 (ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
-    #[(LLVM.PointerType.mk : Attribute)] #[(IntegerType.mk 32 : Attribute)]), by rfl⟩
+    #[(LLVM.PointerType.mk : Attribute)] #[(IntegerType.mk 32 : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<void (ptr, ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(LLVM.PointerType.mk : Attribute), (LLVM.PointerType.mk : Attribute)]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)]), by rfl⟩
+    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
 -- Bare sugar mixed with the explicit `!llvm.ptr` form within one function type.
 #assert expectSuccessType "!llvm.func<void (!llvm.ptr, ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(LLVM.PointerType.mk : Attribute), (LLVM.PointerType.mk : Attribute)]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)]), by rfl⟩
+    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
+-- Variadic function types: a trailing `...`, with or without fixed parameters.
+#assert expectSuccessType "!llvm.func<i32 (ptr, ...)>"
+  ⟨.llvmFunctionType (FunctionType.mk
+    #[(LLVM.PointerType.mk : Attribute)] #[(IntegerType.mk 32 : Attribute)] (isVarArg := true)), by rfl⟩
+#assert expectSuccessType "!llvm.func<i32 (...)>"
+  ⟨.llvmFunctionType (FunctionType.mk #[] #[(IntegerType.mk 32 : Attribute)] (isVarArg := true)), by rfl⟩
 
 /-! ## CUDA Pointer type -/
 #assert expectSuccessType "!cuda_tile.ptr<i1>" (CudaTile.PointerType.mk (IntegerType.mk 1))

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -196,6 +196,7 @@ mutual
 structure FunctionType where
   inputs : Array Attribute
   outputs : Array Attribute
+  isVarArg : Bool := false
 deriving Inhabited, Repr, Hashable
 
 /--
@@ -325,7 +326,11 @@ def FunctionType.decEq (type1 type2 : FunctionType) : Decidable (type1 = type2) 
   match Array.instDecidabelEq' inputs1 inputs2 (fun x y _ _ => Attribute.decEq x y) with
   | isTrue _ =>
     match Array.instDecidabelEq' outputs1 outputs2 (fun x y _ _ => Attribute.decEq x y) with
-    | isTrue _ => isTrue (by grind [cases FunctionType])
+    | isTrue _ =>
+      if h : type1.isVarArg = type2.isVarArg then
+        isTrue (by grind [cases FunctionType])
+      else
+        isFalse (by grind)
     | isFalse _ => isFalse (by grind)
   | isFalse _ => isFalse (by grind)
 termination_by sizeOf type1
@@ -574,7 +579,9 @@ decreasing_by
   grind [Array.sizeOf_lt_of_mem this, cases DictionaryAttr]
 
 def FunctionType.toLLVMString (type : FunctionType) : String :=
-  let params := String.intercalate ", " (type.inputs.toList.map Attribute.toString)
+  let paramStrs := type.inputs.toList.map Attribute.toString
+  let paramStrs := if type.isVarArg then paramStrs ++ ["..."] else paramStrs
+  let params := String.intercalate ", " paramStrs
   let result := match _ : type.outputs.size with
     | 1 => Attribute.toString type.outputs[0]
     | _ => "<invalid>"

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -448,8 +448,8 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
 
 /--
   Parse an LLVM function type `!llvm.func<resultType (paramTypes,...)>`, if present.
-  A `...` parameter marks the function as variadic; its placement within the list is
-  left to the verifier.
+  A trailing `...` parameter marks the function as variadic; the ellipsis is invalid
+  in any position other than the last.
 -/
 partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
   let token ← peekToken
@@ -465,6 +465,8 @@ partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
       return LLVMFuncParam.ellipsis
     return LLVMFuncParam.type (← parseLLVMType)
   parsePunctuation ">"
+  if params.pop.any (· matches .ellipsis) then
+    throwAtCurrentPos "'...' is only valid as the last parameter of an LLVM function type"
   let isVarArg := params.any (· matches .ellipsis)
   let paramTypes := params.filterMap fun
     | .type ty => some ty.val

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -385,6 +385,11 @@ def parseOptionalHWModuleType : AttrParserM (Option HW.ModuleType) := do
   let ports ← parseDelimitedList .angle parseHWModulePort
   return some { ports }
 
+/-- A parsed entry in an LLVM function type's parameter list. -/
+inductive LLVMFuncParam
+  | type (ty : TypeAttr)
+  | ellipsis
+
 mutual
 
 /--
@@ -424,11 +429,11 @@ partial def parseOptionalFunctionType : AttrParserM (Option FunctionType) := do
     -- Convert the parsed types to attributes, as FunctionType stores attributes instead
     -- of types.
     let outputs := outputs.map (fun x => x.val)
-    return some (FunctionType.mk inputs outputs)
+    return some (FunctionType.mk inputs outputs (isVarArg := false))
   | none =>
     -- If there is no list of output, check for a single output type.
     let outputType ← parseType "function type output expected"
-    return some (FunctionType.mk inputs #[outputType])
+    return some (FunctionType.mk inputs #[outputType] (isVarArg := false))
 
 /--
   Parse a type within an LLVM-dialect type body, accepting the LLVM "pretty-print"
@@ -443,6 +448,8 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
 
 /--
   Parse an LLVM function type `!llvm.func<resultType (paramTypes,...)>`, if present.
+  A `...` parameter marks the function as variadic; its placement within the list is
+  left to the verifier.
 -/
 partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
   let token ← peekToken
@@ -453,9 +460,16 @@ partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
   let _ ← consumeToken
   parsePunctuation "<"
   let result ← parseLLVMType "llvm.func result type expected"
-  let params ← parseDelimitedList .paren parseLLVMType
+  let params ← parseDelimitedList .paren do
+    if (← parseOptionalToken .ellipsis).isSome then
+      return LLVMFuncParam.ellipsis
+    return LLVMFuncParam.type (← parseLLVMType)
   parsePunctuation ">"
-  let ft := FunctionType.mk (params.map (·.val)) #[result.val]
+  let isVarArg := params.any (· matches .ellipsis)
+  let paramTypes := params.filterMap fun
+    | .type ty => some ty.val
+    | .ellipsis => none
+  let ft := FunctionType.mk paramTypes #[result.val] isVarArg
   return some ⟨.llvmFunctionType ft, by rfl⟩
 
 /--


### PR DESCRIPTION
this is needed for passing almost any real C code through VeIR