### PR TITLE
chore(parser): print localized error messages for missing operations

### DIFF
--- a/Test/Parsing/operation-expected.mlir
+++ b/Test/Parsing/operation-expected.mlir
@@ -1,0 +1,7 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+this is not an operation
+
+// CHECK:operation-expected.mlir:3:1: error: operation expected
+// CHECK-NEXT:this is not an operation
+// CHECK-NEXT:^

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -558,7 +558,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   Parse an operation.
 -/
 partial def parseOp (ip : Option InsertPoint) : MlirParserM OperationPtr := do
-  let some op ← parseOptionalOp ip | throwString "operation expected"
+  let some op ← parseOptionalOp ip | throwAtCurrentPos "operation expected"
   return op
 
 /--


### PR DESCRIPTION
Now, when an operation was expected but not provided, the error will print back the line that was failing