### PR TITLE
feat(refinement): allow `Interp` refinement between different types

### DIFF
--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -63,7 +63,7 @@ on the underlying values. This asserts:
   but may be either `some .ub` or `some (.ok _)`;
 * when `source` is `none`, `target` may be anything
 -/
-def Interp.isRefinedBy (R : α → α → Prop) (source target : Interp α) : Prop :=
+def Interp.isRefinedBy (R : α → β → Prop) (source : Interp α) (target : Interp β) : Prop :=
   match source, target with
   | some (.ok a), some (.ok b) => R a b
   | some .ub, some _ => True


### PR DESCRIPTION
`Interp.isRefinedBy` was expecting the same type in both the source and the target. However, this would prevent us from talking about refinements between two VariableState of different contexts.