### PR TITLE
feat(parser): add locations on error thrown by `MlirParser.lean`

### DIFF
--- a/Test/Parsing/invalid-property-type.mlir
+++ b/Test/Parsing/invalid-property-type.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %r = "arith.constant"() <{"value" = "hello"}> : () -> i32
+}) : () -> ()
+
+// CHECK:invalid-property-type.mlir:4:27: error: arith.constant: expected 'value' to be an integer attribute, but got "hello"
+// CHECK-NEXT:  %r = "arith.constant"() <{"value" = "hello"}> : () -> i32
+// CHECK-NEXT:                          ^

--- a/Test/Parsing/invalid-result-number.mlir
+++ b/Test/Parsing/invalid-result-number.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a = "test.test"() : () -> i32
+  %b = "test.test"(%a#abc) : (i32) -> i1
+}) : () -> ()
+
+// CHECK:invalid-result-number.mlir:5:22: error: invalid SSA value result number
+// CHECK-NEXT:  %b = "test.test"(%a#abc) : (i32) -> i1
+// CHECK-NEXT:                     ^

--- a/Test/Parsing/missing-properties.mlir
+++ b/Test/Parsing/missing-properties.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %r = "arith.constant"() : () -> i32
+}) : () -> ()
+
+// CHECK:missing-properties.mlir:4:27: error: arith.constant: missing 'value' property
+// CHECK-NEXT:  %r = "arith.constant"() : () -> i32
+// CHECK-NEXT:                          ^

--- a/Test/Parsing/operand-count-mismatch.mlir
+++ b/Test/Parsing/operand-count-mismatch.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a = "test.test"() : (i32) -> i32
+}) : () -> ()
+
+// CHECK:operand-count-mismatch.mlir:4:8: error: operation 'test.test' declares 1 operand types, but 0 operands were provided
+// CHECK-NEXT:  %a = "test.test"() : (i32) -> i32
+// CHECK-NEXT:       ^

--- a/Test/Parsing/result-count-zero.mlir
+++ b/Test/Parsing/result-count-zero.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a:0 = "test.test"() : () -> ()
+}) : () -> ()
+
+// CHECK:result-count-zero.mlir:4:3: error: expected named operation to have at least 1 result
+// CHECK-NEXT:  %a:0 = "test.test"() : () -> ()
+// CHECK-NEXT:  ^

--- a/Test/Parsing/result-type-count-mismatch.mlir
+++ b/Test/Parsing/result-type-count-mismatch.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %a:2 = "test.test"() : () -> i32
+}) : () -> ()
+
+// CHECK:result-type-count-mismatch.mlir:4:10: error: operation 'test.test' declares 1 result types, but 2 result values were provided
+// CHECK-NEXT:  %a:2 = "test.test"() : () -> i32
+// CHECK-NEXT:         ^

--- a/Test/Parsing/type-expected.mlir
+++ b/Test/Parsing/type-expected.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  "test.test"() : () ->
+}) : () -> ()
+
+// CHECK:type-expected.mlir:5:1: error: type expected
+// CHECK-NEXT:}) : () -> ()
+// CHECK-NEXT:^

--- a/Test/Parsing/use-of-undefined-value.mlir
+++ b/Test/Parsing/use-of-undefined-value.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  %b = "test.test"(%c) : (i32) -> i1
+}) : () -> ()
+
+// CHECK:use-of-undefined-value.mlir:4:20: error: use of undefined value %c
+// CHECK-NEXT:  %b = "test.test"(%c) : (i32) -> i1
+// CHECK-NEXT:                   ^

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -258,7 +258,7 @@ def parseOpResult : MlirParserM (ByteArray × Nat × Location) := do
 
   let count := (← parseInteger false false).toNat
   if count ≤ 1 then
-    throwString "expected named operation to have at least 1 result"
+    throwAt tokenPos "expected named operation to have at least 1 result"
 
   return (name, count, tokenPos)
 
@@ -319,9 +319,10 @@ def parseOperand : MlirParserM UnresolvedOperand := do
     | return UnresolvedOperand.mk name none tokenPos
 
   /- Parse the result count as a Nat. -/
+  let hashPos := resultCount.slice.start
   let resultCount := { resultCount.slice with start := resultCount.slice.start + 1 }.of (← getInput) -- skip # character
   let some resultCount := String.fromUTF8? resultCount >>= String.toNat?
-    | throwString "invalid SSA value result number"
+    | throwAt hashPos "invalid SSA value result number"
   return UnresolvedOperand.mk name resultCount tokenPos
 
 /--
@@ -352,7 +353,7 @@ def parseBlockOperands : MlirParserM (Array BlockPtr) := do
 -/
 def resolveOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) : MlirParserM ValuePtr := do
   let some (values, defPos) := (← getValues? operand.name)
-    | throwString s!"use of undefined value %{operand.nameString}"
+    | throwAt operand.pos s!"use of undefined value %{operand.nameString}"
   let some value := values[operand.indexD]?
     | throw (({ msg := s!"invalid result index {operand.indexD} for %{operand.nameString}",
                 pos := some operand.pos } : ParserError).addNote defPos "value defined here")
@@ -380,7 +381,7 @@ def parseOptionalType : MlirParserM (Option TypeAttr) := do
 def parseType (errorMsg : String := "type expected") : MlirParserM TypeAttr := do
   match ← parseOptionalType with
   | some ty => return ty
-  | none => throwString errorMsg
+  | none => throwAtCurrentPos errorMsg
 
 /--
   Parse an operation type, consisting of a colon followed by a function type.
@@ -415,10 +416,11 @@ def parseTypedValue : MlirParserM (ByteArray × TypeAttr × Location) := do
   to parse valid MLIR syntax.
 -/
 def parseOpProperties (opCode : OpCode) : MlirParserM (propertiesOf opCode) := do
+  let propertiesStart ← getPos
   if not (← parseOptionalPunctuation "<") then
     match Properties.fromAttrDict opCode {} with
     | .ok properties => return properties
-    | .error err => throwString err
+    | .error err => throwAtCurrentPos err
   let allowUnregisteredDialect := (← get).allowUnregisteredDialect
   match AttrParser.parseAttributeDictionary.run { allowUnregisteredDialect } (← getThe ParserState) with
   | .ok (properties, _, parserState) =>
@@ -426,7 +428,7 @@ def parseOpProperties (opCode : OpCode) : MlirParserM (propertiesOf opCode) := d
     parsePunctuation ">"
     match Properties.fromAttrDict opCode (.ofArray properties) with
     | .ok properties => return properties
-    | .error err => throwString err
+    | .error err => throwAt propertiesStart err
   | .error err => throw err
 
 /--
@@ -524,11 +526,11 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
 
   /- Check that the number of results matches with the operation type. -/
   if outputTypes.size ≠ numResults then
-    throwString s!"operation '{opName}' declares {outputTypes.size} result types, but {numResults} result values were provided"
+    throwAt opNameStart s!"operation '{opName}' declares {outputTypes.size} result types, but {numResults} result values were provided"
 
   /- Check that the number and types of operands matches with the operation type. -/
   if inputTypes.size ≠ operands.size then
-    throwString s!"operation '{opName}' declares {inputTypes.size} operand types, but {operands.size} operands were provided"
+    throwAt opNameStart s!"operation '{opName}' declares {inputTypes.size} operand types, but {operands.size} operands were provided"
   let operands ← operands.zip inputTypes |>.mapM (fun (operand, type) => resolveOperand operand type)
 
   let op ← modifyContextM' fun ctx => do
@@ -537,7 +539,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
     let ⟨hregions⟩ ← checkAllRegionsInBounds regions ctx.raw
     let ⟨hins⟩ ← checkMaybeInsertPointInBounds ip ctx.raw
     match hctx' : Rewriter.createOp ctx opId outputTypes operands blockOperands regions properties ip hoper hblockOperands hregions hins with
-    | none => throwString "internal error: failed to create operation"
+    | none => throwAt opNameStart "internal error: failed to create operation"
     | some (ctx', op) =>
       have hop : op.InBounds ctx' := Rewriter.createOp_new_inBounds op hctx'
       let ctx'' := op.setAttributes ctx' attrs hop
@@ -576,7 +578,7 @@ partial def parseRegion : MlirParserM RegionPtr := do
   parsePunctuation "{"
   let region := ← modifyContextM' fun ctx => do
     match hctx' : Rewriter.createRegion ctx with
-    | none => throwString "internal error: failed to create region"
+    | none => throwAtCurrentPos "internal error: failed to create region"
     | some (ctx', region) => pure (region, ⟨ctx', by grind [IRContext.wellFormed_Rewriter_createRegion]⟩)
 
   /- Case where there are no blocks inside the region. -/


### PR DESCRIPTION
These are the last errors in `MlirParser.lean` that were missing locations.