### PR TITLE
fix(interpreter): skip over LLVM module flags when looking for an entry point

### DIFF
--- a/Test/Vcc/primes.c
+++ b/Test/Vcc/primes.c
@@ -24,6 +24,7 @@ int main(void) {
         n++;
     }
 
+    // main's return value is 29, the 10th prime number
     return last_prime;
 }
 

--- a/Test/Vcc/primes.c
+++ b/Test/Vcc/primes.c
@@ -1,0 +1,30 @@
+// RUN: ./Tools/vcc -O --emit-mlir %s -o %t.mlir
+// RUN: veir-interpret %t.mlir | filecheck %s
+
+int main(void) {
+    int count = 0;
+    int n = 2;
+    int last_prime = 0;
+
+    while (count < 10) {
+        int prime = 1;
+
+        for (int i = 2; i * i <= n; i++) {
+            if (n % i == 0) {
+                prime = 0;
+                break;
+            }
+        }
+
+        if (prime) {
+            last_prime = n;
+            count++;
+        }
+
+        n++;
+    }
+
+    return last_prime;
+}
+
+// CHECK: Program output: #[0x0000001d#32]

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -67,6 +67,8 @@ partial def scanEntryPoints (ctx : IRContext OpCode) (op : Option OperationPtr)
     | .llvm .func | .func .func =>
       let entryPoints := if isZeroArgMainFunc ctx op then op :: entryPoints else entryPoints
       scanEntryPoints ctx (op.get! ctx).next entryPoints
+    | .llvm .module_flags =>
+      scanEntryPoints ctx (op.get! ctx).next entryPoints
     | _ =>
       IO.eprintln "Error: Top-level operations are disallowed; define a zero-argument function named 'main'"
       IO.Process.exit 1


### PR DESCRIPTION
The module flags emitted by LLVM were breaking our entry point scan, they need to be skipped over.

Also, add a test case ensuring that we can directly interpret MLIR that arrives through the clang->mlir-translate path.