### PR TITLE
fix(test): add Windows support for `lit`

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -15,10 +15,11 @@ for tool in ('clang', 'opt', 'mlir-translate', 'mlir-opt'):
 
 veir_root = Path(config.test_source_root).parent
 config.test_format = lit.formats.ShTest(preamble_commands=[f"cd {veir_root}"])
-config.substitutions.append(('veir-opt', ".lake/build/bin/veir-opt"))
-config.substitutions.append(('veir-interpret', ".lake/build/bin/veir-interpret"))
-config.substitutions.append(("VEIR_ROUNDTRIP", ".lake/build/bin/veir-opt %s | .lake/build/bin/veir-opt | filecheck %s"))
-config.substitutions.append(("VEIR_UNREGISTERED_ROUNDTRIP", ".lake/build/bin/veir-opt %s --allow-unregistered-dialect | .lake/build/bin/veir-opt --allow-unregistered-dialect | filecheck %s"))
+exe_suffix = ".exe" if os.name == "nt" else ""
+config.substitutions.append(('veir-opt', f".lake/build/bin/veir-opt{exe_suffix}"))
+config.substitutions.append(('veir-interpret', f".lake/build/bin/veir-interpret{exe_suffix}"))
+config.substitutions.append(("VEIR_ROUNDTRIP", f".lake/build/bin/veir-opt{exe_suffix} %s | .lake/build/bin/veir-opt{exe_suffix} | filecheck %s"))
+config.substitutions.append(("VEIR_UNREGISTERED_ROUNDTRIP", f".lake/build/bin/veir-opt{exe_suffix} %s --allow-unregistered-dialect | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | filecheck %s"))
 
 mlir_opt = lit.util.which('mlir-opt')
 mlir_versions_supported = ['22', '23']
@@ -37,9 +38,9 @@ if mlir_opt:
   if version_short in mlir_versions_supported:
     print(f"'mlir-opt' version {version_short} ({version}) detected. Running MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP",
-     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt | filecheck %s"))
+     f"mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt{exe_suffix} | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt{exe_suffix} | filecheck %s"))
     config.substitutions.append(("MLIR_UNREGISTERED_ROUNDTRIP",
-     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt --allow-unregistered-dialect | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt --allow-unregistered-dialect | filecheck %s"))
+     f"mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | filecheck %s"))
     # Assert that `mlir-opt` rejects the input. We only check that it fails
     # (non-zero exit), not the exact diagnostic, since:
 	# 1. The message might not be stable across `mlir-opt` versions.


### PR DESCRIPTION
`lit.cfg` is substituting `veir-opt` to be `.lake/build/bin/veir-opt`, while on windows there is an additional `.exe` extension.