### PR TITLE
feat(EDyadic.Round): add directional rounders (RTN, RTP, RTZ)

### DIFF
--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -270,6 +270,29 @@ def computeIsLowerEven (sign : Bool) (mag : Nat) (k prec : Int) : Bool :=
 def computeIsUpperEven (sign : Bool) (mag : Nat) (k prec : Int) : Bool :=
   ! computeIsLowerEven sign mag k prec
 
+/-! ## Directional rounders: RTN, RTP, RTZ
+
+These three modes deterministically pick `lower` or `upper`; they do not
+consult the guard/sticky bits beyond what `computeLower`/`computeUpper`
+already encode. Their integration-level behaviour is exercised in
+`UnitTest.FP.EDyadic.Round`. -/
+
+/-- Round toward `+∞`: always pick `upper`. -/
+private def computeRoundRTP
+    (sign : Bool) (mag : Nat) (k prec : Int) (e s : Nat) : EDyadic :=
+  computeUpper sign mag k prec e s
+
+/-- Round toward `−∞`: always pick `lower`. -/
+private def computeRoundRTN
+    (sign : Bool) (mag : Nat) (k prec : Int) (e s : Nat) : EDyadic :=
+  computeLower sign mag k prec e s
+
+/-- Round toward zero: pick the approximant whose magnitude is smaller. -/
+private def computeRoundRTZ
+    (sign : Bool) (mag : Nat) (k prec : Int) (e s : Nat) : EDyadic :=
+  if sign then computeUpper sign mag k prec e s
+  else computeLower sign mag k prec e s
+
 end Dyadic
 
 end


### PR DESCRIPTION
## Summary
Stage 6 of the EDyadic rounding stack. **Stacked on top of #751** (`round-edyadic-position`).

Adds three IEEE-754 rounding modes that round based on direction'.

- **`computeRoundRTP`** (round toward `+∞`): always pick `upper`.
- **`computeRoundRTN`** (round toward `−∞`): always pick `lower`.
- **`computeRoundRTZ`** (round toward zero): pick the approximant whose magnitude is smaller: i.e. `lower` for nonneg `x`, `upper` for neg `x`.
