### PR TITLE
feat: add an API that can be queried to see if an operation has side effects

### DIFF
--- a/Test/Passes/DCE/basic.mlir
+++ b/Test/Passes/DCE/basic.mlir
@@ -8,9 +8,12 @@
   ^4():
     "func.func"() ({
       ^6(%1 : i64):
-        %2 = "test.test"(%1) : (i64) -> i64
+        %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64
         "test.test"(%1) : (i64) -> ()
-        // CHECK:      "test.test"(%{{.*}}) : (i64) -> ()
+        // The unused %2 is removed; the sink stays right after the block header.
+        // CHECK:      "func.func"() ({
+        // CHECK-NEXT: ^{{.*}}(%{{.*}} : i64):
+        // CHECK-NEXT: "test.test"(%{{.*}}) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
   
@@ -18,13 +21,14 @@
   ^5():
     "func.func"() ({
       ^6():
-        %1 = "test.test"() : () -> i64
-        %2 = "test.test"(%1) : (i64) -> i64
-        %3 = "test.test"(%1, %2) : (i64, i64) -> i64
-        %4 = "test.test"(%3) : (i64) -> i64
-        %5 = "test.test"(%4, %4) : (i64, i64) -> i64
+        %1 = "arith.constant"() <{ "value" = 1 : i64 }> : () -> i64
+        %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64
+        %3 = "llvm.add"(%1, %2) : (i64, i64) -> i64
+        %4 = "llvm.add"(%3, %3) : (i64, i64) -> i64
+        %5 = "llvm.add"(%4, %4) : (i64, i64) -> i64
         "test.test"(%1) : (i64) -> ()
-        // CHECK:      %{{.*}} = "test.test"() : () -> i64
+        // The dead chain %2..%5 is removed; %1 stays because the sink uses it.
+        // CHECK:      %{{.*}} = "arith.constant"() <{"value" = 1 : i64}> : () -> i64
         // CHECK-NEXT: "test.test"(%{{.*}}) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
@@ -33,17 +37,18 @@
   ^6():
     "func.func"() ({
       ^6():
-        %1 = "test.test"() : () -> i64
-        %2 = "test.test"(%1) : (i64) -> i64
-        %3 = "test.test"(%1, %2) : (i64, i64) -> i64
-        %4 = "test.test"(%3) : (i64) -> i64
-        %5 = "test.test"(%4, %4) : (i64, i64) -> i64
+        %1 = "arith.constant"() <{ "value" = 1 : i64 }> : () -> i64
+        %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64
+        %3 = "llvm.add"(%1, %2) : (i64, i64) -> i64
+        %4 = "llvm.add"(%3, %3) : (i64, i64) -> i64
+        %5 = "llvm.add"(%4, %4) : (i64, i64) -> i64
         "test.test"(%5) : (i64) -> ()
-        // CHECK:      %{{.*}} = "test.test"() : () -> i64
-        // CHECK-NEXT: %{{.*}} = "test.test"(%{{.*}}) : (i64) -> i64    
-        // CHECK-NEXT: %{{.*}} = "test.test"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64    
-        // CHECK-NEXT: %{{.*}} = "test.test"(%{{.*}}) : (i64) -> i64    
-        // CHECK-NEXT: %{{.*}} = "test.test"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64    
+        // The whole chain is live because the sink uses %5.
+        // CHECK:      %{{.*}} = "arith.constant"() <{"value" = 1 : i64}> : () -> i64
+        // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+        // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+        // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+        // CHECK-NEXT: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
         // CHECK-NEXT: "test.test"(%{{.*}}) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -8,6 +8,7 @@ public import Veir.Dialects.ModArith.OpInfo
 public import Veir.Dialects.Cf.OpInfo
 public import Veir.Dialects.Comb.OpInfo
 public import Veir.Dialects.HW.OpInfo
+public import Veir.IR.Basic
 
 namespace Veir
 
@@ -324,3 +325,40 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne
   | .hw .output => true
   | _ => false
+
+/--
+  Does this operation have effects that make it ineligible for DCE and
+  other transformations that add / remove / rearrange instructions?
+
+  NOTE: ¬ hasSideEffects does not imply that an operation is safe to
+        speculate. For that we also need it to never trigger immediate
+        UB. We'll have to deal with this later on.
+
+  Also see:
+  https://mlir.llvm.org/docs/Rationale/SideEffectsAndSpeculation/
+-/
+def OperationPtr.hasSideEffects (op : OperationPtr) (ctx : IRContext OpCode) : Bool :=
+  let opCode := op.getOpType! ctx
+  if opCode.isTerminator then true else
+  match opCode with
+  -- These dialects are pure
+  | .arith _ | .comb _ | .mod_arith _ | .datapath _ => false
+  | .builtin .unrealized_conversion_cast => false
+  | .hw .constant => false
+  -- RISC-V is pure register arithmetic except the memory ops
+  | .riscv .ld | .riscv .sd => true
+  | .riscv _ => false
+  -- For LLVM we enumerate the pure ops
+  | .llvm .mlir__constant
+  | .llvm .and | .llvm .or | .llvm .xor
+  | .llvm .add | .llvm .sub | .llvm .mul
+  | .llvm .sdiv | .llvm .udiv | .llvm .srem | .llvm .urem
+  | .llvm .shl | .llvm .lshr | .llvm .ashr
+  | .llvm .icmp | .llvm .select
+  | .llvm .trunc | .llvm .sext | .llvm .zext
+  | .llvm .alloca | .llvm .getelementptr
+  | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => false
+  -- Volatile loads are definitionally side-effecting
+  | .llvm .load => (op.getProperties! ctx (.llvm .load)).volatile_
+  -- For everything else: be conservative!
+  | _ => true

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -356,7 +356,7 @@ def OperationPtr.hasSideEffects (op : OperationPtr) (ctx : IRContext OpCode) : B
   | .llvm .shl | .llvm .lshr | .llvm .ashr
   | .llvm .icmp | .llvm .select
   | .llvm .trunc | .llvm .sext | .llvm .zext
-  | .llvm .alloca | .llvm .getelementptr
+  | .llvm .getelementptr
   | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => false
   -- Volatile loads are definitionally side-effecting
   | .llvm .load => (op.getProperties! ctx (.llvm .load)).volatile_

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -31,7 +31,7 @@ def reconcileRegistersPairingCast (rewriter : PatternRewriter OpCode) (op : Oper
   let rewriter ← rewriter.eraseOp op sorry sorry sorry
   /- If unused and side-effect-free, erase the parent cast operation as well.
     These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ hasSideEffects rewriter op'.op then
+  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ op'.op.hasSideEffects rewriter.ctx.raw then
     rewriter.eraseOp op'.op sorry sorry sorry
   else
     return rewriter
@@ -72,7 +72,7 @@ def reconcileIntegersPairingCast (rewriter : PatternRewriter OpCode) (op : Opera
   let rewriter ← rewriter.eraseOp op sorry sorry sorry
   /- If unused and side-effect-free, erase the parent cast operation as well.
     These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ hasSideEffects rewriter op'.op then
+  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ op'.op.hasSideEffects rewriter.ctx.raw then
     rewriter.eraseOp op'.op sorry sorry sorry
   else
     return rewriter

--- a/Veir/Passes/DCE/dce.lean
+++ b/Veir/Passes/DCE/dce.lean
@@ -6,19 +6,11 @@ namespace Veir
 
 /-! We implement a dead code elimination pass. -/
 
-/--
-  An operation is considered to have side effects if it has zero results.
-
-  TODO: replace this with a side-effect property on `OpCode`.
--/
-def hasSideEffects (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Bool :=
-  0 = op.getNumResults! rewriter.ctx.raw
-
 set_option warn.sorry false in
 def eliminateDeadOp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   /- delete operations that are not used and have no side effects -/
-  if ¬ op.hasUses! rewriter.ctx.raw && ¬ hasSideEffects rewriter op then
+  if ¬ op.hasUses! rewriter.ctx.raw && ¬ op.hasSideEffects rewriter.ctx.raw then
     rewriter.eraseOp op sorry sorry sorry
   else
     return rewriter


### PR DESCRIPTION
Note that there was some polymorphic use of `test.test` which required patching Test/Passes/DCE/basic.mlir regardless of whether it is side-effecting or not. I decided to make it side-effecting.