### PR TITLE
feat(EDyadicFloat): EDyadicFloat type with ofPackedFloat/toPackedFloat

### DIFF
--- a/UnitTest/FP.lean
+++ b/UnitTest/FP.lean
@@ -4,3 +4,4 @@ public import UnitTest.FP.PackedFloat
 public import UnitTest.FP.EDyadic
 public import UnitTest.FP.FastFloat
 public import UnitTest.FP.FastFloatSmoke
+public import UnitTest.FP.EDyadicFloat

--- a/UnitTest/FP/EDyadicFloat.lean
+++ b/UnitTest/FP/EDyadicFloat.lean
@@ -1,0 +1,59 @@
+module
+
+import Veir.Data.FP.EDyadicFloat
+import Veir.Data.FP.PackedFloat.OfFloat
+
+meta import Veir.Data.FP.EDyadicFloat
+meta import Veir.Data.FP.PackedFloat.OfFloat
+
+namespace UnitTest.Fp.EDyadicFloat
+
+open Veir.Data.FP
+
+/-! ## `toPackedFloat ∘ ofPackedFloat = id` on representable values
+
+`ofPackedFloat` interprets the packed bits exactly, and `toPackedFloat` re-encodes
+them, so the round trip is the identity on finite/zero/infinite inputs. -/
+
+/-- Round-trip a double through `EDyadicFloat 11 52 .RNE`. -/
+def rt64 (pf : PackedFloat 11 52) : PackedFloat 11 52 :=
+  EDyadicFloat.toPackedFloat (EDyadicFloat.ofPackedFloat (mode := .RNE) pf)
+
+#guard rt64 (PackedFloat.ofFloat 1.0) = PackedFloat.ofFloat 1.0
+#guard rt64 (PackedFloat.ofFloat 1.5) = PackedFloat.ofFloat 1.5
+#guard rt64 (PackedFloat.ofFloat (-2.0)) = PackedFloat.ofFloat (-2.0)
+#guard rt64 (PackedFloat.ofFloat 0.0) = PackedFloat.ofFloat 0.0
+#guard rt64 (PackedFloat.ofFloat (-0.0)) = PackedFloat.ofFloat (-0.0)
+#guard rt64 (PackedFloat.ofFloat 1024.0) = PackedFloat.ofFloat 1024.0
+#guard rt64 (PackedFloat.ofFloat (1.0 / 0.0)) = PackedFloat.ofFloat (1.0 / 0.0)
+#guard rt64 (PackedFloat.ofFloat 3.140625) = PackedFloat.ofFloat 3.140625
+
+/-- Round-trip a single through `EDyadicFloat 8 23 .RNE`. -/
+def rt32 (pf : PackedFloat 8 23) : PackedFloat 8 23 :=
+  EDyadicFloat.toPackedFloat (EDyadicFloat.ofPackedFloat (mode := .RNE) pf)
+
+#guard rt32 (PackedFloat.ofFloat32 1.0) = PackedFloat.ofFloat32 1.0
+#guard rt32 (PackedFloat.ofFloat32 (-1.5)) = PackedFloat.ofFloat32 (-1.5)
+#guard rt32 (PackedFloat.ofFloat32 0.0) = PackedFloat.ofFloat32 0.0
+
+/-! ## `ofEDyadic` rounds to the format
+
+At the integer-grade format `(4, 0)`, `ofEDyadic` rounds `1.5` to the even
+integer `2` under RNE, exercising the `EDyadic.round` wrapper. -/
+
+#guard (EDyadicFloat.ofEDyadic (e := 4) (s := 0) (mode := .RNE)
+  (EDyadic.ofDyadic false (Dyadic.ofIntWithPrec 3 1))).value = EDyadic.ofDyadic false 2
+-- already representable: identity
+#guard (EDyadicFloat.ofEDyadic (e := 11) (s := 52) (mode := .RNE)
+  (EDyadic.ofDyadic false 3)).value = EDyadic.ofDyadic false 3
+
+/-! ## Specials pass through the rounding wrapper -/
+
+#guard (EDyadicFloat.ofEDyadic (e := 11) (s := 52) (mode := .RNE) EDyadic.nan).value =
+  EDyadic.nan
+#guard (EDyadicFloat.ofEDyadic (e := 11) (s := 52) (mode := .RNE)
+  (EDyadic.infinity true)).value = EDyadic.infinity true
+#guard (EDyadicFloat.ofEDyadic (e := 11) (s := 52) (mode := .RNE)
+  (EDyadic.zero true)).value = EDyadic.zero true
+
+end UnitTest.Fp.EDyadicFloat

--- a/Veir/Data/FP/EDyadicFloat.lean
+++ b/Veir/Data/FP/EDyadicFloat.lean
@@ -1,0 +1,66 @@
+module
+
+public import Veir.Data.FP.EDyadic.Round
+public import Veir.Data.FP.EDyadic.Pack
+public import Veir.Data.FP.PackedFloat.ToEDyadic
+
+namespace Veir.Data.FP
+
+public section
+
+namespace EDyadic
+
+/--
+Round an arbitrary-precision `EDyadic` to the `(e, s)` format under `mode`.
+Specials pass through unchanged; a nonzero finite value is rounded by
+`Dyadic.round` (which itself may yield `±0`/`±∞` on underflow/overflow).
+-/
+def round (mode : RoundingMode) (e s : Nat) : EDyadic → EDyadic
+  | .nan => .nan
+  | .infinity sign => .infinity sign
+  | .zero sign => .zero sign
+  | .nonzeroFinite d hne => Dyadic.round mode d e s hne
+
+end EDyadic
+
+/--
+An `EDyadicFloat e s mode` is an arbitrary-precision `EDyadic` value that is
+representable in the `(e, s)` floating-point format — i.e. the result of
+rounding under `mode`. It is the *high-precision* analogue of `FastFloat`:
+where `FastFloat` re-rounds a native `Float` (and is therefore capped at double
+precision internally), `EDyadicFloat` carries the **exact** dyadic value and
+rounds once, so every operation is correctly rounded at any width `(e, s)`.
+
+The rounding mode is encoded at the type level, so binary operations need no
+extra runtime argument. The pipeline is
+`PackedFloat → EDyadic (exact math) → round → EDyadic → PackedFloat`.
+-/
+@[ext]
+structure EDyadicFloat (e s : Nat) (mode : RoundingMode) where
+  /-- The underlying value, guaranteed representable in `(e, s)` under `mode`. -/
+  value : EDyadic
+deriving DecidableEq, Inhabited
+
+namespace EDyadicFloat
+
+/-- Round an arbitrary `EDyadic` into an `EDyadicFloat e s mode`. -/
+def ofEDyadic {e s : Nat} {mode : RoundingMode} (x : EDyadic) :
+    EDyadicFloat e s mode :=
+  ⟨EDyadic.round mode e s x⟩
+
+/-- Interpret a `PackedFloat e s` as an `EDyadicFloat e s mode`. The packed value
+is already representable, so no rounding is needed. -/
+def ofPackedFloat {e s : Nat} {mode : RoundingMode} (pf : PackedFloat e s) :
+    EDyadicFloat e s mode :=
+  ⟨pf.toEDyadic⟩
+
+/-- Encode an `EDyadicFloat e s mode` as a `PackedFloat e s`. -/
+def toPackedFloat {e s : Nat} {mode : RoundingMode} (x : EDyadicFloat e s mode) :
+    PackedFloat e s :=
+  EDyadic.pack e s x.value
+
+end EDyadicFloat
+
+end -- public section
+
+end Veir.Data.FP

--- a/Veir/Data/FP/FP.lean
+++ b/Veir/Data/FP/FP.lean
@@ -7,3 +7,4 @@ public import Veir.Data.FP.ExtRat.Basic
 public import Veir.Data.FP.PackedFloat.ToExtRat
 public import Veir.Data.FP.EDyadic
 public import Veir.Data.FP.FastFloat
+public import Veir.Data.FP.EDyadicFloat


### PR DESCRIPTION
## What

Adds the high-precision float model `EDyadicFloat e s mode` — a structure wrapping an `EDyadic` value held representable in `(e, s)` — mirroring `FastFloat`, plus:

- `EDyadic.round mode e s : EDyadic → EDyadic` (specials pass through; `nonzeroFinite d _ → Dyadic.round mode d e s`).
- `EDyadicFloat.ofEDyadic` / `ofPackedFloat pf := ⟨pf.toEDyadic⟩` / `toPackedFloat x := EDyadic.pack e s x.value`.

This completes the FP story: `PackedFloat` (storage) → `EDyadic` (exact math) → `EDyadicFloat` (rounded math). Tests in `UnitTest/FP/EDyadicFloat.lean` check `toPackedFloat ∘ ofPackedFloat = id` on representable inputs, `ofEDyadic` rounding, and specials.

## Stack

Part of `full-precision-floats-edyadic` (patch 3/6). Base: #789.

🤖 Generated with [Claude Code](https://claude.com/claude-code)