### PR TITLE
feat(EDyadic.Round): add RoundingMode inductive

### DIFF
--- a/Veir/Data/FP/EDyadic.lean
+++ b/Veir/Data/FP/EDyadic.lean
@@ -2,3 +2,4 @@ module
 
 public import Veir.Data.FP.EDyadic.Basic
 public import Veir.Data.FP.EDyadic.Pack
+public import Veir.Data.FP.EDyadic.Round

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -1,0 +1,23 @@
+module
+
+namespace Veir.Data.FP
+
+public section
+
+/-- IEEE-754 rounding modes. -/
+inductive RoundingMode
+  /-- Round to nearest, tie away from zero. -/
+  | RNA
+  /-- Round to nearest, tie to even (default IEEE-754 mode). -/
+  | RNE
+  /-- Round toward negative infinity. -/
+  | RTN
+  /-- Round toward positive infinity. -/
+  | RTP
+  /-- Round toward zero. -/
+  | RTZ
+  deriving DecidableEq, Repr
+
+end -- public section
+
+end Veir.Data.FP

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -18,6 +18,6 @@ inductive RoundingMode
   | RTZ
   deriving DecidableEq, Repr
 
-end -- public section
+end
 
 end Veir.Data.FP


### PR DESCRIPTION
Introduce the `RoundingMode` inductive (`RNA`, `RNE`, `RTN`, `RTP`, `RTZ`) to represent floating point rounding modes. This PR adds no new behaviour.