### PR TITLE
feat(RISCV): proof strategy and tactic for isel patterns

### DIFF
--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -17,7 +17,6 @@ public section
 /--
   Cast `LLVM.Int` to `RISCV.Reg`.
 -/
-@[grind]
 def LLVM.Int.toReg (i : Veir.Data.LLVM.Int w) : Veir.Data.RISCV.Reg :=
   match i with
   | .poison => .mk 0#64

--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -30,12 +30,12 @@ def LLVM.Int.toReg (i : Veir.Data.LLVM.Int w) : Veir.Data.RISCV.Reg :=
 def RISCV.Reg.toInt (r : Veir.Data.RISCV.Reg) (w : Nat) : Veir.Data.LLVM.Int w :=
   Veir.Data.LLVM.Int.val (BitVec.zeroExtend w r.val)
 
-@[llvm_toBitVec, grind =]
+@[reg_toBitVec, grind =]
 theorem toInt_eq_val {r : Veir.Data.RISCV.Reg} :
     (RISCV.Reg.toInt r 64).getValue = r.val := by
   simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.getValue]
 
-@[llvm_toBitVec, grind =]
+@[reg_toBitVec, grind =]
 theorem toInt_isPoison {r : Veir.Data.RISCV.Reg} :
     (RISCV.Reg.toInt r w).isPoison = false := by
   simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.isPoison]

--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -35,12 +35,12 @@ theorem toInt_eq_val {r : Veir.Data.RISCV.Reg} :
   simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.getValue]
 
 @[reg_toBitVec, grind =]
-theorem toInt_isPoison {r : Veir.Data.RISCV.Reg} :
+theorem toInt_isPoison {w : Nat} {r : Veir.Data.RISCV.Reg} :
     (RISCV.Reg.toInt r w).isPoison = false := by
   simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.isPoison]
 
 @[llvm_toBitVec, grind =]
-theorem val_toReg {i : Veir.Data.LLVM.Int w} :
+theorem val_toReg {w : Nat} {i : Veir.Data.LLVM.Int w} :
     (LLVM.Int.toReg i).val = if h : i.isPoison = true then 0#64 else i.getValue.zeroExtend 64 := by
   simp only [LLVM.Int.toReg, BitVec.truncate_eq_setWidth]
   split

--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -40,7 +40,7 @@ theorem toInt_isPoison {r : Veir.Data.RISCV.Reg} :
   simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.isPoison]
 
 @[llvm_toBitVec, grind =]
-theorem val_toReg{i : Veir.Data.LLVM.Int w} :
+theorem val_toReg {i : Veir.Data.LLVM.Int w} :
     (LLVM.Int.toReg i).val = if h : i.isPoison = true then 0#64 else i.getValue.zeroExtend 64 := by
   simp only [LLVM.Int.toReg, BitVec.truncate_eq_setWidth]
   split

--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -1,7 +1,10 @@
 module
 
 public import Veir.Data.LLVM.Int.Basic
+public import Veir.Data.LLVM.Int.Bitblast
 public import Veir.Data.RISCV.Reg.Basic
+public import Veir.Data.RISCV.Reg.Simp
+import all Veir.Data.LLVM.Int.Bitblast
 
 public section
 
@@ -14,6 +17,7 @@ public section
 /--
   Cast `LLVM.Int` to `RISCV.Reg`.
 -/
+@[grind]
 def LLVM.Int.toReg (i : Veir.Data.LLVM.Int w) : Veir.Data.RISCV.Reg :=
   match i with
   | .poison => .mk 0#64
@@ -22,5 +26,24 @@ def LLVM.Int.toReg (i : Veir.Data.LLVM.Int w) : Veir.Data.RISCV.Reg :=
 /--
   Cast `RISCV.Reg` to `LLVM.Int`.
 -/
+@[grind]
 def RISCV.Reg.toInt (r : Veir.Data.RISCV.Reg) (w : Nat) : Veir.Data.LLVM.Int w :=
   Veir.Data.LLVM.Int.val (BitVec.zeroExtend w r.val)
+
+@[llvm_toBitVec, grind =]
+theorem toInt_eq_val {r : Veir.Data.RISCV.Reg} :
+    (RISCV.Reg.toInt r 64).getValue = r.val := by
+  simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.getValue]
+
+@[llvm_toBitVec, grind =]
+theorem toInt_isPoison {r : Veir.Data.RISCV.Reg} :
+    (RISCV.Reg.toInt r w).isPoison = false := by
+  simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.isPoison]
+
+@[llvm_toBitVec, grind =]
+theorem val_toReg{i : Veir.Data.LLVM.Int w} :
+    (LLVM.Int.toReg i).val = if h : i.isPoison = true then 0#64 else i.getValue.zeroExtend 64 := by
+  simp only [LLVM.Int.toReg, BitVec.truncate_eq_setWidth]
+  split
+  · simp [Veir.Data.LLVM.Int.isPoison]
+  · simp [llvm_toBitVec]

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -15,6 +15,10 @@ import Std.Tactic.BVDecide
 
 namespace Veir.Data.RISCV
 
+macro "riscv_bv_decide" : tactic =>
+  `(tactic| ((try simp only [llvm_toBitVec, reg_toBitVec]; try simp [LLVM.Int.getValue_eq_getValueD]; try bv_decide)))
+
+
 /--
   Prove the correctness of the `constant` lowering pattern.
 
@@ -23,7 +27,7 @@ namespace Veir.Data.RISCV
 -/
 theorem constant_refinement {v : Int}:
     (LLVM.Int.constant 64 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
-  simp [llvm_toBitVec, reg_toBitVec]
+  riscv_bv_decide
 
 /--
   Prove the correctness of the `add` lowering pattern.
@@ -31,6 +35,4 @@ theorem constant_refinement {v : Int}:
 theorem add_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.add x y) ⊒
       (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+  riscv_bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -1,5 +1,9 @@
 import Veir.Data.RISCV.Reg.Basic
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Data.LLVM.Int.Basic
+import Veir.Data.LLVM.Int.Simp
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.LLVM.Int.Bitblast
 import Veir.Data.Casting
 import Veir.Data.Refinement
 import Std.Tactic.BVDecide
@@ -17,24 +21,16 @@ namespace Veir.Data.RISCV
   We do not need to consider the poison case, as the semantics of `llvm_constant`
   are always concrete in the interpreter.
 -/
-theorem constant_refinement:
-    isRefinedBy (LLVM.Int.constant 64 v) (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
-  simp [isRefinedBy, Data.LLVM.Int.constant, Data.RISCV.li, RISCV.Reg.toInt]
+theorem constant_refinement {v : Int}:
+    (LLVM.Int.constant 64 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
+  simp [llvm_toBitVec, reg_toBitVec]
 
 /--
   Prove the correctness of the `add` lowering pattern.
 -/
-theorem add_refinement:
-    isRefinedBy (Data.LLVM.Int.add x y) (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
-  simp only [isRefinedBy, Data.LLVM.Int.add, Bool.false_eq_true, false_and, ↓reduceIte,
-    pure_bind, RISCV.Reg.toInt, Data.RISCV.add, LLVM.Int.toReg, BitVec.truncate_eq_setWidth,
-    BitVec.setWidth_eq]
-  split
-  · split
-    · split
-      <;> bv_decide
-    · split
-      · bv_decide
-      · simp only [Id.run, Data.LLVM.Int.val.injEq] at *
-        bv_decide
-  · bv_decide
+theorem add_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.add x y) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp [LLVM.Int.getValue_eq_getValueD]
+  bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -15,7 +15,7 @@ import Std.Tactic.BVDecide
 
 namespace Veir.Data.RISCV
 
-macro "riscv_bv_decide" : tactic =>
+macro "refine_bv_decide" : tactic =>
   `(tactic| ((try simp only [llvm_toBitVec, reg_toBitVec]; try simp [LLVM.Int.getValue_eq_getValueD]; try bv_decide)))
 
 
@@ -27,7 +27,7 @@ macro "riscv_bv_decide" : tactic =>
 -/
 theorem constant_refinement {v : Int}:
     (LLVM.Int.constant 64 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 64) := by
-  riscv_bv_decide
+  refine_bv_decide
 
 /--
   Prove the correctness of the `add` lowering pattern.
@@ -35,4 +35,4 @@ theorem constant_refinement {v : Int}:
 theorem add_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.add x y) ⊒
       (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
-  riscv_bv_decide
+  refine_bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -15,6 +15,11 @@ import Std.Tactic.BVDecide
 
 namespace Veir.Data.RISCV
 
+/--
+  A tactic to unfold the semantics of operations on `LLVM.Int` and on `RISCV.Reg` to
+  bitvectors, such that `bv_decide` can prove the correctness of the refinement relation
+  over instruction selection patterns.
+-/
 macro "refine_bv_decide" : tactic =>
   `(tactic| ((try simp only [llvm_toBitVec, reg_toBitVec]; try simp [LLVM.Int.getValue_eq_getValueD]; try bv_decide)))
 


### PR DESCRIPTION
We introduce a new `refine_bv_decide` tactic to automate the verification of instruction selection patterns' refinement relation. To do this, we needed some additional lemmas in our simp-sets, in particular regarding the unfolding of the casting ops (`toInt`, `toReg`). 

We show how the tactic works in golfing the current instruction selection proofs. 

As a next step, I shall use the same strategy to prove the refinement relation for all the instruction selection patterns.