### PR TITLE
feat(ir): Add lemmas about `getResults!` and `idxOf`

### DIFF
--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -739,6 +739,15 @@ theorem getResults!.getElem_eq_getResult
   simp only [getResults!, getResult]
   grind
 
+theorem getResult_eq_of_idxOf_getResults! {op : OperationPtr} :
+    value ∈ op.getResults! ctx →
+    (op.getResults! ctx).idxOf value = index →
+    op.getResult index = value := by
+  grind [Array.getElem?_idxOf]
+
+grind_pattern getResult_eq_of_idxOf_getResults! =>
+  value ∈ op.getResults! ctx, (op.getResults! ctx).idxOf value, op.getResult index
+
 def getResultTypes (op : OperationPtr) (ctx : IRContext OpInfo)
     (inBounds : op.InBounds ctx := by grind) : Array TypeAttr :=
   (op.get ctx).results.map (·.type)


### PR DESCRIPTION
This is a simple useful lemma that's used when you want to check if a value is a result of an operation in proofs. You can write `v \in op.getResults! ctx`, then write `v.idxOf (op.getResults! ctx)` to get its index, instead of having to match on `v`.