### PR TITLE
test(riscv): two actual programs, as test cases

### DIFF
--- a/Test/Interpreter/RISCV_programs/primes_O0.mlir
+++ b/Test/Interpreter/RISCV_programs/primes_O0.mlir
@@ -7,17 +7,14 @@
 //
 // RUN: VEIR_UNREGISTERED_ROUNDTRIP
 
-// CHECK: "func.func"() <{"function_type" = (!riscv.reg, !riscv.reg, !riscv.reg) -> !riscv.reg, "sym_name" = "main"}>
+// CHECK: "func.func"() <{"function_type" = (!riscv.reg) -> !riscv.reg, "sym_name" = "main"}>
 
 "builtin.module"() ({
-  // main(sp, ra, s0_caller) -- the architectural registers read on entry.
-  "func.func"() <{sym_name = "main", function_type = (!riscv.reg, !riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  // main(s0) -- frame base pointer for the stack spill slots (the prologue/epilogue
+  // that would set this up and save/restore sp/ra are elided at this abstraction level).
+  "func.func"() <{sym_name = "main", function_type = (!riscv.reg) -> !riscv.reg}> ({
     // %bb.0: entry
-    ^entry(%sp_in : !riscv.reg, %ra_in : !riscv.reg, %s0_caller : !riscv.reg):
-      %fp_sp = "riscv.addi"(%sp_in) <{"value" = -48 : i12}> : (!riscv.reg) -> !riscv.reg   // addi sp, sp, -48
-      "riscv.sd"(%fp_sp, %ra_in) <{"value" = 40 : i12}> : (!riscv.reg, !riscv.reg) -> ()    // sd ra, 40(sp)
-      "riscv.sd"(%fp_sp, %s0_caller) <{"value" = 32 : i12}> : (!riscv.reg, !riscv.reg) -> () // sd s0, 32(sp)
-      %s0 = "riscv.addi"(%fp_sp) <{"value" = 48 : i12}> : (!riscv.reg) -> !riscv.reg        // addi s0, sp, 48
+    ^entry(%s0 : !riscv.reg):
       %e_a0 = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg                          // li a0, 0
       "riscv.sw"(%s0, %e_a0) <{"value" = -20 : i12}> : (!riscv.reg, !riscv.reg) -> ()        // sw a0, -20(s0)
       "riscv.sw"(%s0, %e_a0) <{"value" = -24 : i12}> : (!riscv.reg, !riscv.reg) -> ()        // sw a0, -24(s0)
@@ -109,10 +106,6 @@
     // .LBB0_11: while.end
     ^bb11(%b11_s0 : !riscv.reg):
       %b11_a0 = "riscv.lw"(%b11_s0) <{"value" = -32 : i12}> : (!riscv.reg) -> !riscv.reg      // lw a0, -32(s0)
-      %ex_sp = "riscv.addi"(%b11_s0) <{"value" = -48 : i12}> : (!riscv.reg) -> !riscv.reg     // addi sp, s0, -48
-      %ex_ra = "riscv.ld"(%ex_sp) <{"value" = 40 : i12}> : (!riscv.reg) -> !riscv.reg         // ld ra, 40(sp)
-      %ex_s0 = "riscv.ld"(%ex_sp) <{"value" = 32 : i12}> : (!riscv.reg) -> !riscv.reg         // ld s0, 32(sp)
-      %ex_spf = "riscv.addi"(%ex_sp) <{"value" = 48 : i12}> : (!riscv.reg) -> !riscv.reg      // addi sp, sp, 48
       "func.return"(%b11_a0) : (!riscv.reg) -> ()                                             // ret (value in a0)
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV_programs/primes_O0.mlir
+++ b/Test/Interpreter/RISCV_programs/primes_O0.mlir
@@ -1,0 +1,118 @@
+// Compute the 10th prime in pre-regalloc RISC-V, translated from clang output
+// (clang --target=riscv64 -march=rva23u64 -O0).
+//
+// Unregistered instructions used in this file (not in the riscv dialect):
+//   riscv.lw   -- 32-bit sign-extending load word
+//   riscv.sw   -- 32-bit store word
+//
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+
+// CHECK: "func.func"() <{"function_type" = (!riscv.reg, !riscv.reg, !riscv.reg) -> !riscv.reg, "sym_name" = "main"}>
+
+"builtin.module"() ({
+  // main(sp, ra, s0_caller) -- the architectural registers read on entry.
+  "func.func"() <{sym_name = "main", function_type = (!riscv.reg, !riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+    // %bb.0: entry
+    ^entry(%sp_in : !riscv.reg, %ra_in : !riscv.reg, %s0_caller : !riscv.reg):
+      %fp_sp = "riscv.addi"(%sp_in) <{"value" = -48 : i12}> : (!riscv.reg) -> !riscv.reg   // addi sp, sp, -48
+      "riscv.sd"(%fp_sp, %ra_in) <{"value" = 40 : i12}> : (!riscv.reg, !riscv.reg) -> ()    // sd ra, 40(sp)
+      "riscv.sd"(%fp_sp, %s0_caller) <{"value" = 32 : i12}> : (!riscv.reg, !riscv.reg) -> () // sd s0, 32(sp)
+      %s0 = "riscv.addi"(%fp_sp) <{"value" = 48 : i12}> : (!riscv.reg) -> !riscv.reg        // addi s0, sp, 48
+      %e_a0 = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg                          // li a0, 0
+      "riscv.sw"(%s0, %e_a0) <{"value" = -20 : i12}> : (!riscv.reg, !riscv.reg) -> ()        // sw a0, -20(s0)
+      "riscv.sw"(%s0, %e_a0) <{"value" = -24 : i12}> : (!riscv.reg, !riscv.reg) -> ()        // sw a0, -24(s0)
+      %e_a1 = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg                          // li a1, 2
+      "riscv.sw"(%s0, %e_a1) <{"value" = -28 : i12}> : (!riscv.reg, !riscv.reg) -> ()        // sw a1, -28(s0)
+      "riscv.sw"(%s0, %e_a0) <{"value" = -32 : i12}> : (!riscv.reg, !riscv.reg) -> ()        // sw a0, -32(s0)
+      "riscv_cf.branch"(%s0) [^bb1] : (!riscv.reg) -> ()                                     // j .LBB0_1
+
+    // .LBB0_1: while.cond
+    ^bb1(%b1_s0 : !riscv.reg):
+      %b1_a1 = "riscv.lw"(%b1_s0) <{"value" = -24 : i12}> : (!riscv.reg) -> !riscv.reg       // lw a1, -24(s0)
+      %b1_a0 = "riscv.li"() <{"value" = 9 : i64}> : () -> !riscv.reg                          // li a0, 9
+      // blt a0, a1, .LBB0_11   (taken -> ^bb11; fall -> ^bb2)
+      "riscv_cf.blt"(%b1_a0, %b1_a1, %b1_s0, %b1_s0) [^bb11, ^bb2]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}>
+        : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_2: while.body
+    ^bb2(%b2_s0 : !riscv.reg):
+      %b2_a0 = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg                          // li a0, 1
+      "riscv.sw"(%b2_s0, %b2_a0) <{"value" = -36 : i12}> : (!riscv.reg, !riscv.reg) -> ()     // sw a0, -36(s0)
+      %b2_a0b = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg                         // li a0, 2
+      "riscv.sw"(%b2_s0, %b2_a0b) <{"value" = -40 : i12}> : (!riscv.reg, !riscv.reg) -> ()    // sw a0, -40(s0)
+      "riscv_cf.branch"(%b2_s0) [^bb3] : (!riscv.reg) -> ()                                   // j .LBB0_3
+
+    // .LBB0_3: for.cond
+    ^bb3(%b3_s0 : !riscv.reg):
+      %b3_a0 = "riscv.lw"(%b3_s0) <{"value" = -40 : i12}> : (!riscv.reg) -> !riscv.reg        // lw a0, -40(s0)
+      %b3_a1 = "riscv.mulw"(%b3_a0, %b3_a0) : (!riscv.reg, !riscv.reg) -> !riscv.reg          // mulw a1, a0, a0
+      %b3_a0b = "riscv.lw"(%b3_s0) <{"value" = -28 : i12}> : (!riscv.reg) -> !riscv.reg       // lw a0, -28(s0)
+      // blt a0, a1, .LBB0_8   (taken -> ^bb8; fall -> ^bb4)
+      "riscv_cf.blt"(%b3_a0b, %b3_a1, %b3_s0, %b3_s0) [^bb8, ^bb4]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}>
+        : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_4: for.body
+    ^bb4(%b4_s0 : !riscv.reg):
+      %b4_a0 = "riscv.lw"(%b4_s0) <{"value" = -28 : i12}> : (!riscv.reg) -> !riscv.reg        // lw a0, -28(s0)
+      %b4_a1 = "riscv.lw"(%b4_s0) <{"value" = -40 : i12}> : (!riscv.reg) -> !riscv.reg        // lw a1, -40(s0)
+      %b4_a0r = "riscv.remw"(%b4_a0, %b4_a1) : (!riscv.reg, !riscv.reg) -> !riscv.reg         // remw a0, a0, a1
+      %b4_zero = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg                         // (x0 for bnez)
+      // bnez a0, .LBB0_6  ==  bne a0, x0   (taken -> ^bb6; fall -> ^bb5)
+      "riscv_cf.bne"(%b4_a0r, %b4_zero, %b4_s0, %b4_s0) [^bb6, ^bb5]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}>
+        : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_5: if.then
+    ^bb5(%b5_s0 : !riscv.reg):
+      %b5_a0 = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg                          // li a0, 0
+      "riscv.sw"(%b5_s0, %b5_a0) <{"value" = -36 : i12}> : (!riscv.reg, !riscv.reg) -> ()     // sw a0, -36(s0)
+      "riscv_cf.branch"(%b5_s0) [^bb8] : (!riscv.reg) -> ()                                   // j .LBB0_8
+
+    // .LBB0_6: if.end
+    ^bb6(%b6_s0 : !riscv.reg):
+      "riscv_cf.branch"(%b6_s0) [^bb7] : (!riscv.reg) -> ()                                   // j .LBB0_7
+
+    // .LBB0_7: for.inc
+    ^bb7(%b7_s0 : !riscv.reg):
+      %b7_a0 = "riscv.lw"(%b7_s0) <{"value" = -40 : i12}> : (!riscv.reg) -> !riscv.reg        // lw a0, -40(s0)
+      %b7_a0n = "riscv.addiw"(%b7_a0) <{"value" = 1 : i12}> : (!riscv.reg) -> !riscv.reg      // addiw a0, a0, 1
+      "riscv.sw"(%b7_s0, %b7_a0n) <{"value" = -40 : i12}> : (!riscv.reg, !riscv.reg) -> ()    // sw a0, -40(s0)
+      "riscv_cf.branch"(%b7_s0) [^bb3] : (!riscv.reg) -> ()                                   // j .LBB0_3
+
+    // .LBB0_8: for.end
+    ^bb8(%b8_s0 : !riscv.reg):
+      %b8_a0 = "riscv.lw"(%b8_s0) <{"value" = -36 : i12}> : (!riscv.reg) -> !riscv.reg        // lw a0, -36(s0)
+      %b8_zero = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg                         // (x0 for beqz)
+      // beqz a0, .LBB0_10  ==  beq a0, x0   (taken -> ^bb10; fall -> ^bb9)
+      "riscv_cf.beq"(%b8_a0, %b8_zero, %b8_s0, %b8_s0) [^bb10, ^bb9]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 1, 1>}>
+        : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_9: if.then3
+    ^bb9(%b9_s0 : !riscv.reg):
+      %b9_a0 = "riscv.lw"(%b9_s0) <{"value" = -28 : i12}> : (!riscv.reg) -> !riscv.reg        // lw a0, -28(s0)
+      "riscv.sw"(%b9_s0, %b9_a0) <{"value" = -32 : i12}> : (!riscv.reg, !riscv.reg) -> ()     // sw a0, -32(s0)
+      %b9_a0b = "riscv.lw"(%b9_s0) <{"value" = -24 : i12}> : (!riscv.reg) -> !riscv.reg       // lw a0, -24(s0)
+      %b9_a0n = "riscv.addiw"(%b9_a0b) <{"value" = 1 : i12}> : (!riscv.reg) -> !riscv.reg     // addiw a0, a0, 1
+      "riscv.sw"(%b9_s0, %b9_a0n) <{"value" = -24 : i12}> : (!riscv.reg, !riscv.reg) -> ()    // sw a0, -24(s0)
+      "riscv_cf.branch"(%b9_s0) [^bb10] : (!riscv.reg) -> ()                                  // j .LBB0_10
+
+    // .LBB0_10: if.end5
+    ^bb10(%b10_s0 : !riscv.reg):
+      %b10_a0 = "riscv.lw"(%b10_s0) <{"value" = -28 : i12}> : (!riscv.reg) -> !riscv.reg      // lw a0, -28(s0)
+      %b10_a0n = "riscv.addiw"(%b10_a0) <{"value" = 1 : i12}> : (!riscv.reg) -> !riscv.reg    // addiw a0, a0, 1
+      "riscv.sw"(%b10_s0, %b10_a0n) <{"value" = -28 : i12}> : (!riscv.reg, !riscv.reg) -> ()  // sw a0, -28(s0)
+      "riscv_cf.branch"(%b10_s0) [^bb1] : (!riscv.reg) -> ()                                  // j .LBB0_1
+
+    // .LBB0_11: while.end
+    ^bb11(%b11_s0 : !riscv.reg):
+      %b11_a0 = "riscv.lw"(%b11_s0) <{"value" = -32 : i12}> : (!riscv.reg) -> !riscv.reg      // lw a0, -32(s0)
+      %ex_sp = "riscv.addi"(%b11_s0) <{"value" = -48 : i12}> : (!riscv.reg) -> !riscv.reg     // addi sp, s0, -48
+      %ex_ra = "riscv.ld"(%ex_sp) <{"value" = 40 : i12}> : (!riscv.reg) -> !riscv.reg         // ld ra, 40(sp)
+      %ex_s0 = "riscv.ld"(%ex_sp) <{"value" = 32 : i12}> : (!riscv.reg) -> !riscv.reg         // ld s0, 32(sp)
+      %ex_spf = "riscv.addi"(%ex_sp) <{"value" = 48 : i12}> : (!riscv.reg) -> !riscv.reg      // addi sp, sp, 48
+      "func.return"(%b11_a0) : (!riscv.reg) -> ()                                             // ret (value in a0)
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Interpreter/RISCV_programs/primes_O3.mlir
+++ b/Test/Interpreter/RISCV_programs/primes_O3.mlir
@@ -1,0 +1,112 @@
+// Compute the 10th prime in pre-regalloc RISC-V, translated from clang output
+// (clang --target=riscv64 -march=rva23u64 -O0).
+//
+// Register -> SSA-value mapping (physical registers that are live across
+// block boundaries in the assembly become block arguments here):
+//   a0 = last_prime / return value
+//   a1 = count
+//   a2 = n
+//   a3 = trial divisor i
+//   a4 = scratch
+//   a5 = prime flag (always 1 on the path that reaches BB0_1)
+//   a6 = constant 4
+//   a7 = constant 10
+//
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    // %bb.0: entry
+    ^entry():
+      %a0_0 = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg   // li a0, 0
+      %a1_0 = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg   // li a1, 0
+      %a2_0 = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg   // li a2, 2
+      %a6   = "riscv.li"() <{"value" = 4 : i64}> : () -> !riscv.reg   // li a6, 4
+      %a7   = "riscv.li"() <{"value" = 10 : i64}> : () -> !riscv.reg  // li a7, 10
+      // j .LBB0_2   (forward {a0,a1,a2,a6,a7})
+      "riscv_cf.branch"(%a0_0, %a1_0, %a2_0, %a6, %a7) [^bb2]
+        : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_2: for.cond.preheader   args {a0,a1,a2,a6,a7}
+    ^bb2(%b2_a0 : !riscv.reg, %b2_a1 : !riscv.reg, %b2_a2 : !riscv.reg, %b2_a6 : !riscv.reg, %b2_a7 : !riscv.reg):
+      %a5 = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg     // li a5, 1
+      // bltu a2, a6, .LBB0_1   (taken -> ^bb1 {a1,a2,a5,a6,a7}; fall -> ^bb3 {a0,a1,a2,a5,a6,a7})
+      "riscv_cf.bltu"(%b2_a2, %b2_a6,
+                      %b2_a1, %b2_a2, %a5, %b2_a6, %b2_a7,
+                      %b2_a0, %b2_a1, %b2_a2, %a5, %b2_a6, %b2_a7) [^bb1, ^bb3]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 5, 6>}>
+        : (!riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_1:   args {a1,a2,a5,a6,a7}
+    ^bb1(%b1_a1 : !riscv.reg, %b1_a2 : !riscv.reg, %b1_a5 : !riscv.reg, %b1_a6 : !riscv.reg, %b1_a7 : !riscv.reg):
+      %b1_a0 = "riscv.mv"(%b1_a2) : (!riscv.reg) -> !riscv.reg              // mv   a0, a2
+      %b1_a1n = "riscv.addw"(%b1_a1, %b1_a5) : (!riscv.reg, !riscv.reg) -> !riscv.reg  // addw a1, a1, a5
+      %b1_a2n = "riscv.addiw"(%b1_a2) <{"value" = 1 : i12}> : (!riscv.reg) -> !riscv.reg // addiw a2, a2, 1
+      // bgeu a1, a7, .LBB0_7   (taken -> ^bb7 {a0}; fall -> ^bb2 {a0,a1,a2,a6,a7})
+      "riscv_cf.bgeu"(%b1_a1n, %b1_a7,
+                      %b1_a0,
+                      %b1_a0, %b1_a1n, %b1_a2n, %b1_a6, %b1_a7) [^bb7, ^bb2]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 1, 5>}>
+        : (!riscv.reg, !riscv.reg,
+           !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // %bb.3: for.body.preheader   args {a0,a1,a2,a5,a6,a7}
+    ^bb3(%b3_a0 : !riscv.reg, %b3_a1 : !riscv.reg, %b3_a2 : !riscv.reg, %b3_a5 : !riscv.reg, %b3_a6 : !riscv.reg, %b3_a7 : !riscv.reg):
+      %a3 = "riscv.li"() <{"value" = 3 : i64}> : () -> !riscv.reg     // li a3, 3
+      // (fall through into .LBB0_4)   forward {a0,a1,a2,a3,a5,a6,a7}
+      "riscv_cf.branch"(%b3_a0, %b3_a1, %b3_a2, %a3, %b3_a5, %b3_a6, %b3_a7) [^bb4]
+        : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_4: for.body   args {a0,a1,a2,a3,a5,a6,a7}
+    ^bb4(%b4_a0 : !riscv.reg, %b4_a1 : !riscv.reg, %b4_a2 : !riscv.reg, %b4_a3 : !riscv.reg, %b4_a5 : !riscv.reg, %b4_a6 : !riscv.reg, %b4_a7 : !riscv.reg):
+      %b4_a4_0 = "riscv.addi"(%b4_a3) <{"value" = -1 : i12}> : (!riscv.reg) -> !riscv.reg     // addi  a4, a3, -1
+      %b4_a4 = "riscv.remuw"(%b4_a2, %b4_a4_0) : (!riscv.reg, !riscv.reg) -> !riscv.reg       // remuw a4, a2, a4
+      %b4_zero = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg                        // (x0 for beqz)
+      // beqz a4, .LBB0_6  ==  beq a4, x0, .LBB0_6
+      //   (taken -> ^bb6 {a0,a1,a2,a6,a7}; fall -> ^bb5 {a0,a1,a2,a3,a5,a6,a7})
+      "riscv_cf.beq"(%b4_a4, %b4_zero,
+                     %b4_a0, %b4_a1, %b4_a2, %b4_a6, %b4_a7,
+                     %b4_a0, %b4_a1, %b4_a2, %b4_a3, %b4_a5, %b4_a6, %b4_a7) [^bb6, ^bb5]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 5, 7>}>
+        : (!riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // %bb.5: for.cond   args {a0,a1,a2,a3,a5,a6,a7}
+    ^bb5(%b5_a0 : !riscv.reg, %b5_a1 : !riscv.reg, %b5_a2 : !riscv.reg, %b5_a3 : !riscv.reg, %b5_a5 : !riscv.reg, %b5_a6 : !riscv.reg, %b5_a7 : !riscv.reg):
+      %b5_a4 = "riscv.mulw"(%b5_a3, %b5_a3) : (!riscv.reg, !riscv.reg) -> !riscv.reg           // mulw a4, a3, a3
+      %b5_a3n = "riscv.addi"(%b5_a3) <{"value" = 1 : i12}> : (!riscv.reg) -> !riscv.reg         // addi a3, a3, 1
+      // bgeu a2, a4, .LBB0_4   (taken -> ^bb4 {a0,a1,a2,a3,a5,a6,a7} with a3=a3n;
+      //                         fall  -> j .LBB0_1 -> ^bb1 {a1,a2,a5,a6,a7})
+      "riscv_cf.bgeu"(%b5_a2, %b5_a4,
+                      %b5_a0, %b5_a1, %b5_a2, %b5_a3n, %b5_a5, %b5_a6, %b5_a7,
+                      %b5_a1, %b5_a2, %b5_a5, %b5_a6, %b5_a7) [^bb4, ^bb1]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 7, 5>}>
+        : (!riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+
+    // .LBB0_6:   args {a0,a1,a2,a6,a7}
+    ^bb6(%b6_a0 : !riscv.reg, %b6_a1 : !riscv.reg, %b6_a2 : !riscv.reg, %b6_a6 : !riscv.reg, %b6_a7 : !riscv.reg):
+      %b6_a1s = "riscv.sextw"(%b6_a1) : (!riscv.reg) -> !riscv.reg                 // sext.w a1, a1
+      %b6_a2n = "riscv.addiw"(%b6_a2) <{"value" = 1 : i12}> : (!riscv.reg) -> !riscv.reg  // addiw a2, a2, 1
+      // bltu a1, a7, .LBB0_2   (taken -> ^bb2 {a0,a1,a2,a6,a7} with a1=a1s,a2=a2n;
+      //                         fall  -> ^bb7 {a0})
+      "riscv_cf.bltu"(%b6_a1s, %b6_a7,
+                      %b6_a0, %b6_a1s, %b6_a2n, %b6_a6, %b6_a7,
+                      %b6_a0) [^bb2, ^bb7]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 5, 1>}>
+        : (!riscv.reg, !riscv.reg,
+           !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg,
+           !riscv.reg) -> ()
+
+    // .LBB0_7: while.end   args {a0}
+    ^bb7(%b7_a0 : !riscv.reg):
+      "func.return"(%b7_a0) : (!riscv.reg) -> ()    // ret (return value in a0)
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x000000000000001d#64]


### PR DESCRIPTION
this adds two versions of a silly program that returns the value of the 10th prime number

one of them is literally translated from `clang -O3` output, and this test passes

the other is literally translated from `clang -O0` output, and it does not even roundtrip without allowing unregistered operations.

@nchappe if you feel like adding `riscv.lw` and `riscv.sw`, that would fix this. or perhaps I can do it if it's easy? let me know.

once VeIR supports all of the instructions used in this test, it will still be interesting getting it to interpret, since it creates a stack frame. we'll at least need to ensure that `SP` is initialized, I'm not sure what else. 