### PR TITLE
feat(EDyadic.Round): add lower computation helpers

### DIFF
--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -1,8 +1,14 @@
 module
 
+public import Veir.Data.FP.EDyadic.Basic
+public import Veir.Data.FP.FloatFormat
+public meta import Veir.Data.FP.FloatFormat -- for #guard evaluation.
+
 namespace Veir.Data.FP
 
 public section
+
+open FloatFormat (bias maxBiasedExponent)
 
 /-- IEEE-754 rounding modes. -/
 inductive RoundingMode
@@ -102,6 +108,58 @@ This is used when implementing round to nearest even.
 The truncated magnitude is even iff the LSB is false. -/
 private def computeIsTruncatedMagEven (mag : Nat) (k prec : Int) : Bool :=
   ! mag.testBit (lsbIndex k prec)
+
+/-! ## Nonnegative Lower Computation
+
+Here, we implement the `lower` computation for nonnegative inputs.
+
+-/
+
+/-- Truncated magnitude when rounding from source precision `k` to target
+precision `prec`: `mag >>> (k - prec)`. -/
+private def computeTruncatedMag (mag : Nat) (k prec : Int) : Nat :=
+  mag >>> (k - prec).toNat
+
+/-- The largest finite representable floating point in `(e, s)`,
+encoded as a `Dyadic`.
+
+= 1.111111111111 * 2 ^ (maxBiasedExponent e - bias e)
+  +--s bits--+
+= (2^(s+1) - 1) / 2^-s * 2^(maxBiasedExponent e - bias e)
+= (2^(s+1) - 1) * 2^((maxBiasedExponent e - bias e) - s)
+= (2^(s+1) - 1) * 2^(-(s - (maxBiasedExponent e - bias e)))
+-/
+private def maxFiniteDyadic (e s : Nat) : Dyadic :=
+  Dyadic.ofIntWithPrec ((2 : Int)^(s+1) - 1)
+    ((s : Int) - (maxBiasedExponent e - bias e : Int))
+
+/-- `mag · 2^(-k)` is strictly larger than the largest representable value
+of format `(e, _)`. The largest finite biased exponent is `2^e - 2`;
+anything above overflows. Used by the bracket helpers and position
+predicates to detect far-overflow inputs. -/
+private def isOverflow (mag : Nat) (k : Int) (e : Nat) : Bool :=
+  (bias e : Int) + (mag.log2 : Int) - k > maxBiasedExponent e
+
+/-- For `x = mag · 2^(-k) ≥ 0`: the greatest representable value `≤ x`
+in format `(e, s)`, as an `EDyadic`.
+
+- Overflow: Past `maxFinite`: `+maxFinite`.
+- Normal: Already at target precision (`k ≤ prec`): the input value itself.
+- Normal: Otherwise truncate: `mag >>> (k - prec)`.
+- Underflow: If the truncation is zero, saturate to `+0`.
+  Recall that `lower` computes the *greatest lower bound* of the input.
+  Thus, of the two choices between `-0` and `+0` both of which map to `0`,
+  we pick `+0` as `+0` is the greatest value `≤ 0`.
+-/
+private def computeLowerNonneg (mag : Nat) (k prec : Int) (e s : Nat) : EDyadic :=
+  if isOverflow mag k e then
+    EDyadic.ofDyadic false (maxFiniteDyadic e s)
+  else if k ≤ prec then
+    EDyadic.ofDyadic false (Dyadic.ofIntWithPrec (mag : Int) k)
+  else
+    let truncMag := computeTruncatedMag mag k prec
+    if truncMag = 0 then .zero false
+    else EDyadic.ofDyadic false (Dyadic.ofIntWithPrec (truncMag : Int) prec)
 
 end Dyadic
 

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -133,10 +133,8 @@ private def maxFiniteDyadic (e s : Nat) : Dyadic :=
   Dyadic.ofIntWithPrec ((2 : Int)^(s+1) - 1)
     ((s : Int) - (maxBiasedExponent e - bias e : Int))
 
-/-- `mag · 2^(-k)` is strictly larger than the largest representable value
-of format `(e, _)`. The largest finite biased exponent is `2^e - 2`;
-anything above overflows. Used by the bracket helpers and position
-predicates to detect far-overflow inputs. -/
+/--  If the exponent needed to represent`mag · 2^(-k)` is strictly larger than the largest 
+exponent, then we have an overflow. -/
 private def isOverflow (mag : Nat) (k : Int) (e : Nat) : Bool :=
   (bias e : Int) + (mag.log2 : Int) - k > maxBiasedExponent e
 

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -146,7 +146,7 @@ We write it in format `(e, s)`, as an `EDyadic`.
 
 - if `x` overflows (`≥ maxFinite`): `lower = +maxFinite`.
 - if `x` is nonzero finite and already at target precision (`k ≤ prec`): `lower = x`
-- if `x` is nonzero finite and not at target precision, we truncate: `lower = x.truncate (mag >>> (k - prec))`.
+- if `x` is nonzero finite and not at target precision, we truncate `mag`: `lower = mag.truncate (k - prec) · 2^(-prec)`.
 - if `x` underflows, i.e., the truncation is zero: `lower = +0`, recall that both `-0` and `+0` map to the 
   real`0`, and we pick `+0` as `+0` is the greatest value `≤ 0`.
 -/

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -147,7 +147,7 @@ We write it in format `(e, s)`, as an `EDyadic`.
 - if `x` overflows (≥ `maxFinite`): `lower = +maxFinite`.
 - if `x` is normal and already at target precision (`k ≤ prec`): `lower = x`
 - if `x` is normal and not at target precision, we truncate: `lower = x.truncate (mag >>> (k - prec))`.
-- if `x` underflows, i.e, the truncation is zero: `lower = +0`, recall that both `-0` and `+0` map to the 
+- if `x` underflows, i.e., the truncation is zero: `lower = +0`, recall that both `-0` and `+0` map to the 
   real`0`, and we pick `+0` as `+0` is the greatest value `≤ 0`.
 -/
 private def computeLowerNonneg (mag : Nat) (k prec : Int) (e s : Nat) : EDyadic :=

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -123,6 +123,8 @@ private def computeTruncatedMag (mag : Nat) (k prec : Int) : Nat :=
 /-- The largest finite representable floating point in `(e, s)`,
 encoded as a `Dyadic`.
 
+Recall that `maxBiasedExponent e - bias e` represents the highest exponent we can use to represent a normal number, i.e., a number that is not overflowing/underflowing. 
+
 = 1.111111111111 * 2 ^ (maxBiasedExponent e - bias e)
   +--s bits--+
 = (2^(s+1) - 1) / 2^-s * 2^(maxBiasedExponent e - bias e)

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -133,7 +133,7 @@ private def maxFiniteDyadic (e s : Nat) : Dyadic :=
   Dyadic.ofIntWithPrec ((2 : Int)^(s+1) - 1)
     ((s : Int) - (maxBiasedExponent e - bias e : Int))
 
-/--  If the exponent needed to represent`mag · 2^(-k)` is strictly larger than the largest 
+/-- If the exponent needed to represent`mag · 2^(-k)` is strictly larger than the largest 
 exponent, then we have an overflow. -/
 private def isOverflow (mag : Nat) (k : Int) (e : Nat) : Bool :=
   (bias e : Int) + (mag.log2 : Int) - k > maxBiasedExponent e

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -145,8 +145,8 @@ the *greatest lower bound* of the input, i.e., the greatest representable value 
 We write it in format `(e, s)`, as an `EDyadic`.
 
 - if `x` overflows (`≥ maxFinite`): `lower = +maxFinite`.
-- if `x` is normal and already at target precision (`k ≤ prec`): `lower = x`
-- if `x` is normal and not at target precision, we truncate: `lower = x.truncate (mag >>> (k - prec))`.
+- if `x` is nonzero finite and already at target precision (`k ≤ prec`): `lower = x`
+- if `x` is nonzero finite and not at target precision, we truncate: `lower = x.truncate (mag >>> (k - prec))`.
 - if `x` underflows, i.e., the truncation is zero: `lower = +0`, recall that both `-0` and `+0` map to the 
   real`0`, and we pick `+0` as `+0` is the greatest value `≤ 0`.
 -/

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -2,7 +2,7 @@ module
 
 public import Veir.Data.FP.EDyadic.Basic
 public import Veir.Data.FP.FloatFormat
-public meta import Veir.Data.FP.FloatFormat -- for #guard evaluation.
+public meta import Veir.Data.FP.FloatFormat
 
 namespace Veir.Data.FP
 

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -140,16 +140,15 @@ exponent, then we have an overflow. -/
 private def isOverflow (mag : Nat) (k : Int) (e : Nat) : Bool :=
   (bias e : Int) + (mag.log2 : Int) - k > maxBiasedExponent e
 
-/-- For `x = mag · 2^(-k) ≥ 0`: the greatest representable value `≤ x`
-in format `(e, s)`, as an `EDyadic`.
+/-- We compute the `lower` of a non-negative number for `x = mag · 2^(-k) ≥ 0` as 
+the *greatest lower bound* of the input, i.e., the greatest representable value `≤ x`.
+We write it in format `(e, s)`, as an `EDyadic`.
 
-- Overflow: Past `maxFinite`: `+maxFinite`.
-- Normal: Already at target precision (`k ≤ prec`): the input value itself.
-- Normal: Otherwise truncate: `mag >>> (k - prec)`.
-- Underflow: If the truncation is zero, saturate to `+0`.
-  Recall that `lower` computes the *greatest lower bound* of the input.
-  Thus, of the two choices between `-0` and `+0` both of which map to `0`,
-  we pick `+0` as `+0` is the greatest value `≤ 0`.
+- if `x` overflows (≥ `maxFinite`): `lower = +maxFinite`.
+- if `x` is normal and already at target precision (`k ≤ prec`): `lower = x`
+- if `x` is normal and not at target precision, we truncate: `lower = x.truncate (mag >>> (k - prec))`.
+- if `x` underflows, i.e, the truncation is zero: `lower = +0`, recall that both `-0` and `+0` map to the 
+  real`0`, and we pick `+0` as `+0` is the greatest value `≤ 0`.
 -/
 private def computeLowerNonneg (mag : Nat) (k prec : Int) (e s : Nat) : EDyadic :=
   if isOverflow mag k e then

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -144,7 +144,7 @@ private def isOverflow (mag : Nat) (k : Int) (e : Nat) : Bool :=
 the *greatest lower bound* of the input, i.e., the greatest representable value `≤ x`.
 We write it in format `(e, s)`, as an `EDyadic`.
 
-- if `x` overflows (≥ `maxFinite`): `lower = +maxFinite`.
+- if `x` overflows (`≥ maxFinite`): `lower = +maxFinite`.
 - if `x` is normal and already at target precision (`k ≤ prec`): `lower = x`
 - if `x` is normal and not at target precision, we truncate: `lower = x.truncate (mag >>> (k - prec))`.
 - if `x` underflows, i.e., the truncation is zero: `lower = +0`, recall that both `-0` and `+0` map to the 


### PR DESCRIPTION
Stage 2 of the EDyadic rounding stack (builds on #741, now merged).

Implement  `computeLowerNonneg mag k prec e s : EDyadic`, which produces the greatest representable value `≤ x`. This requires building up helpers for computing the split points of when a number is larger than the maxmimum finite value that floating point can represent.