### PR TITLE
feat(EDyadic.Round): add position predicates (lower-half, tie-break, parity)

### DIFF
--- a/UnitTest/FP/EDyadic.lean
+++ b/UnitTest/FP/EDyadic.lean
@@ -1,3 +1,4 @@
 module
 
 public import UnitTest.FP.EDyadic.Pack
+public import UnitTest.FP.EDyadic.Position

--- a/UnitTest/FP/EDyadic/Position.lean
+++ b/UnitTest/FP/EDyadic/Position.lean
@@ -1,0 +1,48 @@
+module
+
+import Veir.Data.FP.EDyadic.Round
+
+meta import Veir.Data.FP.EDyadic.Round
+
+namespace UnitTest.Fp.EDyadic.Position
+
+open Veir.Data.FP
+
+/-! ## `computeIsLowerHalf` -/
+
+-- `mag = 4 = 0b100`, source `k = 3`, target `prec = 0`, format `e = 11`:
+-- guard bit at position 2 is `1`, so the value `4/8 = 0.5` is at the
+-- midpoint — *not* in the strict lower half.
+#guard Dyadic.computeIsLowerHalf false 4 3 0 11 = false
+-- `mag = 3 = 0b011`: guard bit at position 2 is `0`, so `3/8` is in the strict lower half.
+#guard Dyadic.computeIsLowerHalf false 3 3 0 11 = true
+-- For negative inputs lower and upper swap, so the lower-half check is inverted.
+#guard Dyadic.computeIsLowerHalf true 4 3 0 11 = true
+-- For overflow: `mag = 1`, `k = -8` (= `2^8 = 256`) in `(e = 4, …)` where
+-- `maxFinite ≈ 240`. The Nonneg/Neg variants' override fires.
+#guard Dyadic.computeIsLowerHalf false 1 (-8) (-5) 4 = false
+#guard Dyadic.computeIsLowerHalf true 1 (-8) (-5) 4 = true
+
+/-! ## `computeIsTieBreak` -/
+
+-- `4 = 0b100`: guard `= 1`, sticky `= 0` ⇒ exact midpoint.
+#guard Dyadic.computeIsTieBreak 4 3 0 11 = true
+-- `5 = 0b101`: guard `= 1` but sticky `= 1` ⇒ past midpoint, not a tie.
+#guard Dyadic.computeIsTieBreak 5 3 0 11 = false
+-- `3 = 0b011`: guard `= 0` ⇒ below midpoint, not a tie.
+#guard Dyadic.computeIsTieBreak 3 3 0 11 = false
+-- Overflow is never a tie.
+#guard Dyadic.computeIsTieBreak 1 (-8) (-5) 4 = false
+
+/-! ## `computeIsLowerEven` / `computeIsUpperEven` -/
+
+-- `mag = 6 = 0b110`, `k = 2`, `prec = 0`: truncated mantissa bit (position 2) is `1`
+-- ⇒ truncated mag (`= 1`) is odd; for nonneg `x`, lower = trunc is odd,
+-- so `isLowerEven` is `false` and `isUpperEven` (trunc+1 = 2) is `true`.
+#guard Dyadic.computeIsLowerEven false 6 2 0 = false
+#guard Dyadic.computeIsUpperEven false 6 2 0 = true
+-- For negative `x`, lower and upper swap roles, so the parities flip.
+#guard Dyadic.computeIsLowerEven true 6 2 0 = true
+#guard Dyadic.computeIsUpperEven true 6 2 0 = false
+
+end UnitTest.Fp.EDyadic.Position

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -229,6 +229,47 @@ private def computeUpper (sign : Bool) (mag : Nat) (k prec : Int) (e s : Nat) : 
   if sign then computeUpperNeg mag k prec e s
   else computeUpperNonneg mag k prec e s
 
+/-! ## Position predicates: lower-half, tie-break, parity
+
+These predicates classify `x`'s position within the interval `[lower, upper]`.
+
+- `computeIsLowerHalf` checks whether `x` is strictly closer to `lower` than `upper`.
+- `computeIsTieBreak` checks whether`x` is exactly at the midpoint.
+- `computeIsLowerEven` / `computeIsUpperEven` checks whether the `lower` / `upper` candidat
+  have even magnitude (i.e. the lsb of the significand is zero).
+  This is used for RNE rounding.
+-/
+
+/-- Nonneg `x`: When `x` is finite, `x` is in the lower half iff the guard bit is zero.
+For overflow inputs, the abstract definition says that `x` is *never* in the lower half.
+-/
+private def computeIsLowerHalfNonneg (mag : Nat) (k prec : Int) (e : Nat) : Bool :=
+  if isOverflow mag k e then false
+  else ! computeGuardBit mag k prec
+
+/-- Neg `x`: `x` is not in the lower half iff `-x` is in the lower half. -/
+private def computeIsLowerHalfNeg (mag : Nat) (k prec : Int) (e : Nat) : Bool :=
+  ! computeIsLowerHalfNonneg mag k prec e
+
+/--  `x` is strictly in the lower half of the interval `[lower, upper]`. -/
+def computeIsLowerHalf (sign : Bool) (mag : Nat) (k prec : Int) (e : Nat) : Bool :=
+  if sign then computeIsLowerHalfNeg mag k prec e
+  else computeIsLowerHalfNonneg mag k prec e
+
+/-- A tie: `x` is exactly at the midpoint of `[lower, upper]`. Overflows are never ties. -/
+def computeIsTieBreak (mag : Nat) (k prec : Int) (e : Nat) : Bool :=
+  if isOverflow mag k e then false
+  else computeGuardBit mag k prec && ! computeStickyBit mag k prec
+
+/-- Whether the significand of `lower x` is even. -/
+def computeIsLowerEven (sign : Bool) (mag : Nat) (k prec : Int) : Bool :=
+  if sign then ! computeIsTruncatedMagEven mag k prec
+  else computeIsTruncatedMagEven mag k prec
+
+/-- Whether the significand of `upper x` is even. -/
+def computeIsUpperEven (sign : Bool) (mag : Nat) (k prec : Int) : Bool :=
+  ! computeIsLowerEven sign mag k prec
+
 end Dyadic
 
 end


### PR DESCRIPTION
This PR adds the predicates needed to make rounding decisions. The subsequent PRs will add in the rounding modes based on these decisions, and a toplevel `round` function.