### PR TITLE
feat(mod_arith): add a basic --mod-arith-to-arith lowering

### DIFF
--- a/Test/Passes/ModArithToArith/add.mlir
+++ b/Test/Passes/ModArithToArith/add.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-opt %s -p=mod-arith-to-arith | filecheck %s
+
+// Lowering of mod_arith.add into the arith dialect. Each operand is unpacked into a wider
+// intermediate type (i33), the sum + final reduction run there (so they cannot overflow), and
+// the result is packed back down to i32 / !mod_arith.int.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>, sym_name = "main"}> ({
+    ^bb0(%0 : !mod_arith.int<7 : i32>, %1 : !mod_arith.int<7 : i32>):
+      %r = "mod_arith.add"(%0, %1) : (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>
+      "func.return"(%r) : (!mod_arith.int<7 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      ^{{.*}}([[ARG0:%.*]] : !mod_arith.int<7 : i32>, [[ARG1:%.*]] : !mod_arith.int<7 : i32>):
+// CHECK-NEXT:   [[C0:%.*]] = "builtin.unrealized_conversion_cast"([[ARG0]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E0:%.*]] = "arith.extui"([[C0]]) : (i32) -> i33
+// CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG1]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E1:%.*]] = "arith.extui"([[C1]]) : (i32) -> i33
+// CHECK-NEXT:   [[Q:%.*]] = "arith.constant"() <{"value" = 7 : i33}> : () -> i33
+// CHECK-NEXT:   [[SUM:%.*]] = "arith.addi"([[E0]], [[E1]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[SUMR:%.*]] = "arith.remui"([[SUM]], [[Q]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[SUMR]]) <{"overflowFlags" = 2 : i32}> : (i33) -> i32
+// CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i32) -> !mod_arith.int<7 : i32>
+// CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/Test/Passes/ModArithToArith/constant.mlir
+++ b/Test/Passes/ModArithToArith/constant.mlir
@@ -1,0 +1,18 @@
+// RUN: veir-opt %s -p=mod-arith-to-arith | filecheck %s
+
+// Lowering of mod_arith.constant: the value is assumed to already be in [0, q)
+// and materialised as an arith.constant cast up to the mod_arith type.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> !mod_arith.int<17 : i32>, sym_name = "main"}> ({
+    ^bb0():
+      %c = "mod_arith.constant"() <{"value" = 3 : i32}> : () -> !mod_arith.int<17 : i32>
+      "func.return"(%c) : (!mod_arith.int<17 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "func.func"
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:   [[C:%.*]] = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
+// CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !mod_arith.int<17 : i32>
+// CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<17 : i32>) -> ()

--- a/Test/Passes/ModArithToArith/mul.mlir
+++ b/Test/Passes/ModArithToArith/mul.mlir
@@ -1,0 +1,24 @@
+// RUN: veir-opt %s -p=mod-arith-to-arith | filecheck %s
+
+// Lowering of mod_arith.mul into the arith dialect. The product is computed in a double-width
+// intermediate type (i64) so it cannot overflow before the final reduction, then packed to i32.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>, sym_name = "main"}> ({
+    ^bb0(%0 : !mod_arith.int<7 : i32>, %1 : !mod_arith.int<7 : i32>):
+      %r = "mod_arith.mul"(%0, %1) : (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>
+      "func.return"(%r) : (!mod_arith.int<7 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      ^{{.*}}([[ARG0:%.*]] : !mod_arith.int<7 : i32>, [[ARG1:%.*]] : !mod_arith.int<7 : i32>):
+// CHECK-NEXT:   [[C0:%.*]] = "builtin.unrealized_conversion_cast"([[ARG0]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E0:%.*]] = "arith.extui"([[C0]]) : (i32) -> i64
+// CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG1]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E1:%.*]] = "arith.extui"([[C1]]) : (i32) -> i64
+// CHECK-NEXT:   [[Q:%.*]] = "arith.constant"() <{"value" = 7 : i64}> : () -> i64
+// CHECK-NEXT:   [[PROD:%.*]] = "arith.muli"([[E0]], [[E1]]) : (i64, i64) -> i64
+// CHECK-NEXT:   [[PRODR:%.*]] = "arith.remui"([[PROD]], [[Q]]) : (i64, i64) -> i64
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[PRODR]]) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
+// CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i32) -> !mod_arith.int<7 : i32>
+// CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/Test/Passes/ModArithToArith/sub.mlir
+++ b/Test/Passes/ModArithToArith/sub.mlir
@@ -1,0 +1,26 @@
+// RUN: veir-opt %s -p=mod-arith-to-arith | filecheck %s
+
+// Lowering of mod_arith.sub into the arith dialect. To avoid unsigned underflow when lhs < rhs,
+// the difference is computed as (a + q) - b in a wider intermediate type (i33), which stays in
+// (0, 2q), before reducing modulo q and packing back down.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>, sym_name = "main"}> ({
+    ^bb0(%0 : !mod_arith.int<7 : i32>, %1 : !mod_arith.int<7 : i32>):
+      %r = "mod_arith.sub"(%0, %1) : (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>
+      "func.return"(%r) : (!mod_arith.int<7 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      ^{{.*}}([[ARG0:%.*]] : !mod_arith.int<7 : i32>, [[ARG1:%.*]] : !mod_arith.int<7 : i32>):
+// CHECK-NEXT:   [[C0:%.*]] = "builtin.unrealized_conversion_cast"([[ARG0]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E0:%.*]] = "arith.extui"([[C0]]) : (i32) -> i33
+// CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG1]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E1:%.*]] = "arith.extui"([[C1]]) : (i32) -> i33
+// CHECK-NEXT:   [[Q:%.*]] = "arith.constant"() <{"value" = 7 : i33}> : () -> i33
+// CHECK-NEXT:   [[AQ:%.*]] = "arith.addi"([[E0]], [[Q]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[DIFF:%.*]] = "arith.subi"([[AQ]], [[E1]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[DIFFR:%.*]] = "arith.remui"([[DIFF]], [[Q]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[DIFFR]]) <{"overflowFlags" = 2 : i32}> : (i33) -> i32
+// CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i32) -> !mod_arith.int<7 : i32>
+// CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -11,7 +11,7 @@ namespace Veir
   translating `!mod_arith.int<q : iN>` values to their canonical representation in `[0, q)`.
   The current lowering is trivial, eagerly reducing at all times.
 
-  Since VEIR has no Dialect Conversion framework, this pass eagerly inserts unrealized_conversion_casts
+  Since Veir has no Dialect Conversion framework, this pass eagerly inserts `unrealized_conversion_casts`
   to handle the type conversions between `!mod_arith.int<q : iN>` and `iN` that are needed.
 -/
 
@@ -75,7 +75,7 @@ def packValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ty : ModArithT
 /-! ## Arith Helpers -/
 
 set_option warn.sorry false in
-/-- Emit `arith.constant c : i<width>`. Requires c to fit into width (unsigned) -/
+/-- Emit `arith.constant c : i<width>`. Requires `c` to fit into width (unsigned) -/
 def emitArithConstant (rewriter : PatternRewriter OpCode) (c : Int) (width : Nat)
     (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
   let ty : TypeAttr := IntegerType.mk width

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -1,0 +1,194 @@
+import Veir.Pass
+import Veir.PatternRewriter.Basic
+import Veir.Passes.Matching
+
+namespace Veir
+
+/-!
+  # ModArithToArith pass
+
+  Lowers operations from the `mod_arith` dialect into operations in the `arith` dialect,
+  translating `!mod_arith.int<q : iN>` values to their canonical representation in `[0, q)`.
+  The current lowering is trivial, eagerly reducing at all times.
+
+  Since VEIR has no Dialect Conversion framework, this pass eagerly inserts unrealized_conversion_casts
+  to handle the type conversions between `!mod_arith.int<q : iN>` and `iN` that are needed.
+-/
+
+/-! ## Unrealized Conversion Casts -/
+
+set_option warn.sorry false in
+/-- Emit `unrealized_conversion_cast v : !mod_arith.int<q:iN> → iN`. -/
+def castToStorage (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ip : InsertPoint) :
+    Option (PatternRewriter OpCode × ValuePtr) := do
+  let .modArithType mt := (v.getType! rewriter.ctx.raw).val
+    | none
+  let storageType : TypeAttr := mt.modulus.type
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast)
+    #[storageType] #[v] #[] #[] () (some ip) sorry (by simp) (by simp) sorry
+  return (rewriter, (castOp.getResult 0 : ValuePtr))
+
+set_option warn.sorry false in
+/-- Emit `unrealized_conversion_cast x : iN → ty`, where `ty` is a `mod_arith` type. -/
+def castToModArith (rewriter : PatternRewriter OpCode) (x : ValuePtr) (ty : ModArithType)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast)
+    #[ty] #[x] #[] #[] () (some ip) sorry (by simp) (by simp) sorry
+  return (rewriter, (castOp.getResult 0 : ValuePtr))
+
+/-! ## Unpack / Pack ModArithType -/
+
+set_option warn.sorry false in
+/--
+  Unpack a `!mod_arith.int<q:iN>` value `v` into the IntegerType `intermediateType`
+-/
+def unpackValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (intermediateType : IntegerType)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let (rewriter, stored) ← castToStorage rewriter v ip
+  let .integerType storageType := (stored.getType! rewriter.ctx.raw).val
+    | none
+  if intermediateType.bitwidth > storageType.bitwidth then
+    let (rewriter, ext) ← rewriter.createOp (.arith .extui)
+      #[intermediateType] #[stored] #[] #[] { nneg := false } (some ip) sorry (by simp) (by simp) sorry
+    return (rewriter, (ext.getResult 0 : ValuePtr))
+  else
+    return (rewriter, stored)
+
+set_option warn.sorry false in
+/--
+  Pack an IntegerType value `v` of IntegerType `intermediateType` into a value of `!mod_arith.int<q:iN>` type `ty`.
+-/
+def packValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ty : ModArithType)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let .integerType intermediateType := (v.getType! rewriter.ctx.raw).val
+    | none
+  let storageType := ty.modulus.type
+  if intermediateType.bitwidth > storageType.bitwidth then
+    let (rewriter, narrowed) ← rewriter.createOp (.arith .trunci)
+      #[storageType] #[v] #[] #[] { nsw := false, nuw := true }
+      (some ip) sorry (by simp) (by simp) sorry
+    castToModArith rewriter (narrowed.getResult 0 : ValuePtr) ty ip
+  else
+    castToModArith rewriter (v : ValuePtr) ty ip
+
+
+/-! ## Arith Helpers -/
+
+set_option warn.sorry false in
+/-- Emit `arith.constant c : i<width>`. Requires c to fit into width (unsigned) -/
+def emitArithConstant (rewriter : PatternRewriter OpCode) (c : Int) (width : Nat)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let ty : TypeAttr := IntegerType.mk width
+  let props : ArithConstantProperties := { value := IntegerAttr.mk c (IntegerType.mk width) }
+  let (rewriter, c) ← rewriter.createOp (.arith .constant)
+    #[ty] #[] #[] #[] props (some ip) sorry (by simp) (by simp) sorry
+  return (rewriter, (c.getResult 0 : ValuePtr))
+
+set_option warn.sorry false in
+/-- Emit a binary Arith op `arithOp` on `a` and `b` -/
+def emitArithBinOp (rewriter : PatternRewriter OpCode) (arithOp : Arith)
+    (props : propertiesOf (.arith arithOp)) (a b : ValuePtr) (ip : InsertPoint) :
+    Option (PatternRewriter OpCode × ValuePtr) := do
+  let ty := a.getType! rewriter.ctx.raw
+  let (rewriter, r) ← rewriter.createOp (.arith arithOp)
+    #[ty] #[a, b] #[] #[] props (some ip) sorry (by simp) (by simp) sorry
+  return (rewriter, (r.getResult 0 : ValuePtr))
+
+
+/-! ## Binary op lowering Template -/
+
+abbrev Builder :=
+  (rewriter : PatternRewriter OpCode) →
+  (lhs rhs modulus : ValuePtr) →
+  (ip : InsertPoint) →
+  Option (PatternRewriter OpCode × ValuePtr)
+
+set_option warn.sorry false in
+/-- Lower a binary `mod_arith` op `modOp`,
+    using intermediate Type iM given storage type iM, with M = `widen` N,
+    and using Builder `build` to determine the exact `arith` operations to emit -/
+def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builder)
+    (rewriter : PatternRewriter OpCode) (op : OperationPtr) : Option (PatternRewriter OpCode) := do
+  -- match op and extract operands:
+  let some (operands, _) := matchOp op rewriter.ctx (.mod_arith modOp) 2
+    | return rewriter
+  let lhs := operands[0]!
+  let rhs := operands[1]!
+  -- type setup
+  let .modArithType modArithType := ((op.getResult 0 : ValuePtr).getType! rewriter.ctx.raw).val
+    | return rewriter
+  let intermediateWidth := widen modArithType.modulus.type.bitwidth
+  let intermediateType  := IntegerType.mk intermediateWidth
+  -- actual lowering:
+  let ip := InsertPoint.before op
+  let (rewriter, a) ← unpackValue rewriter lhs intermediateType ip
+  let (rewriter, b) ← unpackValue rewriter rhs intermediateType ip
+  let (rewriter, q) ← emitArithConstant rewriter modArithType.modulus.value intermediateWidth ip
+  let (rewriter, r) ← build rewriter a b q ip
+  let (rewriter, r) ← emitArithBinOp rewriter .remui () r q ip
+  let (rewriter, r) ← packValue rewriter r modArithType ip
+  let rewriter := rewriter.replaceValue (op.getResult 0) r sorry sorry sorry
+  rewriter.eraseOp op sorry sorry sorry
+
+/-! ## Binary op lowering Patterns -/
+
+def buildAdd : Builder :=
+  fun rewriter a b _ ip =>
+  emitArithBinOp rewriter .addi { nsw := false, nuw := false } a b ip
+
+def lowerModArithAddOp := lowerModArithBinOp .add (· + 1) buildAdd
+
+def buildMul : Builder :=
+  fun rewriter a b _ ip =>
+  emitArithBinOp rewriter .muli { nsw := false, nuw := false } a b ip
+
+def lowerModArithMulOp := lowerModArithBinOp .mul (2 * ·) buildMul
+
+def buildSub : Builder :=
+  fun (rewriter : PatternRewriter OpCode) (a b q : ValuePtr) (ip : InsertPoint) => do
+    -- we compute a - b (mod q) as ((a+q) - b) % q to avoid unsigned underflow when a < b.
+    let (rewriter, aq) ← emitArithBinOp rewriter .addi { nsw := false, nuw := false } a q ip
+    emitArithBinOp rewriter .subi { nsw := false, nuw := false } aq b ip
+
+def lowerModArithSubOp := lowerModArithBinOp .sub (· + 1) buildSub
+
+/-! ## Constant lowering Pattern -/
+
+set_option warn.sorry false in
+/-- Lower `mod_arith.constant` to an `arith.constant` (assumes value is in `[0, q)` already). -/
+def lowerModArithConstant (rewriter : PatternRewriter OpCode) (op : OperationPtr) : Option (PatternRewriter OpCode) := do
+  -- match op and extract attribute:
+  let some (_, props) := matchOp op rewriter.ctx (.mod_arith .constant) 0
+    | return rewriter
+  let c := props.value.value
+  -- type setup
+  let .modArithType modArithType := ((op.getResult 0 : ValuePtr).getType! rewriter.ctx.raw).val
+    | return rewriter
+  let storageType := modArithType.modulus.type
+  -- actual lowering:
+  let ip := InsertPoint.before op
+  let (rewriter, r) ← emitArithConstant rewriter c storageType.bitwidth ip
+  let (rewriter, out) ← castToModArith rewriter (r : ValuePtr) modArithType ip
+  let rewriter := rewriter.replaceValue (op.getResult 0) out sorry sorry sorry
+  rewriter.eraseOp op sorry sorry sorry
+
+/-! ## Pass implementation -/
+
+def ModArithToArithPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
+    (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
+  let pattern := RewritePattern.GreedyRewritePattern #[
+    lowerModArithConstant,
+    lowerModArithAddOp,
+    lowerModArithSubOp,
+    lowerModArithMulOp
+  ]
+  match RewritePattern.applyInContext pattern ctx with
+  | none => throw "Error while applying mod-arith-to-arith lowering"
+  | some ctx => pure ctx
+
+public def ModArithToArithPass : Pass OpCode :=
+  { name := "mod-arith-to-arith"
+    description := "Lower mod_arith operations to the arith dialect."
+    run := ModArithToArithPass.impl }
+
+end Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -13,6 +13,7 @@ import Veir.Passes.InstructionSelection.RISCV64
 import Veir.Passes.DCE.dce
 import Veir.Passes.CastsReconciliation.Reconciliation
 import Veir.Passes.Combines.Combine
+import Veir.Passes.ModArithToArith
 
 open Veir.Parser
 open Veir.Parser.ParserError
@@ -30,6 +31,7 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
     |>.insert DCEPass.name DCEPass
     |>.insert CastReconcilePass.name CastReconcilePass
     |>.insert RISCV.Combine.name RISCV.Combine
+    |>.insert ModArithToArithPass.name ModArithToArithPass
 
 /--
   Arguments for the `veir-opt` command-line tool, parsed from the CLI.


### PR DESCRIPTION
This PR adds a very basic (and overly conservative) lowering from `mod_arith` to `arith`, using `unrealized_conversion_cast` as "fake dialect conversion", and aggressively reducing as well as extending the bitwidth for intermediate values to prevent any possibility of overflow. 

For example, it lowers (the generically printed version of)
```llvm
!Z7_i32 = !mod_arith.int<7 : i32>
func.func @main(%arg0: !Z7_i32, %arg1: !Z7_i32) -> !Z7_i32 {
  %0 = mod_arith.add %arg0, %arg1 : !Z7_i32
  return %0 : !Z7_i32
}
```
to (the generically printed version of)
```llvm
!Z7_i32 = !mod_arith.int<7 : i32>
func.func @main(%arg0: !Z7_i32, %arg1: !Z7_i32) -> !Z7_i32 {
  %0 = builtin.unrealized_conversion_cast %arg0 : !Z7_i32 to i32
  %1 = arith.extui %0 : i32 to i33
  %2 = builtin.unrealized_conversion_cast %arg1 : !Z7_i32 to i32
  %3 = arith.extui %2 : i32 to i33
  %c7_i33 = arith.constant 7 : i33
  %4 = arith.addi %1, %3 : i33
  %5 = arith.remui %4, %c7_i33 : i33
  %6 = arith.trunci %5 overflow<nuw> : i33 to i32
  %7 = builtin.unrealized_conversion_cast %6 : i32 to !Z7_i32
  return %7 : !Z7_i32
}
```