### PR TITLE
test: pass unregistered dialect flag to mlir-opt in MLIR_UNREGISTERED_ROUNDTRIP

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -39,7 +39,7 @@ if mlir_opt:
     config.substitutions.append(("MLIR_ROUNDTRIP",
      "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt | filecheck %s"))
     config.substitutions.append(("MLIR_UNREGISTERED_ROUNDTRIP",
-     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt --allow-unregistered-dialect | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt --allow-unregistered-dialect | filecheck %s"))
+     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope --allow-unregistered-dialect %s | .lake/build/bin/veir-opt --allow-unregistered-dialect | mlir-opt --mlir-print-op-generic --mlir-print-local-scope --allow-unregistered-dialect | .lake/build/bin/veir-opt --allow-unregistered-dialect | filecheck %s"))
   else:
     print(f"'mlir-opt' version {version_short} ({version}) detected, but only {mlir_versions_supported} supported. Skipping MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP", "true"))


### PR DESCRIPTION
Current behavior: `MLIR_UNREGISTERED_ROUNDTRIP` actually doesn't pass `--allow-unregistered-dialect` on the command-line to `mlir-opt`. @math-fehr is this intended?