### PR TITLE
test: relax fastNTT test so it passes on MacOS

### DIFF
--- a/Test/Vcc/fastntt.c
+++ b/Test/Vcc/fastntt.c
@@ -96,8 +96,8 @@ __attribute__((always_inline)) void fastNTT(long *coeffs, long n, long cmod, con
 
 // CHECK: "builtin.module"() ({
 // CHECK-NEXT:   ^4():
-// CHECK-NEXT:     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
-// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, "passthrough" = {{\[\[}}"min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "fastNTT", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:     "llvm.module_flags"()
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], {{.*}}"function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, {{.*}}"sym_name" = "fastNTT"{{.*}}}> ({
 // CHECK-NEXT:       ^7(%[[VAL_0:.*]] : !llvm.ptr, %[[VAL_1:.*]] : i64, %[[VAL_2:.*]] : i64, %[[VAL_3:.*]] : !llvm.ptr, %[[VAL_4:.*]] : i64, %[[VAL_5:.*]] : i64):
 // CHECK-NEXT:         %[[VAL_6:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
 // CHECK-NEXT:         %[[VAL_7:.*]] = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
@@ -204,4 +204,4 @@ __attribute__((always_inline)) void fastNTT(long *coeffs, long n, long cmod, con
 // CHECK-NEXT:       ^40():
 // CHECK-NEXT:         "llvm.return"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT: }) {"dlti.dl_spec" = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, "llvm.ident" = "Ubuntu clang version 18.1.3 (1ubuntu1)", "llvm.module_asm" = [], "llvm.target_triple" = "x86_64-pc-linux-gnu"} : () -> ()
+// CHECK-NEXT: }) {{.*}} : () -> ()


### PR DESCRIPTION
clang for MacOS and clang for Linux inject some different metadata into the LLVM module they emit. this was causing fastNTT to fail on my Mac.

this PR relaxes the checks so that we only check for a common subset. 

another way to fix this would be to insert Linux-specific and OSX-specific CHECK: lines into the test case, but that feels like overkill to me.