### PR TITLE
feat(EDyadicFloat): add/sub/mul/div with correctly-rounded results

### DIFF
--- a/UnitTest/FP/EDyadicFloat.lean
+++ b/UnitTest/FP/EDyadicFloat.lean
@@ -56,4 +56,53 @@ integer `2` under RNE, exercising the `EDyadic.round` wrapper. -/
 #guard (EDyadicFloat.ofEDyadic (e := 11) (s := 52) (mode := .RNE)
   (EDyadic.zero true)).value = EDyadic.zero true
 
+/-! ## Arithmetic on representable values
+
+For operands and results exactly representable in the format, the rounded
+operation reproduces the packed encoding of the mathematical result. -/
+
+/-- Build/extract `EDyadicFloat 11 52 .RNE` from/to a double's packed form. -/
+def mk64 (f : Float) : EDyadicFloat 11 52 .RNE := EDyadicFloat.ofPackedFloat (PackedFloat.ofFloat f)
+def out64 (x : EDyadicFloat 11 52 .RNE) : PackedFloat 11 52 := EDyadicFloat.toPackedFloat x
+
+#guard out64 (mk64 1.0 + mk64 2.0) = PackedFloat.ofFloat 3.0
+#guard out64 (mk64 3.0 - mk64 1.0) = PackedFloat.ofFloat 2.0
+#guard out64 (mk64 1.5 * mk64 2.0) = PackedFloat.ofFloat 3.0
+#guard out64 (mk64 6.0 / mk64 2.0) = PackedFloat.ofFloat 3.0
+#guard out64 (mk64 1.0 / mk64 4.0) = PackedFloat.ofFloat 0.25
+-- exact cancellation → +0
+#guard out64 (mk64 1.0 - mk64 1.0) = PackedFloat.ofFloat 0.0
+-- correctly-rounded inexact quotient matches native (both round-to-nearest-even)
+#guard out64 (mk64 1.0 / mk64 3.0) = PackedFloat.ofFloat (1.0 / 3.0)
+-- specials propagate
+#guard out64 (mk64 (1.0 / 0.0) + mk64 1.0) = PackedFloat.ofFloat (1.0 / 0.0)
+
+/-- Build/extract `EDyadicFloat 8 23 .RNE` from/to a single's packed form. -/
+def mk32 (f : Float32) : EDyadicFloat 8 23 .RNE := EDyadicFloat.ofPackedFloat (PackedFloat.ofFloat32 f)
+def out32 (x : EDyadicFloat 8 23 .RNE) : PackedFloat 8 23 := EDyadicFloat.toPackedFloat x
+
+#guard out32 (mk32 1.5 + mk32 2.5) = PackedFloat.ofFloat32 4.0
+#guard out32 (mk32 7.0 / mk32 2.0) = PackedFloat.ofFloat32 3.5
+
+/-! ## Sign of an additive zero depends on the rounding mode
+
+IEEE-754 §6.3: an additive zero is `+0` in every mode except `RTN`, where it is
+`-0` — *unless* both operands are like-signed zeros, which keep their sign in all
+modes. `EDyadicFloat.add`/`sub` route this through `EDyadic.addRound`, so the
+`.RNE` and `.RTN` instances disagree exactly where IEEE says they should. -/
+
+/-- Build/extract `EDyadicFloat 11 52 .RTN` from/to a double's packed form. -/
+def mkRTN (f : Float) : EDyadicFloat 11 52 .RTN := EDyadicFloat.ofPackedFloat (PackedFloat.ofFloat f)
+def outRTN (x : EDyadicFloat 11 52 .RTN) : PackedFloat 11 52 := EDyadicFloat.toPackedFloat x
+
+-- exact cancellation `x + (-x)`: `+0` under RNE, `-0` under RTN
+#guard out64 (mk64 1.0 - mk64 1.0) = PackedFloat.ofFloat 0.0
+#guard outRTN (mkRTN 1.0 - mkRTN 1.0) = PackedFloat.ofFloat (-0.0)
+-- mixed-sign zero operands `(+0) + (-0)`: same mode rule
+#guard out64 (mk64 0.0 + mk64 (-0.0)) = PackedFloat.ofFloat 0.0
+#guard outRTN (mkRTN 0.0 + mkRTN (-0.0)) = PackedFloat.ofFloat (-0.0)
+-- like-signed zero operands keep their sign regardless of mode
+#guard outRTN (mkRTN (-0.0) + mkRTN (-0.0)) = PackedFloat.ofFloat (-0.0)
+#guard outRTN (mkRTN 0.0 + mkRTN 0.0) = PackedFloat.ofFloat 0.0
+
 end UnitTest.Fp.EDyadicFloat

--- a/Veir/Data/FP/EDyadicFloat.lean
+++ b/Veir/Data/FP/EDyadicFloat.lean
@@ -2,6 +2,8 @@ module
 
 public import Veir.Data.FP.EDyadic.Round
 public import Veir.Data.FP.EDyadic.Pack
+public import Veir.Data.FP.EDyadic.Arith
+public import Veir.Data.FP.EDyadic.DivRound
 public import Veir.Data.FP.PackedFloat.ToEDyadic
 
 namespace Veir.Data.FP
@@ -20,6 +22,30 @@ def round (mode : RoundingMode) (e s : Nat) : EDyadic → EDyadic
   | .infinity sign => .infinity sign
   | .zero sign => .zero sign
   | .nonzeroFinite d hne => Dyadic.round mode d e s hne
+
+/--
+Sign (`true = negative`) of an *additive* zero under `mode`. Two like-signed
+zeros keep that sign, independent of the mode; every other way addition reaches
+zero — mixed-sign zeros `(+0) + (-0)`, or an exact cancellation `x + (-x)` of
+nonzero operands — yields `+0`, except under `RTN` (round toward `-∞`) which
+yields `-0`. This is IEEE-754 §6.3, and the only place addition's zero sign
+depends on the rounding mode.
+-/
+def addZeroSign (mode : RoundingMode) : EDyadic → EDyadic → Bool
+  | .zero sa, .zero sb => if sa = sb then sa else decide (mode = .RTN)
+  | _, _ => decide (mode = .RTN)
+
+/--
+Add `a` and `b` and round the result to `(e, s)` under `mode` — the mode-aware
+counterpart of `EDyadic.add`, mirroring `EDyadic.divRound`. The exact sum is
+formed by `add`; a nonzero result is rounded by `round`, while an exact zero has
+its IEEE sign re-assigned by `addZeroSign` (the exact `add` returns only a
+provisional zero, since a zero value no longer records its operands).
+-/
+def addRound (mode : RoundingMode) (e s : Nat) (a b : EDyadic) : EDyadic :=
+  match EDyadic.add a b with
+  | .zero _ => .zero (addZeroSign mode a b)
+  | r => EDyadic.round mode e s r
 
 end EDyadic
 
@@ -58,6 +84,39 @@ def ofPackedFloat {e s : Nat} {mode : RoundingMode} (pf : PackedFloat e s) :
 def toPackedFloat {e s : Nat} {mode : RoundingMode} (x : EDyadicFloat e s mode) :
     PackedFloat e s :=
   EDyadic.pack e s x.value
+
+/-! ## Arithmetic
+
+`add`, `sub` use `EDyadic.addRound` (exact sum, then mode-aware rounding *and*
+zero-sign assignment); `mul` forms the exact product and rounds it once; `div`
+uses `EDyadic.divRound`, which fuses the (inexact) quotient and the rounding.
+Each result is therefore the IEEE-754 correctly-rounded value. -/
+
+/-- Add, rounding the exact sum to `(e, s)` under `mode`. -/
+def add {e s : Nat} {mode : RoundingMode} (a b : EDyadicFloat e s mode) :
+    EDyadicFloat e s mode :=
+  ⟨EDyadic.addRound mode e s a.value b.value⟩
+
+/-- Subtract, rounding the exact difference to `(e, s)` under `mode`. `a - b` is
+`a + (-b)`, so this shares `addRound`'s zero-sign handling. -/
+def sub {e s : Nat} {mode : RoundingMode} (a b : EDyadicFloat e s mode) :
+    EDyadicFloat e s mode :=
+  ⟨EDyadic.addRound mode e s a.value (-b.value)⟩
+
+/-- Multiply, rounding the exact product to `(e, s)` under `mode`. -/
+def mul {e s : Nat} {mode : RoundingMode} (a b : EDyadicFloat e s mode) :
+    EDyadicFloat e s mode :=
+  ⟨EDyadic.round mode e s (a.value * b.value)⟩
+
+/-- Divide, returning the correctly-rounded quotient in `(e, s)` under `mode`. -/
+def div {e s : Nat} {mode : RoundingMode} (a b : EDyadicFloat e s mode) :
+    EDyadicFloat e s mode :=
+  ⟨EDyadic.divRound mode e s a.value b.value⟩
+
+instance {e s : Nat} {mode : RoundingMode} : Add (EDyadicFloat e s mode) := ⟨add⟩
+instance {e s : Nat} {mode : RoundingMode} : Sub (EDyadicFloat e s mode) := ⟨sub⟩
+instance {e s : Nat} {mode : RoundingMode} : Mul (EDyadicFloat e s mode) := ⟨mul⟩
+instance {e s : Nat} {mode : RoundingMode} : Div (EDyadicFloat e s mode) := ⟨div⟩
 
 end EDyadicFloat
 


### PR DESCRIPTION
## What

Adds arithmetic to `EDyadicFloat`: `mul` computes exactly on `EDyadic` then rounds once; `div` uses the fused `EDyadic.divRound`. `add`/`sub` use the new mode-aware `EDyadic.addRound`, which forms the exact sum and then applies *both* the magnitude rounding and the IEEE-754 §6.3 sign-of-zero rule. Provides `Add`/`Sub`/`Mul`/`Div` instances. Each operation yields the correctly-rounded result for `(e, s)` under `mode`.

### `addRound` / `addZeroSign`

The sign of an additive zero is mode-dependent (`+0` except `RTN` → `−0`), and a zero value can't record the operands that produced it — so it can't be recovered by the value-level rounder. `addRound` mirrors `divRound`: exact core (`EDyadic.add`) + mode-aware finalization. `addZeroSign` keeps a like-signed zero pair's sign and otherwise defers to the mode. (`mul` needs none of this — its zero sign is the mode-independent xor.)

Tests extend `UnitTest/FP/EDyadicFloat.lean` with round-trip arithmetic `#guard`s and a section pinning the additive-zero sign across `.RNE` vs `.RTN` (cancellation, mixed-sign zeros, like-signed zeros).

## Stack

Part of `full-precision-floats-edyadic` (patch 4/6). Base: #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)