### PR TITLE
feat(refinement): Generalize `InterpreterState.isRefinedBy`

### DIFF
--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -13,11 +13,16 @@ relate a program to a rewritten or lowered version of it). Refinement is defined
   with any arguments and memory is refined by interpreting the target.
 * `OperationPtr.isRefinedByAsModule` relates two modules: every top-level `func.func` of the source
   module must be refined, as a function, by a same-named top-level `func.func` of the target module.
+
+Additionally, we define a refinement relation between two interpreter states given a mapping of
+variables in the source to variables in the target.
 -/
 
 open Veir.Data
 
 namespace Veir
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
 
 /-- Refinement relation between two runtime values. -/
 def RuntimeValue.isRefinedBy (source target : RuntimeValue) : Prop :=
@@ -114,5 +119,32 @@ def OperationPtr.isModuleRefinedBy (mod₁ : OperationPtr) (ctx₁ : WfIRContext
       ∃ (func₂ : OperationPtr) (func₂In : func₂.InBounds ctx₂.raw),
         func₂.IsTopLevelFuncWithName mod₂ ctx₂.raw name ∧
           func₁.isRefinedByAsFunction ctx₁ func₂ ctx₂ func₁In func₂In
+
+abbrev ValueMapping (ctx ctx' : WfIRContext OpInfo) : Type :=
+  {v : ValuePtr // v.InBounds ctx.raw} → {v : ValuePtr // v.InBounds ctx'.raw}
+
+/--
+A variable state `state` is refined by `state'` through the value renaming `mapping`: every
+variable defined in `state` is, after renaming through `mapping`, also defined in `state'` with a
+value that refines the source value.
+-/
+def VariableState.isRefinedBy {ctx ctx' : WfIRContext OpInfo}
+    (state : VariableState ctx) (state' : VariableState ctx')
+    (mapping : ValueMapping ctx ctx') : Prop :=
+  ∀ (val : ValuePtr) (valIn : val.InBounds ctx.raw),
+  ∀ sourceVar, state.getVar? val = some sourceVar →
+  ∃ targetVar, state'.getVar? (mapping ⟨val, valIn⟩) = some targetVar ∧
+  sourceVar ⊒ targetVar
+
+/--
+An interpreter state `state` is refined by `state'` through the value mapping
+`mapping`: they have the same memory, and the variable state of `state` is refined by the variable
+state of `state'` through `mapping`.
+-/
+def InterpreterState.isRefinedBy {ctx ctx' : WfIRContext OpInfo}
+    (state : InterpreterState ctx) (state' : InterpreterState ctx')
+    (mapping : ValueMapping ctx ctx') : Prop :=
+  state.memory = state'.memory ∧
+  state.variables.isRefinedBy state'.variables mapping
 
 end Veir

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -3,6 +3,8 @@ import Veir.Interpreter.Refinement.Basic
 namespace Veir
 open Veir.Data
 
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
 /-! ## Reflexivity  -/
 
 @[simp, grind .]
@@ -21,6 +23,18 @@ theorem FunctionResult.isRefinedBy_refl (r : MemoryState × Array RuntimeValue) 
 theorem Interp.isRefinedBy_refl_of_ne_none {α : Type} {R : α → α → Prop}
     (hR : ∀ a, R a a) (x : Interp α) (neNone : x ≠ none) : Interp.isRefinedBy R x x := by
   rcases x with _ | (x | _) <;> grind [Interp.isRefinedBy]
+
+@[simp, grind .]
+theorem VariableState.isRefinedBy_refl
+    {ctx : WfIRContext OpInfo} {state : VariableState ctx} :
+    state.isRefinedBy state id := by
+  grind [VariableState.isRefinedBy]
+
+@[simp, grind .]
+theorem InterpreterState.isRefinedBy_refl
+    {ctx : WfIRContext OpInfo} {state : InterpreterState ctx} :
+    state.isRefinedBy state id := by
+  grind [InterpreterState.isRefinedBy, VariableState.isRefinedBy]
 
 /-! ## Transitivity -/
 

--- a/Veir/PatternRewriter/Semantics.lean
+++ b/Veir/PatternRewriter/Semantics.lean
@@ -3,6 +3,7 @@ import Veir.Interpreter
 import Veir.IR.WellFormed
 import Veir.Passes.Matching
 import Veir.Rewriter.WfRewriter
+import Veir.Interpreter.Refinement.Basic
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
@@ -81,16 +82,55 @@ def LocalRewritePattern.ReturnValues (pattern : LocalRewritePattern OpCode) : Pr
   newValues.size = op.getNumResults! ctx.raw
 
 /--
-Asserts that a state refines pointwise another state at every value dominating
-the given insert point.
-Also, the memory states are the same.
+All values returned by the pattern are in bounds of the new context.
 -/
-def InterpreterState.isRefinedByAt {ctx ctx' : WfIRContext OpInfo} (state : InterpreterState ctx)
-    (state' : InterpreterState ctx') (insertPoint : InsertPoint) : Prop :=
-  state.memory = state'.memory ∧
-  ∀ (val : ValuePtr), ValuePtr.dominatesIp val insertPoint ctx →
-  ∀ sourceVar, state.variables.getVar? val = some sourceVar →
-  ∃ targetVar, state'.variables.getVar? val = some targetVar ∧ sourceVar ⊒ targetVar
+def LocalRewritePattern.ReturnValuesInBounds (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ ctx op newCtx newOps newValues, pattern ctx op = some (newCtx, some (newOps, newValues)) →
+  ∀ v ∈ newValues, v.InBounds newCtx.raw
+
+/--
+Indexed access on the returned values is in bounds of the new context.
+Discharges the second `sorry` in `LocalRewritePattern.Mapping`.
+-/
+theorem LocalRewritePattern.ReturnValuesInBounds.getElem!_inBounds
+    {pattern : LocalRewritePattern OpCode}
+    (hReturn : pattern.ReturnValuesInBounds)
+    (hpattern : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    {index : Nat} (hindex : index < newValues.size) :
+    newValues[index]!.InBounds newCtx.raw := by
+  rw [getElem!_pos newValues index hindex]
+  exact hReturn ctx op newCtx newOps newValues hpattern newValues[index] (Array.getElem_mem hindex)
+
+/--
+A value that is in bounds of the input context is also in bounds of the new context returned
+by the pattern. Discharges the third `sorry` in `LocalRewritePattern.Mapping`.
+-/
+theorem LocalRewritePattern.ReturnCtxChanges.valuePtr_inBounds
+    {pattern : LocalRewritePattern OpCode}
+    (hReturn : pattern.ReturnCtxChanges)
+    (hpattern : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    {v : ValuePtr} (vInBounds : v.InBounds ctx.raw) :
+    v.InBounds newCtx.raw := by
+  have hCreated := hReturn ctx op newCtx newOps newValues hpattern
+  have := hCreated.inBounds_mono (GenericPtr.value v) (by grind)
+  grind
+
+def LocalRewritePattern.mapping
+    {pattern : LocalRewritePattern OpCode}
+    (hpattern : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    (hreturn : pattern.ReturnValuesInBounds := by grind)
+    (hreturn₂ : pattern.ReturnValues := by grind)
+    (hreturn₃ : pattern.ReturnCtxChanges := by grind) :
+    ValueMapping ctx newCtx :=
+  fun ⟨v, vInBounds⟩ =>
+    if h : v ∈ op.getResults! ctx.raw then
+      let index := (op.getResults! ctx.raw).idxOf v
+      have : v = op.getResult index := by grind
+      ⟨newValues[index]!, by
+        apply LocalRewritePattern.ReturnValuesInBounds.getElem!_inBounds hreturn hpattern
+        grind [LocalRewritePattern.ReturnValues]⟩
+    else
+      ⟨v, by grind⟩
 
 /--
 Preservation of semantics for a local rewrite pattern.
@@ -99,14 +139,15 @@ the matched operation in a state is refined by interpreting the new operations i
 -/
 def LocalRewritePattern.PreservesSemantics
   (pattern : LocalRewritePattern OpCode)
-  (_ : ReturnOps pattern) (_ : ReturnCtxChanges pattern) : Prop :=
+  (_ : pattern.ReturnOps) (_ : pattern.ReturnCtxChanges)
+  (_ : pattern.ReturnValuesInBounds) (_ : pattern.ReturnValues) : Prop :=
   ∀ ctx (ctxDom : ctx.Dom) (ctxVerif : ctx.Verified) (op : OperationPtr) (opInBounds : op.InBounds ctx.raw),
   ∀ newCtx newOps newValues (hpattern : pattern ctx op = some (newCtx, some (newOps, newValues))),
   ∀ (state : InterpreterState ctx), state.EquationLemmaAt (InsertPoint.before op) →
   ∀ newState cf, interpretOp op state = some (newState, cf) →
   ∀ sourceValues, (op.getResults ctx.raw).mapM (newState.variables.getVar? ·) = some sourceValues →
   ∀ (state' : InterpreterState newCtx), state'.EquationLemmaAt (InsertPoint.before op) →
-  state.isRefinedByAt state' (InsertPoint.before op) →
+  state.isRefinedBy state' (LocalRewritePattern.mapping hpattern) →
   ∃ newState',
     interpretOpList newOps.toList state' (by grind [ReturnOps]) = some (newState', cf) ∧
     newState.memory = newState'.memory ∧


### PR DESCRIPTION
Now, the interpreter state refinement explicitly takes as input a mapping between in bounds variables. This will be necessary to do the refinement lifting proof of peephole rewrites.

Also, remove the refinement of `InterpreterState` in the `Refinement/Basic.lean` file
