### PR TITLE
fix(refinements): allow `Interp` to refine `none` to everything

### DIFF
--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -61,12 +61,13 @@ on the underlying values. This asserts:
   `some (.ok b)` of `target` with `R a b`;
 * when `source` is undefined behaviour (`some .ub`), `target` must succeed (i.e. not be `none`),
   but may be either `some .ub` or `some (.ok _)`;
-* when `source` or `target` failed interpretation (i.e. are `none`), no refinement exists.
+* when `source` is `none`, `target` may be anything
 -/
 def Interp.isRefinedBy (R : α → α → Prop) (source target : Interp α) : Prop :=
   match source, target with
   | some (.ok a), some (.ok b) => R a b
   | some .ub, some _ => True
+  | none, _ => True
   | _, _ => False
 
 /--


### PR DESCRIPTION
Currently, if the interpretation fails in either the source or the target program, there is no refinement relation between them.

With this PR, a failure in the source program interpretation implies that any target program refines the source.