### PR TITLE
feat: typechecking of return operations against functions' declared types

### DIFF
--- a/Test/Interpreter/LLVM/br.mlir
+++ b/Test/Interpreter/LLVM/br.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i32 ()>}> ({
     ^1():
       %x1 = "llvm.mlir.constant"() <{"value" = 8 : i32}> : () -> i32
       %x2 = "llvm.mlir.constant"() <{"value" = 11 : i32}> : () -> i32

--- a/Test/Interpreter/LLVM/br_predecessor_value.mlir
+++ b/Test/Interpreter/LLVM/br_predecessor_value.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i32 ()>}> ({
     ^1():
       %x1 = "llvm.mlir.constant"() <{"value" = 8 : i32}> : () -> i32
       %x2 = "llvm.mlir.constant"() <{"value" = 11 : i32}> : () -> i32

--- a/Test/Interpreter/LLVM/cond_br.mlir
+++ b/Test/Interpreter/LLVM/cond_br.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i32 ()>}> ({
     ^1():
       %x1 = "llvm.mlir.constant"() <{"value" = 8 : i32}> : () -> i32
       %x2 = "llvm.mlir.constant"() <{"value" = 11 : i32}> : () -> i32

--- a/Test/Interpreter/LLVM/cond_br_poison.mlir
+++ b/Test/Interpreter/LLVM/cond_br_poison.mlir
@@ -3,7 +3,7 @@
 // Branching on a poison i1 is undefined behaviour. The i1 poison is produced by
 // `llvm.add nuw` on i1 (1 + 1 overflows unsigned).
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i32 ()>}> ({
     ^entry():
       %one    = "llvm.mlir.constant"() <{"value" = 1 : i1}> : () -> i1
       %poison = "llvm.add"(%one, %one) <{"overflowFlags" = 2 : i32}> : (i1, i1) -> i1

--- a/Test/Interpreter/LLVM/cond_br_poison_propagates.mlir
+++ b/Test/Interpreter/LLVM/cond_br_poison_propagates.mlir
@@ -4,7 +4,7 @@
 // through `interpretBlockCFG`'s recursive call rather than being lost or
 // reported as a malformed-program error.
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i32 ()>}> ({
     ^entry():
       "llvm.br"() [^poison_block] : () -> ()
     ^poison_block():

--- a/Test/Interpreter/LLVM/getelementptr.mlir
+++ b/Test/Interpreter/LLVM/getelementptr.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i8 ()>}> ({
     ^bb0():
       %size = "llvm.mlir.constant"() <{ "value" = 4 : i64 }> : () -> i64
       %array = "llvm.alloca"(%size) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr

--- a/Test/Interpreter/LLVM/getelementptr_array.mlir
+++ b/Test/Interpreter/LLVM/getelementptr_array.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i8 ()>}> ({
     ^bb0():
       %size = "llvm.mlir.constant"() <{ "value" = 4 : i64 }> : () -> i64
       %array = "llvm.alloca"(%size) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr

--- a/Test/Verifier/func_return_arity_mismatch.mlir
+++ b/Test/Verifier/func_return_arity_mismatch.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f"}> ({
+  ^bb0(%arg0: i32):
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected 1 return operand(s)

--- a/Test/Verifier/func_return_arity_mismatch.mlir
+++ b/Test/Verifier/func_return_arity_mismatch.mlir
@@ -7,4 +7,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Expected 1 func.return operand(s)
+// CHECK: Expected func.return to have 1 operand(s)

--- a/Test/Verifier/func_return_arity_mismatch.mlir
+++ b/Test/Verifier/func_return_arity_mismatch.mlir
@@ -7,4 +7,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Expected 1 return operand(s)
+// CHECK: Expected 1 func.return operand(s)

--- a/Test/Verifier/func_return_in_llvm_func.mlir
+++ b/Test/Verifier/func_return_in_llvm_func.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i32 ()>, sym_name = "f"}> ({
+    %0 = "llvm.mlir.constant"() <{value = 13 : i32}> : () -> i32
+    "func.return"(%0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected func.return to be enclosed by func.func

--- a/Test/Verifier/func_return_missing_function_type.mlir
+++ b/Test/Verifier/func_return_missing_function_type.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() ({
+  ^bb0():
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected enclosing func.func to have a function_type attribute

--- a/Test/Verifier/func_return_type_mismatch.mlir
+++ b/Test/Verifier/func_return_type_mismatch.mlir
@@ -7,4 +7,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Return operand 0 type does not match the function's declared result type
+// CHECK: func.return operand 0 type does not match the function's declared result type

--- a/Test/Verifier/func_return_type_mismatch.mlir
+++ b/Test/Verifier/func_return_type_mismatch.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f"}> ({
+  ^bb0(%arg0: i1):
+    "func.return"(%arg0) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Return operand 0 type does not match the function's declared result type

--- a/Test/Verifier/func_return_type_ok.mlir
+++ b/Test/Verifier/func_return_type_ok.mlir
@@ -1,0 +1,14 @@
+// RUN: veir-opt %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f"}> ({
+  ^bb0(%arg0: i32):
+    "func.return"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "func.func"() <{
+// CHECK-SAME:   "function_type" = (i32) -> i32
+// CHECK-SAME:   "sym_name" = "f"
+// CHECK-SAME: }> ({
+// CHECK:        "func.return"(%{{.*}}) : (i32) -> ()

--- a/Test/Verifier/llvm_return_in_func_func.mlir
+++ b/Test/Verifier/llvm_return_in_func_func.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f"}> ({
+  ^bb0(%arg0: i32):
+    "llvm.return"(%arg0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected llvm.return to be enclosed by llvm.func

--- a/Test/Verifier/llvm_return_type_mismatch.mlir
+++ b/Test/Verifier/llvm_return_type_mismatch.mlir
@@ -7,4 +7,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Return operand 0 type does not match the function's declared result type
+// CHECK: llvm.return operand 0 type does not match the function's declared result type

--- a/Test/Verifier/llvm_return_type_mismatch.mlir
+++ b/Test/Verifier/llvm_return_type_mismatch.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i16 ()>, sym_name = "f"}> ({
+    %0 = "llvm.mlir.constant"() <{value = 13 : i32}> : () -> i32
+    "llvm.return"(%0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Return operand 0 type does not match the function's declared result type

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -10,51 +10,67 @@ import Veir.ForLean
 namespace Veir
 
 /--
-  Find the declared result types of the function that encloses `op`,
-  or fail if the function signature cannot be determined.
+  Walk up from `op` (a return-like terminator named `opName`) to the
+  operation that encloses its parent region, i.e. the enclosing function
+  operation.
 -/
-def OperationPtr.getEnclosingFunctionOutputs (op : OperationPtr) (ctx : WfIRContext OpCode) :
-    Except String (Array Attribute) := do
+def OperationPtr.getEnclosingFunctionOp (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opName : String) : Except String OperationPtr := do
   let some block := (op.get! ctx.raw).parent
-    | throw "Expected return operation to have a parent block"
+    | throw s!"Expected {opName} to have a parent block"
   let some region := (block.get! ctx.raw).parent
-    | throw "Expected return operation's parent block to have a parent region"
+    | throw s!"Expected {opName}'s parent block to have a parent region"
   let some funcOp := (region.get! ctx.raw).parent
-    | throw "Expected return operation's parent region to have a parent operation"
-  match funcOp.getOpType! ctx.raw with
-  | .func .func =>
-    let props := funcOp.getProperties! ctx.raw (.func .func)
-    match props.extra.entries.find? (fun entry => entry.1 == "function_type".toUTF8) with
+    | throw s!"Expected {opName}'s parent region to have a parent operation"
+  pure funcOp
+
+/--
+  Check that a `func.return` returns the declared result types of its
+  enclosing `func.func`.
+-/
+def OperationPtr.verifyFuncReturnTypes (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let funcOp ← op.getEnclosingFunctionOp ctx "func.return"
+  let .func .func := funcOp.getOpType! ctx.raw
+    | throw "Expected func.return to be enclosed by func.func"
+  let props := funcOp.getProperties! ctx.raw (.func .func)
+  let outputs ← match props.extra.entries.find? (fun entry => entry.1 == "function_type".toUTF8) with
     | some (_, .functionType ft) => pure ft.outputs
     | some _ => throw "Expected enclosing func.func's function_type to be a function type"
     | none => throw "Expected enclosing func.func to have a function_type attribute"
-  | .llvm .func =>
-    let props := funcOp.getProperties! ctx.raw (.llvm .func)
-    let normalize (ft : FunctionType) : Array Attribute :=
-      match ft.outputs with
-      | #[.llvmVoidType _] => #[]
-      | outputs => outputs
-    let some functionType := props.function_type
-      | throw "Expected enclosing llvm.func to have a function_type attribute"
-    match functionType.val with
-    | .functionType ft => pure (normalize ft)
-    | .llvmFunctionType ft => pure (normalize ft)
-    | _ => throw "Expected enclosing llvm.func's function_type to be a function type"
-  | _ => throw "Expected return operation to be enclosed by func.func or llvm.func"
-
-/--
-  For a return-like terminator operation, check that it returns the
-  same type that its enclosing function returns.
--/
-def OperationPtr.verifyReturnTypes (op : OperationPtr) (ctx : WfIRContext OpCode)
-    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
-  let outputs ← op.getEnclosingFunctionOutputs ctx
   if op.getNumOperands ctx.raw opIn ≠ outputs.size then
-    throw s!"Expected {outputs.size} return operand(s)"
+    throw s!"Expected {outputs.size} func.return operand(s)"
   let opTypes := op.getOperandTypes! ctx.raw
   for i in [0:outputs.size] do
     if (opTypes[i]!).val ≠ outputs[i]! then
-      throw s!"Return operand {i} type does not match the function's declared result type"
+      throw s!"func.return operand {i} type does not match the function's declared result type"
+
+/--
+  Check that an `llvm.return` returns the declared result types of its
+  enclosing `llvm.func`. A single `llvm.void` result is normalized to no
+  results.
+-/
+def OperationPtr.verifyLLVMReturnTypes (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let funcOp ← op.getEnclosingFunctionOp ctx "llvm.return"
+  let .llvm .func := funcOp.getOpType! ctx.raw
+    | throw "Expected llvm.return to be enclosed by llvm.func"
+  let props := funcOp.getProperties! ctx.raw (.llvm .func)
+  let some functionType := props.function_type
+    | throw "Expected enclosing llvm.func to have a function_type attribute"
+  let ft ← match functionType.val with
+    | .functionType ft | .llvmFunctionType ft => pure ft
+    | _ => throw "Expected enclosing llvm.func's function_type to be a function type"
+  -- A single `llvm.void` result corresponds to no return operands.
+  let outputs := match ft.outputs with
+    | #[.llvmVoidType _] => #[]
+    | outputs => outputs
+  if op.getNumOperands ctx.raw opIn ≠ outputs.size then
+    throw s!"Expected {outputs.size} llvm.return operand(s)"
+  let opTypes := op.getOperandTypes! ctx.raw
+  for i in [0:outputs.size] do
+    if (opTypes[i]!).val ≠ outputs[i]! then
+      throw s!"llvm.return operand {i} type does not match the function's declared result type"
 
 /--
   Verify local invariants of an operation.
@@ -436,7 +452,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    op.verifyReturnTypes ctx opIn
+    op.verifyFuncReturnTypes ctx opIn
   /- CF -/
   | .cf .br => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -675,7 +691,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    op.verifyReturnTypes ctx opIn
+    op.verifyLLVMReturnTypes ctx opIn
   | .llvm .unreachable => do
     if op.getNumOperands ctx.raw opIn ≠ 0 then
       throw "Expected 0 operands"

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -39,7 +39,7 @@ def OperationPtr.verifyFuncReturnTypes (op : OperationPtr) (ctx : WfIRContext Op
     | some _ => throw "Expected enclosing func.func's function_type to be a function type"
     | none => throw "Expected enclosing func.func to have a function_type attribute"
   if op.getNumOperands ctx.raw opIn ≠ outputs.size then
-    throw s!"Expected {outputs.size} func.return operand(s)"
+    throw s!"Expected func.return to have {outputs.size} operand(s)"
   let opTypes := op.getOperandTypes! ctx.raw
   for i in [0:outputs.size] do
     if (opTypes[i]!).val ≠ outputs[i]! then
@@ -66,7 +66,7 @@ def OperationPtr.verifyLLVMReturnTypes (op : OperationPtr) (ctx : WfIRContext Op
     | #[.llvmVoidType _] => #[]
     | outputs => outputs
   if op.getNumOperands ctx.raw opIn ≠ outputs.size then
-    throw s!"Expected {outputs.size} llvm.return operand(s)"
+    throw s!"Expected llvm.return to have {outputs.size} operand(s)"
   let opTypes := op.getOperandTypes! ctx.raw
   for i in [0:outputs.size] do
     if (opTypes[i]!).val ≠ outputs[i]! then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -10,6 +10,53 @@ import Veir.ForLean
 namespace Veir
 
 /--
+  Find the declared result types of the function that encloses `op`,
+  or fail if the function signature cannot be determined.
+-/
+def OperationPtr.getEnclosingFunctionOutputs (op : OperationPtr) (ctx : WfIRContext OpCode) :
+    Except String (Array Attribute) := do
+  let some block := (op.get! ctx.raw).parent
+    | throw "Expected return operation to have a parent block"
+  let some region := (block.get! ctx.raw).parent
+    | throw "Expected return operation's parent block to have a parent region"
+  let some funcOp := (region.get! ctx.raw).parent
+    | throw "Expected return operation's parent region to have a parent operation"
+  match funcOp.getOpType! ctx.raw with
+  | .func .func =>
+    let props := funcOp.getProperties! ctx.raw (.func .func)
+    match props.extra.entries.find? (fun entry => entry.1 == "function_type".toUTF8) with
+    | some (_, .functionType ft) => pure ft.outputs
+    | some _ => throw "Expected enclosing func.func's function_type to be a function type"
+    | none => throw "Expected enclosing func.func to have a function_type attribute"
+  | .llvm .func =>
+    let props := funcOp.getProperties! ctx.raw (.llvm .func)
+    let normalize (ft : FunctionType) : Array Attribute :=
+      match ft.outputs with
+      | #[.llvmVoidType _] => #[]
+      | outputs => outputs
+    let some functionType := props.function_type
+      | throw "Expected enclosing llvm.func to have a function_type attribute"
+    match functionType.val with
+    | .functionType ft => pure (normalize ft)
+    | .llvmFunctionType ft => pure (normalize ft)
+    | _ => throw "Expected enclosing llvm.func's function_type to be a function type"
+  | _ => throw "Expected return operation to be enclosed by func.func or llvm.func"
+
+/--
+  For a return-like terminator operation, check that it returns the
+  same type that its enclosing function returns.
+-/
+def OperationPtr.verifyReturnTypes (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let outputs ← op.getEnclosingFunctionOutputs ctx
+  if op.getNumOperands ctx.raw opIn ≠ outputs.size then
+    throw s!"Expected {outputs.size} return operand(s)"
+  let opTypes := op.getOperandTypes! ctx.raw
+  for i in [0:outputs.size] do
+    if (opTypes[i]!).val ≠ outputs[i]! then
+      throw s!"Return operand {i} type does not match the function's declared result type"
+
+/--
   Verify local invariants of an operation.
   This typically includes checking that the number of operands, successors, results, and regions
   match the expected values for the given operation type.
@@ -389,7 +436,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    pure ()
+    op.verifyReturnTypes ctx opIn
   /- CF -/
   | .cf .br => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -628,7 +675,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    pure ()
+    op.verifyReturnTypes ctx opIn
   | .llvm .unreachable => do
     if op.getNumOperands ctx.raw opIn ≠ 0 then
       throw "Expected 0 operands"


### PR DESCRIPTION
This closes the loop with my big PR yesterday that added return types to lots of functions in our `Test` directory, by actually checking that these types agree with return statements inside functions.

The way I did this here is very simple: when we reach a return operation, we walk up the tree to find the return type of the enclosing function. It would likely be more efficient to remember the function return type when we first encounter it and then thread that through the verifier, but when I started to do this it felt quite invasive, whereas the current approach here is not invasive.