### PR TITLE
feat(RISCV): instruction selection pattern for `load`

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/load.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+
+"builtin.module"() ({
+    "func.func"() ({
+    ^bb0(%a: !llvm.ptr):
+        %val = "llvm.load"(%a) : (!llvm.ptr) -> i64
+        
+        "func.return"() : () -> ()
+    }) : () -> ()
+    
+}) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/load.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load.mlir
@@ -4,7 +4,9 @@
     "func.func"() ({
     ^bb0(%a: !llvm.ptr):
         %val = "llvm.load"(%a) : (!llvm.ptr) -> i64
-        
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !reg
+        // CHECK-NEXT: {{.*}} = "riscv.ld"({{.*}}) <{"value" = 0 : i64}> : (!reg) -> !reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
     

--- a/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+
+"builtin.module"() ({
+    "func.func"() ({
+    ^bb0(%a: !llvm.ptr):
+        %val = "llvm.load"(%a) : (!llvm.ptr) -> i32
+        // CHECK: {{.*}} = "llvm.load"({{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -606,24 +606,18 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | return rewriter
   if type'.bitwidth ≠ 64 then return rewriter
-  /- First, cast the pointer operand to a register -/
-  let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Actual `riscv.ld` -/
+  /- Create`riscv.ld` -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
+  let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[ptr]
       #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Cast back result for type consistency -/
-  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+  rewriter.replaceOp op ldOp sorry sorry sorry sorry sorry
 
 /-! # Pass implementation -/
 
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[constant, add, and, ashr, icmp, or, xor, mul,
-    sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub]
+    sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -606,7 +606,7 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | return rewriter
   if type'.bitwidth ≠ 64 then return rewriter
-  /- Create`riscv.ld` -/
+  /- Create`riscv.ld` with offset zero -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
   let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[ptr]
       #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -622,7 +622,7 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[constant, add, and, ashr, icmp, or, xor, mul,
-    sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load, store, gep]
+    sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -617,51 +617,6 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
-set_option warn.sorry false in
-def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
-    Option (PatternRewriter OpCode) := do
-  dbg_trace "store pattern invoked"
-  let some (ptr, val, _) := matchStore op rewriter.ctx | return rewriter
-  dbg_trace "store pattern matched"
-  /- only support storing `i64` -/
-  let .integerType vty := (val.getType! rewriter.ctx.raw).val | return rewriter
-  if vty.bitwidth ≠ 64 then return rewriter
-  /- value (i64) -> register -/
-  let (rewriter, vcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[val]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- ptr (!llvm.ptr) -> register -/
-  let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- `riscv.sd` with offset zero — order the operands to match sd's signature -/
-  let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, sdOp) ← rewriter.createOp (.riscv .sd) #[] #[vcastOp.getResult 0, pcastOp.getResult 0]
-      #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-  return rewriter
-
-set_option warn.sorry false in
-/-- llvm.getelementptr (i64 elem, single index) -> riscv.sh3add -/
-def gep (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
-    Option (PatternRewriter OpCode) := do
-  let some (base, idx, _) := matchGep op rewriter.ctx | return rewriter
-  /- only support element type `i64` (scale 8 = sh3add) with one index -/
-  let .integerType vty := (base.getType! rewriter.ctx.raw).val | return rewriter
-  if vty.bitwidth ≠ 64 then return rewriter
-  /- index (i64) -> register -/
-  let (rewriter, icastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[idx]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- base (!llvm.ptr) -> register -/
-  let (rewriter, bcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- `riscv.sh3add` -/
-  let (rewriter, addOp) ← rewriter.createOp (.riscv .sh3add) #[RegisterType.mk] #[icastOp.getResult 0, bcastOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- register -> !llvm.ptr -/
-  let ptrTy := ((op.getResult 0).get! rewriter.ctx.raw).type
-  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[ptrTy] #[addOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
-
-
 /-! # Pass implementation -/
 
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -616,6 +616,52 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+
+/-- llvm.store -> riscv.sd -/
+def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+    Option (PatternRewriter OpCode) := do
+  let some (val, ptr, _) := matchStore op rewriter.ctx | return rewriter
+  let .integerType vty := (val.getType! rewriter.ctx.raw).val | return rewriter
+  let type := ((op.getResult 0).get! rewriter.ctx.raw).type
+  /- only support storing `i64` -/
+  if vty.bitwidth ≠ 64 then return rewriter
+  /- value (i64) -> register -/
+  let (rewriter, vcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[val]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- ptr (!llvm.ptr) -> register -/
+  let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- `riscv.sd` with offset zero -/
+  let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+  let (rewriter, sdOp) ← rewriter.createOp (.riscv .sd) #[] #[vcastOp.getResult 0, pcastOp.getResult 0]
+      #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[sdOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+
+/-- llvm.getelementptr (i64 elem, single index) -> riscv.sh3add -/
+def gep (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+    Option (PatternRewriter OpCode) := do
+  let some (base, idx, _) := matchGep op rewriter.ctx | return rewriter
+  /- only support element type `i64` (scale 8 = sh3add) with one index -/
+  let .integerType vty := (base.getType! rewriter.ctx.raw).val | return rewriter
+  if vty.bitwidth ≠ 64 then return rewriter
+  /- index (i64) -> register -/
+  let (rewriter, icastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[idx]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- base (!llvm.ptr) -> register -/
+  let (rewriter, bcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- `riscv.sh3add` -/
+  let (rewriter, addOp) ← rewriter.createOp (.riscv .sh3add) #[RegisterType.mk] #[icastOp.getResult 0, bcastOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- register -> !llvm.ptr -/
+  let ptrTy := ((op.getResult 0).get! rewriter.ctx.raw).type
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[ptrTy] #[addOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+
+
 /-! # Pass implementation -/
 
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -602,16 +602,20 @@ set_option warn.sorry false in
 def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (ptr, _) := matchLoad op rewriter.ctx | return rewriter
-  /- only support `i64`: the constraint is on the loaded (result) type, not the pointer -/
+  /- only support `i64` (the loaded value type) -/
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | return rewriter
   if type'.bitwidth ≠ 64 then return rewriter
-  /- Create`riscv.ld` with offset zero -/
+  /- cast ptr (!llvm.ptr) -> register -/
+  let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- `riscv.ld` with offset zero -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[ptr]
+  let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
       #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-  rewriter.replaceOp op ldOp sorry sorry sorry sorry sorry
-
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 /-! # Pass implementation -/
 
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -617,13 +617,14 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
-/-- llvm.store -> riscv.sd -/
+set_option warn.sorry false in
 def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
-  let some (val, ptr, _) := matchStore op rewriter.ctx | return rewriter
-  let .integerType vty := (val.getType! rewriter.ctx.raw).val | return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx.raw).type
+  dbg_trace "store pattern invoked"
+  let some (ptr, val, _) := matchStore op rewriter.ctx | return rewriter
+  dbg_trace "store pattern matched"
   /- only support storing `i64` -/
+  let .integerType vty := (val.getType! rewriter.ctx.raw).val | return rewriter
   if vty.bitwidth ≠ 64 then return rewriter
   /- value (i64) -> register -/
   let (rewriter, vcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[val]
@@ -631,14 +632,13 @@ def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
   /- ptr (!llvm.ptr) -> register -/
   let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- `riscv.sd` with offset zero -/
+  /- `riscv.sd` with offset zero — order the operands to match sd's signature -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
   let (rewriter, sdOp) ← rewriter.createOp (.riscv .sd) #[] #[vcastOp.getResult 0, pcastOp.getResult 0]
       #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[sdOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+  return rewriter
 
+set_option warn.sorry false in
 /-- llvm.getelementptr (i64 elem, single index) -> riscv.sh3add -/
 def gep (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
@@ -667,7 +667,7 @@ def gep (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[constant, add, and, ashr, icmp, or, xor, mul,
-    sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load]
+    sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load, store, gep]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -597,6 +597,26 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
+set_option warn.sorry false in
+/-- llvm.load -> riscv.ld -/
+def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+    Option (PatternRewriter OpCode) := do
+  let some (ptr, _) := matchLoad op rewriter.ctx | return rewriter
+  /- only support `i64`: the constraint is on the loaded (result) type, not the pointer -/
+  let type := ((op.getResult 0).get! rewriter.ctx.raw).type
+  let .integerType type' := type.val | return rewriter
+  if type'.bitwidth ≠ 64 then return rewriter
+  /- First, cast the pointer operand to a register -/
+  let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- Actual `riscv.ld` -/
+  let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+  let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
+      #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+  /- Cast back result for type consistency -/
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 /-! # Pass implementation -/
 

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -130,12 +130,3 @@ def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × 
 def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .load)) := do
   let (op, properties) ← matchOp op ctx (.llvm .load) 1
   return (op[0]!, properties)
-
-def matchStore (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
-  let (operands, properties) ← matchOp op ctx (.llvm .store) 2
-  return (operands[0]!, operands[1]!, properties)
-
-def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .getelementptr)) := do
-  let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 1
-  return (op[0]!, op[1]!, properties)

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -126,3 +126,15 @@ def matchLshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
 def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .sub)) := do
   let (op, properties) ← matchOp op ctx (.llvm .sub) 2
   return (op[0]!, op[1]!, properties)
+
+def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
+  let (op, properties) ← matchOp op ctx (.llvm .load) 2
+  return (op[0]!, op[1]!, properties)
+
+def matchStore (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
+  let (op, properties) ← matchOp op ctx (.llvm .load) 2
+  return (op[0]!, op[1]!, properties)
+
+def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
+  let (op, properties) ← matchOp op ctx (.llvm .load) 2
+  return (op[0]!, op[1]!, properties)

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -131,10 +131,11 @@ def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
   let (op, properties) ← matchOp op ctx (.llvm .load) 1
   return (op[0]!, properties)
 
-def matchStore (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
-  let (op, properties) ← matchOp op ctx (.llvm .store) 2
-  return (op[0]!, op[1]!, properties)
+def matchStore (op : OperationPtr) (ctx : IRContext OpCode) :
+    Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
+  let (operands, properties) ← matchOp op ctx (.llvm .store) 2
+  return (operands[0]!, operands[1]!, properties)
 
-def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .getelementptr)) := do
+def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .getelementptr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 1
-  return (op[0]!, properties)
+  return (op[0]!, op[1]!, properties)

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -127,14 +127,14 @@ def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × 
   let (op, properties) ← matchOp op ctx (.llvm .sub) 2
   return (op[0]!, op[1]!, properties)
 
-def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
+def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .load)) := do
   let (op, properties) ← matchOp op ctx (.llvm .load) 1
-  return (op[0]!, op[1]!, properties)
+  return (op[0]!, properties)
 
 def matchStore (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
   let (op, properties) ← matchOp op ctx (.llvm .store) 2
   return (op[0]!, op[1]!, properties)
 
-def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .getelementptr)) := do
+def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .getelementptr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 1
-  return (op[0]!, op[1]!, properties)
+  return (op[0]!, properties)

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -128,13 +128,13 @@ def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × 
   return (op[0]!, op[1]!, properties)
 
 def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
-  let (op, properties) ← matchOp op ctx (.llvm .load) 2
+  let (op, properties) ← matchOp op ctx (.llvm .load) 1
   return (op[0]!, op[1]!, properties)
 
-def matchStore (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
-  let (op, properties) ← matchOp op ctx (.llvm .load) 2
+def matchStore (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
+  let (op, properties) ← matchOp op ctx (.llvm .store) 2
   return (op[0]!, op[1]!, properties)
 
-def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .load)) := do
-  let (op, properties) ← matchOp op ctx (.llvm .load) 2
+def matchGep (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .getelementptr)) := do
+  let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 1
   return (op[0]!, op[1]!, properties)


### PR DESCRIPTION
Add a basic instruction selection pattern for `llvm.load`, as inspected in LLVM [here](github.com/llvm/llvm-project/pull/201383).