### PR TITLE
fix(ci): only store benchmarks results for PR from the same repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
           .github/scripts/run_benchmarks.sh 1000 100 5
 
       - name: Store benchmark result
-        if: github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
+        if: github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: VeIR Benchmarks


### PR DESCRIPTION
The relevant condition was previously reverted by accident. This is now fixed.