### PR TITLE
feat(LLVM): add llvm.freeze interpreter support

### DIFF
--- a/Test/Interpreter/LLVM/freeze.mlir
+++ b/Test/Interpreter/LLVM/freeze.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i32, i32)}> ({
+    %cneg = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
+    %a = "llvm.zext"(%cneg) <{nneg}> : (i8) -> i32
+    %a_freeze = "llvm.freeze"(%a) : (i32) -> i32
+    "func.return"(%a, %a_freeze) : (i32, i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison, 0x00000000#32]

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -513,6 +513,16 @@ def select {w : Nat} (c : Int 1) (x y : Int w) : Int w := Id.run do
   let val c' := c | poison
   if c' == 1#1 then x else y
 
+
+/--
+ The `freeze` instruction converts a poison value to a non-poison value by
+ replacing it with an arbitrary value. We currently always pick zero.
+-/
+def freeze {w : Nat} (x : Int w) : Int w := Id.run do
+  match x with
+  | .val v => .val v
+  | .poison => .val 0
+
 end Int
 end
 end Veir.Data.LLVM

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -693,6 +693,9 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     match idx with
     | .val idx => return (#[.addr (ptr.toNat + idx.toNat * size).toUInt64], mem, none)
     | .poison => Interp.ub
+  | .freeze => do
+    let [RuntimeValue.int w val] := operands.toList | none
+    return (#[RuntimeValue.int w (LLVM.Int.freeze val)], mem, none)
   | _ => none
 
 def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasDialectOpInfo.propertiesOf opType)


### PR DESCRIPTION
We currently always freeze to zero, as we do not have full support for choice trees.