### PR TITLE
feat: Parse and verify RISCV stack operations

### DIFF
--- a/Test/RISCV_Stack/identity.mlir
+++ b/Test/RISCV_Stack/identity.mlir
@@ -1,0 +1,18 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %1 = "riscv_stack.alloca"() <{"value_type" = i64, "alignment" = 8 : i64}> : () -> !riscv.reg
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "riscv_stack.alloca"() <{"alignment" = 8 : i64, "value_type" = i64}> : () -> !riscv.reg
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -278,9 +278,6 @@ macro "#assert " e:term : command =>
 /-! ## RISCV Register type -/
 #assert expectSuccessType "!riscv.reg" (RegisterType.mk)
 
-/-! ## RISCV Stack slot type -/
-#assert expectSuccessType "!riscv_stack.ptr<i64>" (Riscv_Stack.StackSlotType.mk (IntegerType.mk 64))
-
 /-! ## Flat symbol reference attribute -/
 #assert expectSuccessAttr "@foo" (FlatSymbolRefAttr.mk "@foo")
 #assert expectSuccessAttr "@printf" (FlatSymbolRefAttr.mk "@printf")

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -1,0 +1,21 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Riscv_Stack.propertiesOf (op : Riscv_Stack) : Type :=
+match op with
+| .alloca => RISCVStackAllocaProperties
+
+instance : HasDialectOpInfo Riscv_Stack where
+  propertiesOf := Riscv_Stack.propertiesOf
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -4,6 +4,7 @@ public import Veir.Dialects.Arith.OpInfo
 public import Veir.Dialects.LLVM.OpInfo
 public import Veir.Dialects.RISCV.OpInfo
 public import Veir.Dialects.RISCV_Cf.OpInfo
+public import Veir.Dialects.RISCV_Stack.OpInfo
 public import Veir.Dialects.ModArith.OpInfo
 public import Veir.Dialects.Cf.OpInfo
 public import Veir.Dialects.Comb.OpInfo
@@ -25,6 +26,7 @@ match opCode with
 | .llvm op => Llvm.propertiesOf op
 | .riscv op => Riscv.propertiesOf op
 | .riscv_cf op => Riscv_Cf.propertiesOf op
+| .riscv_stack op => Riscv_Stack.propertiesOf op
 | .mod_arith op => Mod_Arith.propertiesOf op
 | .cf op => Cf.propertiesOf op
 | .comb op => Comb.propertiesOf op
@@ -89,6 +91,10 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case bge => exact (RISCVBrProperties.fromAttrDict attrDict)
     case bltu => exact (RISCVBrProperties.fromAttrDict attrDict)
     case bgeu => exact (RISCVBrProperties.fromAttrDict attrDict)
+    all_goals exact (Except.ok ())
+  case riscv_stack op =>
+    cases op
+    case alloca => exact (RISCVStackAllocaProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case llvm op =>
     cases op
@@ -218,6 +224,10 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
   | .riscv .slliw | .riscv .srliw | .riscv .sraiw | .riscv .rori | .riscv .roriw | .riscv .slliuw
   | .riscv .bclri | .riscv .bexti | .riscv .binvi | .riscv .bseti | .riscv .ld | .riscv .sd | .mod_arith .constant =>
     (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
+  | .riscv_stack .alloca => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
+    dict.insert "value_type".toUTF8 props.value_type
   | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .blt | .riscv_cf .bge
   | .riscv_cf .bltu | .riscv_cf .bgeu =>
     (Std.HashMap.emptyWithCapacity 1).insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -327,9 +327,6 @@ structure LLVM.ArrayType where
   type : Attribute
 deriving Repr, Hashable
 
-structure Riscv_Stack.StackSlotType where
-  type : Attribute
-
 /--
   A data structure that represents compile-time information in the IR.
   Attributes are used either as type annotations for SSA values, or
@@ -394,8 +391,6 @@ inductive Attribute
 | llvmArrayType (type : LLVM.ArrayType)
 /-- LLVM function type -/
 | llvmFunctionType (type : FunctionType)
-/-- RISCV Stack slot type -/
-| riscvStackSlotType (type : Riscv_Stack.StackSlotType)
 /-- Cuda Tile pointer type -/
 | cudaTilePointerType (type : CudaTile.PointerType)
 /-- CIRCT hw module type -/
@@ -437,10 +432,6 @@ theorem DictionaryAttr.sizeOf_elems_entries {da : DictionaryAttr} (hx : x ∈ da
 theorem LLVM.ArrayType.sizeOf_elems_type {t : ArrayType} :
     sizeOf t.type < sizeOf t := by
   grind [cases ArrayType]
-
-theorem Riscv_Stack.StackSlotType.sizeOf_elems_type {t : StackSlotType} :
-    sizeOf t.type < sizeOf t := by
-  grind [cases StackSlotType]
 
 /-!
   ## DecidableEq instances
@@ -494,17 +485,6 @@ def LLVM.ArrayType.decEq (arr1 arr2 : LLVM.ArrayType) : Decidable (arr1 = arr2) 
 termination_by sizeOf arr1
 decreasing_by
   have := @LLVM.ArrayType.sizeOf_elems_type
-  grind
-
-def Riscv_Stack.StackSlotType.decEq (t1 t2 : Riscv_Stack.StackSlotType) : Decidable (t1 = t2) :=
-  let type1 := t1.type
-  let type2 := t2.type
-  match Attribute.decEq type1 type2 with
-  | isTrue _ => isTrue (by grind [cases Riscv_Stack.StackSlotType])
-  | isFalse _ => isFalse (by grind)
-termination_by sizeOf t1
-decreasing_by
-  have := @Riscv_Stack.StackSlotType.sizeOf_elems_type
   grind
 
 def DictionaryAttr.decEq (dict1 dict2 : DictionaryAttr) : Decidable (dict1 = dict2) :=
@@ -627,10 +607,6 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
       | isFalse hEq => isFalse (by grind))
   case llvmFunctionType.llvmFunctionType type1 type2 =>
     exact (match FunctionType.decEq type1 type2 with
-      | isTrue hEq => isTrue (by grind)
-      | isFalse hEq => isFalse (by grind))
-  case riscvStackSlotType.riscvStackSlotType type1 type2 =>
-    exact (match Riscv_Stack.StackSlotType.decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
   case cudaTilePointerType.cudaTilePointerType type1 type2 =>
@@ -851,12 +827,6 @@ termination_by sizeOf type
 decreasing_by
   apply LLVM.ArrayType.sizeOf_elems_type
 
-def Riscv_Stack.StackSlotType.toString (type : Riscv_Stack.StackSlotType) : String :=
-  s!"!riscv_stack.ptr<{Attribute.toString type.type}>"
-termination_by sizeOf type
-decreasing_by
-  apply Riscv_Stack.StackSlotType.sizeOf_elems_type
-
 /--
   Convert an attribute to a string representation.
 -/
@@ -891,7 +861,6 @@ def Attribute.toString (attr : Attribute) : String :=
   | .llvmPointerType type => ToString.toString type
   | .llvmArrayType type => type.toString
   | .llvmFunctionType type => type.toLLVMString
-  | .riscvStackSlotType type => type.toString
   | .cudaTilePointerType type => ToString.toString type
   | .hwModuleType type => ToString.toString type
 termination_by sizeOf attr
@@ -912,9 +881,6 @@ instance : ToString DictionaryAttr where
 
 instance : ToString LLVM.ArrayType where
   toString := LLVM.ArrayType.toString
-
-instance : ToString Riscv_Stack.StackSlotType where
-  toString := Riscv_Stack.StackSlotType.toString
 
 /-!
   ## Coercion instances to Attribute
@@ -999,9 +965,6 @@ instance : Coe LLVM.PointerType Attribute where
 instance : Coe LLVM.ArrayType Attribute where
   coe type := .llvmArrayType type
 
-instance : Coe Riscv_Stack.StackSlotType Attribute where
-  coe type := .riscvStackSlotType type
-
 instance : Coe CudaTile.PointerType Attribute where
   coe type := .cudaTilePointerType type
 
@@ -1052,7 +1015,6 @@ def isType (attr : Attribute) : Bool :=
   | .llvmPointerType _ => true
   | .llvmArrayType _ => true
   | .llvmFunctionType _ => true
-  | .riscvStackSlotType _ => true
   | .cudaTilePointerType _ => true
   | .hwModuleType _ => true
 
@@ -1107,8 +1069,6 @@ theorem isType_llvmPointerType type : (llvmPointerType type).isType = true := by
 theorem isType_llvmArrayType type : (llvmArrayType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_llvmFunctionType type : (llvmFunctionType type).isType = true := by rfl
-@[simp, grind =]
-theorem isType_riscvStackSlotType type : (riscvStackSlotType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_cudaTilePointerType type : (cudaTilePointerType type).isType = true := by rfl
 @[simp, grind =]
@@ -1173,9 +1133,6 @@ instance : Coe LLVM.PointerType TypeAttr where
 
 instance : Coe LLVM.ArrayType TypeAttr where
   coe type := ⟨.llvmArrayType type, by rfl⟩
-
-instance : Coe Riscv_Stack.StackSlotType TypeAttr where
-  coe type := ⟨.riscvStackSlotType type, by rfl⟩
 
 instance : Coe CudaTile.PointerType TypeAttr where
   coe type := ⟨.cudaTilePointerType type, by rfl⟩

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -229,6 +229,11 @@ inductive Riscv_Cf where
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
+inductive Riscv_Stack where
+| alloca
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[opcodes]
 inductive Mod_Arith where
 | add
 | constant

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -592,22 +592,6 @@ partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
   return some ⟨.llvmFunctionType ft, by rfl⟩
 
 /--
-  Parse a RISCV stack slot type, if present.
-  Its syntax is `!riscv_stack.ptr<size>`.
--/
-partial def parseOptionalRiscvStackSlotType : AttrParserM (Option TypeAttr) := do
-  let token ← peekToken
-  let .exclamationIdent := token.kind | return none
-  let input := (← getThe ParserState).input
-  let typeName := { token.slice with start := token.slice.start + 1 }.of input
-  if typeName ≠ "riscv_stack.ptr".toByteArray then return none
-  let _ ← consumeToken
-  parsePunctuation "<"
-  let ty ← parseType
-  parsePunctuation ">"
-  return some ⟨.riscvStackSlotType ⟨ty.val⟩, by rfl⟩
-
-/--
   Parse a type, if present.
 -/
 partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
@@ -627,8 +611,6 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some llvmArrayType
   if let some llvmFunctionType ← parseOptionalLLVMFunctionType then
     return some llvmFunctionType
-  if let some riscvStackSlotType := ← parseOptionalRiscvStackSlotType then
-    return some riscvStackSlotType
   if let some cudaTilePointerType := ← parseOptionalCudaTilePointerType then
     return some cudaTilePointerType
   if let some hwModuleType ← parseOptionalHWModuleType then

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -217,6 +217,23 @@ def RISCVBrProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) 
   let .denseArrayAttr sizesAttr := sizesAttr
     | throw s!"riscv_cf: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
   return { operandSegmentSizes := sizesAttr }
+
+structure RISCVStackAllocaProperties where
+  alignment : IntegerAttr
+  value_type : TypeAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def RISCVStackAllocaProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String RISCVStackAllocaProperties := do
+  let alignAttr ← match attrDict["alignment".toUTF8]? with
+    | some (.integerAttr alignAttr) => .ok alignAttr
+    | some attr => .error s!"expected 'alignment' to be an optional integer attribute, but got {attr}"
+    | none => .ok { value := 0, type := { bitwidth := 64 } }
+  let some typeAttr := attrDict["value_type".toUTF8]?
+    | throw "alloca: missing 'value_type' property"
+  if _ : typeAttr.isType = false then throw "alloca: expected 'value_type' to be a type attribute" else
+  return { alignment := alignAttr, value_type := typeAttr.asType }
+
 /--
   Properties of the `mod_arith.constant` operation.
 -/

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -2072,6 +2072,18 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
       throw "Expected 2 operands plus 2 variadic operands"
     pure ()
+  /- RISCV Stack -/
+  | .riscv_stack .alloca => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  /- Comb -/
   | .comb .add | .comb .and | .comb .mul | .comb .or | .comb .xor => do
     if op.getNumOperands ctx.raw opIn < 1 then
       throw "Expected 1 or more operands"


### PR DESCRIPTION
This departs a bit from https://github.com/xdslproject/xdsl/pull/6086 as alloca expects a value_type attribute to determine the size of the allocation, and it returns a RISCV register.