### PR TITLE
feat(ir): add inBounds lemmas for Rewriter.init* functions

### DIFF
--- a/Veir/Rewriter/GetSet/BlockOperands.lean
+++ b/Veir/Rewriter/GetSet/BlockOperands.lean
@@ -487,6 +487,20 @@ theorem OpOperandPtrPtr.get!_initBlockOperands {opOperandPtr : OpOperandPtrPtr} 
     opOperandPtr.get! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
+@[grind =]
+theorem Rewriter.initBlockOperands_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (initBlockOperands ctx op operands n h₁ h₂ h₃ hn) ↔
+    match ptr with
+    | .blockOperand operandPtr
+    | .blockOperandPtr (.blockOperandNextUse operandPtr) =>
+      if operandPtr.op = op then
+        operandPtr.index < op.getNumSuccessors! ctx + n
+      else
+        ptr.InBounds ctx
+    | _ => ptr.InBounds ctx := by
+  fun_induction Rewriter.initBlockOperands <;>
+    grind [BlockOperandPtr.inBounds_def]
+
 end Rewriter.initBlockOperands
 
 end Veir

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -445,7 +445,7 @@ theorem OperationPtr.next!_createOp {operation : OperationPtr} :
     | none =>
       if operation = newOp then none else (operation.get! ctx).next := by
   simp only [Rewriter.createOp]
-  grind (gen := 20) (splits := 20) [cases InsertPoint]
+  grind (gen := 20) (splits := 20) (instances := 2000) [cases InsertPoint]
 
 @[grind =>]
 theorem OperationPtr.parent!_createOp {operation : OperationPtr} :

--- a/Veir/Rewriter/GetSet/Operands.lean
+++ b/Veir/Rewriter/GetSet/Operands.lean
@@ -509,6 +509,20 @@ OpOperandPtrPtr.get!_initOpOperands is too complex to be expressed, and should n
 in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
+@[grind =]
+theorem Rewriter.initOpOperands_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (initOpOperands ctx op h₁ operands h₂ h₃ n hn) ↔
+    match ptr with
+    | .opOperand operandPtr
+    | .opOperandPtr (.operandNextUse operandPtr) =>
+      if operandPtr.op = op then
+        operandPtr.index < op.getNumOperands! ctx + n
+      else
+        ptr.InBounds ctx
+    | _ => ptr.InBounds ctx := by
+  fun_induction Rewriter.initOpOperands <;>
+    grind [OpOperandPtr.inBounds_def]
+
 end Rewriter.initOpOperands
 
 end Veir

--- a/Veir/Rewriter/GetSet/Regions.lean
+++ b/Veir/Rewriter/GetSet/Regions.lean
@@ -414,6 +414,16 @@ theorem OpOperandPtrPtr.get!_initOpRegions {opOperandPtr : OpOperandPtrPtr}
     opOperandPtr.get! ctx' = opOperandPtr.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
+theorem Rewriter.initOpRegions_inBounds {ptr : GenericPtr} {ctx' : IRContext OpInfo} :
+    initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx' →
+    (ptr.InBounds ctx ↔ ptr.InBounds ctx') := by
+  fun_induction Rewriter.initOpRegions <;> grind
+
+grind_pattern Rewriter.initOpRegions_inBounds =>
+  Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄, some ctx', ptr.InBounds ctx
+grind_pattern Rewriter.initOpRegions_inBounds =>
+  Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄, some ctx', ptr.InBounds ctx'
+
 end Rewriter.initOpRegions
 
 end Veir

--- a/Veir/Rewriter/GetSet/Results.lean
+++ b/Veir/Rewriter/GetSet/Results.lean
@@ -433,6 +433,21 @@ theorem OpOperandPtrPtr.get!_initOpResults {opOperandPtr : OpOperandPtrPtr} :
   · grind
   · simp only [get!_valueFirstUse_eq, ValuePtr.getFirstUse!_initOpResults, dite_eq_ite]; grind
 
+@[grind =]
+theorem Rewriter.initOpResults_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (initOpResults ctx op types index hop hidx) ↔
+    match ptr with
+    | .opResult resPtr
+    | .value (.opResult resPtr)
+    | .opOperandPtr (.valueFirstUse (.opResult resPtr)) =>
+      if resPtr.op = op then
+        resPtr.index < op.getNumResults! ctx + (types.size - index)
+      else
+        ptr.InBounds ctx
+    | _ => ptr.InBounds ctx := by
+  fun_induction Rewriter.initOpResults <;>
+    grind [OpResultPtr.inBounds_def]
+
 end Rewriter.initOpResults
 
 end Veir


### PR DESCRIPTION
These are added in the `GetSet` folder, as they rely on get-set lemmas on the proof side.