### PR TITLE
feat(interpreter): replace `interpretOpList`

### DIFF
--- a/Veir/IR/WellFormed.lean
+++ b/Veir/IR/WellFormed.lean
@@ -867,7 +867,9 @@ theorem RegionPtr.WellFormed_unchanged {regionPtr : RegionPtr}
     regionPtr.WellFormed ctx' := by
   constructor <;> grind [RegionPtr.WellFormed]
 
-noncomputable def BlockPtr.operationList (block : BlockPtr) (ctx : IRContext OpInfo) (hctx : ctx.WellFormed) (hblock : block.InBounds ctx) : Array OperationPtr :=
+noncomputable def BlockPtr.operationList (block : BlockPtr) (ctx : IRContext OpInfo)
+    (hctx : ctx.WellFormed := by grind) (hblock : block.InBounds ctx := by grind) :
+    Array OperationPtr :=
   (hctx.opChain block hblock).choose
 
 theorem BlockPtr.operationListWF (ctx : IRContext OpInfo) (block : BlockPtr) (hblock : block.InBounds ctx)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1146,24 +1146,57 @@ def interpretOp (op : OperationPtr) {ctx : WfIRContext OpCode} (state : Interpre
   return (newState, action)
 
 /--
-  Interpret a list of operations, starting from the given operation pointer.
+  Interpret a chain of operations, starting from the given operation pointer.
   Continue to interpret operations until a terminator is encountered,
   or the end of the block is reached.
   Return a ControlFlowAction indicating how to continue the interpretation.
   Return `none` if any errors occur during interpretation.
 -/
-def interpretOpList (op : OperationPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+def interpretOpChain (op : OperationPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
     (opInBounds : op.InBounds ctx.raw := by grind)
     : Interp (InterpreterState ctx × ControlFlowAction) := do
   let (state, action) ← interpretOp op state
   match action with
   | none =>
     rlet next ← (op.get ctx.raw).next
-    interpretOpList next state
+    interpretOpChain next state
   | some action =>
     return (state, action)
 termination_by op.idxInParentFromTail ctx.raw
 decreasing_by grind
+
+/--
+  Interpret a list of operations passed as a `List`, stopping at the first terminator.
+  Return the new interpreter state, and an optional control flow action indicating how to
+  continue the interpretation, with an absent control flow action indicating that the end of the
+  list was reached without encountering a terminator.
+  Return `none` if any errors occur during interpretation.
+-/
+def interpretOpList {ctx : WfIRContext OpCode} (ops : List OperationPtr)
+    (state : InterpreterState ctx)
+    (opInBounds : ∀ op ∈ ops, op.InBounds ctx.raw := by grind)
+    : Interp (InterpreterState ctx × Option ControlFlowAction) :=
+  match ops with
+  | [] => return (state, none)
+  | op :: ops => do
+    let (state, action) ← interpretOp op state
+    match action with
+    | none => interpretOpList ops state (by grind)
+    | some cf => return (state, cf)
+
+/--
+  Interpret a list of operations passed as a `List`, stopping at the first terminator.
+  Return the new interpreter state, and a control flow action indicating how to continue the
+  interpretation. If no terminator is encountered, return `none`.
+  Return `none` if any errors occur during interpretation.
+-/
+def interpretTerminatedOpList {ctx : WfIRContext OpCode} (ops : List OperationPtr)
+    (state : InterpreterState ctx)
+    (opInBounds : ∀ op ∈ ops, op.InBounds ctx.raw := by grind)
+    : Interp (InterpreterState ctx × ControlFlowAction) := do
+  match ← interpretOpList ops state opInBounds with
+  | (_, none) => none
+  | (state, some cf) => return (state, cf)
 
 /--
   Interpret a block of operations, starting from the first operation in the block.
@@ -1178,7 +1211,7 @@ def interpretBlock (blockPtr : BlockPtr) (values : Array RuntimeValue) {ctx : Wf
   let newVars ← state.variables.setArgumentValues? blockPtr values
   let state := ⟨newVars, state.memory⟩
   rlet firstOp ← (blockPtr.get ctx.raw).firstOp
-  interpretOpList firstOp state
+  interpretOpChain firstOp state
 
 /--
   Interpret a CFG, starting from the given block.

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -206,3 +206,118 @@ theorem VariableState.setResultValues?_setResultValues?_self :
     simp only [hvs₂, Option.some.injEq]
     ext
     grind [VariableState.getVar?_setResultValues?]
+
+section interpretOpList
+
+variable {ctx : WfIRContext OpCode}
+variable {state : InterpreterState ctx}
+
+@[simp, grind =]
+theorem interpretOpList_nil :
+    interpretOpList [] state inBounds = some (.ok (state, none)) := by
+  simp [interpretOpList, pure]
+
+theorem interpretOpList_cons :
+    interpretOpList (op :: l) state inBounds =
+    match interpretOp op state with
+    | none => none
+    | some .ub => some .ub
+    | some (.ok (state', none)) => interpretOpList l state' (by grind)
+    | some (.ok (state', some cf)) => some (.ok (state', some cf)) := by
+  simp [interpretOpList, bind, pure]
+  grind
+
+theorem interpretOpList_append :
+    interpretOpList (l₁ ++ l₂) state inBounds =
+    match interpretOpList l₁ state (by grind) with
+    | some (.ok (state', none)) => interpretOpList l₂ state' (by grind)
+    | some (.ok (state', some cf)) => some (.ok (state', some cf))
+    | some .ub => some .ub
+    | none => none := by
+  induction l₁ generalizing state
+  · simp
+  · grind [interpretOpList_cons]
+
+@[simp, grind =]
+theorem interpretTerminatedOpList_nil :
+    interpretTerminatedOpList [] state inBounds = none := by
+  simp [interpretTerminatedOpList, interpretOpList_nil, bind]
+
+theorem interpretTerminatedOpList_cons {ctx : WfIRContext OpCode}
+    {op : OperationPtr} {l : List OperationPtr}
+    {state : InterpreterState ctx}
+    {inBounds : ∀ op' ∈ op :: l, op'.InBounds ctx.raw} :
+    interpretTerminatedOpList (op :: l) state inBounds =
+    match interpretOp op state with
+    | none => none
+    | some .ub => some .ub
+    | some (.ok (state', none)) => interpretTerminatedOpList l state' (by grind)
+    | some (.ok (state', some cf)) => some (.ok (state', cf)) := by
+  simp [interpretTerminatedOpList, interpretOpList_cons, bind, pure]
+  grind
+
+theorem interpretTerminatedOpList_append :
+    interpretTerminatedOpList (l₁ ++ l₂) state inBounds =
+    match interpretOpList l₁ state (by grind) with
+    | some (.ok (state', none)) => interpretTerminatedOpList l₂ state' (by grind)
+    | some (.ok (state', some cf))=> some (.ok (state', cf))
+    | some .ub => some .ub
+    | none => none := by
+  simp [interpretTerminatedOpList, interpretOpList_append, bind, pure]
+  grind
+
+theorem interpretOpChain_of_next!_eq_some {state' : InterpreterState ctx}
+    (hnext : (op.get! ctx.raw).next = some op') :
+    interpretOpChain op state' inBounds =
+    match interpretOp op state' (by grind) with
+    | none => none
+    | some .ub => some .ub
+    | some (.ok (state'', none)) => interpretOpChain op' state'' (by grind)
+    | some (.ok (state'', some cf)) => some (.ok (state'', cf)) := by
+  rw [interpretOpChain]
+  simp [bind, pure]
+  grind
+
+theorem interpretOpChain_of_next!_eq_none {state' : InterpreterState ctx}
+    (hnext : (op.get! ctx.raw).next = none) :
+    interpretOpChain op state' inBounds =
+    match interpretOp op state' (by grind) with
+    | none => none
+    | some .ub => some .ub
+    | some (.ok (_, none)) => none
+    | some (.ok (state'', some cf)) => some (.ok (state'', cf)) := by
+  rw [interpretOpChain]
+  simp [bind, pure]
+  grind
+
+@[simp, grind =]
+theorem Laeu {l : Array α} : List.drop l.size l.toList = [] := by
+  induction l <;> simp
+
+theorem interpretOpChain_getElem_array_eq_interpretTerminatedOpList_of_opChain
+    (hchain : BlockPtr.OpChain block ctx.raw array) (n : Nat) :
+    ∀ (i : Nat) (state' : InterpreterState ctx)
+      (_hni : i + n = array.size) (hi : i < array.size),
+      interpretOpChain array[i] state' (hchain.arrayInBounds (Array.getElem_mem hi)) =
+      interpretTerminatedOpList (array.toList.drop i) state' (by grind [BlockPtr.OpChain]) := by
+  induction n
+  case zero => grind
+  case succ n ih =>
+    intros i state' hni hi
+    have hnext := hchain.next hi
+    grind [interpretOpChain_of_next!_eq_none, interpretOpChain_of_next!_eq_some,
+      interpretTerminatedOpList_cons, List.drop_eq_getElem_cons]
+
+theorem interpretOpChain_eq_interpretTerminatedOpList_of_firstOp
+    {block : BlockPtr} (blockInBounds : block.InBounds ctx.raw) :
+    (block.get! ctx.raw).firstOp = some op →
+    interpretOpChain op state opInBounds =
+    interpretTerminatedOpList (block.operationList ctx.raw).toList state
+      (by grind [BlockPtr.operationListWF, BlockPtr.OpChain]) := by
+  intro hfirst
+  have hchain := BlockPtr.operationListWF ctx.raw block blockInBounds ctx.wellFormed
+  have := interpretOpChain_getElem_array_eq_interpretTerminatedOpList_of_opChain hchain
+    (block.operationList ctx.raw).size 0 state (by omega) (by grind [BlockPtr.OpChain])
+  grind [BlockPtr.OpChain]
+
+end interpretOpList


### PR DESCRIPTION
This renames `interpretOpList` to `interpretOpChain`, and implements `interpretOpList` and `interpretTerminatedOpList` which now takes a list as input.

`interpretOpList` doesn't expect to terminate with a terminator, while `interpretTerminatedOpList` expects it.

These function is going to be very useful to prove the correctness of rewrites, and overall to reason about interpreting a basic block.

This PR also add lemmas about `interpretOpList` and `interpretTerminatedOpList`