### PR TITLE
feat(LLVM): add first-class `#llvm.fastmath` attribute

### DIFF
--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -143,7 +143,7 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan, ninf, nsz>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
 // CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
   "llvm.module_flags"() <{flags = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
@@ -44,30 +45,31 @@
     ^9(%ptr : !llvm.ptr):
       %32 = "llvm.getelementptr"(%ptr, %6) <{elem_type = !llvm.struct<(i32, f32)>, rawConstantIndices = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
       %34 = "llvm.fadd"(%fcst, %fcst) : (f64, f64) -> f64
-      %35 = "llvm.fadd"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
-      %36 = "llvm.fadd"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
-      %37 = "llvm.fadd"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
-      %38 = "llvm.fadd"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %35 = "llvm.fadd"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<none, fast>}> : (f64, f64) -> f64
+      %36 = "llvm.fadd"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+      %37 = "llvm.fadd"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+      %38 = "llvm.fadd"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
       %39 = "llvm.fsub"(%fcst, %fcst) : (f64, f64) -> f64
-      %40 = "llvm.fsub"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
-      %41 = "llvm.fsub"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
-      %42 = "llvm.fsub"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
-      %43 = "llvm.fsub"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %40 = "llvm.fsub"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+      %41 = "llvm.fsub"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+      %42 = "llvm.fsub"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+      %43 = "llvm.fsub"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
       %44 = "llvm.fmul"(%fcst, %fcst) : (f64, f64) -> f64
-      %45 = "llvm.fmul"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
-      %46 = "llvm.fmul"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
-      %47 = "llvm.fmul"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
-      %48 = "llvm.fmul"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %45 = "llvm.fmul"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+      %46 = "llvm.fmul"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+      %47 = "llvm.fmul"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+      %48 = "llvm.fmul"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
       %49 = "llvm.fdiv"(%fcst, %fcst) : (f64, f64) -> f64
-      %50 = "llvm.fdiv"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
-      %51 = "llvm.fdiv"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
-      %52 = "llvm.fdiv"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
-      %53 = "llvm.fdiv"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
-      %54 = "llvm.frem"(%fcst, %fcst) : (f64, f64) -> f64
-      %55 = "llvm.frem"(%fcst, %fcst) <{fast}> : (f64, f64) -> f64
-      %56 = "llvm.frem"(%fcst, %fcst) <{nnan}> : (f64, f64) -> f64
-      %57 = "llvm.frem"(%fcst, %fcst) <{ninf}> : (f64, f64) -> f64
-      %58 = "llvm.frem"(%fcst, %fcst) <{nsz}> : (f64, f64) -> f64
+      %50 = "llvm.fdiv"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+      %51 = "llvm.fdiv"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+      %52 = "llvm.fdiv"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+      %53 = "llvm.fdiv"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+      %54 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, f64) -> f64
+      %55 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+      %56 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+      %57 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+      %58 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+      %59 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz, nnan, ninf>}> : (f64, f64) -> f64
       "llvm.return"(%arg7_0) : (i32) -> ()
   }) : () -> ()
 }) : () -> ()
@@ -116,31 +118,32 @@
 // CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:     ^{{.*}}(%{{.*}} : !llvm.ptr):
 // CHECK-NEXT:       %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = !llvm.struct<(i32, f32)>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, 0>}> : (!llvm.ptr, i1) -> !llvm.ptr
-// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{fast}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nnan}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{ninf}> : (f64, f64) -> f64
-// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{nsz}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fadd"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fsub"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fmul"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fdiv"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nnan, ninf, nsz>}> : (f64, f64) -> f64
 // CHECK-NEXT:       "llvm.return"(%{{.*}}) : (i32) -> ()
 // CHECK-NEXT:   }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -178,16 +178,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
 
     dict
   | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 2
-    if props.fast then
-      dict := dict.insert "fast".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    if props.nnan then
-      dict := dict.insert "nnan".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    if props.ninf then
-      dict := dict.insert "ninf".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    if props.nsz then
-      dict := dict.insert "nsz".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    dict
+    (Std.HashMap.emptyWithCapacity 1).insert "fastmathFlags".toUTF8 (Attribute.fastMathFlagsAttr props.attr)
   | .arith .cmpi | .llvm .icmp => Id.run do
     let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
     (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr value)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -65,6 +65,16 @@ structure IntegerAttr where
   type : IntegerType
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/--
+ Floating point fastmath flags attribute.
+-/
+structure FastMathFlagsAttr where
+  fast : Bool
+  nnan : Bool
+  ninf : Bool
+  nsz : Bool
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 structure RegisterAttr where
   value : Int
   type : RegisterType
@@ -241,6 +251,8 @@ inductive Attribute
 | floatType (type : FloatType)
 /-- Integer attribute -/
 | integerAttr (attr : IntegerAttr)
+/-- Float fast math flags attribute -/
+| fastMathFlagsAttr (attr : FastMathFlagsAttr)
 /-- Register type -/
 | registerType (type : RegisterType)
 /-- Register attribute -/
@@ -393,6 +405,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case fastMathFlagsAttr.fastMathFlagsAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case unregisteredAttr.unregisteredAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -484,6 +500,17 @@ instance : ToString IntegerType where
 
 instance : ToString FloatType where
   toString type := s!"f{type.bitwidth}"
+
+instance : ToString FastMathFlagsAttr where
+  toString type := Id.run do
+    let mut array : List String := []
+    if type.fast then array := array ++ ["fast"]
+    else
+      if type.nnan then array := array ++ ["nnan"]
+      if type.ninf then array := array ++ ["ninf"]
+      if type.nsz then array := array ++ ["nsz"]
+      if !type.nnan && !type.ninf && !type.nsz then array := array ++ ["none"]
+    s!"#llvm.fastmath<{String.intercalate ", " array}>"
 
 instance : ToString IntegerAttr where
   toString attr := s!"{attr.value} : {attr.type}"
@@ -628,6 +655,7 @@ def Attribute.toString (attr : Attribute) : String :=
   match attr with
   | .integerType type => ToString.toString type
   | .floatType type => ToString.toString type
+  | .fastMathFlagsAttr attr => ToString.toString attr
   | .integerAttr attr => ToString.toString attr
   | .registerType type => ToString.toString type
   | .registerAttr attr => ToString.toString attr
@@ -675,6 +703,9 @@ instance : Coe IntegerType Attribute where
 
 instance : Coe FloatType Attribute where
   coe type := .floatType type
+
+instance : Coe FastMathFlagsAttr Attribute where
+  coe flags := .fastMathFlagsAttr flags
 
 instance : Coe IntegerAttr Attribute where
   coe attr := .integerAttr attr
@@ -738,6 +769,7 @@ def isType (attr : Attribute) : Bool :=
   match attr with
   | .integerType _ => true
   | .floatType _ => true
+  | .fastMathFlagsAttr _ => false
   | .integerAttr _ => false
   | .stringAttr _ => false
   | .unitAttr _ => false
@@ -761,6 +793,8 @@ def isType (attr : Attribute) : Bool :=
 theorem isType_integerType type : (integerType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_floatType type : (floatType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_fastMathFlags flags : (fastMathFlagsAttr flags).isType = false := by rfl
 @[simp, grind =]
 theorem isType_unregistered unregistered :
   (unregisteredAttr unregistered).isType = unregistered.isType := by rfl

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -69,7 +69,6 @@ deriving Inhabited, Repr, DecidableEq, Hashable
  Floating point fastmath flags attribute.
 -/
 structure FastMathFlagsAttr where
-  fast : Bool
   nnan : Bool
   ninf : Bool
   nsz : Bool
@@ -504,7 +503,7 @@ instance : ToString FloatType where
 instance : ToString FastMathFlagsAttr where
   toString type := Id.run do
     let mut array : List String := []
-    if type.fast then array := array ++ ["fast"]
+    if type.nnan && type.ninf && type.nsz then array := array ++ ["fast"]
     else
       if type.nnan then array := array ++ ["nnan"]
       if type.ninf then array := array ++ ["ninf"]

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -163,17 +163,17 @@ def parseOptionalDenseArrayAttr : AttrParserM (Option DenseArrayAttr) := do
 
 def parseFastMathFlag : AttrParserM FastMathFlagsAttr := do
   if (← parseOptionalKeyword "fast".toByteArray) then
-    return { fast := true, nnan := false, ninf := false, nsz := false }
+    return { nnan := true, ninf := true, nsz := true }
   else if (← parseOptionalKeyword "nnan".toByteArray) then
-    return { fast := false, nnan := true, ninf := false, nsz := false }
+    return { nnan := true, ninf := false, nsz := false }
   else if (← parseOptionalKeyword "ninf".toByteArray) then
-    return { fast := false, nnan := false, ninf := true, nsz := false }
+    return { nnan := false, ninf := true, nsz := false }
   else if (← parseOptionalKeyword "nsz".toByteArray) then
-    return { fast := false, nnan := false, ninf := false, nsz := true }
+    return { nnan := false, ninf := false, nsz := true }
   else if (← parseOptionalKeyword "none".toByteArray) then
-    return { fast := false, nnan := false, ninf := false, nsz := false }
+    return { nnan := false, ninf := false, nsz := false }
   else
-    return { fast := false, nnan := false, ninf := false, nsz := false }
+    return { nnan := false, ninf := false, nsz := false }
 
 /--
   Parse an optional fastmath flags attribute, if present.
@@ -182,10 +182,9 @@ def parseFloatFastMathFlagsAttr : AttrParserM (Option FastMathFlagsAttr) := do
   parsePunctuation "<"
   let values ← parseList parseFastMathFlag
   parsePunctuation ">"
-  let mut floatFastMathFlags := FastMathFlagsAttr.mk false false false false
+  let mut floatFastMathFlags := FastMathFlagsAttr.mk false false false
   for flag in values do
     floatFastMathFlags := { floatFastMathFlags with
-      fast := floatFastMathFlags.fast || flag.fast,
       nnan := floatFastMathFlags.nnan || flag.nnan,
       ninf := floatFastMathFlags.ninf || flag.ninf,
       nsz := floatFastMathFlags.nsz || flag.nsz }

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -161,6 +161,36 @@ def parseOptionalDenseArrayAttr : AttrParserM (Option DenseArrayAttr) := do
   parsePunctuation ">"
   return some (DenseArrayAttr.mk elementType values)
 
+def parseFastMathFlag : AttrParserM FastMathFlagsAttr := do
+  if (← parseOptionalKeyword "fast".toByteArray) then
+    return { fast := true, nnan := false, ninf := false, nsz := false }
+  else if (← parseOptionalKeyword "nnan".toByteArray) then
+    return { fast := false, nnan := true, ninf := false, nsz := false }
+  else if (← parseOptionalKeyword "ninf".toByteArray) then
+    return { fast := false, nnan := false, ninf := true, nsz := false }
+  else if (← parseOptionalKeyword "nsz".toByteArray) then
+    return { fast := false, nnan := false, ninf := false, nsz := true }
+  else if (← parseOptionalKeyword "none".toByteArray) then
+    return { fast := false, nnan := false, ninf := false, nsz := false }
+  else
+    return { fast := false, nnan := false, ninf := false, nsz := false }
+
+/--
+  Parse an optional fastmath flags attribute, if present.
+-/
+def parseFloatFastMathFlagsAttr : AttrParserM (Option FastMathFlagsAttr) := do
+  parsePunctuation "<"
+  let values ← parseList parseFastMathFlag
+  parsePunctuation ">"
+  let mut floatFastMathFlags := FastMathFlagsAttr.mk false false false false
+  for flag in values do
+    floatFastMathFlags := { floatFastMathFlags with
+      fast := floatFastMathFlags.fast || flag.fast,
+      nnan := floatFastMathFlags.nnan || flag.nnan,
+      ninf := floatFastMathFlags.ninf || flag.ninf,
+      nsz := floatFastMathFlags.nsz || flag.nsz }
+  return some floatFastMathFlags
+
 def isClosingBracket (kind : TokenKind) : Bool :=
   kind = .greater || kind = .rParen || kind = .rSquare || kind = .rBrace
 
@@ -260,6 +290,10 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   let startPos ← getPos
   let dialectName ← parseOptionalPrefixedKeyword .hashIdent
   let some dialectName := dialectName | return none
+
+  if dialectName = "llvm.fastmath".toByteArray then do
+    return ← parseFloatFastMathFlagsAttr
+
   if !(← getThe AttrParserState).allowUnregisteredDialect then
     throwAt startPos s!"attribute is not registered. Consider using --allow-unregistered-dialect."
   parsePunctuation "<"

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -122,7 +122,7 @@ def FastMathFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
     Except String FastMathFlagsProperties := do
 
   let value ← match attrDict["fastmathFlags".toUTF8]? with
-    | none => .ok { fast := false, nnan := false, ninf := false, nsz := false }
+    | none => .ok { nnan := false, ninf := false, nsz := false }
     | some (.fastMathFlagsAttr flags) => .ok flags
     | some (.unregisteredAttr attr) =>
         .error s!"expected 'fastmathFlags' to be a fast math flags attribute, but got unregistered {attr}"

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -115,19 +115,20 @@ def NnegProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
   return { nneg := nneg }
 
 structure FastMathFlagsProperties where
-  fast : Bool
-  nnan : Bool
-  ninf : Bool
-  nsz : Bool
+  attr : FastMathFlagsAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def FastMathFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String FastMathFlagsProperties := do
-  let fast ← getUnitAttr "fast" attrDict
-  let nnan ← getUnitAttr "nnan" attrDict
-  let ninf ← getUnitAttr "ninf" attrDict
-  let nsz ← getUnitAttr "nsz" attrDict
-  return { fast, nnan, ninf, nsz }
+
+  let value ← match attrDict["fastmathFlags".toUTF8]? with
+    | none => .ok { fast := false, nnan := false, ninf := false, nsz := false }
+    | some (.fastMathFlagsAttr flags) => .ok flags
+    | some (.unregisteredAttr attr) =>
+        .error s!"expected 'fastmathFlags' to be a fast math flags attribute, but got unregistered {attr}"
+    | some attr => .error s!"expected 'fastmathFlags' to be a float fast math flags attribute, but got {attr}"
+
+  return ⟨value⟩
 
 /--
   Properties of the `llvm.constant` operation.


### PR DESCRIPTION
We add a first-class `#llvm.fastmath<>` attribute, replacing the previously used `fast`, `nnan`, `ninf`, and `nsz` unit attributes. This aligns our treatment of fastmath properties with `mlir-opt`. Concluding a series of patches, we can now also add `MLIR_ROUNDTRIP` to `Test/LLVM/identity.mlir`.

In contrast to MLIR, we do not store the `fast` flag separately, but always treat it as the combination of `nnan`, `ninf`, and `nsz`, which is canonical. Whenever all three options are set we print `fast` as the fast math mode, which is a simplification MLIR itself does not do. However, mlir folds `nnan`, `ninf`, and `nsz` into `fast` when both are present.