### PR TITLE
test(parsing): verify that mlir-opt rejects unparenthesized function types

### DIFF
--- a/Test/Parsing/invalid-function-type-unparenthesized.mlir
+++ b/Test/Parsing/invalid-function-type-unparenthesized.mlir
@@ -1,4 +1,5 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+// RUN: MLIR_INVALID
 
 // A function type's input must be a parenthesized type list, matching MLIR: the
 // unparenthesized form `i32 -> ()` is rejected (use `(i32) -> ()` instead). See #675.
@@ -10,6 +11,6 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:invalid-function-type-unparenthesized.mlir:7:39: error: closing delimiter '}' expected
+// CHECK:invalid-function-type-unparenthesized.mlir:8:39: error: closing delimiter '}' expected
 // CHECK-NEXT:  "func.func"() <{function_type = i32 -> (), sym_name = "main"}> ({
 // CHECK-NEXT:                                      ^


### PR DESCRIPTION
Fully resolve the shenanigans surrounding the syntax of function types that grew out of #675. Complements #738. Depends on #739.