### PR TITLE
feat(PackedFloat.Round): add PackedFloat.round wrapper with pack-round-trip tests

### DIFF
--- a/UnitTest/FP/EDyadic/Round.lean
+++ b/UnitTest/FP/EDyadic/Round.lean
@@ -105,10 +105,14 @@ A value smaller than half-min-subnormal rounds to `+0`. -/
 #guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 11) 4 3 =
   EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 9)
 
-/-! ## Round-trip via `pack ∘ round` against IEEE-754 doubles
+/-! ## Round-trip via `pack ∘ round` against IEEE-754 doubles.
 
 For doubles already representable in the format, `round` is the identity
-on the dyadic value, and `pack` recovers the original bit pattern. -/
+on the dyadic value, and `pack` recovers the original bit pattern.
+
+Recall that the double format has
+`e = 11` exponent bits and `s = 52` significand bits.
+-/
 
 def asDyadic (pf : PackedFloat 11 52) : Dyadic :=
   match toEDyadic pf with

--- a/UnitTest/FP/EDyadic/Round.lean
+++ b/UnitTest/FP/EDyadic/Round.lean
@@ -1,12 +1,18 @@
 module
 
 import Veir.Data.FP.EDyadic.Round
+import Veir.Data.FP.EDyadic.Pack
+import Veir.Data.FP.PackedFloat.ToEDyadic
 
 meta import Veir.Data.FP.EDyadic.Round
+meta import Veir.Data.FP.EDyadic.Pack
+meta import Veir.Data.FP.PackedFloat.OfFloat
+meta import Veir.Data.FP.PackedFloat.ToEDyadic
 
 namespace UnitTest.Fp.EDyadic.Round
 
 open Veir.Data.FP
+open Veir.Data.FP.PackedFloat
 
 /-! ## Identity on representable values
 
@@ -98,5 +104,26 @@ A value smaller than half-min-subnormal rounds to `+0`. -/
 -- 3 · 2^(-11) = 2^(-9) · 3/4: closer to 2^(-9) than to 0, rounds up.
 #guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 11) 4 3 =
   EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 9)
+
+/-! ## Round-trip via `pack ∘ round` against IEEE-754 doubles
+
+For doubles already representable in the format, `round` is the identity
+on the dyadic value, and `pack` recovers the original bit pattern. -/
+
+def asDyadic (pf : PackedFloat 11 52) : Dyadic :=
+  match toEDyadic pf with
+  | .nonzeroFinite d _ => d
+  | _ => 0
+
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1.0)) 11 52) =
+  ofFloat 1.0
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1.5)) 11 52) =
+  ofFloat 1.5
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat (-1.5))) 11 52) =
+  ofFloat (-1.5)
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 0.5)) 11 52) =
+  ofFloat 0.5
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1024.0)) 11 52) =
+  ofFloat 1024.0
 
 end UnitTest.Fp.EDyadic.Round

--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -4,4 +4,4 @@ public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.PackedFloat.OfFloat
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.PackedFloat.ToEDyadic
-
+public import Veir.Data.FP.PackedFloat.Round

--- a/Veir/Data/FP/PackedFloat/Round.lean
+++ b/Veir/Data/FP/PackedFloat/Round.lean
@@ -32,6 +32,6 @@ def round {e s : Nat} (mode : RoundingMode) (etarget starget : Nat)
     | special => special
   EDyadic.pack etarget starget edRounded
 
-end -- public section
+end
 
 end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/Round.lean
+++ b/Veir/Data/FP/PackedFloat/Round.lean
@@ -1,0 +1,37 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.ToEDyadic
+public import Veir.Data.FP.EDyadic.Round
+public import Veir.Data.FP.EDyadic.Pack
+
+namespace Veir.Data.FP.PackedFloat
+
+public section
+
+/--
+Round a `PackedFloat e s` into target format `PackedFloat etarget starget`
+using the given IEEE-754 rounding mode.
+
+The implementation is the composition
+`PackedFloat → EDyadic → (rounded) EDyadic → PackedFloat`:
+* `PackedFloat.toEDyadic` converts the input to its precise dyadic value
+  (preserving NaN, ±∞, and ±0).
+* `Dyadic.round mode` rounds finite nonzero values to a representable
+  value in `(etarget, starget)` per the given rounding mode.
+* `EDyadic.pack` re-encodes the result in the target packed format.
+
+NaN, ±∞, and ±0 are propagated through; only the exponent and significand
+widths change.
+-/
+def round {e s : Nat} (mode : RoundingMode) (etarget starget : Nat)
+    (pf : PackedFloat e s) : PackedFloat etarget starget :=
+  let edRounded : EDyadic :=
+    match pf.toEDyadic with
+    | .nonzeroFinite d hne => Dyadic.round mode d etarget starget hne
+    | special => special
+  EDyadic.pack etarget starget edRounded
+
+end -- public section
+
+end Veir.Data.FP.PackedFloat


### PR DESCRIPTION
This PR adds `PackedFloat.round`, a wrapper that rounds a `PackedFloat e s` into a target format `PackedFloat etarget starget` under a given IEEE-754 rounding mode. The implementation is the composition `PackedFloat → EDyadic → (rounded) EDyadic → PackedFloat`.
