### PR TITLE
feat(refinement): Use ControlFlow refinement instead of equality

### DIFF
--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -402,7 +402,8 @@ set_option warn.sorry false in
 def interpretOp'_monotone {operands operands' : Array RuntimeValue} :
     operands ⊒ operands' →
     Interp.isRefinedBy (α := Array RuntimeValue × MemoryState × Option ControlFlowAction)
-      (fun r₁ r₂ => r₁.1 ⊒ r₂.1 ∧ r₁.2 = r₂.2)
+      (fun r₁ r₂ => r₁.1 ⊒ r₂.1 ∧ r₁.2.1 = r₂.2.1 ∧
+        ControlFlowAction.optionIsRefinedBy r₁.2.2 r₂.2.2)
       (interpretOp' opType properties resultTypes operands blockOperands mem)
       (interpretOp' opType properties resultTypes operands' blockOperands mem) := by
   sorry

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -70,6 +70,26 @@ def Interp.isRefinedBy (R : α → α → Prop) (source target : Interp α) : Pr
   | _, _ => False
 
 /--
+Refinement between two control flow actions: same constructor, equal successor block `dest`, and
+the carried value payloads refine pointwise.
+-/
+def ControlFlowAction.isRefinedBy : ControlFlowAction → ControlFlowAction → Prop
+  | .return vals, .return vals' => vals ⊒ vals'
+  | .branch vals dest, .branch vals' dest' => dest = dest' ∧ vals ⊒ vals'
+  | _, _ => False
+
+@[inherit_doc] infix:50 " ⊒ " => ControlFlowAction.isRefinedBy
+
+/--
+Refinement between two optional control flow actions. They should either both be `none`, or both be
+`some` and refine.
+-/
+def ControlFlowAction.optionIsRefinedBy : Option ControlFlowAction → Option ControlFlowAction → Prop
+  | none, none => True
+  | some a, some b => a.isRefinedBy b
+  | _, _ => False
+
+/--
 The function described by source `op₁` (in `ctx₁`) is *refined by* target `op₂` (in `ctx₂`) when,
 for every argument `values` and initial memory `mem`, interpreting `op₁` is refined by interpreting
 `op₂`.

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -61,12 +61,13 @@ on the underlying values. This asserts:
   `some (.ok b)` of `target` with `R a b`;
 * when `source` is undefined behaviour (`some .ub`), `target` must succeed (i.e. not be `none`),
   but may be either `some .ub` or `some (.ok _)`;
-* when `source` or `target` failed interpretation (i.e. are `none`), no refinement exists.
+* when `source` is `none`, `target` may be anything
 -/
 def Interp.isRefinedBy (R : α → α → Prop) (source target : Interp α) : Prop :=
   match source, target with
   | some (.ok a), some (.ok b) => R a b
   | some .ub, some _ => True
+  | none, _ => True
   | _, _ => False
 
 /--

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -36,6 +36,17 @@ theorem InterpreterState.isRefinedBy_refl
     state.isRefinedBy state id := by
   grind [InterpreterState.isRefinedBy, VariableState.isRefinedBy]
 
+@[simp, grind .]
+theorem ControlFlowAction.isRefinedBy_refl (cf : ControlFlowAction) : cf ⊒ cf := by
+  cases cf <;> simp [ControlFlowAction.isRefinedBy]
+
+@[simp, grind .]
+theorem ControlFlowAction.optionIsRefinedBy_refl (cf : Option ControlFlowAction) :
+    ControlFlowAction.optionIsRefinedBy cf cf := by
+  cases cf with
+  | none => trivial
+  | some a => cases a <;> simp [ControlFlowAction.optionIsRefinedBy, ControlFlowAction.isRefinedBy]
+
 /-! ## Transitivity -/
 
 theorem RuntimeValue.isRefinedBy_trans {v₁ v₂ v₃ : RuntimeValue}


### PR DESCRIPTION
The previous use of equality in `interpretOp'_monotone` was making this lemma False for terminators.