### PR TITLE
feat(llvm): support cconv and linkage attributes

### DIFF
--- a/Test/LLVM/cconv-linkage.mlir
+++ b/Test/LLVM/cconv-linkage.mlir
@@ -1,0 +1,25 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i32 (f64)>, linkage = #llvm.linkage<external>, sym_name = "f1", visibility_ = 0 : i64}> ({
+  ^bb0(%arg0: f64):
+    "llvm.unreachable"() : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{CConv = #llvm.cconv<fastcc>, function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<internal>, sym_name = "f2", visibility_ = 0 : i64}> ({
+  ^bb0(%arg0: i32):
+    "llvm.unreachable"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, "function_type" = !llvm.func<i32 (f64)>, "linkage" = #llvm.linkage<external>, "sym_name" = "f1", "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : f64):
+// CHECK-NEXT:         "llvm.unreachable"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<fastcc>, "function_type" = !llvm.func<void (i32)>, "linkage" = #llvm.linkage<internal>, "sym_name" = "f2", "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT:         "llvm.unreachable"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -259,6 +259,12 @@ macro "#assert " e:term : command =>
 #assert expectSuccessType "!llvm.func<i32 (...)>"
   ⟨.llvmFunctionType (FunctionType.mk #[] #[(IntegerType.mk 32 : Attribute)] (isVarArg := true)), by rfl⟩
 
+/-! ## LLVM calling convention and linkage attributes -/
+#assert expectSuccessAttr "#llvm.cconv<ccc>" (CConvAttr.mk "ccc")
+#assert expectSuccessAttr "#llvm.cconv<fastcc>" (CConvAttr.mk "fastcc")
+#assert expectSuccessAttr "#llvm.linkage<external>" (LinkageAttr.mk "external")
+#assert expectSuccessAttr "#llvm.linkage<internal>" (LinkageAttr.mk "internal")
+
 /-! ## CUDA Pointer type -/
 #assert expectSuccessType "!cuda_tile.ptr<i1>" (CudaTile.PointerType.mk (IntegerType.mk 1))
 #assert expectSuccessType "!cuda_tile.ptr<i32>" (CudaTile.PointerType.mk (IntegerType.mk 32))

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -74,6 +74,20 @@ structure FastMathFlagsAttr where
   nsz : Bool
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/--
+  LLVM calling convention attribute, e.g. `#llvm.cconv<ccc>`.
+-/
+structure CConvAttr where
+  value : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  LLVM linkage attribute, e.g. `#llvm.linkage<external>`.
+-/
+structure LinkageAttr where
+  value : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 structure RegisterAttr where
   value : Int
   type : RegisterType
@@ -287,6 +301,10 @@ inductive Attribute
 | floatAttr (attr : FloatAttr)
 /-- Float fast math flags attribute -/
 | fastMathFlagsAttr (attr : FastMathFlagsAttr)
+/-- LLVM calling convention attribute -/
+| cconvAttr (attr : CConvAttr)
+/-- LLVM linkage attribute -/
+| linkageAttr (attr : LinkageAttr)
 /-- Register type -/
 | registerType (type : RegisterType)
 /-- Register attribute -/
@@ -445,6 +463,14 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case cconvAttr.cconvAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case linkageAttr.linkageAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case unregisteredAttr.unregisteredAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -553,6 +579,12 @@ instance : ToString FastMathFlagsAttr where
       if type.nsz then array := array ++ ["nsz"]
       if !type.nnan && !type.ninf && !type.nsz then array := array ++ ["none"]
     s!"#llvm.fastmath<{String.intercalate ", " array}>"
+
+instance : ToString CConvAttr where
+  toString attr := s!"#llvm.cconv<{attr.value}>"
+
+instance : ToString LinkageAttr where
+  toString attr := s!"#llvm.linkage<{attr.value}>"
 
 instance : ToString IntegerAttr where
   toString attr := s!"{attr.value} : {attr.type}"
@@ -707,6 +739,8 @@ def Attribute.toString (attr : Attribute) : String :=
   | .integerType type => ToString.toString type
   | .floatType type => ToString.toString type
   | .fastMathFlagsAttr attr => ToString.toString attr
+  | .cconvAttr attr => ToString.toString attr
+  | .linkageAttr attr => ToString.toString attr
   | .integerAttr attr => ToString.toString attr
   | .floatAttr attr => ToString.toString attr
   | .registerType type => ToString.toString type
@@ -759,6 +793,12 @@ instance : Coe FloatType Attribute where
 
 instance : Coe FastMathFlagsAttr Attribute where
   coe flags := .fastMathFlagsAttr flags
+
+instance : Coe CConvAttr Attribute where
+  coe attr := .cconvAttr attr
+
+instance : Coe LinkageAttr Attribute where
+  coe attr := .linkageAttr attr
 
 instance : Coe IntegerAttr Attribute where
   coe attr := .integerAttr attr
@@ -829,6 +869,8 @@ def isType (attr : Attribute) : Bool :=
   | .integerType _ => true
   | .floatType _ => true
   | .fastMathFlagsAttr _ => false
+  | .cconvAttr _ => false
+  | .linkageAttr _ => false
   | .integerAttr _ => false
   | .floatAttr _ => false
   | .stringAttr _ => false
@@ -856,6 +898,10 @@ theorem isType_integerType type : (integerType type).isType = true := by rfl
 theorem isType_floatType type : (floatType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_fastMathFlags flags : (fastMathFlagsAttr flags).isType = false := by rfl
+@[simp, grind =]
+theorem isType_cconv attr : (cconvAttr attr).isType = false := by rfl
+@[simp, grind =]
+theorem isType_linkage attr : (linkageAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_unregistered unregistered :
   (unregisteredAttr unregistered).isType = unregistered.isType := by rfl

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -311,6 +311,18 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   if dialectName = "llvm.fastmath".toByteArray then do
     return ← parseFloatFastMathFlagsAttr
 
+  if dialectName = "llvm.cconv".toByteArray then do
+    parsePunctuation "<"
+    let body ← parseUnregisteredAttrBody
+    parsePunctuation ">"
+    return some (CConvAttr.mk body : Attribute)
+
+  if dialectName = "llvm.linkage".toByteArray then do
+    parsePunctuation "<"
+    let body ← parseUnregisteredAttrBody
+    parsePunctuation ">"
+    return some (LinkageAttr.mk body : Attribute)
+
   if !(← getThe AttrParserState).allowUnregisteredDialect then
     throwAt startPos s!"attribute is not registered. Consider using --allow-unregistered-dialect."
   parsePunctuation "<"


### PR DESCRIPTION
this is supposed to be a boring PR that simply supports a couple of LLVM attributes. this is on the path to roundtripping LLVM-dialect MLIR from `clang` without requiring our `--allow-unregistered-dialect` flag