### PR TITLE
chore(IR): move lemma to the correct file

### DIFF
--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -881,3 +881,15 @@ def IRContext.create OpInfo [HasOpInfo OpInfo] : Option (IRContext OpInfo × Ope
   rlet (ctx, operation) ← Rewriter.createOp ctx HasOpInfo.moduleOpCode #[] #[] #[] #[region] default none
   rlet (ctx, block) ← Rewriter.createBlock ctx #[] (some (.atEnd region)) (by grind) (by grind)
   return (ctx, operation)
+
+@[grind →]
+theorem IRContext.create_fieldsInBounds {op: OperationPtr} (h : IRContext.create OpInfo = some (ctx, op)) :
+    ctx.FieldsInBounds := by
+  simp only [IRContext.create] at h
+  grind
+
+@[grind →]
+theorem IRContext.create_inBounds {op: OperationPtr} (h : IRContext.create OpInfo = some (ctx, op)) :
+    op.InBounds ctx := by
+  simp only [IRContext.create] at h
+  grind (gen := 10)

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -645,10 +645,4 @@ theorem OperationPtr.getNumOperands_iff_replaceValue?
     OperationPtr.getNumOperands op ctx (by grind) := by
   grind [OpOperandPtr.inBounds_if_operand_size_eq]
 
-@[grind →]
-theorem IRContext.create_fieldsInBounds {op: OperationPtr} (h : IRContext.create OpInfo = some (ctx, op)) :
-    ctx.FieldsInBounds ∧ op.InBounds ctx := by
-  simp only [IRContext.create] at h
-  constructor <;> grind (gen := 10)
-
 end Veir


### PR DESCRIPTION
We keep our `inBounds` lemmas about the `Rewriter` in their file directly, instead of the GetSet file.