### PR TITLE
chore: improve vcc a little

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,21 @@ lake exec veir-opt -p=instcombine,dce demorgan-opt.mlir
 ```
 
 Alternatively, you can batch up these commands using the provided
-compiler driver (and, in this case, emit the optimized MLIR to
-stdout):
+compiler driver and emit the optimized MLIR to stdout:
 ```bash
-Tools/vcc demorgan.c -O -o -
+Tools/vcc demorgan.c --emit-mlir -O -o -
+```
+
+Without an explicit emit mode, `vcc` translates VeIR's output back to
+LLVM IR and asks `clang` to produce an executable:
+```bash
+cat << _end_ > hello.c
+#include <stdio.h>
+
+int main(void) {
+  printf("hello, world\n");
+}
+_end_
+
+Tools/vcc hello.c -o hello
 ```

--- a/Test/Vcc/demorgan.c
+++ b/Test/Vcc/demorgan.c
@@ -1,4 +1,8 @@
-// RUN: ./Tools/vcc -O %s -o - | filecheck %s
+// RUN: ./Tools/vcc --emit-mlir -O %s -o - | filecheck %s
+// RUN: ./Tools/vcc -c %s -o %t.o
+// RUN: test -s %t.o
+// RUN: ./Tools/vcc -S %s -o %t.s
+// RUN: test -s %t.s
 
 unsigned d1(unsigned p, unsigned q) {
   return ~(~p & ~q);

--- a/Tools/vcc
+++ b/Tools/vcc
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """VeIR compiler driver.
 
-Compiles a C source file to MLIR ready for the VeIR interpreter
+Compiles a C source file via VeIR, producing an executable by default.
 """
 
 from __future__ import annotations
@@ -33,7 +33,7 @@ def run(cmd: list[str], *, stdin: bytes | None = None, cwd: Path | None = None) 
     return result.stdout
 
 
-def compile_to_mlir(src: Path, dst: Path | None, veir_optimize: bool) -> None:
+def compile_to_mlir(src: Path, veir_optimize: bool) -> bytes:
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp = Path(tmpdir)
         bc = tmp / (src.stem + ".bc")
@@ -58,40 +58,132 @@ def compile_to_mlir(src: Path, dst: Path | None, veir_optimize: bool) -> None:
             opt_cmd,
             cwd=REPO_ROOT,
         )
+        return mlir
+
+
+def translate_mlir_to_llvm(mlir: bytes, src_stem: str) -> bytes:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / (src_stem + ".mlir")
+        path.write_bytes(mlir)
+        return run(["mlir-translate", "--mlir-to-llvmir", str(path)])
+
+
+def write_output(output: bytes, dst: Path | None) -> None:
+    if dst is None:
+        sys.stdout.buffer.write(output)
+    else:
+        dst.write_bytes(output)
+
+
+def finish_llvm_ir(llvm_ir: bytes, dst: Path | None, emit: str) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = Path(tmpdir) / "input.ll"
+        path.write_bytes(llvm_ir)
+        cmd = ["clang"]
+        if emit == "object":
+            cmd.append("-c")
+        elif emit == "assembly":
+            cmd.append("-S")
+        cmd.extend([str(path), "-o", "-" if dst is None else str(dst)])
+        output = run(cmd)
         if dst is None:
-            sys.stdout.buffer.write(mlir)
+            sys.stdout.buffer.write(output)
+
+
+def optimize_from_levels(levels: list[str] | None) -> bool:
+    if levels is None:
+        return False
+    return levels[-1] != "0"
+
+
+def parse_opt_level(level: str) -> str:
+    if not level.isdigit():
+        raise argparse.ArgumentTypeError("optimization level must be a nonnegative integer")
+    return level
+
+
+def normalize_args(argv: list[str]) -> list[str]:
+    result: list[str] = []
+    for arg in argv:
+        if arg == "-O":
+            result.extend(["--opt-level", "1"])
+        elif arg.startswith("-O") and arg[2:].isdigit():
+            result.extend(["--opt-level", arg[2:]])
         else:
-            dst.write_bytes(mlir)
+            result.append(arg)
+    return result
 
 
 def main() -> None:
     parser = argparse.ArgumentParser(
         prog="vcc",
-        description="Compile a C file to MLIR for the VeIR interpreter.",
+        usage="vcc [-h] [-o OUTPUT] [-c | -S | --emit-mlir | --emit-llvm] [-O[N]] source",
+        description="Compile a C file via VeIR.",
     )
     parser.add_argument("source", type=Path, help="C source file")
     parser.add_argument(
         "-o", "--output",
-        help="output .mlir path, or - for stdout (default: <source stem>.mlir)",
+        help="output path, or - for stdout with non-executable outputs (default: a.out)",
+    )
+    emit = parser.add_mutually_exclusive_group()
+    emit.add_argument(
+        "-c", action="store_const", const="object", dest="emit",
+        help="emit an object file instead of an executable",
+    )
+    emit.add_argument(
+        "-S", action="store_const", const="assembly", dest="emit",
+        help="emit assembly instead of an executable",
+    )
+    emit.add_argument(
+        "--emit-mlir", action="store_const", const="mlir", dest="emit",
+        help="emit MLIR instead of an executable",
+    )
+    emit.add_argument(
+        "--emit-llvm", action="store_const", const="llvm", dest="emit",
+        help="emit LLVM IR instead of an executable",
     )
     parser.add_argument(
-        "-O", dest="optimize", action="store_true",
-        help="run the VeIR optimizer (instcombine,dce) on the result",
+        "--opt-level", dest="opt_levels", action="append",
+        type=parse_opt_level, metavar="N",
+        help=argparse.SUPPRESS,
     )
-    args = parser.parse_args()
+    parser.epilog = "-O0 disables VeIR optimization; -O and other numeric -O levels run the same optimizer."
+    parser.set_defaults(emit="executable")
+    args = parser.parse_args(normalize_args(sys.argv[1:]))
 
     if not args.source.is_file():
         sys.exit(f"vcc: source file not found: {args.source}")
 
     check_tools(BASE_TOOLS + VEIR_TOOLS)
 
-    if args.output is None:
-        dst: Path | None = Path(args.source.stem + ".mlir")
-    elif args.output == "-":
+    if args.output == "-":
+        if args.emit == "executable":
+            sys.exit("vcc: cannot write an executable to stdout")
         dst = None
-    else:
+    elif args.output is not None:
         dst = Path(args.output)
-    compile_to_mlir(args.source, dst, args.optimize)
+    elif args.emit == "object":
+        dst = Path(args.source.stem + ".o")
+    elif args.emit == "assembly":
+        dst = Path(args.source.stem + ".s")
+    elif args.emit == "mlir":
+        dst = Path(args.source.stem + ".mlir")
+    elif args.emit == "llvm":
+        dst = Path(args.source.stem + ".ll")
+    else:
+        dst = Path("a.out")
+
+    mlir = compile_to_mlir(args.source, optimize_from_levels(args.opt_levels))
+    if args.emit == "mlir":
+        write_output(mlir, dst)
+        return
+
+    llvm_ir = translate_mlir_to_llvm(mlir, args.source.stem)
+    if args.emit == "llvm":
+        write_output(llvm_ir, dst)
+        return
+
+    finish_llvm_ir(llvm_ir, dst, args.emit)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
since we can now parse/emit variadics, this commit extends `vcc` to actually produce executables and adds a hello world example to our README

my overall plan for vcc is for it to slowly evolve into a drop-in cc replacement so we can do things like `cmake -DCMAKE_C_COMPILER=vcc` and build real stuff using Veir

I don't think anyone needs to closely review the `vcc` changes, which are vibe coded. if we ever want this utility to be done right, I can either clean up what we have here or just start over.