### PR TITLE
Parse short-form LLVM array types

### DIFF
--- a/Test/LLVM/getelementptr.mlir
+++ b/Test/LLVM/getelementptr.mlir
@@ -15,7 +15,7 @@
       %g2 = "llvm.getelementptr"(%ptr, %i, %j) <{elem_type = !llvm.array<10 x i8>, rawConstantIndices = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
 
       // 3 dynamic indices: ptr[i][j][k]
-      %g3 = "llvm.getelementptr"(%ptr, %i, %j, %k) <{elem_type = !llvm.array<10 x !llvm.array<10 x i8>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
+      %g3 = "llvm.getelementptr"(%ptr, %i, %j, %k) <{elem_type = !llvm.array<10 x array<10 x i8>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64) -> !llvm.ptr
 
       // 4 dynamic indices: ptr[i][j][k][l]
       %g4 = "llvm.getelementptr"(%ptr, %i, %j, %k, %l) <{elem_type = !llvm.array<10 x !llvm.array<10 x !llvm.array<10 x i8>>>, rawConstantIndices = array<i32: -2147483648, -2147483648, -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64, i64, i64) -> !llvm.ptr

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -445,19 +445,23 @@ mutual
 
 /--
   Parse an LLVM array type, if present.
-  Its syntax is `!llvm.array<size x type>`.
+  Its syntax is `!llvm.array<size x type>`,
+  or (exclusively) the shorter form `array<size x type>` if the corresponding argument is set.
 -/
-partial def parseOptionalLLVMArrayType : AttrParserM (Option TypeAttr) := do
-  let token ← peekToken
-  let .exclamationIdent := token.kind | return none
-  let input := (← getThe ParserState).input
-  let typeName := { token.slice with start := token.slice.start + 1 }.of input
-  if typeName ≠ "llvm.array".toByteArray then return none
-  let _ ← consumeToken
+partial def parseOptionalLLVMArrayType (short := false) : AttrParserM (Option TypeAttr) := do
+  if short then
+    let .true ← parseOptionalKeyword "array".toByteArray | return none
+  else
+    let token ← peekToken
+    let .exclamationIdent := token.kind | return none
+    let input := (← getThe ParserState).input
+    let typeName := { token.slice with start := token.slice.start + 1 }.of input
+    if typeName ≠ "llvm.array".toByteArray then return none
+    let _ ← consumeToken
   parsePunctuation "<"
   let size ← parseInteger false false
   parseKeyword "x".toByteArray
-  let ty ← parseType
+  let ty ← parseLLVMType
   parsePunctuation ">"
   return some (LLVM.ArrayType.mk size.toNat ty)
 
@@ -495,6 +499,8 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
     return ⟨.unregisteredAttr (UnregisteredAttr.mk "!llvm.void" true), by grind⟩
   if ← parseOptionalKeyword "ptr".toByteArray then
     return (LLVM.PointerType.mk : TypeAttr)
+  if let some type ← parseOptionalLLVMArrayType true then
+    return type
   parseType errorMsg
 
 /--


### PR DESCRIPTION
This form is allowed inside other LLVM-related types.
