### PR TITLE
feat(LLVM): support llvm.unreachable

### DIFF
--- a/Test/Interpreter/LLVM/unreachable.mlir
+++ b/Test/Interpreter/LLVM/unreachable.mlir
@@ -1,0 +1,10 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Executing `llvm.unreachable` is immediate undefined behaviour.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main"}> ({
+    "llvm.unreachable"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -320,7 +320,7 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   match opCode with
   | .cf .br | .cf .cond_br
   | .func .return
-  | .llvm .br | .llvm .cond_br | .llvm .return
+  | .llvm .br | .llvm .cond_br | .llvm .return | .llvm .unreachable
   | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne
   | .hw .output => true
   | _ => false

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -636,6 +636,8 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     return (#[.int bw (LLVM.Int.select cond lhs rhs)], mem, none)
   | .return => do
     return (#[], mem, some (.return operands))
+  | .unreachable =>
+    Interp.ub
   | .br => do
     let [dest] := blockOperands.toList | none
     return (#[], mem, some (.branch operands dest))

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -92,6 +92,7 @@ inductive Llvm where
 | zext
 | br
 | cond_br
+| unreachable
 | alloca
 | load
 | store

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -623,6 +623,16 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  | .llvm .unreachable => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
   | .llvm .br => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
       throw "Expected 0 results"


### PR DESCRIPTION
`llvm.unreachable` comes up fairly commonly in code that we get via `clang` -> `mlir-translate`. luckily it has an extremely easy semantics in veir :)