### PR TITLE
test(parsing,cuda_tile): correctly test function type parsing with parentheses

### DIFF
--- a/Test/CudaTile/types.mlir
+++ b/Test/CudaTile/types.mlir
@@ -1,9 +1,6 @@
 // RUN: VEIR_ROUNDTRIP
 "builtin.module"() ({
-  // TODO(#675): the proper type should be without quotes, i.e.
-  // `!cuda_tile.ptr<i1> -> ()`. Our parser cannot handle this right now, it's a
-  // bug that should be fixed.
-  "func.func"() <{function_type = "!cuda_tile.ptr<i1> -> ()", sym_name = "main"}> ({
+  "func.func"() <{function_type = (!cuda_tile.ptr<i1>) -> (), sym_name = "main"}> ({
     ^bb0(%arg0: !cuda_tile.ptr<i1>):
       %0 = "test.test"() : () -> !cuda_tile.ptr<i1>
       "func.return"() : () -> ()
@@ -12,7 +9,7 @@
 
 // CHECK-NEXT: "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "func.func"() <{"function_type" = "!cuda_tile.ptr<i1> -> ()", "sym_name" = "main"}> ({
+// CHECK-NEXT:     "func.func"() <{"function_type" = (!cuda_tile.ptr<i1>) -> (), "sym_name" = "main"}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : !cuda_tile.ptr<i1>):
 // CHECK-NEXT:         %{{.*}} = "test.test"() : () -> !cuda_tile.ptr<i1>
 // CHECK-NEXT:         "func.return"() : () -> ()

--- a/Test/Parsing/function-type-parens.mlir
+++ b/Test/Parsing/function-type-parens.mlir
@@ -1,0 +1,19 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+// A function type with a parenthesized input list parses, matching MLIR. See #675.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> (), sym_name = "main"}> ({
+    ^bb0(%arg0: i32):
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK-NEXT: "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/Parsing/invalid-function-type-unparenthesized.mlir
+++ b/Test/Parsing/invalid-function-type-unparenthesized.mlir
@@ -1,0 +1,15 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+// A function type's input must be a parenthesized type list, matching MLIR: the
+// unparenthesized form `i32 -> ()` is rejected (use `(i32) -> ()` instead). See #675.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = i32 -> (), sym_name = "main"}> ({
+    ^bb0(%arg0: i32):
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:invalid-function-type-unparenthesized.mlir:7:39: error: closing delimiter '}' expected
+// CHECK-NEXT:  "func.func"() <{function_type = i32 -> (), sym_name = "main"}> ({
+// CHECK-NEXT:                                      ^

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -263,6 +263,9 @@ macro "#assert " e:term : command =>
 #assert expectSuccessType "!cuda_tile.ptr<i1>" (CudaTile.PointerType.mk (IntegerType.mk 1))
 #assert expectSuccessType "!cuda_tile.ptr<i32>" (CudaTile.PointerType.mk (IntegerType.mk 32))
 #assert expectErrorType "!cuda_tile.ptr<16>" "integer type expected" (some 15)
+-- A `!cuda_tile.ptr<...>` may appear as a (parenthesized) function-type input. See #675.
+#assert expectSuccessType "(!cuda_tile.ptr<i1>) -> ()"
+  (FunctionType.mk #[(CudaTile.PointerType.mk (IntegerType.mk 1) : Attribute)] #[] (isVarArg := false))
 
 /-! ## Flat symbol reference attribute -/
 #assert expectSuccessAttr "@foo" (FlatSymbolRefAttr.mk "@foo")


### PR DESCRIPTION
Fixes #675.

My claim about the intended behavior in #675 is actually incorrect. Per the MLIR syntax:
```
function-type     ::= (type | type-list-parens) `->` (type | type-list-parens)
```
So it's actually correct that `!cuda_tile.ptr<i1> -> ()` is not parse-able! Instead, it should be written as `(!cuda_tile.ptr<i1>) -> ()`. I fixed this test, and also added two tests that confirm we accept the latter (with parentheses) and reject the former (without parentheses). The positive test runs `MLIR_ROUNDTRIP` in addition to `VEIR_ROUNDTRIP` to asserting that `mlir-opt` has the same behavior.