### PR TITLE
feat(rewriter): add Rewriter.setType and prove well-formedness preservation

### DIFF
--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -266,6 +266,23 @@ theorem Rewriter.replaceUse_fieldsInBounds :
      ctx.FieldsInBounds → (replaceUse ctx use newValue useIn newIn ctxIn).FieldsInBounds := by
   grind [replaceUse]
 
+/--
+Set the type of a value (an op result or a block argument).
+-/
+def Rewriter.setType (ctx : IRContext OpInfo) (value : ValuePtr) (newType : TypeAttr)
+    (valueIn : value.InBounds ctx := by grind) : IRContext OpInfo :=
+  value.setType ctx newType
+
+@[grind =]
+theorem Rewriter.setType_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (setType ctx value newType valueIn) ↔ ptr.InBounds ctx := by
+  grind [setType]
+
+@[grind .]
+theorem Rewriter.setType_fieldsInBounds :
+    ctx.FieldsInBounds → (setType ctx value newType valueIn).FieldsInBounds := by
+  grind [setType, ValuePtr.setType_fieldsInBounds]
+
 @[irreducible]
 def Rewriter.replaceValue? (ctx: IRContext OpInfo) (oldValue: ValuePtr) (newValue: ValuePtr)
     (oldIn: oldValue.InBounds ctx := by grind)

--- a/Veir/Rewriter/WellFormed/Value.lean
+++ b/Veir/Rewriter/WellFormed/Value.lean
@@ -13,6 +13,8 @@ public section
 
 namespace Veir
 
+/-! ## Rewriter.replaceUse -/
+
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
 
@@ -162,6 +164,8 @@ theorem Rewriter.replaceUse_WellFormed (ctx: IRContext OpInfo) (use : OpOperandP
     case regions =>
       intros regionPtr regionPtrInBounds
       apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind [IRContext.WellFormed]
+
+/-! ## Rewriter.replaceValue? -/
 
 theorem Rewriter.replaceValue?_WellFormed (ctx: IRContext OpInfo) (oldValue: ValuePtr) (newValue: ValuePtr)
     (oldIn: oldValue.InBounds ctx)
@@ -367,5 +371,77 @@ info: 'Veir.Rewriter.replaceValue?_WellFormed' depends on axioms: [propext, Clas
 #guard_msgs in
 #print axioms Rewriter.replaceValue?_WellFormed
 
+/-! ## Rewriter.setType
+
+`Rewriter.setType` only updates the `type` field of a value (an op result or a block argument).
+It touches no indices, owners, use links, parents, or def-use/op/block chains, and
+`IRContext.WellFormed` imposes no constraint on the `type` field, so it preserves
+well-formedness. Every chain is therefore "unchanged" by the rewrite. -/
+
+theorem BlockPtr.opChain_rewriter_setType
+    (hWf : BlockPtr.OpChain block ctx array missingOps) :
+    BlockPtr.OpChain block (Rewriter.setType ctx value newType hvalue) array missingOps := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind [Rewriter.setType]
+
+theorem ValuePtr.defUse_rewriter_setType
+    (hWf : ValuePtr.DefUse value' ctx array missingUses) :
+    ValuePtr.DefUse value' (Rewriter.setType ctx value newType hvalue) array missingUses := by
+  apply ValuePtr.DefUse.unchanged (ctx := ctx) <;> grind [Rewriter.setType]
+
+theorem BlockPtr.defUse_rewriter_setType
+    (hWf : BlockPtr.DefUse block ctx array missingUses) :
+    BlockPtr.DefUse block (Rewriter.setType ctx value newType hvalue) array missingUses := by
+  apply BlockPtr.DefUse.unchanged (ctx := ctx) <;> grind [Rewriter.setType]
+
+theorem RegionPtr.blockChain_rewriter_setType
+    (hWf : RegionPtr.BlockChain region ctx array) :
+    RegionPtr.BlockChain region (Rewriter.setType ctx value newType hvalue) array := by
+  apply RegionPtr.blockChain_unchanged (ctx := ctx) hWf <;> grind [Rewriter.setType]
+
+theorem IRContext.wellFormed_rewriter_setType
+    {value : ValuePtr} {newType : TypeAttr} {hvalue : value.InBounds ctx} :
+    ctx.WellFormed → (Rewriter.setType ctx value newType hvalue).WellFormed := by
+  intro wf
+  have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := wf
+  constructor
+  case inBounds => grind [Rewriter.setType_fieldsInBounds]
+  case valueDefUseChains =>
+    intros val hval
+    have ⟨array, harray⟩ := h₂ val (by grind)
+    exists array
+    grind [ValuePtr.defUse_rewriter_setType]
+  case blockDefUseChains =>
+    intros block hblock
+    have ⟨array, harray⟩ := h₃ block (by grind)
+    exists array
+    grind [BlockPtr.defUse_rewriter_setType]
+  case opChain =>
+    intros block hblock
+    have ⟨array, harray⟩ := h₄ block (by grind)
+    exists array
+    grind [BlockPtr.opChain_rewriter_setType]
+  case blockChain =>
+    intros region hregion
+    have ⟨array, harray⟩ := h₅ region (by grind)
+    exists array
+    grind [RegionPtr.blockChain_rewriter_setType]
+  case operations =>
+    intros op hop
+    have : op.InBounds ctx := by grind
+    apply OperationPtr.WellFormed_unchanged (ctx := ctx) (h₆ op this) <;> grind [Rewriter.setType]
+  case blocks =>
+    intros bl hbl
+    have : bl.InBounds ctx := by grind
+    apply BlockPtr.WellFormed_unchanged (ctx := ctx) (h₇ bl this) <;> grind [Rewriter.setType]
+  case regions =>
+    intros reg hreg
+    have : reg.InBounds ctx := by grind
+    apply RegionPtr.WellFormed_unchanged (ctx := ctx) (h₈ reg this) <;> grind [Rewriter.setType]
+
+/--
+info: 'Veir.IRContext.wellFormed_rewriter_setType' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in
+#print axioms IRContext.wellFormed_rewriter_setType
 
 end Veir


### PR DESCRIPTION
This function is necessary to write lowerings between types, as function need to change their argument types.