### PR TITLE
feat(lit): run binaries without going through lake

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -15,12 +15,14 @@ for tool in ('clang', 'opt', 'mlir-translate', 'mlir-opt'):
 
 veir_root = Path(config.test_source_root).parent
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {veir_root}"])
-config.substitutions.append(('veir-opt', "lake exec veir-opt"))
-config.substitutions.append(('veir-interpret', "lake exec veir-interpret"))
-config.substitutions.append(("VEIR_ROUNDTRIP", "lake exec veir-opt %s | lake exec veir-opt | filecheck %s"))
+config.substitutions.append(('veir-opt', ".lake/build/bin/veir-opt"))
+config.substitutions.append(('veir-interpret', ".lake/build/bin/veir-interpret"))
+config.substitutions.append(("VEIR_ROUNDTRIP", ".lake/build/bin/veir-opt %s | .lake/build/bin/veir-opt | filecheck %s"))
 
 mlir_opt = lit.util.which('mlir-opt')
 mlir_versions_supported = ['22.0.0git', '23.0.0git']
+
+result = subprocess.run(['lake', 'build'], cwd =veir_root)
 
 if mlir_opt:
   result = subprocess.run([mlir_opt, '--version'], capture_output=True, text=True)
@@ -32,7 +34,7 @@ if mlir_opt:
   if version in mlir_versions_supported:
     print(f"'mlir-opt' version {version} detected. Running MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP",
-     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | lake exec veir-opt | filecheck %s"))
+     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt | filecheck %s"))
   else:
     print(f"'mlir-opt' version {version} detected, but only {mlir_versions_supported} supported. Skipping MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP", "true"))


### PR DESCRIPTION
Call `lake build` before running the individual test cases and then directly run `.lake/build/bin/veir-opt`. This avoids potential race conditions triggered by multiple `lake build`. It also accelerates the individual test cases as we only check a single time (for all test cases) if the binary must be rebuild.

This improves testing time on a recent Mac Book Pro (M4) from `21.83s` to `2.19s`, a speedup of about `10x`. Our GitHub CI accelerates from `1m22s` to `19s`.