### PR TITLE
feat(FastFloat): add FastFloat type, Float32 helpers, smoke tests

### DIFF
--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -2,3 +2,5 @@ module
 
 public import UnitTest.FP.PackedFloat
 public import UnitTest.FP.EDyadic
+public import UnitTest.FP.FastFloat
+public import UnitTest.FP.FastFloatSmoke

--- a/UnitTest/FP/FastFloat.lean
+++ b/UnitTest/FP/FastFloat.lean
@@ -1,0 +1,81 @@
+module
+
+import Veir.Data.FP.FastFloat
+
+meta import Veir.Data.FP.FastFloat
+
+namespace UnitTest.Fp.FastFloat
+
+open Veir.Data.FP
+
+/-! ## `FastFloat 8 23 .RNE` against native `Float32`
+
+`FastFloat 8 23 .RNE` simulates IEEE-754 single-precision (the same
+shape as `Float32`) by rounding every result to single-precision width
+under round-to-nearest-ties-to-even. This file uses native `Float32`
+results as a golden reference: for each input pair, the bit pattern
+extracted from `(FastFloat.ofFloat32 a + FastFloat.ofFloat32 b).value`
+(when narrowed back to `Float32`) must match `a + b` performed natively.
+
+We narrow `FastFloat`'s underlying `Float` back to `Float32` by routing
+through the packed-float encoding (this is the round-trip that defines
+`FastFloat`'s precision contract). -/
+
+/-- Convert the underlying `Float` of a `FastFloat 8 23 mode` to a `Float32`
+via the packed encoding. -/
+def fastToFloat32 {mode : RoundingMode} (x : FastFloat 8 23 mode) : Float32 :=
+  PackedFloat.toFloat32 (PackedFloat.ofFloat x.value
+    |> PackedFloat.round mode 8 23)
+
+/-- The `Float32` golden value for a pair under `op`. -/
+def goldF32 (op : Float32 → Float32 → Float32) (a b : Float32) : Float32 :=
+  op a b
+
+/-- The simulated value via `FastFloat 8 23 .RNE`. -/
+def simF32
+    (op : ∀ {e s : Nat} {m : RoundingMode},
+      FastFloat e s m → FastFloat e s m → FastFloat e s m)
+    (a b : Float32) : Float32 :=
+  let af : FastFloat 8 23 .RNE := FastFloat.ofFloat32 a
+  let bf : FastFloat 8 23 .RNE := FastFloat.ofFloat32 b
+  fastToFloat32 (op af bf)
+
+/-- Bit-pattern equality on `Float32` (treats `NaN` bit patterns as ordered). -/
+def bitsEq (a b : Float32) : Bool :=
+  Float32.toBits a == Float32.toBits b
+
+/-! ### Addition matches `Float32 + Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a + b) 1.0 2.0) (1.0 + 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.5 2.5) (1.5 + 2.5 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 0.1 0.2) (0.1 + 0.2 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) (-1.0) 1.0) (-1.0 + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.0e10 1.0) (1.0e10 + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.0e-30 1.0e-30) (1.0e-30 + 1.0e-30 : Float32)
+
+/-! ### Subtraction matches `Float32 - Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a - b) 3.0 1.0) (3.0 - 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a - b) 1.0 2.0) (1.0 - 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a - b) 1.0e10 1.0) (1.0e10 - 1.0 : Float32)
+
+/-! ### Multiplication matches `Float32 * Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a * b) 1.5 2.0) (1.5 * 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 0.1 0.1) (0.1 * 0.1 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 1.0e15 1.0e15) (1.0e15 * 1.0e15 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) (-2.0) 3.0) ((-2.0) * 3.0 : Float32)
+
+/-! ### Division matches `Float32 / Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a / b) 1.0 3.0) (1.0 / 3.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a / b) 22.0 7.0) (22.0 / 7.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a / b) (-1.0) 4.0) ((-1.0) / 4.0 : Float32)
+
+/-! ### Specials propagate -/
+
+#guard bitsEq (simF32 (fun a b => a + b) (1.0 / 0.0) 1.0) ((1.0 / 0.0) + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 0.0 0.0) (0.0 * 0.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) (-0.0) 0.0) ((-0.0) + 0.0 : Float32)
+
+end UnitTest.Fp.FastFloat

--- a/UnitTest/FP/FastFloatSmoke.lean
+++ b/UnitTest/FP/FastFloatSmoke.lean
@@ -1,0 +1,90 @@
+module
+
+import Veir.Data.FP.FastFloat
+
+meta import Veir.Data.FP.FastFloat
+
+namespace UnitTest.Fp.FastFloatSmoke
+
+open Veir.Data.FP
+
+/-! # Smoke test: `FastFloat 8 23 .RNE` against native `Float32`
+
+Enumerates a representative sample of `Float32` values — all five
+specials, the boundary subnormal/normal values, and 50
+logarithmically-spaced points across the dynamic range — and verifies
+that for every input pair, each of `add`/`sub`/`mul`/`div` performed
+through `FastFloat 8 23 .RNE` produces the same `Float32` bit pattern as
+the native `Float32` operation. NaNs are compared as
+`isNaN ↔ isNaN` (their bit patterns may differ across paths).
+
+Total cost: with 59 values, every operator runs over `59 × 59 = 3481`
+pairs at elaboration. -/
+
+/-- Round-trip a `FastFloat 8 23 mode`'s underlying `Float` to `Float32`. -/
+private def fastToFloat32 {mode : RoundingMode}
+    (x : FastFloat 8 23 mode) : Float32 :=
+  PackedFloat.toFloat32
+    (PackedFloat.round mode 8 23 (PackedFloat.ofFloat x.value))
+
+/-- Run `op` on `Float32` inputs via the `FastFloat 8 23 .RNE` path. -/
+private def viaFast
+    (op : ∀ {e s : Nat} {m : RoundingMode},
+      FastFloat e s m → FastFloat e s m → FastFloat e s m)
+    (a b : Float32) : Float32 :=
+  let af : FastFloat 8 23 .RNE := FastFloat.ofFloat32 a
+  let bf : FastFloat 8 23 .RNE := FastFloat.ofFloat32 b
+  fastToFloat32 (op af bf)
+
+/-- Equality on `Float32` results: bit-equal, or both NaN. -/
+private def f32eq (a b : Float32) : Bool :=
+  (a.isNaN && b.isNaN) || (Float32.toBits a == Float32.toBits b)
+
+/-- Build a `Float32` from a 32-bit pattern. -/
+private def f32 (bits : UInt32) : Float32 := Float32.ofBits bits
+
+/--
+The smoke-test sample of `Float32` values:
+
+* nine specials (NaN, ±∞, ±0, ±minSubnormal, ±maxNormal),
+* fifty values whose biased exponent steps roughly evenly across
+  `[1, 254]` (significand left at zero), giving 50 powers of two
+  spread logarithmically across the dynamic range.
+-/
+private def smokeValues : List Float32 :=
+  let specials : List Float32 := [
+    f32 0x7fc00000,  -- NaN (canonical quiet)
+    f32 0x7f800000,  -- +∞
+    f32 0xff800000,  -- −∞
+    f32 0x00000000,  -- +0
+    f32 0x80000000,  -- −0
+    f32 0x00000001,  -- +minSubnormal
+    f32 0x80000001,  -- −minSubnormal
+    f32 0x7f7fffff,  -- +maxNormal
+    f32 0xff7fffff   -- −maxNormal
+  ]
+  let logSpaced : List Float32 :=
+    (List.range 50).map fun i =>
+      let biasedExp : Nat := 1 + (i * 253) / 49
+      f32 ((UInt32.ofNat biasedExp) <<< 23)
+  specials ++ logSpaced
+
+/-- All ordered pairs from the smoke set. -/
+private def smokePairs : List (Float32 × Float32) :=
+  smokeValues.flatMap fun a => smokeValues.map fun b => (a, b)
+
+/-! ### Each operator agrees with native `Float32` on every pair -/
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· + ·) a b) (a + b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· - ·) a b) (a - b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· * ·) a b) (a * b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· / ·) a b) (a / b)
+
+end UnitTest.Fp.FastFloatSmoke

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -6,3 +6,4 @@ public import Veir.Data.FP.ScientificBV.Basic
 public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.EDyadic
+public import Veir.Data.FP.FastFloat

--- a/Veir/Data/FP/FastFloat.lean
+++ b/Veir/Data/FP/FastFloat.lean
@@ -1,0 +1,98 @@
+module
+
+public import Veir.Data.FP.PackedFloat.OfFloat
+public import Veir.Data.FP.PackedFloat.Round
+
+namespace Veir.Data.FP
+
+public section
+
+/--
+A `FastFloat e s mode` is a Lean `Float` (IEEE-754 double) whose value
+has been rounded to the precision of an `(e, s)`-format packed float
+under the given IEEE-754 rounding `mode`.
+
+The rounding mode is encoded at the type level so that arithmetic
+operations can use it without requiring it as an extra runtime argument:
+`add`, `sub`, `mul`, `div` all delegate to native `Float` arithmetic
+and then re-round the result to `(e, s)` precision via
+`PackedFloat.round` under `mode`.
+
+To switch the rounding mode of an existing value, use
+`FastFloat.setRoundingMode`.
+-/
+@[ext]
+structure FastFloat (e s : Nat) (mode : RoundingMode) where
+  /-- The underlying double, normalized to `(e, s)` precision under `mode`. -/
+  value : Float
+deriving Inhabited
+
+namespace FastFloat
+
+/--
+Round a Lean `Float` to `(e, s)` precision and back to `Float`,
+using rounding `mode`.
+The trip is `Float → PackedFloat 11 52 → PackedFloat e s → PackedFloat 11 52 → Float`,
+applying `PackedFloat.round mode` for each width change.
+-/
+def roundFloat (mode : RoundingMode) (e s : Nat) (f : Float) : Float :=
+  let pfDouble : PackedFloat 11 52 := PackedFloat.ofFloat f
+  let pfTarget : PackedFloat e s := PackedFloat.round mode e s pfDouble
+  let pfBack : PackedFloat 11 52 := PackedFloat.round mode 11 52 pfTarget
+  PackedFloat.toFloat pfBack
+
+/-- Lift a `Float` to a `FastFloat e s mode`, rounding to target precision. -/
+def ofFloat {e s : Nat} {mode : RoundingMode} (f : Float) : FastFloat e s mode :=
+  ⟨roundFloat mode e s f⟩
+
+/--
+Lift a `Float32` to a `FastFloat e s mode`. The single-precision value
+is widened to a `Float` and then rounded to `(e, s)` precision.
+-/
+def ofFloat32 {e s : Nat} {mode : RoundingMode} (f : Float32) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s f.toFloat⟩
+
+/-- Extract the underlying `Float`. -/
+def toFloat {e s : Nat} {mode : RoundingMode} (x : FastFloat e s mode) : Float :=
+  x.value
+
+/--
+Re-tag a `FastFloat` with a different rounding mode. The underlying
+`Float` value is unchanged; subsequent arithmetic on the result will use
+the new mode when re-rounding.
+-/
+def setRoundingMode {e s : Nat} {m : RoundingMode}
+    (newMode : RoundingMode) (x : FastFloat e s m) : FastFloat e s newMode :=
+  ⟨x.value⟩
+
+/-- Add two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def add {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value + b.value)⟩
+
+/-- Subtract two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def sub {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value - b.value)⟩
+
+/-- Multiply two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def mul {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value * b.value)⟩
+
+/-- Divide two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def div {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value / b.value)⟩
+
+instance {e s : Nat} {mode : RoundingMode} : Add (FastFloat e s mode) := ⟨add⟩
+instance {e s : Nat} {mode : RoundingMode} : Sub (FastFloat e s mode) := ⟨sub⟩
+instance {e s : Nat} {mode : RoundingMode} : Mul (FastFloat e s mode) := ⟨mul⟩
+instance {e s : Nat} {mode : RoundingMode} : Div (FastFloat e s mode) := ⟨div⟩
+
+end FastFloat
+
+end -- public section
+
+end Veir.Data.FP

--- a/Veir/Data/FP/FastFloat.lean
+++ b/Veir/Data/FP/FastFloat.lean
@@ -93,6 +93,6 @@ instance {e s : Nat} {mode : RoundingMode} : Div (FastFloat e s mode) := ‚ü®div‚
 
 end FastFloat
 
-end -- public section
+end
 
 end Veir.Data.FP

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -26,5 +26,24 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
   Float.ofBits (UInt64.ofBitVec bits)
 
+/--
+Convert a Lean single-precision float (`Float32`) to a `PackedFloat 8 23`.
+A IEEE single-precision float has the layout:
+  - 1 bit for the sign
+  - 8 bits for the exponent
+  - 23 bits for the significand
+-/
+def ofFloat32 (f : Float32) : PackedFloat 8 23 :=
+  let bits : BitVec 32 := (Float32.toBits f).toBitVec
+  let sign : Bool := (bits >>> 31) ≠ 0#_
+  let exponent := (bits >>> 23) &&& (1 <<< 8 - 1)
+  let significand := bits &&& (1 <<< 23 - 1)
+  PackedFloat.mk sign (exponent.setWidth 8) (significand.setWidth 23)
+
+/-- Convert a `PackedFloat 8 23` back to a Lean single-precision float (`Float32`). -/
+def toFloat32 (pf : PackedFloat 8 23) : Float32 :=
+  let bits : BitVec 32 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
+  Float32.ofBits (UInt32.ofBitVec bits)
+
 end -- public section
 end Veir.Data.FP.PackedFloat


### PR DESCRIPTION
## What

Adds `FastFloat e s mode` — a native `Float`-backed model re-rounded to `(e, s)` after each operation — plus the `Float32`/`PackedFloat` bridge helpers (`PackedFloat.ofFloat32` / `toFloat32`) and smoke tests. This is the prerequisite layer for the `EDyadicFloat` conformance tests stacked above it.

## Stack

Part of the `full-precision-floats-edyadic` stack. Base: #783 (`round-edyadic-packed-round`). This patch is the FastFloat layer peeled off the `round-edyadic` draft (#531), continuing the same peeling that produced #783.

🤖 Generated with [Claude Code](https://claude.com/claude-code)