### PR TITLE
fix(llvm): flip order of operands to llvm.store

### DIFF
--- a/Test/Interpreter/LLVM/getelementptr.mlir
+++ b/Test/Interpreter/LLVM/getelementptr.mlir
@@ -8,7 +8,7 @@
       %off1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
       %ptr1 = "llvm.getelementptr"(%array, %off1) <{ elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
       %val1 = "llvm.mlir.constant"() <{ "value" = 256 : i64 }> : () -> i64
-      "llvm.store"(%ptr1, %val1) : (!llvm.ptr, i64) -> ()
+      "llvm.store"(%val1, %ptr1) : (i64, !llvm.ptr) -> ()
       %off2 = "llvm.mlir.constant"() <{ "value" = 9 : i64 }> : () -> i64
       %ptr2 = "llvm.getelementptr"(%array, %off2) <{ elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
       %val2 = "llvm.load"(%ptr2) : (!llvm.ptr) -> i8

--- a/Test/Interpreter/LLVM/getelementptr_array.mlir
+++ b/Test/Interpreter/LLVM/getelementptr_array.mlir
@@ -8,7 +8,7 @@
       %off1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
       %ptr1 = "llvm.getelementptr"(%array, %off1) <{ elem_type = !llvm.array<8 x i8>, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
       %val1 = "llvm.mlir.constant"() <{ "value" = 256 : i64 }> : () -> i64
-      "llvm.store"(%ptr1, %val1) : (!llvm.ptr, i64) -> ()
+      "llvm.store"(%val1, %ptr1) : (i64, !llvm.ptr) -> ()
       %off2 = "llvm.mlir.constant"() <{ "value" = 9 : i64 }> : () -> i64
       %ptr2 = "llvm.getelementptr"(%array, %off2) <{ elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
       %val2 = "llvm.load"(%ptr2) : (!llvm.ptr) -> i8

--- a/Test/Interpreter/LLVM/mem.mlir
+++ b/Test/Interpreter/LLVM/mem.mlir
@@ -7,8 +7,8 @@
     %3 = "llvm.mlir.constant"() <{ "value" = 5 : i8 }> : () -> i8
     %4 = "llvm.alloca"(%1) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr
     %5 = "llvm.alloca"(%1) <{ "elem_type" = i8 }> : (i64) -> !llvm.ptr
-    "llvm.store"(%4, %2) : (!llvm.ptr, i64) -> ()
-    "llvm.store"(%5, %3) : (!llvm.ptr, i8) -> ()
+    "llvm.store"(%2, %4) : (i64, !llvm.ptr) -> ()
+    "llvm.store"(%3, %5) : (i8, !llvm.ptr) -> ()
     %6 = "llvm.load"(%4) : (!llvm.ptr) -> i64
     %7 = "llvm.load"(%4) : (!llvm.ptr) -> i8
     %8 = "llvm.load"(%5) : (!llvm.ptr) -> i8

--- a/Test/LLVM/store.mlir
+++ b/Test/LLVM/store.mlir
@@ -1,0 +1,25 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i64 (i64)>, linkage = #llvm.linkage<external>, sym_name = "store_load", visibility_ = 0 : i64}> ({
+  ^bb0(%arg0: i64):
+    %0 = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
+    %1 = "llvm.alloca"(%0) <{alignment = 0 : i64, elem_type = i64}> : (i64) -> !llvm.ptr
+    "llvm.store"(%arg0, %1) <{access_groups = [], alias_scopes = [], alignment = 0 : i64, noalias_scopes = [], tbaa = []}> : (i64, !llvm.ptr) -> ()
+    %2 = "llvm.load"(%1) <{access_groups = [], alias_scopes = [], alignment = 0 : i64, noalias_scopes = [], tbaa = []}> : (!llvm.ptr) -> i64
+    "llvm.return"(%2) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, "function_type" = !llvm.func<i64 (i64)>, "linkage" = #llvm.linkage<external>, "sym_name" = "store_load", "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:       ^{{.*}}(%[[ARG:.*]] : i64):
+// CHECK-NEXT:         %[[C1:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
+// CHECK-NEXT:         %[[PTR:.*]] = "llvm.alloca"(%[[C1]]) <{"alignment" = 0 : i64, "elem_type" = i64}> : (i64) -> !llvm.ptr
+// CHECK-NEXT:         "llvm.store"(%[[ARG]], %[[PTR]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+// CHECK-NEXT:         %[[LD:.*]] = "llvm.load"(%[[PTR]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         "llvm.return"(%[[LD]]) : (i64) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -683,7 +683,7 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     let val ← mem.loadValue addr type
     return (#[val], mem, none)
   | .store => do
-    let [.addr addr, val] := operands.toList | none
+    let [val, .addr addr] := operands.toList | none
     let mem ← mem.storeValue addr val
     return (#[], mem, none)
   | .getelementptr => do


### PR DESCRIPTION
it should be `llvm.store %val, %ptr`, not `llvm.store %ptr, %val`
as documented here:
https://mlir.llvm.org/docs/Dialects/LLVM/#llvmstore-llvmstoreop
