### PR TITLE
feat(llvm): support the frame pointer kind attribute

### DIFF
--- a/Test/LLVM/cconv-linkage.mlir
+++ b/Test/LLVM/cconv-linkage.mlir
@@ -2,11 +2,11 @@
 // RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
-  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i32 (f64)>, linkage = #llvm.linkage<external>, sym_name = "f1", visibility_ = 0 : i64}> ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, frame_pointer = #llvm.framePointerKind<all>, function_type = !llvm.func<i32 (f64)>, linkage = #llvm.linkage<external>, sym_name = "f1", visibility_ = 0 : i64}> ({
   ^bb0(%arg0: f64):
     "llvm.unreachable"() : () -> ()
   }) : () -> ()
-  "llvm.func"() <{CConv = #llvm.cconv<fastcc>, function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<internal>, sym_name = "f2", visibility_ = 0 : i64}> ({
+  "llvm.func"() <{CConv = #llvm.cconv<fastcc>, frame_pointer = #llvm.framePointerKind<none>, function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<internal>, sym_name = "f2", visibility_ = 0 : i64}> ({
   ^bb0(%arg0: i32):
     "llvm.unreachable"() : () -> ()
   }) : () -> ()
@@ -14,11 +14,11 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, "function_type" = !llvm.func<i32 (f64)>, "linkage" = #llvm.linkage<external>, "sym_name" = "f1", "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<i32 (f64)>, "linkage" = #llvm.linkage<external>, "sym_name" = "f1", "visibility_" = 0 : i64}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : f64):
 // CHECK-NEXT:         "llvm.unreachable"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
-// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<fastcc>, "function_type" = !llvm.func<void (i32)>, "linkage" = #llvm.linkage<internal>, "sym_name" = "f2", "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<fastcc>, "frame_pointer" = #llvm.framePointerKind<none>, "function_type" = !llvm.func<void (i32)>, "linkage" = #llvm.linkage<internal>, "sym_name" = "f2", "visibility_" = 0 : i64}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:         "llvm.unreachable"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -88,6 +88,13 @@ structure LinkageAttr where
   value : String
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/--
+  LLVM frame pointer kind attribute, e.g. `#llvm.framePointerKind<all>`.
+-/
+structure FramePointerKindAttr where
+  value : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 structure RegisterAttr where
   value : Int
   type : RegisterType
@@ -305,6 +312,8 @@ inductive Attribute
 | cconvAttr (attr : CConvAttr)
 /-- LLVM linkage attribute -/
 | linkageAttr (attr : LinkageAttr)
+/-- LLVM frame pointer kind attribute -/
+| framePointerKindAttr (attr : FramePointerKindAttr)
 /-- Register type -/
 | registerType (type : RegisterType)
 /-- Register attribute -/
@@ -471,6 +480,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case framePointerKindAttr.framePointerKindAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case unregisteredAttr.unregisteredAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -585,6 +598,9 @@ instance : ToString CConvAttr where
 
 instance : ToString LinkageAttr where
   toString attr := s!"#llvm.linkage<{attr.value}>"
+
+instance : ToString FramePointerKindAttr where
+  toString attr := s!"#llvm.framePointerKind<{attr.value}>"
 
 instance : ToString IntegerAttr where
   toString attr := s!"{attr.value} : {attr.type}"
@@ -741,6 +757,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .fastMathFlagsAttr attr => ToString.toString attr
   | .cconvAttr attr => ToString.toString attr
   | .linkageAttr attr => ToString.toString attr
+  | .framePointerKindAttr attr => ToString.toString attr
   | .integerAttr attr => ToString.toString attr
   | .floatAttr attr => ToString.toString attr
   | .registerType type => ToString.toString type
@@ -799,6 +816,9 @@ instance : Coe CConvAttr Attribute where
 
 instance : Coe LinkageAttr Attribute where
   coe attr := .linkageAttr attr
+
+instance : Coe FramePointerKindAttr Attribute where
+  coe attr := .framePointerKindAttr attr
 
 instance : Coe IntegerAttr Attribute where
   coe attr := .integerAttr attr
@@ -871,6 +891,7 @@ def isType (attr : Attribute) : Bool :=
   | .fastMathFlagsAttr _ => false
   | .cconvAttr _ => false
   | .linkageAttr _ => false
+  | .framePointerKindAttr _ => false
   | .integerAttr _ => false
   | .floatAttr _ => false
   | .stringAttr _ => false
@@ -902,6 +923,8 @@ theorem isType_fastMathFlags flags : (fastMathFlagsAttr flags).isType = false :=
 theorem isType_cconv attr : (cconvAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_linkage attr : (linkageAttr attr).isType = false := by rfl
+@[simp, grind =]
+theorem isType_framePointerKind attr : (framePointerKindAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_unregistered unregistered :
   (unregisteredAttr unregistered).isType = unregistered.isType := by rfl

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -323,6 +323,12 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
     parsePunctuation ">"
     return some (LinkageAttr.mk body : Attribute)
 
+  if dialectName = "llvm.framePointerKind".toByteArray then do
+    parsePunctuation "<"
+    let body ← parseUnregisteredAttrBody
+    parsePunctuation ">"
+    return some (FramePointerKindAttr.mk body : Attribute)
+
   if !(← getThe AttrParserState).allowUnregisteredDialect then
     throwAt startPos s!"attribute is not registered. Consider using --allow-unregistered-dialect."
   parsePunctuation "<"


### PR DESCRIPTION
Just another little step towards making MLIR that originates with Clang roundtrip through VeIR without any unregistered attributes.