### PR TITLE
first-class support for LLVM void type

### DIFF
--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -212,6 +212,9 @@ macro "#assert " e:term : command =>
 /-! ## LLVM Pointer type -/
 #assert expectSuccessType "!llvm.ptr" (LLVM.PointerType.mk)
 
+/-! ## LLVM Void type -/
+#assert expectSuccessType "!llvm.void" (LLVM.VoidType.mk)
+
 /-! ## LLVM Array type -/
 #assert expectSuccessType "!llvm.array<2 x i32>" (LLVM.ArrayType.mk 2 $ IntegerType.mk 32)
 #assert expectSuccessAttr "!llvm.array<2 x !llvm.array<3x i64>>" (LLVM.ArrayType.mk 2 $ LLVM.ArrayType.mk 3 $ IntegerType.mk 64)
@@ -232,23 +235,23 @@ macro "#assert " e:term : command =>
 -- LLVM pretty-print sugar: bare `void` and `ptr` keywords inside `!llvm.func<...>`.
 #assert expectSuccessType "!llvm.func<void ()>"
   ⟨.llvmFunctionType (FunctionType.mk #[]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
+    #[(LLVM.VoidType.mk : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<void (i32)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(IntegerType.mk 32 : Attribute)]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
+    #[(LLVM.VoidType.mk : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<i32 (ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(LLVM.PointerType.mk : Attribute)] #[(IntegerType.mk 32 : Attribute)] (isVarArg := false)), by rfl⟩
 #assert expectSuccessType "!llvm.func<void (ptr, ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(LLVM.PointerType.mk : Attribute), (LLVM.PointerType.mk : Attribute)]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
+    #[(LLVM.VoidType.mk : Attribute)] (isVarArg := false)), by rfl⟩
 -- Bare sugar mixed with the explicit `!llvm.ptr` form within one function type.
 #assert expectSuccessType "!llvm.func<void (!llvm.ptr, ptr)>"
   ⟨.llvmFunctionType (FunctionType.mk
     #[(LLVM.PointerType.mk : Attribute), (LLVM.PointerType.mk : Attribute)]
-    #[(UnregisteredAttr.mk "!llvm.void" true : Attribute)] (isVarArg := false)), by rfl⟩
+    #[(LLVM.VoidType.mk : Attribute)] (isVarArg := false)), by rfl⟩
 -- Variadic function types: a trailing `...`, with or without fixed parameters.
 #assert expectSuccessType "!llvm.func<i32 (ptr, ...)>"
   ⟨.llvmFunctionType (FunctionType.mk

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -172,6 +172,9 @@ deriving Inhabited, Repr, DecidableEq, Hashable
 
 namespace LLVM
 
+structure VoidType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 structure PointerType
 deriving Inhabited, Repr, DecidableEq, Hashable
 
@@ -308,6 +311,8 @@ inductive Attribute
 | flatSymbolRefAttr (attr : FlatSymbolRefAttr)
 /-- HEIR modarith type -/
 | modArithType (type : ModArithType)
+/-- LLVM void type -/
+| llvmVoidType (type : LLVM.VoidType)
 /-- LLVM pointer type -/
 | llvmPointerType (type : LLVM.PointerType)
 /-- LLVM array type -/
@@ -488,6 +493,8 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case llvmVoidType.llvmVoidType type1 type2 =>
+    exact (isTrue (by grind))
   case llvmPointerType.llvmPointerType type1 type2 =>
     exact (isTrue (by grind))
   case llvmArrayType.llvmArrayType type1 type2 =>
@@ -596,6 +603,9 @@ instance : ToString ModArithType where
     | some modulusType => s!" : {modulusType}"
     | none => "") ++ ">"
 
+instance : ToString LLVM.VoidType where
+  toString _ := "!llvm.void"
+
 instance : ToString LLVM.PointerType where
   toString _ := "!llvm.ptr"
 
@@ -648,7 +658,10 @@ def FunctionType.toLLVMString (type : FunctionType) : String :=
   let paramStrs := if type.isVarArg then paramStrs ++ ["..."] else paramStrs
   let params := String.intercalate ", " paramStrs
   let result := match _ : type.outputs.size with
-    | 1 => Attribute.toString type.outputs[0]
+    | 1 =>
+      match type.outputs[0] with
+      | .llvmVoidType _ => "void"
+      | _ => Attribute.toString type.outputs[0]
     | _ => "<invalid>"
   s!"!llvm.func<{result} ({params})>"
 termination_by sizeOf type
@@ -708,6 +721,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .flatSymbolRefAttr attr => ToString.toString attr
   | .functionType type => type.toString
   | .modArithType type => ToString.toString type
+  | .llvmVoidType type => ToString.toString type
   | .llvmPointerType type => ToString.toString type
   | .llvmArrayType type => type.toString
   | .llvmFunctionType type => type.toLLVMString
@@ -782,6 +796,9 @@ instance : Coe FunctionType Attribute where
 instance : Coe ModArithType Attribute where
   coe type := .modArithType type
 
+instance : Coe LLVM.VoidType Attribute where
+  coe type := .llvmVoidType type
+
 instance : Coe LLVM.PointerType Attribute where
   coe type := .llvmPointerType type
 
@@ -826,6 +843,7 @@ def isType (attr : Attribute) : Bool :=
   | .modArithType _ => true
   | .registerType _ => true
   | .registerAttr _ => false
+  | .llvmVoidType _ => true
   | .llvmPointerType _ => true
   | .llvmArrayType _ => true
   | .llvmFunctionType _ => true
@@ -847,6 +865,8 @@ theorem isType_functionType type : (functionType type).isType = true := by rfl
 theorem isType_modArithType type : (modArithType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_registerType type : (registerType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_llvmVoidType type : (llvmVoidType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_llvmPointerType type : (llvmPointerType type).isType = true := by rfl
 @[simp, grind =]
@@ -908,6 +928,9 @@ instance : Coe ModArithType TypeAttr where
 
 instance : Coe RegisterType TypeAttr where
   coe type := ⟨.registerType type, by rfl⟩
+
+instance : Coe LLVM.VoidType TypeAttr where
+  coe type := ⟨.llvmVoidType type, by rfl⟩
 
 instance : Coe LLVM.PointerType TypeAttr where
   coe type := ⟨.llvmPointerType type, by rfl⟩

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -341,6 +341,18 @@ partial def parseOptionalLocationAttr : AttrParserM (Option Attribute) := do
   return some (LocationAttr.mk body)
 
 /--
+  Parse an LLVM void type `!llvm.void`, if present.
+-/
+partial def parseOptionalLLVMVoidType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "llvm.void".toByteArray then return none
+  let _ ← consumeToken
+  return some LLVM.VoidType.mk
+
+/--
   Parse an LLVM pointer type `!llvm.ptr`, if present.
 -/
 partial def parseOptionalLLVMPointerType : AttrParserM (Option TypeAttr) := do
@@ -492,7 +504,7 @@ partial def parseOptionalFunctionType : AttrParserM (Option FunctionType) := do
 -/
 partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM TypeAttr := do
   if ← parseOptionalKeyword "void".toByteArray then
-    return ⟨.unregisteredAttr (UnregisteredAttr.mk "!llvm.void" true), by grind⟩
+    return LLVM.VoidType.mk
   if ← parseOptionalKeyword "ptr".toByteArray then
     return (LLVM.PointerType.mk : TypeAttr)
   parseType errorMsg
@@ -537,6 +549,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some registerType
   if let some modArithType ← parseOptionalModArithType then
     return some modArithType
+  if let some llvmVoidType := ← parseOptionalLLVMVoidType then
+    return some llvmVoidType
   if let some llvmPointerType := ← parseOptionalLLVMPointerType then
     return some llvmPointerType
   if let some llvmArrayType := ← parseOptionalLLVMArrayType then


### PR DESCRIPTION
this is a preliminary patch to actually support LLVM's void type (instead of leaving it unregistered) prior to typechecking function return operations against functions' declared return types