### PR TITLE
feat(dominance): Add dominance API for blocks

### DIFF
--- a/UnitTest/DataFlowFramework/Dominance.lean
+++ b/UnitTest/DataFlowFramework/Dominance.lean
@@ -321,18 +321,17 @@ def testDomIfLoopIf : String :=
   do not dominate each other.
 -/
 def testDomNestedRegions : String :=
-  run
-    "\"builtin.module\"() ({\n\
-    ^bb0:\n\
-      \"test.test\"() ({\n\
-      ^bb1:\n\
-        \"test.test\"() : () -> ()\n\
-      }) : () -> ()\n\
-      \"test.test\"() ({\n\
-      ^bb2:\n\
-        \"test.test\"() : () -> ()\n\
-      }) : () -> ()\n\
-    }) : () -> ()"
+  run r#""builtin.module"() ({
+^bb0:
+  "test.test"() ({
+  ^bb1:
+    "test.test"() : () -> ()
+  }) : () -> ()
+  "test.test"() ({
+  ^bb2:
+    "test.test"() : () -> ()
+  }) : () -> ()
+}) : () -> ()"#
     #[ { name := "bb0", dominators := { "bb0" },        iDom := "bb0" }
      , { name := "bb1", dominators := { "bb0", "bb1" }, iDom := "bb1" }
      , { name := "bb2", dominators := { "bb0", "bb2" }, iDom := "bb2" }
@@ -354,20 +353,19 @@ def testDomNestedRegions : String :=
           └───────┘
 -/
 def testDomDiamondNestedJoin : String :=
-  run
-    "\"builtin.module\"() ({\n\
-^bb0:\n\
-  \"test.test\"() [^bb1, ^bb2] : () -> ()\n\
-^bb1:\n\
-  \"test.test\"() [^bb3] : () -> ()\n\
-^bb2:\n\
-  \"test.test\"() [^bb3] : () -> ()\n\
-^bb3:\n\
-  \"test.test\"() ({\n\
-^bb4:\n\
-    \"test.test\"() : () -> ()\n\
-  }) : () -> ()\n\
-}) : () -> ()"
+  run r#""builtin.module"() ({
+^bb0:
+  "test.test"() [^bb1, ^bb2] : () -> ()
+^bb1:
+  "test.test"() [^bb3] : () -> ()
+^bb2:
+  "test.test"() [^bb3] : () -> ()
+^bb3:
+  "test.test"() ({
+^bb4:
+    "test.test"() : () -> ()
+  }) : () -> ()
+}) : () -> ()"#
     #[ { name := "bb0", dominators := { "bb0" },               iDom := "bb0" }
      , { name := "bb1", dominators := { "bb0", "bb1" },        iDom := "bb0" }
      , { name := "bb2", dominators := { "bb0", "bb2" },        iDom := "bb0" }
@@ -388,24 +386,55 @@ def testDomDiamondNestedJoin : String :=
         └───────────┘
 -/
 def testDomTwoLevelNested : String :=
-  run
-    "\"builtin.module\"() ({\n\
-^bb0:\n\
-  \"test.test\"() : () -> ()\n\
-  \"test.test\"() ({\n\
-^bb1:\n\
-    \"test.test\"() : () -> ()\n\
-    \"test.test\"() ({\n\
-^bb2:\n\
-      \"test.test\"() : () -> ()\n\
-    }) : () -> ()\n\
-  }) : () -> ()\n\
-}) : () -> ()"
+  run r#""builtin.module"() ({
+^bb0:
+  "test.test"() : () -> ()
+  "test.test"() ({
+^bb1:
+    "test.test"() : () -> ()
+    "test.test"() ({
+^bb2:
+      "test.test"() : () -> ()
+    }) : () -> ()
+  }) : () -> ()
+}) : () -> ()"#
     #[ { name := "bb0", dominators := { "bb0" },               iDom := "bb0" }
      , { name := "bb1", dominators := { "bb0", "bb1" },        iDom := "bb1" }
      , { name := "bb2", dominators := { "bb0", "bb1", "bb2" }, iDom := "bb2" }
      ]
-
+/-
+  Test: Diamond with a loop
+  ┌────────┐
+  │      ┌─▼─┐
+  │   ┌──┤ 0 ├──┐
+  │   │  └───┘  │
+  │ ┌─▼─┐     ┌─▼─┐
+  │ │ 1 │     │ 2 ├──┐
+  │ └─┬─┘     └─┬─┘  │
+  │   │  ┌───┐  │  ┌─▼─┐
+  │   └──► 3 ◄──┘  │ 4 │
+  │      └─┬─┘     └───┘
+  └────────┘
+-/
+def testDomDiamonLoop: String :=
+  run r#""builtin.module"() ({
+^bb0:
+  "test.test"() [^bb1, ^bb2] : () -> ()
+^bb1:
+  "test.test"() [^bb3] : () -> ()
+^bb2:
+  "test.test"() [^bb3, ^bb4] : () -> ()
+^bb3:
+  "test.test"() [^bb0] : () -> ()
+^bb4:
+  "test.test"() : () -> ()
+}) : () -> ()"#
+    #[ { name := "bb0", dominators := { "bb0" },               iDom := "bb0" }
+     , { name := "bb1", dominators := { "bb0", "bb1" },        iDom := "bb0" }
+     , { name := "bb2", dominators := { "bb0", "bb2" },        iDom := "bb0" }
+     , { name := "bb3", dominators := { "bb0", "bb3" },        iDom := "bb0" }
+     , { name := "bb4", dominators := { "bb0", "bb2", "bb4" }, iDom := "bb2" }
+     ]
 /--
 info: "ok"
 -/
@@ -447,5 +476,11 @@ info: "ok"
 -/
 #guard_msgs in
 #eval! testDomTwoLevelNested
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDomDiamonLoop
 
 end DominanceAnalysis

--- a/UnitTest/DataFlowFramework/Dominance.lean
+++ b/UnitTest/DataFlowFramework/Dominance.lean
@@ -29,9 +29,9 @@ private def compareExpectedDominator
     | return #[s!"dominators {expected.name}: missing block label {expectedDom}"]
   let shouldProperlyDom := expectedDom ≠ expected.name
   let mut report := #[]
-  if !Veir.DominanceAnalysis.dominates expectedBlock block dfCtx irCtx then
+  if !expectedBlock.dominates block dfCtx irCtx then
     report := report.push s!"dominators {expected.name}: missing expected dominator {expectedDom}"
-  if Veir.DominanceAnalysis.properlyDominates expectedBlock block dfCtx irCtx ≠ shouldProperlyDom then
+  if expectedBlock.properlyDominates block dfCtx irCtx ≠ shouldProperlyDom then
     report := report.push
       s!"dominators {expected.name}: unexpected properlyDominates result for {expectedDom}"
   return report
@@ -49,8 +49,8 @@ private def compareObservedDominator
     (expected : ExpectedBlockDominators)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : MismatchReport := Id.run do
-  let observedByRelation := Veir.DominanceAnalysis.dominates observedBlock block dfCtx irCtx
-  let observedProperly := Veir.DominanceAnalysis.properlyDominates observedBlock block dfCtx irCtx
+  let observedByRelation := observedBlock.dominates block dfCtx irCtx
+  let observedProperly := observedBlock.properlyDominates block dfCtx irCtx
   let mut report := #[]
   if observedProperly ≠ (observedByRelation && observedBlock ≠ block) then
     report := report.push
@@ -308,6 +308,104 @@ def testDomIfLoopIf : String :=
      , { name := "bb7", dominators := { "bb0", "bb7" },        iDom := "bb0" }
      ]
 
+/-
+  Test: nested sibling regions inside the same outer block.
+
+          ┌───────────────┐
+          │ ┌───┐   ┌───┐ │
+          │ │ 1 │ 0 │ 2 │ │
+          │ └───┘   └───┘ │
+          └───────────────┘
+
+  The outer block dominates both nested entry blocks, but sibling nested blocks
+  do not dominate each other.
+-/
+def testDomNestedRegions : String :=
+  run
+    "\"builtin.module\"() ({\n\
+    ^bb0:\n\
+      \"test.test\"() ({\n\
+      ^bb1:\n\
+        \"test.test\"() : () -> ()\n\
+      }) : () -> ()\n\
+      \"test.test\"() ({\n\
+      ^bb2:\n\
+        \"test.test\"() : () -> ()\n\
+      }) : () -> ()\n\
+    }) : () -> ()"
+    #[ { name := "bb0", dominators := { "bb0" },        iDom := "bb0" }
+     , { name := "bb1", dominators := { "bb0", "bb1" }, iDom := "bb1" }
+     , { name := "bb2", dominators := { "bb0", "bb2" }, iDom := "bb2" }
+     ]
+
+/-
+  Test: diamond, nested region inside the join block.
+            ┌───┐
+        ┌───┤ 0 ├───┐
+        │   └───┘   │
+      ┌─▼─┐       ┌─▼─┐
+      │ 1 │       │ 2 │
+      └─┬─┘       └─┬─┘
+        │ ┌───────┐ │
+        │ │   3   │ │
+        │ │ ┌───┐ │ │
+        └─► │ 4 │ ◄─┘
+          │ └───┘ │
+          └───────┘
+-/
+def testDomDiamondNestedJoin : String :=
+  run
+    "\"builtin.module\"() ({\n\
+^bb0:\n\
+  \"test.test\"() [^bb1, ^bb2] : () -> ()\n\
+^bb1:\n\
+  \"test.test\"() [^bb3] : () -> ()\n\
+^bb2:\n\
+  \"test.test\"() [^bb3] : () -> ()\n\
+^bb3:\n\
+  \"test.test\"() ({\n\
+^bb4:\n\
+    \"test.test\"() : () -> ()\n\
+  }) : () -> ()\n\
+}) : () -> ()"
+    #[ { name := "bb0", dominators := { "bb0" },               iDom := "bb0" }
+     , { name := "bb1", dominators := { "bb0", "bb1" },        iDom := "bb0" }
+     , { name := "bb2", dominators := { "bb0", "bb2" },        iDom := "bb0" }
+     , { name := "bb3", dominators := { "bb0", "bb3" },        iDom := "bb0" }
+     , { name := "bb4", dominators := { "bb0", "bb3", "bb4" }, iDom := "bb4" }
+     ]
+
+/-
+  Test: two levels of nesting.
+        ┌───────────┐
+        │     0     │
+        │ ┌───────┐ │
+        │ │   1   │ │
+        │ │ ┌───┐ │ │
+        │ │ │ 2 │ │ │
+        │ │ └───┘ │ │
+        │ └───────┘ │
+        └───────────┘
+-/
+def testDomTwoLevelNested : String :=
+  run
+    "\"builtin.module\"() ({\n\
+^bb0:\n\
+  \"test.test\"() : () -> ()\n\
+  \"test.test\"() ({\n\
+^bb1:\n\
+    \"test.test\"() : () -> ()\n\
+    \"test.test\"() ({\n\
+^bb2:\n\
+      \"test.test\"() : () -> ()\n\
+    }) : () -> ()\n\
+  }) : () -> ()\n\
+}) : () -> ()"
+    #[ { name := "bb0", dominators := { "bb0" },               iDom := "bb0" }
+     , { name := "bb1", dominators := { "bb0", "bb1" },        iDom := "bb1" }
+     , { name := "bb2", dominators := { "bb0", "bb1", "bb2" }, iDom := "bb2" }
+     ]
+
 /--
 info: "ok"
 -/
@@ -331,5 +429,23 @@ info: "ok"
 -/
 #guard_msgs in
 #eval! testDomIfLoopIf
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDomNestedRegions
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDomDiamondNestedJoin
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDomTwoLevelNested
 
 end DominanceAnalysis

--- a/UnitTest/DataFlowFramework/Dominance.lean
+++ b/UnitTest/DataFlowFramework/Dominance.lean
@@ -416,7 +416,7 @@ def testDomTwoLevelNested : String :=
   │      └─┬─┘     └───┘
   └────────┘
 -/
-def testDomDiamonLoop: String :=
+def testDomDiamondLoop: String :=
   run r#""builtin.module"() ({
 ^bb0:
   "test.test"() [^bb1, ^bb2] : () -> ()
@@ -481,6 +481,6 @@ info: "ok"
 info: "ok"
 -/
 #guard_msgs in
-#eval! testDomDiamonLoop
+#eval! testDomDiamondLoop
 
 end DominanceAnalysis

--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -279,31 +279,6 @@ def visit
       dfCtx.modifyFactAndPropagate .dominator anchor (fun fact =>
        (fact.setIDom (some newIDom), some newIDom ≠ fact.iDom)) irCtx
 
-/-- Recurse up the dominator tree to see if `dominator` dominates `block`. -/
-def dominates
-    (dominator block : BlockPtr)
-    (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode) : Bool := Id.run do
-  let some fact ← block.getDominatorFact? dfCtx irCtx | false
-  if dominator = block then 
-    return true
-  let mut current := fact.iDom
-  while let some candidate := current do
-    if candidate = dominator then
-      return true
-    let next := candidate.getIDom? dfCtx irCtx
-    if next = some candidate then
-      return false
-    current := next
-  false
-
-/-- Same thing as `dominates` except a block dominating itself doesn't count. -/
-def properlyDominates
-    (dominator block : BlockPtr)
-    (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode) : Bool :=
-  dominator ≠ block && dominates dominator block dfCtx irCtx
-
 end DominanceAnalysis
 
 def DominanceAnalysis : DataFlowAnalysis :=

--- a/Veir/IR/Dominance.lean
+++ b/Veir/IR/Dominance.lean
@@ -15,7 +15,7 @@ operations until the point lies in a block directly contained in `region`.
 If `point` already lies in `region`, it is returned unchanged. If the walk
 escapes the IR hierarchy before reaching `region`, return `none`.
 -/
-private partial def normalizeInsertPoint?
+private partial def normalizeInsertPoint
     (region : RegionPtr)
     (point : InsertPoint)
     (irCtx : IRContext OpCode) : Option InsertPoint := do
@@ -24,7 +24,7 @@ private partial def normalizeInsertPoint?
     return point
   let parentRegion ← (block.get! irCtx).parent
   let parentOp ← (parentRegion.get! irCtx).parent
-  normalizeInsertPoint? region (.before parentOp) irCtx
+  normalizeInsertPoint region (.before parentOp) irCtx
 
 /--
 Check dominance between two blocks that are already known
@@ -33,16 +33,16 @@ to lie in the same region.
 This follows the immediate dominator chain from `block` 
 upward until it either reaches `dominator` or the chain ends.
 -/
-private partial def dominatesWithinRegion
+private partial def BlockPtr.dominatesWithinRegion
     (dominator block : BlockPtr)
     (dfCtx : DataFlowContext)
-    (irCtx : IRContext OpCode) : Bool :=
+    (irCtx : IRContext OpCode) : Bool := Id.run do
   if dominator = block then
     true
   else
-    match block.getIDom? dfCtx irCtx with
-    | some idom => idom ≠ block && dominatesWithinRegion dominator idom dfCtx irCtx
-    | none => false
+    let some idom := block.getIDom? dfCtx irCtx | return false
+    idom ≠ block && dominatesWithinRegion dominator idom dfCtx irCtx
+
 
 /--
 Check dominance between two operations that are already known 
@@ -51,7 +51,7 @@ to lie in the same block.
 Iterates from `dominator` down the block until it either reaches 
 `op` or reaches the end of the block.
 -/
-private def dominatesWithinBlock
+private def OperationPtr.dominatesWithinBlock
     (dominator op : OperationPtr)
     (irCtx : IRContext OpCode) : Bool := Id.run do
   let mut current := some dominator
@@ -62,6 +62,24 @@ private def dominatesWithinBlock
   false
 
 namespace InsertPoint
+
+/--
+Check dominance between two points that are already known
+to lie in the same block.
+-/
+private def dominatesWithinBlock
+    (dominator point : InsertPoint)
+    (irCtx : IRContext OpCode) : Bool := Id.run do
+  if dominator = point then
+    return true
+  match dominator, point with
+    | .before dominatorOp, .before op =>
+        dominatorOp.dominatesWithinBlock op irCtx
+    | .before _, .atEnd _ =>
+        true
+    | .atEnd _, _ =>
+        false
+
 
 /--
 Proper dominance query between two insertion points.
@@ -84,33 +102,20 @@ private def properlyDominates
     | return false
   let some dominatorRegion := (dominatorBlock.get! irCtx).parent
     | return false
-  let pointInRegion? :=
-    match point.block! irCtx with
-    | none => none
-    | some pointBlock =>
-        if (pointBlock.get! irCtx).parent = dominatorRegion then
-          point
-        else
-          -- Scoot up the point's region tree until we find a location in the
-          -- dominator's region that encloses it.  If this fails, then we know 
-          -- there is no dominance relation.
-          normalizeInsertPoint? dominatorRegion point irCtx
-  let some point := pointInRegion?
-    | return false
+
+  -- If the point does not lie in the same region as `dominator`, scoot up
+  -- the point's region tree until we find a location in the dominator's
+  -- region that encloses it. If this fails, then we know `dominator`
+  -- doesn't properly dominate the point.
+  let some point := normalizeInsertPoint dominatorRegion point irCtx
+    | return false 
   let some pointBlock := point.block! irCtx
     | return false
 
-  if dominator = point then
-    return true
   if dominatorBlock = pointBlock then
-    match dominator, point with
-    | .before dominatorOp, .before op =>
-        return dominatesWithinBlock dominatorOp op irCtx
-    | .before _, .atEnd _ =>
-        return true
-    | .atEnd _, _ =>
-        return false
-  return dominatesWithinRegion dominatorBlock pointBlock dfCtx irCtx
+    dominator.dominatesWithinBlock point irCtx
+  else
+    return dominatorBlock.dominatesWithinRegion pointBlock dfCtx irCtx
 
 /--
 Dominance query between two insertion points.
@@ -141,7 +146,7 @@ def immediateDominator?
   block.getIDom? dfCtx irCtx
 
 /--
-Dominance query between two blocks.
+Dominance query between two blocks, where a block dominates itself.
 -/
 def dominates
     [FactSpec .dominator]
@@ -151,7 +156,7 @@ def dominates
   (InsertPoint.atStart! dominator irCtx).dominates (InsertPoint.atStart! block irCtx) dfCtx irCtx
 
 /--
-Proper version of `BlockPtr.dominates`.
+Dominance query between two blocks, where a block does not dominate itself.
 -/
 def properlyDominates
     [FactSpec .dominator]

--- a/Veir/IR/Dominance.lean
+++ b/Veir/IR/Dominance.lean
@@ -80,9 +80,8 @@ private def dominatesWithinBlock
     | .atEnd _, _ =>
         false
 
-
 /--
-Proper dominance query between two insertion points.
+Dominance query between two insertion points.
 
 If `point` lies in a nested region outside the region containing `dominator`, it
 is normalized into the dominator's region by replacing it with the enclosing
@@ -90,14 +89,11 @@ operation position. Once both insertion points lie in the same region,
 dominance is decided by same block insertion point order or by block
 dominance.
 -/
-private def properlyDominates
+private def dominates
     (dominator : InsertPoint)
     (point : InsertPoint)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : Bool := Id.run do
-  if dominator = point then
-    return false
-
   let some dominatorBlock := dominator.block! irCtx
     | return false
   let some dominatorRegion := (dominatorBlock.get! irCtx).parent
@@ -118,17 +114,17 @@ private def properlyDominates
     return dominatorBlock.dominatesWithinRegion pointBlock dfCtx irCtx
 
 /--
-Dominance query between two insertion points.
+Proper dominance query between two insertion points.
 
-An insertion point dominates itself. Otherwise this is the same query as
-`InsertPoint.properlyDominates`.
+An insertion point does not properly dominate itself. Otherwise this is the same query as `InsertPoint.dominates`.
 -/
-private def dominates
+private def properlyDominates
     (dominator : InsertPoint)
     (point : InsertPoint)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : Bool :=
-  dominator = point || dominator.properlyDominates point dfCtx irCtx
+  dominator ≠ point && dominator.dominates point dfCtx irCtx
+
 
 end InsertPoint
 

--- a/Veir/IR/Dominance.lean
+++ b/Veir/IR/Dominance.lean
@@ -6,6 +6,127 @@ public section
 
 namespace Veir
 
+open Std (HashSet)
+
+/--
+Normalize an insertion point into `region` by walking outward through enclosing
+operations until the point lies in a block directly contained in `region`.
+
+If `point` already lies in `region`, it is returned unchanged. If the walk
+escapes the IR hierarchy before reaching `region`, return `none`.
+-/
+private partial def normalizeInsertPoint?
+    (region : RegionPtr)
+    (point : InsertPoint)
+    (irCtx : IRContext OpCode) : Option InsertPoint := do
+  let block ← point.block! irCtx
+  if (block.get! irCtx).parent = some region then
+    return point
+  let parentRegion ← (block.get! irCtx).parent
+  let parentOp ← (parentRegion.get! irCtx).parent
+  normalizeInsertPoint? region (.before parentOp) irCtx
+
+/--
+Check dominance between two blocks that are already known
+to lie in the same region.
+
+This follows the immediate dominator chain from `block` 
+upward until it either reaches `dominator` or the chain ends.
+-/
+private partial def dominatesWithinRegion
+    (dominator block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  if dominator = block then
+    true
+  else
+    match block.getIDom? dfCtx irCtx with
+    | some idom => idom ≠ block && dominatesWithinRegion dominator idom dfCtx irCtx
+    | none => false
+
+/--
+Check dominance between two operations that are already known 
+to lie in the same block.
+
+Iterates from `dominator` down the block until it either reaches 
+`op` or reaches the end of the block.
+-/
+private def dominatesWithinBlock
+    (dominator op : OperationPtr)
+    (irCtx : IRContext OpCode) : Bool := Id.run do
+  let mut current := some dominator
+  while let some operation := current do
+    if operation = op then
+      return true
+    current := (operation.get! irCtx).next
+  false
+
+namespace InsertPoint
+
+/--
+Proper dominance query between two insertion points.
+
+If `point` lies in a nested region outside the region containing `dominator`, it
+is normalized into the dominator's region by replacing it with the enclosing
+operation position. Once both insertion points lie in the same region,
+dominance is decided by same block insertion point order or by block
+dominance.
+-/
+private def properlyDominates
+    (dominator : InsertPoint)
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool := Id.run do
+  if dominator = point then
+    return false
+
+  let some dominatorBlock := dominator.block! irCtx
+    | return false
+  let some dominatorRegion := (dominatorBlock.get! irCtx).parent
+    | return false
+  let pointInRegion? :=
+    match point.block! irCtx with
+    | none => none
+    | some pointBlock =>
+        if (pointBlock.get! irCtx).parent = dominatorRegion then
+          point
+        else
+          -- Scoot up the point's region tree until we find a location in the
+          -- dominator's region that encloses it.  If this fails, then we know 
+          -- there is no dominance relation.
+          normalizeInsertPoint? dominatorRegion point irCtx
+  let some point := pointInRegion?
+    | return false
+  let some pointBlock := point.block! irCtx
+    | return false
+
+  if dominator = point then
+    return true
+  if dominatorBlock = pointBlock then
+    match dominator, point with
+    | .before dominatorOp, .before op =>
+        return dominatesWithinBlock dominatorOp op irCtx
+    | .before _, .atEnd _ =>
+        return true
+    | .atEnd _, _ =>
+        return false
+  return dominatesWithinRegion dominatorBlock pointBlock dfCtx irCtx
+
+/--
+Dominance query between two insertion points.
+
+An insertion point dominates itself. Otherwise this is the same query as
+`InsertPoint.properlyDominates`.
+-/
+private def dominates
+    (dominator : InsertPoint)
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  dominator = point || dominator.properlyDominates point dfCtx irCtx
+
+end InsertPoint
+
 namespace BlockPtr
 
 /--
@@ -18,6 +139,27 @@ def immediateDominator?
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : Option BlockPtr :=
   block.getIDom? dfCtx irCtx
+
+/--
+Dominance query between two blocks.
+-/
+def dominates
+    [FactSpec .dominator]
+    (dominator block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  (InsertPoint.atStart! dominator irCtx).dominates (InsertPoint.atStart! block irCtx) dfCtx irCtx
+
+/--
+Proper version of `BlockPtr.dominates`.
+-/
+def properlyDominates
+    [FactSpec .dominator]
+    (dominator block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  (InsertPoint.atStart! dominator irCtx).properlyDominates
+    (InsertPoint.atStart! block irCtx) dfCtx irCtx
 
 end BlockPtr
 


### PR DESCRIPTION
Similar to MLIR, this is region-aware (i.e., you can ask for the dominance relation between two blocks from differing regions). I created private `InsertPoint` dominance functions which the public block dominance functions use. Operation dominance functions will use them too eventually. I also added tests for dominance with regions.