### PR TITLE
refactor(dominance): clean up of dominance analysis unit tests

### DIFF
--- a/UnitTest/DataFlowFramework/Dominance.lean
+++ b/UnitTest/DataFlowFramework/Dominance.lean
@@ -2,70 +2,61 @@ import UnitTest.DataFlowFramework.Helpers
 
 import Veir.Analysis.DataFlow.DominanceAnalysis
 
-open Std (HashMap HashSet)
+open Std (HashSet)
 open Veir
+
+/-- Expected dominance information for one named block in the test harness. -/
+private structure ExpectedBlockDominators where
+  name : String
+  dominators : HashSet String
 
 /--
 Compare one expected dominator label against the observed dominance information.
 
-This checks `dominates`, `properlyDominates`, and membership in the dominator
-set returned by `BlockPtr.getDoms?`.
+This is the completeness half of the reachable block check: every expected
+dominator must be observed.
 -/
 private def compareExpectedDominator
-    (name : String)
+    (expected : ExpectedBlockDominators)
     (block : BlockPtr)
-    (observedDoms : HashSet BlockPtr)
+    (recovered : RecoveredNames)
+    (expectedDom : String)
     (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode)
-    (blockMap : HashMap String BlockPtr)
-    (expectedDom : String) : MismatchReport :=
-  match blockMap[expectedDom]? with
-  | none =>
-    #[s!"dominators {name}: missing block label {expectedDom}"]
-  | some expectedBlock =>
-    Id.run do
-      let shouldProperlyDom := expectedDom ≠ name
-      let mut report := #[]
-      if !Veir.DominanceAnalysis.dominates expectedBlock block dfCtx irCtx then
-        report := report.push s!"dominators {name}: missing expected dominator {expectedDom}"
-      if !observedDoms.contains expectedBlock then
-        report := report.push
-          s!"dominators {name}: BlockPtr.getDoms? missing expected dominator {expectedDom}"
-      if Veir.DominanceAnalysis.properlyDominates expectedBlock block dfCtx irCtx ≠ shouldProperlyDom then
-        report := report.push
-          s!"dominators {name}: unexpected properlyDominates result for {expectedDom}"
-      report
+    (irCtx : IRContext OpCode) : MismatchReport := Id.run do
+  let some expectedBlock := recovered.blocks[expectedDom]?
+    | return #[s!"dominators {expected.name}: missing block label {expectedDom}"]
+  let shouldProperlyDom := expectedDom ≠ expected.name
+  let mut report := #[]
+  if !Veir.DominanceAnalysis.dominates expectedBlock block dfCtx irCtx then
+    report := report.push s!"dominators {expected.name}: missing expected dominator {expectedDom}"
+  if Veir.DominanceAnalysis.properlyDominates expectedBlock block dfCtx irCtx ≠ shouldProperlyDom then
+    report := report.push
+      s!"dominators {expected.name}: unexpected properlyDominates result for {expectedDom}"
+  return report
 
 /--
 Compare one observed block label against the expected dominator list.
 
-This also cross checks the three ways of observing dominance for consistency:
-`dominates`, `properlyDominates`, and membership in `BlockPtr.getDoms?`.
+This is the soundness half of the reachable block check: every observed
+dominator must be expected.
 -/
 private def compareObservedDominator
-    (name : String)
+    (expected : ExpectedBlockDominators)
     (block : BlockPtr)
-    (observedDoms : HashSet BlockPtr)
-    (expectedDoms : Array String)
-    (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode)
     (observedName : String)
-    (observedBlock : BlockPtr) : MismatchReport :=
-  Id.run do
+    (observedBlock : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : MismatchReport := Id.run do
     let observedByRelation := Veir.DominanceAnalysis.dominates observedBlock block dfCtx irCtx
-    let observedBySet := observedDoms.contains observedBlock
     let observedProperly := Veir.DominanceAnalysis.properlyDominates observedBlock block dfCtx irCtx
     let mut report := #[]
-    if observedByRelation ≠ observedBySet then
-      report := report.push s!"dominators {name}: dominates/getDoms? disagree on {observedName}"
     if observedProperly ≠ (observedByRelation && observedBlock ≠ block) then
-      report := report.push s!"dominators {name}: dominates/properlyDominates disagree on {observedName}"
-    if observedByRelation && !expectedDoms.contains observedName then
-      report := report.push s!"dominators {name}: unexpected dominator {observedName}"
-    if observedBySet && !expectedDoms.contains observedName then
-      report := report.push s!"dominators {name}: BlockPtr.getDoms? has unexpected dominator {observedName}"
-    if observedProperly && (!expectedDoms.contains observedName || observedName = name) then
-      report := report.push s!"dominators {name}: unexpected proper dominator {observedName}"
+      report := report.push
+        s!"dominators {expected.name}: dominates/properlyDominates disagree on {observedName}"
+    if observedByRelation && !expected.dominators.contains observedName then
+      report := report.push s!"dominators {expected.name}: unexpected dominator {observedName}"
+    if observedProperly && (!expected.dominators.contains observedName || observedName = expected.name) then
+      report := report.push s!"dominators {expected.name}: unexpected proper dominator {observedName}"
     report
 
 /--
@@ -75,64 +66,56 @@ This runs both passes of the reachable block check: every expected dominator mus
 be observed, and every observed dominator must be expected.
 -/
 private def compareReachableDominators
-    (name : String)
+    (expected : ExpectedBlockDominators)
     (block : BlockPtr)
-    (observedDoms : HashSet BlockPtr)
+    (recovered : RecoveredNames)
     (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode)
-    (blockMap : HashMap String BlockPtr)
-    (expectedDoms : Array String) : MismatchReport := Id.run do
+    (irCtx : IRContext OpCode) : MismatchReport := Id.run do
   let mut report := #[]
-  for expectedDom in expectedDoms do
+  for expectedDom in expected.dominators.toArray do
     report := report ++ compareExpectedDominator
-      name block observedDoms dfCtx irCtx blockMap expectedDom
-  for (observedName, observedBlock) in blockMap.toList do
+      expected block recovered expectedDom dfCtx irCtx
+  for (observedName, observedBlock) in recovered.blocks.toList do
     report := report ++ compareObservedDominator
-      name block observedDoms expectedDoms dfCtx irCtx observedName observedBlock
+      expected block observedName observedBlock dfCtx irCtx
   report
 
 /--
 Compare the observed dominator information for one named block.
 
-An expected value of `none` means the block should be unreachable and therefore
-should not have an initialized dominator set.
+An empty expected dominator set means the block should be unreachable and
+therefore should not have an initialized dominator fact.
 -/
 private def compareNamedBlockDominators
+    (recovered : RecoveredNames)
+    (expected : ExpectedBlockDominators)
     (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode)
-    (blockMap : HashMap String BlockPtr)
-    (name : String)
-    (expectedDoms? : Option (Array String)) : MismatchReport :=
-  match blockMap[name]? with
-  | none =>
-    #[s!"dominators {name}: missing block label"]
-  | some block =>
-    let observedDoms? := block.getDoms? dfCtx irCtx
-    match expectedDoms? with
-    | none =>
-      if observedDoms?.isSome then
-        #[s!"dominators {name}: expected unreachable block, observed initialized state"]
-      else
-        #[]
-    | some expectedDoms =>
-      match observedDoms? with
-      | none =>
-        #[s!"dominators {name}: expected initialized state, observed none"]
-      | some observedDoms =>
-        compareReachableDominators name block observedDoms dfCtx irCtx blockMap expectedDoms
+    (irCtx : IRContext OpCode) : MismatchReport := Id.run do
+  let some block := recovered.blocks[expected.name]?
+    | return #[s!"dominators {expected.name}: missing block label"]
+  let observedFact? := block.getDominatorFact? dfCtx irCtx
+  match expected.dominators.isEmpty, observedFact? with
+  | true, none =>
+      return #[]
+  | true, some _ =>
+      return #[s!"dominators {expected.name}: expected unreachable block, observed initialized state"]
+  | false, none =>
+      return #[s!"dominators {expected.name}: expected initialized state, observed unreachable block"]
+  | false, some _ =>
+      return compareReachableDominators expected block recovered dfCtx irCtx
 
 /--
 Compare the observed dominator relation against an expected map keyed by block
 label.
 -/
 private def compareNamedDominators
+    (recovered : RecoveredNames)
+    (expectations : Array ExpectedBlockDominators)
     (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode)
-    (blockMap : HashMap String BlockPtr)
-    (expected : Array (String × Option (Array String))) : MismatchReport := Id.run do
+    (irCtx : IRContext OpCode) : MismatchReport := Id.run do
   let mut report := #[]
-  for (name, expectedDoms?) in expected do
-    report := report ++ compareNamedBlockDominators dfCtx irCtx blockMap name expectedDoms?
+  for expected in expectations do
+    report := report ++ compareNamedBlockDominators recovered expected dfCtx irCtx
   report
 
 namespace DominanceAnalysis
@@ -140,16 +123,18 @@ namespace DominanceAnalysis
 /--
 Run the dominance analysis test harness on one MLIR snippet.
 
-The expected data associates each block label with either the full set of blocks
-that should dominate it, or `none` if the block should remain unreachable.
+The expected data associates each block label with the full set of blocks that
+should dominate it. An empty set means the block should remain unreachable.
 -/
 def run
     (mlir : String)
-    (expected : Array (String × Option (Array String))) : String :=
+    (expected : Array ExpectedBlockDominators) : String :=
   runWithAnalyses mlir #[Veir.DominanceAnalysis] (fun top dfCtx parserState => Id.run do
-    let some recovered := recoverNames? top parserState.ctx mlir
-      | return #["failed to recover block/value names from MLIR"]
-    compareNamedDominators dfCtx parserState.ctx recovered.blocks expected)
+    match recoverNames top parserState.ctx mlir with
+    | Except.error err =>
+        return #[err]
+    | Except.ok recovered =>
+        compareNamedDominators recovered expected dfCtx parserState.ctx)
 
 /-
   Test: loop with a backedge
@@ -177,9 +162,9 @@ def testDomLoop : String :=
 ^bb2:\n\
   \"test.test\"() [^bb1] : () -> ()\n\
 }) : () -> ()"
-    #[ ("bb0", some #["bb0"])
-     , ("bb1", some #["bb0", "bb1"])
-     , ("bb2", some #["bb0", "bb1", "bb2"])
+    #[ { name := "bb0", dominators := { "bb0" } }
+     , { name := "bb1", dominators := { "bb0", "bb1" } }
+     , { name := "bb2", dominators := { "bb0", "bb1", "bb2" } }
      ]
 
 /-
@@ -206,10 +191,10 @@ def testDomDiamond : String :=
 ^bb3:\n\
   \"test.test\"() : () -> ()\n\
 }) : () -> ()"
-    #[ ("bb0", some #["bb0"])
-     , ("bb1", some #["bb0", "bb1"])
-     , ("bb2", some #["bb0", "bb2"])
-     , ("bb3", some #["bb0", "bb3"])
+    #[ { name := "bb0", dominators := { "bb0" } }
+     , { name := "bb1", dominators := { "bb0", "bb1" } }
+     , { name := "bb2", dominators := { "bb0", "bb2" } }
+     , { name := "bb3", dominators := { "bb0", "bb3" } }
      ]
 
 /-
@@ -242,10 +227,10 @@ def testDomLine : String :=
 ^bb3:\n\
   \"test.test\"() : () -> ()\n\
 }) : () -> ()"
-    #[ ("bb0", some #["bb0"])
-     , ("bb1", some #["bb0", "bb1"])
-     , ("bb2", some #["bb0", "bb1", "bb2"])
-     , ("bb3", some #["bb0", "bb1", "bb2", "bb3"])
+    #[ { name := "bb0", dominators := { "bb0" } }
+     , { name := "bb1", dominators := { "bb0", "bb1" } }
+     , { name := "bb2", dominators := { "bb0", "bb1", "bb2" } }
+     , { name := "bb3", dominators := { "bb0", "bb1", "bb2", "bb3" } }
      ]
 
 /-
@@ -286,14 +271,14 @@ def testDomIfLoopIf : String :=
 ^bb7:\n\
   \"test.test\"() : () -> ()\n\
 }) : () -> ()"
-    #[ ("bb0", some #["bb0"])
-     , ("bb1", some #["bb0", "bb1"])
-     , ("bb2", some #["bb0", "bb2"])
-     , ("bb3", some #["bb0", "bb2", "bb3"])
-     , ("bb4", some #["bb0", "bb2", "bb4"])
-     , ("bb5", some #["bb0", "bb1", "bb5"])
-     , ("bb6", some #["bb0", "bb2", "bb6"])
-     , ("bb7", some #["bb0", "bb7"])
+    #[ { name := "bb0", dominators := { "bb0" } }
+     , { name := "bb1", dominators := { "bb0", "bb1" } }
+     , { name := "bb2", dominators := { "bb0", "bb2" } }
+     , { name := "bb3", dominators := { "bb0", "bb2", "bb3" } }
+     , { name := "bb4", dominators := { "bb0", "bb2", "bb4" } }
+     , { name := "bb5", dominators := { "bb0", "bb1", "bb5" } }
+     , { name := "bb6", dominators := { "bb0", "bb2", "bb6" } }
+     , { name := "bb7", dominators := { "bb0", "bb7" } }
      ]
 
 /--

--- a/UnitTest/DataFlowFramework/Helpers.lean
+++ b/UnitTest/DataFlowFramework/Helpers.lean
@@ -26,15 +26,10 @@ Parse one top level MLIR operation together with the parser state that owns its 
 def parseTopLevelOp (s : String) : Except String (OperationPtr × MlirParserState) := do
   let some (ctx, _) := WfIRContext.create OpCode
     | throw "internal error: failed to create IR context"
-  let parserState ←
-    match ParserState.fromInput s.toByteArray with
-    | .ok parserState => pure parserState
-    | .error err => throw (toString err)
-  match (parseOp none).run (MlirParserState.fromContext ctx) parserState with
-  | .ok (op, mlirState, _) =>
-    pure (op, mlirState)
-  | .error err =>
-    throw (toString err)
+  let parserState ← (ParserState.fromInput s.toByteArray).mapError toString
+  let (op, mlirState, _) ←
+    ((parseOp none).run (MlirParserState.fromContext ctx) parserState).mapError toString
+  pure (op, mlirState)
 
 /--
 Recover textual block labels such as `^bb0` from an MLIR snippet string.
@@ -62,7 +57,7 @@ def parseSsaName? (fragment : String) : Option String :=
 /--
 Recover textual SSA names from block arguments and operation result definitions.
 -/
-def definedSsaNamesFromMlir (mlir : String) : Array String := Id.run do
+def ssaNamesFromMlir (mlir : String) : Array String := Id.run do
   let mut names := #[]
   for line in mlir.splitOn "\n" do
     let trimmed := (line.trimAsciiStart).toString
@@ -103,7 +98,7 @@ Collect all SSA values in source order.
 This includes the operation's results, followed by block arguments and nested
 operation results inside each region.
 -/
-partial def collectDefinedValuesInSourceOrder
+partial def collectValuesInSourceOrder
     (top : OperationPtr)
     (irCtx : IRContext OpCode)
     (acc : Array ValuePtr := #[]) : Array ValuePtr := Id.run do
@@ -118,7 +113,7 @@ partial def collectDefinedValuesInSourceOrder
         acc := acc.push arg
       let mut currentOp := (block.get! irCtx).firstOp
       while let some nestedOp := currentOp do
-        acc := collectDefinedValuesInSourceOrder nestedOp irCtx acc
+        acc := collectValuesInSourceOrder nestedOp irCtx acc
         currentOp := (nestedOp.get! irCtx).next
       currentBlock := (block.get! irCtx).next
   acc
@@ -133,27 +128,28 @@ structure RecoveredNames where
 /--
 Recover block and SSA value maps by pairing MLIR source names with IR traversal order.
 -/
-def recoverNames?
+def recoverNames
     (top : OperationPtr)
     (irCtx : IRContext OpCode)
-    (mlir : String) : Option RecoveredNames :=
+    (mlir : String) : Except String RecoveredNames := do
   let blockLabels := blockLabelsFromMlir mlir
   let blocks := collectBlocksInSourceOrder top irCtx
-  let valueNames := definedSsaNamesFromMlir mlir
-  let values := collectDefinedValuesInSourceOrder top irCtx
-  if blockLabels.size ≠ blocks.size || valueNames.size ≠ values.size then
-    none
-  else
-    some <| Id.run do
-      let mut blockMap : HashMap String BlockPtr := HashMap.emptyWithCapacity blockLabels.size
-      for (blockLabel, block) in blockLabels.zip blocks do
-        blockMap := blockMap.insert blockLabel block
+  let valueNames := ssaNamesFromMlir mlir
+  let values := collectValuesInSourceOrder top irCtx
+  if blockLabels.size ≠ blocks.size then
+    throw s!"failed to recover block names: source has {blockLabels.size} labels but IR has {blocks.size} blocks"
+  if valueNames.size ≠ values.size then
+    throw s!"failed to recover value names: source has {valueNames.size} names but IR has {values.size} values"
 
-      let mut valueMap : HashMap String ValuePtr := HashMap.emptyWithCapacity valueNames.size
-      for (valueName, value) in valueNames.zip values do
-        valueMap := valueMap.insert valueName value
+  let mut blockMap : HashMap String BlockPtr := HashMap.emptyWithCapacity blockLabels.size
+  for (blockLabel, block) in blockLabels.zip blocks do
+    blockMap := blockMap.insert blockLabel block
 
-      { blocks := blockMap, values := valueMap }
+  let mut valueMap : HashMap String ValuePtr := HashMap.emptyWithCapacity valueNames.size
+  for (valueName, value) in valueNames.zip values do
+    valueMap := valueMap.insert valueName value
+
+  return { blocks := blockMap, values := valueMap }
 
 /--
 Parse an MLIR snippet string, run the requested dataflow analyses to a fixpoint, and
@@ -162,13 +158,11 @@ render any test mismatches produced by `check`.
 def runWithAnalyses
     (mlir : String)
     (analyses : Array DataFlowAnalysis)
-    (check : OperationPtr -> DataFlowContext -> MlirParserState -> MismatchReport) : String :=
+    (check : OperationPtr -> DataFlowContext -> MlirParserState -> MismatchReport) : String := Id.run do
   match parseTopLevelOp mlir with
   | .error err =>
-    s!"parse failed: {err}"
+      return s!"parse failed: {err}"
   | .ok (top, parserState) =>
-    match fixpointSolve top analyses parserState.ctx with
-    | some dfCtx =>
-      renderReport (check top dfCtx parserState)
-    | none =>
-      "analysis did not converge"
+      let some dfCtx := fixpointSolve top analyses parserState.ctx
+        | return "analysis did not converge"
+      return renderReport (check top dfCtx parserState)

--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -62,28 +62,6 @@ def getIDom? [FactSpec .dominator] (block : BlockPtr) (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : Option BlockPtr :=
   block.getDominatorFact? dfCtx irCtx >>= (·.iDom)
 
-/--
-Collect the dominators currently reachable from `block` by following the `iDom`
-chain.
-
-The returned set always includes `block` itself. If `block` has no dominator
-fact, returns `none`. Otherwise, this walks the currently known immediate
-dominator chain until it reaches a root or a self-loop, so during analysis it
-may return only the known prefix of the full dominator set.
--/
-def getDoms? [FactSpec .dominator] (block : BlockPtr) (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode) : Option (HashSet BlockPtr) := do
-  let fact ← block.getDominatorFact? dfCtx irCtx
-  let mut doms := (∅ : HashSet BlockPtr).insert block
-  let mut current := fact.iDom
-  while let some dom := current do
-    doms := doms.insert dom
-    let next := dom.getIDom? dfCtx irCtx
-    if next = some dom then
-      return doms
-    current := next
-  doms
-
 end BlockPtr
 
 namespace RegionPtr


### PR DESCRIPTION
Also removed dominance analysis' `getDoms?` since no one will use it.

What was cleaned up:
 - Created a private type `ExpectedBlockDominance` so that dominance tests aren't passing an `Array (String × Option (Array String))` which has no readable semantic meaning. Instead, it now passes a `structure` with a block label and its expected dominators.
    - Consequently, I am not passing around `String`s and `Array String`s into my helpers - I just pass `ExpectedBlockDominance` and `Array ExpectedBlockDominance` directly.
 - On a similar note, I originally passed the `RecoveredNames.blocks` into my helpers - so their type signature often had `HashMap String BlockPtr` - also not as readable. I decided to just pass `RecoveredNames` directly. 
 - Many functions had nested `match` and if statements. I flattened them.
 - Many of these functions take in `IRContext` and `DataFlowContext`, but the ordering of these parameters were random. I normalized them (`IRContext` and `DataFlowContext` are the last parameters, which is what all of my functions do in the dataflow analysis framework)
 - I changed some of the comments for functions to be more concise.
 - `recoverNames?` now returns an exception if it fails.