### PR TITLE
feat(LLVM): add barebone support for f64 values in 'llvm.constant'

### DIFF
--- a/Test/Interpreter/LLVM/constant.mlir
+++ b/Test/Interpreter/LLVM/constant.mlir
@@ -5,8 +5,9 @@
     %pos = "llvm.mlir.constant"() <{ "value" = 3 : i32 }> : () -> i32
     %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
     %neg = "llvm.mlir.constant"() <{ "value" = -4 : i32 }> : () -> i32
-    "func.return"(%pos, %zero, %neg) : (i32, i32, i32) -> ()
+    %fzero = "llvm.mlir.constant"() <{ "value" = 1.0 : f64 }> : () -> f64
+    "func.return"(%pos, %zero, %neg, %fzero) : (i32, i32, i32, f64) -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x00000003#32, 0x00000000#32, 0xfffffffc#32]
+// CHECK: Program output: #[0x00000003#32, 0x00000000#32, 0xfffffffc#32, 1.000000]

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -160,7 +160,11 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .arith .constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
   | .llvm .mlir__constant =>
-    (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
+    match props.value with
+    | .integer intAttr =>
+      (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr intAttr)
+    | .float floatAttr =>
+      (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.floatAttr floatAttr)
   | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci
   | .llvm .add | .llvm .sub | .llvm .mul | .llvm .shl | .llvm .trunc => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 1

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -162,9 +162,9 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .llvm .mlir__constant =>
     match props.value with
     | .integer intAttr =>
-      (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr intAttr)
+      (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr intAttr)
     | .float floatAttr =>
-      (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.floatAttr floatAttr)
+      (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.floatAttr floatAttr)
   | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci
   | .llvm .add | .llvm .sub | .llvm .mul | .llvm .shl | .llvm .trunc => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 1

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -80,7 +80,7 @@ structure RegisterAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
-  A floating point attribute storing a Lean `Float` value with an associated float type.
+A floating point attribute storing a Lean `Float` value with an associated float type.
 -/
 structure FloatAttr where
   value : Float

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -80,6 +80,36 @@ structure RegisterAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  A floating point attribute storing a Lean `Float` value with an associated float type.
+-/
+structure FloatAttr where
+  value : Float
+  type : FloatType
+deriving Inhabited, Repr
+
+/--
+  Temporary bridge lemma for deciding `FloatAttr` equality via `Float.toBits`.
+-/
+axiom floatEqOfToBitsEq {a b : Float} : a.toBits = b.toBits → a = b
+
+instance : DecidableEq FloatAttr
+  | a, b =>
+    if hv : a.value.toBits = b.value.toBits then
+      if ht : a.type = b.type then
+        have hval : a.value = b.value := floatEqOfToBitsEq hv
+        isTrue (by
+          cases a
+          cases b
+          simp_all)
+      else
+        isFalse (by intro h; exact ht (congrArg FloatAttr.type h))
+    else
+      isFalse (by intro h; exact hv (congrArg (Float.toBits ∘ FloatAttr.value) h))
+
+instance : Hashable FloatAttr where
+  hash a := mixHash (hash a.value.toBits) (hash a.type)
+
+/--
   An attribute containing a string.
   The string is stored as a `ByteArray` as unicode is not supported.
 -/
@@ -286,6 +316,8 @@ inductive Attribute
 | cudaTilePointerType (type : CudaTile.PointerType)
 /-- CIRCT hw module type -/
 | hwModuleType (type : HW.ModuleType)
+/-- Float attribute -/
+| floatAttr (attr : FloatAttr)
 deriving Inhabited, Repr, Hashable
 
 end
@@ -478,6 +510,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case floatAttr.floatAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -512,6 +548,9 @@ instance : ToString FastMathFlagsAttr where
     s!"#llvm.fastmath<{String.intercalate ", " array}>"
 
 instance : ToString IntegerAttr where
+  toString attr := s!"{attr.value} : {attr.type}"
+
+instance : ToString FloatAttr where
   toString attr := s!"{attr.value} : {attr.type}"
 
 instance : ToString RegisterType where
@@ -673,6 +712,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .llvmFunctionType type => type.toLLVMString
   | .cudaTilePointerType type => ToString.toString type
   | .hwModuleType type => ToString.toString type
+  | .floatAttr attr => s!"{attr.value} : {attr.type}"
 termination_by sizeOf attr
 
 end
@@ -727,6 +767,9 @@ instance : Coe FlatSymbolRefAttr Attribute where
 instance : Coe ArrayAttr Attribute where
   coe attr := .arrayAttr attr
 
+instance : Coe FloatAttr Attribute where
+  coe attr := .floatAttr attr
+
 instance : Coe DenseArrayAttr Attribute where
   coe attr := .denseArrayAttr attr
 
@@ -770,6 +813,7 @@ def isType (attr : Attribute) : Bool :=
   | .floatType _ => true
   | .fastMathFlagsAttr _ => false
   | .integerAttr _ => false
+  | .floatAttr _ => false
   | .stringAttr _ => false
   | .unitAttr _ => false
   | .locationAttr _ => false

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -280,6 +280,8 @@ inductive Attribute
 | floatType (type : FloatType)
 /-- Integer attribute -/
 | integerAttr (attr : IntegerAttr)
+/-- Float attribute -/
+| floatAttr (attr : FloatAttr)
 /-- Float fast math flags attribute -/
 | fastMathFlagsAttr (attr : FastMathFlagsAttr)
 /-- Register type -/
@@ -316,8 +318,6 @@ inductive Attribute
 | cudaTilePointerType (type : CudaTile.PointerType)
 /-- CIRCT hw module type -/
 | hwModuleType (type : HW.ModuleType)
-/-- Float attribute -/
-| floatAttr (attr : FloatAttr)
 deriving Inhabited, Repr, Hashable
 
 end
@@ -456,6 +456,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case floatAttr.floatAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case stringAttr.stringAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -508,10 +512,6 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
       | isFalse hEq => isFalse (by grind))
   case hwModuleType.hwModuleType type1 type2 =>
     exact (match decEq type1 type2 with
-      | isTrue hEq => isTrue (by grind)
-      | isFalse hEq => isFalse (by grind))
-  case floatAttr.floatAttr attr1 attr2 =>
-    exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
   all_goals exact isFalse (by grind)
@@ -695,6 +695,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .floatType type => ToString.toString type
   | .fastMathFlagsAttr attr => ToString.toString attr
   | .integerAttr attr => ToString.toString attr
+  | .floatAttr attr => ToString.toString attr
   | .registerType type => ToString.toString type
   | .registerAttr attr => ToString.toString attr
   | .stringAttr attr => ToString.toString attr
@@ -712,7 +713,6 @@ def Attribute.toString (attr : Attribute) : String :=
   | .llvmFunctionType type => type.toLLVMString
   | .cudaTilePointerType type => ToString.toString type
   | .hwModuleType type => ToString.toString type
-  | .floatAttr attr => s!"{attr.value} : {attr.type}"
 termination_by sizeOf attr
 
 end

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -88,7 +88,7 @@ structure FloatAttr where
 deriving Inhabited, Repr
 
 /--
-  Temporary bridge lemma for deciding `FloatAttr` equality via `Float.toBits`.
+Temporary bridge lemma for deciding `FloatAttr` equality via `Float.toBits`.
 -/
 axiom floatEqOfToBitsEq {a b : Float} : a.toBits = b.toBits → a = b
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -36,6 +36,7 @@ variable {ctx : WfIRContext OpInfo}
 -/
 inductive RuntimeValue where
 | int (bitwidth : Nat) (value : LLVM.Int bitwidth)
+| float (bitwidth : Nat) (value : Float)
 | addr (value : UInt64)
 | reg (value : RISCV.Reg)
 deriving Inhabited
@@ -43,6 +44,7 @@ deriving Inhabited
 instance : ToString (RuntimeValue) where
   toString
     | .int _ val => ToString.toString val
+    | .float _ val => ToString.toString val
     | .addr val => ToString.toString val
     | .reg val => ToString.toString val
 
@@ -56,6 +58,7 @@ namespace RuntimeValue
 def Conforms (val : RuntimeValue) (ty : TypeAttr) : Prop :=
   match val, ty with
   | .int bw _, ⟨.integerType intType, _⟩ => intType.bitwidth = bw
+  | .float bw _, ⟨.floatType floatType, _⟩ => floatType.bitwidth = bw
   | .reg _, ⟨.registerType _, _⟩ => True
   | .addr _, ⟨.llvmPointerType _, _⟩ => True
   | _, _ => False
@@ -485,9 +488,17 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
   match opType with
   | .mlir__constant => do
     let some resType := resultTypes[0]? | none
-    let .integerType bw := resType.val
-      | none
-    return (#[.int bw.bitwidth (LLVM.Int.constant bw.bitwidth properties.value.value)], mem, none)
+    match properties.value with
+    | .integer intAttr =>
+      let .integerType bw := resType.val
+        | none
+      return (#[.int bw.bitwidth (LLVM.Int.constant bw.bitwidth intAttr.value)], mem, none)
+    | .float floatAttr =>
+      let .floatType bw := resType.val
+        | none
+      if bw.bitwidth ≠ 64 then
+        none
+      return (#[.float 64 floatAttr.value], mem, none)
   | .add => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -80,6 +80,18 @@ theorem Conforms.integerType :
   all_goals grind
 
 @[grind <=]
+theorem Conforms.floatType :
+    Conforms runtimeValue ⟨.floatType fltType, h⟩ →
+    ∃ val, runtimeValue = .float fltType.bitwidth val := by
+  simp only [Conforms]
+  cases runtimeValue
+  case float bw val =>
+    simp only [float.injEq, exists_and_left]
+    intro _; subst bw
+    grind
+  all_goals grind
+
+@[grind <=]
 theorem Conforms.registerType :
     Conforms runtimeValue ⟨.registerType regType, h⟩ →
     ∃ val, runtimeValue = .reg val := by

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -1,8 +1,10 @@
 import Veir.Parser.Parser
 import Veir.IR.Basic
+import Veir.IR.Attribute
 
 open Veir.Parser.Lexer
 open Veir.Parser
+open Veir
 
 namespace Veir.AttrParser
 
@@ -126,6 +128,22 @@ def parseOptionalStringAttr : AttrParserM (Option StringAttr) := do
   let some str ← parseOptionalStringLiteral
     | return none
   return some (StringAttr.mk str.toByteArray)
+
+/--
+  Parse a float attribute, if present.
+  Only `1.0 : f64` is supported; the value is stored as Lean's `Float`.
+-/
+def parseOptionalFloatAttr : AttrParserM (Option FloatAttr) := do
+  let some tok ← parseOptionalToken .floatLit | return none
+  let str := String.fromUTF8! (tok.slice.of (← getThe ParserState).input)
+  if str ≠ "1.0" then
+    throwAtCurrentPos s!"unsupported floating-point literal '{str}', only '1.0 : f64' is supported"
+  parsePunctuation ":"
+  let some floatType ← parseOptionalFloatType
+    | throwAtCurrentPos "float type expected after ':' in float attribute"
+  if floatType.bitwidth ≠ 64 then
+    throwAtCurrentPos "unsupported float type, only f64 is supported"
+  return some (Veir.FloatAttr.mk 1.0 floatType)
 
 /--
   Parse a string attribute.
@@ -602,6 +620,8 @@ partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
     return some type.val
   else if let some integerAttr ← parseOptionalIntegerAttr then
     return some integerAttr
+  else if let some floatAttr ← parseOptionalFloatAttr then
+    return some floatAttr
   else if let some stringAttr ← parseOptionalStringAttr then
     return some stringAttr
   else if let some denseArrayAttr ← parseOptionalDenseArrayAttr then

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -130,8 +130,8 @@ def parseOptionalStringAttr : AttrParserM (Option StringAttr) := do
   return some (StringAttr.mk str.toByteArray)
 
 /--
-  Parse a float attribute, if present.
-  Only `1.0 : f64` is supported; the value is stored as Lean's `Float`.
+Parse a float attribute, if present.
+Only `1.0 : f64` is supported; the value is stored as Lean's `Float`.
 -/
 def parseOptionalFloatAttr : AttrParserM (Option FloatAttr) := do
   let some tok ← parseOptionalToken .floatLit | return none

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -39,7 +39,7 @@ def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     return rewriter
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
-  let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
+  let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
   let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
@@ -93,7 +93,7 @@ def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     return rewriter
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
-  let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
+  let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
   let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
@@ -121,7 +121,7 @@ def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     return rewriter
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
-  let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
+  let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
   let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
@@ -173,7 +173,7 @@ def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     return rewriter
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
-  let cstProp := LLVMConstantProperties.mk (IntegerAttr.mk 0 type)
+  let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
   let (rewriter, newOp) ← rewriter.createOp (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -19,7 +19,7 @@ def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchMuli op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 2 then
     return rewriter
@@ -33,7 +33,7 @@ def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchMuli op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
@@ -50,7 +50,7 @@ def addiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchAddi op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
@@ -63,7 +63,7 @@ def mulIOneToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchMuli op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 1 then
     return rewriter
@@ -76,7 +76,7 @@ def subiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSubi op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
@@ -115,7 +115,7 @@ def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAndi op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
@@ -132,7 +132,7 @@ def oriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOri op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
@@ -156,7 +156,7 @@ def xoriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchXori op rewriter.ctx
     | return rewriter
-  let some cst := matchConstantVal rhs rewriter.ctx
+  let some cst := matchConstantIntVal rhs rewriter.ctx
     | return rewriter
   if cst.value ≠ 0 then
     return rewriter
@@ -183,7 +183,7 @@ def matchNot (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
   let .opResult opResultPtr := val | none
   let op := opResultPtr.op
   let (lhs, rhs) ← matchXori op ctx
-  let cst ← matchConstantVal rhs ctx
+  let cst ← matchConstantIntVal rhs ctx
   guard (cst.value = -1)
   return lhs
 

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -15,7 +15,7 @@ set_option warn.sorry false in
 /-- llvm.constant -> riscv.li -/
 def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
-  let some const := matchConstantOp op rewriter.ctx
+  let some const := matchConstantIntOp op rewriter.ctx
       | return rewriter
   if const.type.bitwidth ≠ 64 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -50,16 +50,16 @@ def matchXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
   let (op, _) ← matchOp op ctx (.llvm .xor) 2
   return (op[0]!, op[1]!)
 
-def matchConstantOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
+def matchConstantIntOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .llvm .mlir__constant := op.getOpType! ctx | none
   let properties := op.getProperties! ctx (.llvm .mlir__constant)
   let .integer intAttr := properties.value | none
   return intAttr
 
-def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
+def matchConstantIntVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .opResult opResultPtr := val | none
   let op := opResultPtr.op
-  matchConstantOp op ctx
+  matchConstantIntOp op ctx
 
 def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .builtin .unrealized_conversion_cast := op.getOpType! ctx | none

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -53,7 +53,8 @@ def matchXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
 def matchConstantOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .llvm .mlir__constant := op.getOpType! ctx | none
   let properties := op.getProperties! ctx (.llvm .mlir__constant)
-  return properties.value
+  let .integer intAttr := properties.value | none
+  return intAttr
 
 def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .opResult opResultPtr := val | none
@@ -63,7 +64,8 @@ def matchConstantVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerA
 def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .builtin .unrealized_conversion_cast := op.getOpType! ctx | none
   let properties := op.getProperties! ctx (.llvm .mlir__constant)
-  return properties.value
+  let .integer intAttr := properties.value | none
+  return intAttr
 
 def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .ashr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .ashr) 2

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -131,7 +131,7 @@ def FastMathFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
   return ⟨value⟩
 
 /--
-  The two type of constants an LLVM constant can store.
+The two types of constants an LLVM constant can store.
 -/
 inductive LLVMConstantValue where
 | integer (value : IntegerAttr)

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -131,10 +131,18 @@ def FastMathFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
   return ⟨value⟩
 
 /--
+  The two type of constants an LLVM constant can store.
+-/
+inductive LLVMConstantValue where
+| integer (value : IntegerAttr)
+| float (value : FloatAttr)
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+/--
   Properties of the `llvm.constant` operation.
 -/
 structure LLVMConstantProperties where
-  value : IntegerAttr
+  value : LLVMConstantValue
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def LLVMConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
@@ -143,9 +151,13 @@ def LLVMConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attrib
     throw s!"llvm.constant: expected only 'value' property, but got {attrDict.size} properties"
   let some attr := attrDict["value".toUTF8]?
     | throw "llvm.constant: missing 'value' property"
-  let .integerAttr intAttr := attr
-    | throw s!"llvm.constant: expected 'value' to be an integer attribute, but got {attr}"
-  return { value := intAttr }
+  match attr with
+  | .integerAttr intAttr =>
+    return { value := .integer intAttr }
+  | .floatAttr floatAttr =>
+    return { value := .float floatAttr }
+  | _ =>
+    throw s!"llvm.constant: expected 'value' to be an integer or float attribute, but got {attr}"
 
 /-- Properties of integer comparison operations in the LLVM and arith dialects. -/
 structure IcmpProperties where


### PR DESCRIPTION
This adds support for parsing a float type passed as a value to `llvm.constant` as well as basic interpreter support. Floats are stored as Lean's native double-precision `Float` type, which should make them sufficiently fast to interpret. We currently only support parsing a constant of value `1.0`. In subsequent changes, we add (a) a full floating point parser, (b) interpreter support for various floating point operations, as well as (a) support for lower precision floating point types.