### PR TITLE
feat(EDyadic.Arith): exact add/sub/mul on EDyadic

### DIFF
--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -2,3 +2,5 @@ module
 
 public import UnitTest.FP.PackedFloat
 public import UnitTest.FP.EDyadic
+public import UnitTest.FP.FastFloat
+public import UnitTest.FP.FastFloatSmoke

--- a/UnitTest/FP/EDyadic.lean
+++ b/UnitTest/FP/EDyadic.lean
@@ -1,5 +1,6 @@
 module
 
+public import UnitTest.FP.EDyadic.Arith
 public import UnitTest.FP.EDyadic.Pack
 public import UnitTest.FP.EDyadic.Position
 public import UnitTest.FP.EDyadic.Round

--- a/UnitTest/FP/EDyadic/Arith.lean
+++ b/UnitTest/FP/EDyadic/Arith.lean
@@ -1,0 +1,87 @@
+module
+
+import Veir.Data.FP.EDyadic.Arith
+
+meta import Veir.Data.FP.EDyadic.Arith
+
+namespace UnitTest.Fp.EDyadic.Arith
+
+open Veir.Data.FP
+
+/-! ## Exact addition
+
+Finite dyadics add exactly (no rounding). We compare against the dyadic
+value built directly with `Dyadic.ofIntWithPrec n prec` (value `n · 2^(-prec)`). -/
+
+-- 1 + 2 = 3
+#guard EDyadic.add (EDyadic.ofDyadic false 1) (EDyadic.ofDyadic false 2) =
+  EDyadic.ofDyadic false 3
+-- 0.5 + 0.5 = 1   (0.5 = 1·2^-1)
+#guard EDyadic.add (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 1))
+    (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 1)) = EDyadic.ofDyadic false 1
+-- 1.5 + 2.5 = 4
+#guard EDyadic.add (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 1))
+    (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 5 1)) = EDyadic.ofDyadic false 4
+-- 0.25 + 0.5 = 0.75   (3·2^-2)
+#guard EDyadic.add (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 2))
+    (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 1)) =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 2)
+-- exact cancellation 1 + (-1) = +0
+#guard EDyadic.add (EDyadic.ofDyadic false 1) (EDyadic.ofDyadic false (-1)) =
+  EDyadic.zero false
+-- `+` instance
+#guard (EDyadic.ofDyadic false 1) + (EDyadic.ofDyadic false 2) = EDyadic.ofDyadic false 3
+
+/-! ## Exact subtraction -/
+
+-- 3 - 1 = 2
+#guard EDyadic.sub (EDyadic.ofDyadic false 3) (EDyadic.ofDyadic false 1) =
+  EDyadic.ofDyadic false 2
+-- 1 - 2 = -1
+#guard (EDyadic.ofDyadic false 1) - (EDyadic.ofDyadic false 2) = EDyadic.ofDyadic false (-1)
+-- 0.5 - 0.25 = 0.25
+#guard EDyadic.sub (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 1))
+    (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 2)) =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 2)
+
+/-! ## Exact multiplication -/
+
+-- 1.5 * 2 = 3
+#guard EDyadic.mul (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 1))
+    (EDyadic.ofDyadic false 2) = EDyadic.ofDyadic false 3
+-- 1.5 * 1.5 = 2.25   (9·2^-2)
+#guard EDyadic.mul (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 1))
+    (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 1)) =
+  EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 9 2)
+-- (-2) * 3 = -6
+#guard (EDyadic.ofDyadic false (-2)) * (EDyadic.ofDyadic false 3) =
+  EDyadic.ofDyadic false (-6)
+-- (-2) * (-3) = 6
+#guard EDyadic.mul (EDyadic.ofDyadic false (-2)) (EDyadic.ofDyadic false (-3)) =
+  EDyadic.ofDyadic false 6
+
+/-! ## Special values (IEEE-754) -/
+
+-- NaN propagates
+#guard EDyadic.add EDyadic.nan (EDyadic.ofDyadic false 1) = EDyadic.nan
+#guard EDyadic.mul (EDyadic.ofDyadic false 1) EDyadic.nan = EDyadic.nan
+-- ∞ + ∞ = ∞ (same sign); ∞ + (-∞) = NaN
+#guard EDyadic.add (EDyadic.infinity false) (EDyadic.infinity false) = EDyadic.infinity false
+#guard EDyadic.add (EDyadic.infinity false) (EDyadic.infinity true) = EDyadic.nan
+-- ∞ + finite = ∞
+#guard EDyadic.add (EDyadic.infinity true) (EDyadic.ofDyadic false 5) = EDyadic.infinity true
+-- signed zeros
+#guard EDyadic.add (EDyadic.zero true) (EDyadic.zero true) = EDyadic.zero true
+#guard EDyadic.add (EDyadic.zero false) (EDyadic.zero true) = EDyadic.zero false
+#guard EDyadic.add (EDyadic.zero true) (EDyadic.ofDyadic false 2) = EDyadic.ofDyadic false 2
+-- ∞ * 0 = NaN
+#guard EDyadic.mul (EDyadic.infinity false) (EDyadic.zero false) = EDyadic.nan
+-- ∞ * finite = ∞ with xor sign
+#guard EDyadic.mul (EDyadic.infinity false) (EDyadic.ofDyadic false (-2)) = EDyadic.infinity true
+-- ∞ * ∞ sign
+#guard EDyadic.mul (EDyadic.infinity true) (EDyadic.infinity true) = EDyadic.infinity false
+-- 0 * finite = signed 0
+#guard EDyadic.mul (EDyadic.zero false) (EDyadic.ofDyadic false (-3)) = EDyadic.zero true
+#guard EDyadic.mul (EDyadic.zero true) (EDyadic.ofDyadic false (-3)) = EDyadic.zero false
+
+end UnitTest.Fp.EDyadic.Arith

--- a/UnitTest/FP/EDyadic/Round.lean
+++ b/UnitTest/FP/EDyadic/Round.lean
@@ -1,12 +1,18 @@
 module
 
 import Veir.Data.FP.EDyadic.Round
+import Veir.Data.FP.EDyadic.Pack
+import Veir.Data.FP.PackedFloat.ToEDyadic
 
 meta import Veir.Data.FP.EDyadic.Round
+meta import Veir.Data.FP.EDyadic.Pack
+meta import Veir.Data.FP.PackedFloat.OfFloat
+meta import Veir.Data.FP.PackedFloat.ToEDyadic
 
 namespace UnitTest.Fp.EDyadic.Round
 
 open Veir.Data.FP
+open Veir.Data.FP.PackedFloat
 
 /-! ## Identity on representable values
 
@@ -98,5 +104,26 @@ A value smaller than half-min-subnormal rounds to `+0`. -/
 -- 3 · 2^(-11) = 2^(-9) · 3/4: closer to 2^(-9) than to 0, rounds up.
 #guard Dyadic.round .RNE (Dyadic.ofIntWithPrec 3 11) 4 3 =
   EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 1 9)
+
+/-! ## Round-trip via `pack ∘ round` against IEEE-754 doubles
+
+For doubles already representable in the format, `round` is the identity
+on the dyadic value, and `pack` recovers the original bit pattern. -/
+
+def asDyadic (pf : PackedFloat 11 52) : Dyadic :=
+  match toEDyadic pf with
+  | .nonzeroFinite d _ => d
+  | _ => 0
+
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1.0)) 11 52) =
+  ofFloat 1.0
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1.5)) 11 52) =
+  ofFloat 1.5
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat (-1.5))) 11 52) =
+  ofFloat (-1.5)
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 0.5)) 11 52) =
+  ofFloat 0.5
+#guard EDyadic.pack 11 52 (Dyadic.round .RNE (asDyadic (ofFloat 1024.0)) 11 52) =
+  ofFloat 1024.0
 
 end UnitTest.Fp.EDyadic.Round

--- a/UnitTest/FP/FastFloat.lean
+++ b/UnitTest/FP/FastFloat.lean
@@ -1,0 +1,81 @@
+module
+
+import Veir.Data.FP.FastFloat
+
+meta import Veir.Data.FP.FastFloat
+
+namespace UnitTest.Fp.FastFloat
+
+open Veir.Data.FP
+
+/-! ## `FastFloat 8 23 .RNE` against native `Float32`
+
+`FastFloat 8 23 .RNE` simulates IEEE-754 single-precision (the same
+shape as `Float32`) by rounding every result to single-precision width
+under round-to-nearest-ties-to-even. This file uses native `Float32`
+results as a golden reference: for each input pair, the bit pattern
+extracted from `(FastFloat.ofFloat32 a + FastFloat.ofFloat32 b).value`
+(when narrowed back to `Float32`) must match `a + b` performed natively.
+
+We narrow `FastFloat`'s underlying `Float` back to `Float32` by routing
+through the packed-float encoding (this is the round-trip that defines
+`FastFloat`'s precision contract). -/
+
+/-- Convert the underlying `Float` of a `FastFloat 8 23 mode` to a `Float32`
+via the packed encoding. -/
+def fastToFloat32 {mode : RoundingMode} (x : FastFloat 8 23 mode) : Float32 :=
+  PackedFloat.toFloat32 (PackedFloat.ofFloat x.value
+    |> PackedFloat.round mode 8 23)
+
+/-- The `Float32` golden value for a pair under `op`. -/
+def goldF32 (op : Float32 → Float32 → Float32) (a b : Float32) : Float32 :=
+  op a b
+
+/-- The simulated value via `FastFloat 8 23 .RNE`. -/
+def simF32
+    (op : ∀ {e s : Nat} {m : RoundingMode},
+      FastFloat e s m → FastFloat e s m → FastFloat e s m)
+    (a b : Float32) : Float32 :=
+  let af : FastFloat 8 23 .RNE := FastFloat.ofFloat32 a
+  let bf : FastFloat 8 23 .RNE := FastFloat.ofFloat32 b
+  fastToFloat32 (op af bf)
+
+/-- Bit-pattern equality on `Float32` (treats `NaN` bit patterns as ordered). -/
+def bitsEq (a b : Float32) : Bool :=
+  Float32.toBits a == Float32.toBits b
+
+/-! ### Addition matches `Float32 + Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a + b) 1.0 2.0) (1.0 + 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.5 2.5) (1.5 + 2.5 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 0.1 0.2) (0.1 + 0.2 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) (-1.0) 1.0) (-1.0 + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.0e10 1.0) (1.0e10 + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) 1.0e-30 1.0e-30) (1.0e-30 + 1.0e-30 : Float32)
+
+/-! ### Subtraction matches `Float32 - Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a - b) 3.0 1.0) (3.0 - 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a - b) 1.0 2.0) (1.0 - 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a - b) 1.0e10 1.0) (1.0e10 - 1.0 : Float32)
+
+/-! ### Multiplication matches `Float32 * Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a * b) 1.5 2.0) (1.5 * 2.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 0.1 0.1) (0.1 * 0.1 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 1.0e15 1.0e15) (1.0e15 * 1.0e15 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) (-2.0) 3.0) ((-2.0) * 3.0 : Float32)
+
+/-! ### Division matches `Float32 / Float32` -/
+
+#guard bitsEq (simF32 (fun a b => a / b) 1.0 3.0) (1.0 / 3.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a / b) 22.0 7.0) (22.0 / 7.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a / b) (-1.0) 4.0) ((-1.0) / 4.0 : Float32)
+
+/-! ### Specials propagate -/
+
+#guard bitsEq (simF32 (fun a b => a + b) (1.0 / 0.0) 1.0) ((1.0 / 0.0) + 1.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a * b) 0.0 0.0) (0.0 * 0.0 : Float32)
+#guard bitsEq (simF32 (fun a b => a + b) (-0.0) 0.0) ((-0.0) + 0.0 : Float32)
+
+end UnitTest.Fp.FastFloat

--- a/UnitTest/FP/FastFloatSmoke.lean
+++ b/UnitTest/FP/FastFloatSmoke.lean
@@ -1,0 +1,90 @@
+module
+
+import Veir.Data.FP.FastFloat
+
+meta import Veir.Data.FP.FastFloat
+
+namespace UnitTest.Fp.FastFloatSmoke
+
+open Veir.Data.FP
+
+/-! # Smoke test: `FastFloat 8 23 .RNE` against native `Float32`
+
+Enumerates a representative sample of `Float32` values — all five
+specials, the boundary subnormal/normal values, and 50
+logarithmically-spaced points across the dynamic range — and verifies
+that for every input pair, each of `add`/`sub`/`mul`/`div` performed
+through `FastFloat 8 23 .RNE` produces the same `Float32` bit pattern as
+the native `Float32` operation. NaNs are compared as
+`isNaN ↔ isNaN` (their bit patterns may differ across paths).
+
+Total cost: with 59 values, every operator runs over `59 × 59 = 3481`
+pairs at elaboration. -/
+
+/-- Round-trip a `FastFloat 8 23 mode`'s underlying `Float` to `Float32`. -/
+private def fastToFloat32 {mode : RoundingMode}
+    (x : FastFloat 8 23 mode) : Float32 :=
+  PackedFloat.toFloat32
+    (PackedFloat.round mode 8 23 (PackedFloat.ofFloat x.value))
+
+/-- Run `op` on `Float32` inputs via the `FastFloat 8 23 .RNE` path. -/
+private def viaFast
+    (op : ∀ {e s : Nat} {m : RoundingMode},
+      FastFloat e s m → FastFloat e s m → FastFloat e s m)
+    (a b : Float32) : Float32 :=
+  let af : FastFloat 8 23 .RNE := FastFloat.ofFloat32 a
+  let bf : FastFloat 8 23 .RNE := FastFloat.ofFloat32 b
+  fastToFloat32 (op af bf)
+
+/-- Equality on `Float32` results: bit-equal, or both NaN. -/
+private def f32eq (a b : Float32) : Bool :=
+  (a.isNaN && b.isNaN) || (Float32.toBits a == Float32.toBits b)
+
+/-- Build a `Float32` from a 32-bit pattern. -/
+private def f32 (bits : UInt32) : Float32 := Float32.ofBits bits
+
+/--
+The smoke-test sample of `Float32` values:
+
+* nine specials (NaN, ±∞, ±0, ±minSubnormal, ±maxNormal),
+* fifty values whose biased exponent steps roughly evenly across
+  `[1, 254]` (significand left at zero), giving 50 powers of two
+  spread logarithmically across the dynamic range.
+-/
+private def smokeValues : List Float32 :=
+  let specials : List Float32 := [
+    f32 0x7fc00000,  -- NaN (canonical quiet)
+    f32 0x7f800000,  -- +∞
+    f32 0xff800000,  -- −∞
+    f32 0x00000000,  -- +0
+    f32 0x80000000,  -- −0
+    f32 0x00000001,  -- +minSubnormal
+    f32 0x80000001,  -- −minSubnormal
+    f32 0x7f7fffff,  -- +maxNormal
+    f32 0xff7fffff   -- −maxNormal
+  ]
+  let logSpaced : List Float32 :=
+    (List.range 50).map fun i =>
+      let biasedExp : Nat := 1 + (i * 253) / 49
+      f32 ((UInt32.ofNat biasedExp) <<< 23)
+  specials ++ logSpaced
+
+/-- All ordered pairs from the smoke set. -/
+private def smokePairs : List (Float32 × Float32) :=
+  smokeValues.flatMap fun a => smokeValues.map fun b => (a, b)
+
+/-! ### Each operator agrees with native `Float32` on every pair -/
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· + ·) a b) (a + b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· - ·) a b) (a - b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· * ·) a b) (a * b)
+
+#guard smokePairs.all fun (a, b) =>
+  f32eq (viaFast (· / ·) a b) (a / b)
+
+end UnitTest.Fp.FastFloatSmoke

--- a/Veir/Data/FP/EDyadic.lean
+++ b/Veir/Data/FP/EDyadic.lean
@@ -3,3 +3,4 @@ module
 public import Veir.Data.FP.EDyadic.Basic
 public import Veir.Data.FP.EDyadic.Pack
 public import Veir.Data.FP.EDyadic.Round
+public import Veir.Data.FP.EDyadic.Arith

--- a/Veir/Data/FP/EDyadic/Arith.lean
+++ b/Veir/Data/FP/EDyadic/Arith.lean
@@ -1,0 +1,80 @@
+module
+
+public import Veir.Data.FP.EDyadic.Basic
+
+namespace Veir.Data.FP
+
+public section
+
+namespace EDyadic
+
+/-! ## Exact arithmetic on `EDyadic`
+
+`EDyadic` represents an *unbounded* dyadic rational together with the IEEE
+special values (`±0`, `±∞`, `NaN`). The dyadics are closed under addition,
+subtraction, and multiplication, so the operations below are **exact**: no
+rounding happens here. Rounding to a finite `(e, s)` format is a separate step
+(`Dyadic.round`), applied by `EDyadicFloat`.
+
+The special-value behaviour follows IEEE-754:
+- `NaN` propagates through every operation;
+- `∞ + (-∞)` is `NaN`, otherwise an infinite operand dominates a finite one;
+- `∞ * 0` is `NaN`; products carry the xor of the signs;
+- multiplicative zeros take the xor sign, and like-signed additive zeros are
+  kept (`(-0) + (-0) = -0`).
+
+The sign of an *additive* zero whose operands are not like-signed zeros — the
+mixed case `(+0) + (-0)` and an exact cancellation `x + (-x)` — depends on the
+rounding mode (`+0`, except `RTN` which gives `-0`). A zero value cannot record
+the operands that produced it, so `add` cannot decide this; it returns a
+provisional zero and the mode-aware `EDyadic.addRound` re-assigns the sign.
+-/
+
+/-- Exact sum of two `EDyadic` values. Finite values are added at their common
+precision, yielding another dyadic; specials follow IEEE-754. -/
+def add : EDyadic → EDyadic → EDyadic
+  | .nan, _ => .nan
+  | _, .nan => .nan
+  | .infinity sa, .infinity sb => if sa = sb then .infinity sa else .nan
+  | .infinity sa, _ => .infinity sa
+  | _, .infinity sb => .infinity sb
+  | .zero sa, .zero sb => .zero (sa && sb)
+  | .zero _, b => b
+  | a, .zero _ => a
+  | .nonzeroFinite (.ofOdd na ka _) _, .nonzeroFinite (.ofOdd nb kb _) _ =>
+    -- `na · 2^(-ka) + nb · 2^(-kb)` aligned to the common precision `K`.
+    -- `K - ka` and `K - kb` are nonnegative, so `.toNat` is exact.
+    let K := max ka kb
+    let num := na * (2 : Int) ^ (K - ka).toNat + nb * (2 : Int) ^ (K - kb).toNat
+    EDyadic.ofDyadic false (Dyadic.ofIntWithPrec num K)
+
+/-- Exact negation, reusing `EDyadic.neg`. -/
+def sub (a b : EDyadic) : EDyadic := add a (-b)
+
+/-- Exact product of two `EDyadic` values. Finite values multiply numerators and
+add precisions; specials follow IEEE-754 (`∞ * 0 = NaN`, sign = xor of signs). -/
+def mul : EDyadic → EDyadic → EDyadic
+  | .nan, _ => .nan
+  | _, .nan => .nan
+  | .infinity _, .zero _ => .nan
+  | .zero _, .infinity _ => .nan
+  | .infinity sa, .infinity sb => .infinity (sa != sb)
+  | .infinity sa, .nonzeroFinite (.ofOdd nb _ _) _ => .infinity (sa != decide (nb < 0))
+  | .nonzeroFinite (.ofOdd na _ _) _, .infinity sb => .infinity (decide (na < 0) != sb)
+  | .zero sa, .zero sb => .zero (sa != sb)
+  | .zero sa, .nonzeroFinite (.ofOdd nb _ _) _ => .zero (sa != decide (nb < 0))
+  | .nonzeroFinite (.ofOdd na _ _) _, .zero sb => .zero (decide (na < 0) != sb)
+  | .nonzeroFinite (.ofOdd na ka _) _, .nonzeroFinite (.ofOdd nb kb _) _ =>
+    -- `(na · nb) · 2^(-(ka + kb))`; the sign rides on the integer product, so
+    -- the `ofDyadic` sign argument (used only for zero) is irrelevant here.
+    EDyadic.ofDyadic false (Dyadic.ofIntWithPrec (na * nb) (ka + kb))
+
+instance : Add EDyadic := ⟨EDyadic.add⟩
+instance : Sub EDyadic := ⟨EDyadic.sub⟩
+instance : Mul EDyadic := ⟨EDyadic.mul⟩
+
+end EDyadic
+
+end -- public section
+
+end Veir.Data.FP

--- a/Veir/Data/FP/EDyadic/Round.lean
+++ b/Veir/Data/FP/EDyadic/Round.lean
@@ -396,6 +396,7 @@ def round (mode : RoundingMode) (x : Dyadic) (e s : Nat)
     let prec : Int := targetPrec value e s
     computeRoundByMode mode sign n.natAbs k prec e s
 
+
 end Dyadic
 
 end

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -6,3 +6,4 @@ public import Veir.Data.FP.ScientificBV.Basic
 public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.EDyadic
+public import Veir.Data.FP.FastFloat

--- a/Veir/Data/FP/FastFloat.lean
+++ b/Veir/Data/FP/FastFloat.lean
@@ -1,0 +1,98 @@
+module
+
+public import Veir.Data.FP.PackedFloat.OfFloat
+public import Veir.Data.FP.PackedFloat.Round
+
+namespace Veir.Data.FP
+
+public section
+
+/--
+A `FastFloat e s mode` is a Lean `Float` (IEEE-754 double) whose value
+has been rounded to the precision of an `(e, s)`-format packed float
+under the given IEEE-754 rounding `mode`.
+
+The rounding mode is encoded at the type level so that arithmetic
+operations can use it without requiring it as an extra runtime argument:
+`add`, `sub`, `mul`, `div` all delegate to native `Float` arithmetic
+and then re-round the result to `(e, s)` precision via
+`PackedFloat.round` under `mode`.
+
+To switch the rounding mode of an existing value, use
+`FastFloat.setRoundingMode`.
+-/
+@[ext]
+structure FastFloat (e s : Nat) (mode : RoundingMode) where
+  /-- The underlying double, normalized to `(e, s)` precision under `mode`. -/
+  value : Float
+deriving Inhabited
+
+namespace FastFloat
+
+/--
+Round a Lean `Float` to `(e, s)` precision and back to `Float`,
+using rounding `mode`.
+The trip is `Float → PackedFloat 11 52 → PackedFloat e s → PackedFloat 11 52 → Float`,
+applying `PackedFloat.round mode` for each width change.
+-/
+def roundFloat (mode : RoundingMode) (e s : Nat) (f : Float) : Float :=
+  let pfDouble : PackedFloat 11 52 := PackedFloat.ofFloat f
+  let pfTarget : PackedFloat e s := PackedFloat.round mode e s pfDouble
+  let pfBack : PackedFloat 11 52 := PackedFloat.round mode 11 52 pfTarget
+  PackedFloat.toFloat pfBack
+
+/-- Lift a `Float` to a `FastFloat e s mode`, rounding to target precision. -/
+def ofFloat {e s : Nat} {mode : RoundingMode} (f : Float) : FastFloat e s mode :=
+  ⟨roundFloat mode e s f⟩
+
+/--
+Lift a `Float32` to a `FastFloat e s mode`. The single-precision value
+is widened to a `Float` and then rounded to `(e, s)` precision.
+-/
+def ofFloat32 {e s : Nat} {mode : RoundingMode} (f : Float32) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s f.toFloat⟩
+
+/-- Extract the underlying `Float`. -/
+def toFloat {e s : Nat} {mode : RoundingMode} (x : FastFloat e s mode) : Float :=
+  x.value
+
+/--
+Re-tag a `FastFloat` with a different rounding mode. The underlying
+`Float` value is unchanged; subsequent arithmetic on the result will use
+the new mode when re-rounding.
+-/
+def setRoundingMode {e s : Nat} {m : RoundingMode}
+    (newMode : RoundingMode) (x : FastFloat e s m) : FastFloat e s newMode :=
+  ⟨x.value⟩
+
+/-- Add two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def add {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value + b.value)⟩
+
+/-- Subtract two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def sub {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value - b.value)⟩
+
+/-- Multiply two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def mul {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value * b.value)⟩
+
+/-- Divide two `FastFloat e s mode` values, rounding the result to `(e, s)` under `mode`. -/
+def div {e s : Nat} {mode : RoundingMode} (a b : FastFloat e s mode) :
+    FastFloat e s mode :=
+  ⟨roundFloat mode e s (a.value / b.value)⟩
+
+instance {e s : Nat} {mode : RoundingMode} : Add (FastFloat e s mode) := ⟨add⟩
+instance {e s : Nat} {mode : RoundingMode} : Sub (FastFloat e s mode) := ⟨sub⟩
+instance {e s : Nat} {mode : RoundingMode} : Mul (FastFloat e s mode) := ⟨mul⟩
+instance {e s : Nat} {mode : RoundingMode} : Div (FastFloat e s mode) := ⟨div⟩
+
+end FastFloat
+
+end -- public section
+
+end Veir.Data.FP

--- a/Veir/Data/FP/PackedFloat.lean
+++ b/Veir/Data/FP/PackedFloat.lean
@@ -4,4 +4,4 @@ public import Veir.Data.FP.PackedFloat.Basic
 public import Veir.Data.FP.PackedFloat.OfFloat
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.PackedFloat.ToEDyadic
-
+public import Veir.Data.FP.PackedFloat.Round

--- a/Veir/Data/FP/PackedFloat/OfFloat.lean
+++ b/Veir/Data/FP/PackedFloat/OfFloat.lean
@@ -26,5 +26,24 @@ def toFloat (pf : PackedFloat 11 52) : Float :=
   let bits : BitVec 64 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
   Float.ofBits (UInt64.ofBitVec bits)
 
+/--
+Convert a Lean single-precision float (`Float32`) to a `PackedFloat 8 23`.
+A IEEE single-precision float has the layout:
+  - 1 bit for the sign
+  - 8 bits for the exponent
+  - 23 bits for the significand
+-/
+def ofFloat32 (f : Float32) : PackedFloat 8 23 :=
+  let bits : BitVec 32 := (Float32.toBits f).toBitVec
+  let sign : Bool := (bits >>> 31) ≠ 0#_
+  let exponent := (bits >>> 23) &&& (1 <<< 8 - 1)
+  let significand := bits &&& (1 <<< 23 - 1)
+  PackedFloat.mk sign (exponent.setWidth 8) (significand.setWidth 23)
+
+/-- Convert a `PackedFloat 8 23` back to a Lean single-precision float (`Float32`). -/
+def toFloat32 (pf : PackedFloat 8 23) : Float32 :=
+  let bits : BitVec 32 := (BitVec.ofBool pf.sign) ++ pf.ex ++ pf.sig
+  Float32.ofBits (UInt32.ofBitVec bits)
+
 end -- public section
 end Veir.Data.FP.PackedFloat

--- a/Veir/Data/FP/PackedFloat/Round.lean
+++ b/Veir/Data/FP/PackedFloat/Round.lean
@@ -1,0 +1,37 @@
+module
+
+public import Veir.Data.FP.PackedFloat.Basic
+public import Veir.Data.FP.PackedFloat.ToEDyadic
+public import Veir.Data.FP.EDyadic.Round
+public import Veir.Data.FP.EDyadic.Pack
+
+namespace Veir.Data.FP.PackedFloat
+
+public section
+
+/--
+Round a `PackedFloat e s` into target format `PackedFloat etarget starget`
+using the given IEEE-754 rounding mode.
+
+The implementation is the composition
+`PackedFloat → EDyadic → (rounded) EDyadic → PackedFloat`:
+* `PackedFloat.toEDyadic` converts the input to its precise dyadic value
+  (preserving NaN, ±∞, and ±0).
+* `Dyadic.round mode` rounds finite nonzero values to a representable
+  value in `(etarget, starget)` per the given rounding mode.
+* `EDyadic.pack` re-encodes the result in the target packed format.
+
+NaN, ±∞, and ±0 are propagated through; only the exponent and significand
+widths change.
+-/
+def round {e s : Nat} (mode : RoundingMode) (etarget starget : Nat)
+    (pf : PackedFloat e s) : PackedFloat etarget starget :=
+  let edRounded : EDyadic :=
+    match pf.toEDyadic with
+    | .nonzeroFinite d hne => Dyadic.round mode d etarget starget hne
+    | special => special
+  EDyadic.pack etarget starget edRounded
+
+end -- public section
+
+end Veir.Data.FP.PackedFloat


### PR DESCRIPTION
## What

Adds exact (unbounded) arithmetic on `EDyadic`: `EDyadic.add`, `EDyadic.sub`, `EDyadic.mul` with `Add`/`Sub`/`Mul` instances. Dyadics are closed under +/−/×, so these are computed exactly with no rounding.

- `add`: common scale `K := max ka kb`, numerator `na·2^(K-ka) + nb·2^(K-kb)`, rebuilt via `Dyadic.ofIntWithPrec`; exact cancellation collapses to a (provisional) zero.
- `sub a b := add a (-b)`.
- `mul`: `ofIntWithPrec (na*nb) (ka+kb)`.
- IEEE specials: NaN propagates; `∞ + (−∞) = NaN`; `∞ * 0 = NaN`; sign rules incl. signed zeros.

Tests in `UnitTest/FP/EDyadic/Arith.lean` check exact values and special cases.

## Note on the sign of an additive zero

This layer is mode-free, so it does **not** decide the sign of an additive zero (`x + (−x)`, or mixed-sign zero operands). Per IEEE-754 §6.3 that sign is mode-dependent (`+0` except `RTN` → `−0`), and a zero value no longer records its operands — so `add` returns a provisional zero and the mode-aware `EDyadic.addRound` (in the `edyadicfloat-ops` PR, #791) assigns the correct sign. `mul`'s zero sign is the mode-independent xor and is set here.

## Stack

Part of `full-precision-floats-edyadic` (patch 1/6). Base: `round-edyadic-fastfloat` (#787).

🤖 Generated with [Claude Code](https://claude.com/claude-code)