### PR TITLE
chore(IR): add `OperationPtr.getParentOp!`

### DIFF
--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -2408,6 +2408,11 @@ end BlockOperandPtrPtr
 
 namespace OperationPtr
 
+def getParentOp! (op : OperationPtr) (ctx : IRContext OpInfo) : Option OperationPtr := do
+  rlet block ← (op.get! ctx).parent
+  rlet region ← (block.get! ctx).parent
+  (region.get! ctx).parent
+
 def hasUses.loop (op : OperationPtr) (ctx : IRContext OpInfo) (index : Nat)
     (opIn : op.InBounds ctx := by grind)
     (hresult : index < op.getNumResults ctx := by grind) : Bool :=


### PR DESCRIPTION
This is a useful method to have on `OperationPtr`. I do not define the non-! version of it yet, as it requires `FieldsInBounds` to be correct and we should figure out where to put these definitions first.