### PR TITLE
feat(ISel): prove correctness of selection patterns

### DIFF
--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -39,6 +39,11 @@ theorem toInt_isPoison {w : Nat} {r : Veir.Data.RISCV.Reg} :
     (RISCV.Reg.toInt r w).isPoison = false := by
   simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.isPoison]
 
+@[reg_toBitVec, grind =]
+theorem toInt_getValue {w : Nat} {r : Veir.Data.RISCV.Reg} :
+    (RISCV.Reg.toInt r w).getValue = (r.val).zeroExtend w := by
+  simp [RISCV.Reg.toInt, Veir.Data.LLVM.Int.getValue]
+
 @[llvm_toBitVec, grind =]
 theorem val_toReg {w : Nat} {i : Veir.Data.LLVM.Int w} :
     (LLVM.Int.toReg i).val = if h : i.isPoison = true then 0#64 else i.getValue.zeroExtend 64 := by

--- a/Veir/Data/RISCV/Reg/Lemmas.lean
+++ b/Veir/Data/RISCV/Reg/Lemmas.lean
@@ -155,7 +155,7 @@ theorem val_remuw :
     ((r1.val.extractLsb 31 0).umod (r2.val.extractLsb 31 0)).signExtend 64 := (rfl)
 
 @[reg_toBitVec]
-theorem val_mul : (mul r2 r1).val = r2.val * r1.val := (rfl)
+theorem val_mul : (mul r2 r1).val = r1.val * r2.val := (rfl)
 
 @[reg_toBitVec]
 theorem val_mulh :

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -15,23 +15,6 @@ import Std.Tactic.BVDecide
 
 namespace Veir.Data.RISCV
 
-@[simp]
-theorem BitVec.ult_one_iff_of_lt {lhs : BitVec w} (h : 0 < w) :
-    (lhs.ult 1#w) = decide (lhs = 0#w) := by
-  simp only [BitVec.ult_eq_decide, BitVec.toNat_ofNat, decide_eq_decide]
-  rw [Nat.mod_eq_of_lt (by grind)]
-  simp [← BitVec.toNat_inj]
-
-@[simp]
-theorem BitVec.ult_zero_false {lhs : BitVec w} :
-    (0#w).ult lhs = decide (¬ lhs = 0#w) := by
-  by_cases hzero : lhs = 0#w
-  · simp [hzero, BitVec.ult]
-  · by_cases hlt : (0#w).ult lhs
-    · simp [hlt, hzero]
-    · simp [BitVec.ult_eq_decide] at hlt
-      simp [BitVec.ult_eq_decide, hlt, ← BitVec.toNat_inj]
-
 /--
   A tactic to unfold the semantics of operations on `LLVM.Int` and on `RISCV.Reg` to
   bitvectors, such that `bv_decide` can prove the correctness of the refinement relation

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -15,13 +15,30 @@ import Std.Tactic.BVDecide
 
 namespace Veir.Data.RISCV
 
+@[simp]
+theorem BitVec.ult_one_iff_of_lt {lhs : BitVec w} (h : 0 < w) :
+    (lhs.ult 1#w) = decide (lhs = 0#w) := by
+  simp only [BitVec.ult_eq_decide, BitVec.toNat_ofNat, decide_eq_decide]
+  rw [Nat.mod_eq_of_lt (by grind)]
+  simp [← BitVec.toNat_inj]
+
+@[simp]
+theorem BitVec.ult_zero_false {lhs : BitVec w} :
+    (0#w).ult lhs = decide (¬ lhs = 0#w) := by
+  by_cases hzero : lhs = 0#w
+  · simp [hzero, BitVec.ult]
+  · by_cases hlt : (0#w).ult lhs
+    · simp [hlt, hzero]
+    · simp [BitVec.ult_eq_decide] at hlt
+      simp [BitVec.ult_eq_decide, hlt, ← BitVec.toNat_inj]
+
 /--
   A tactic to unfold the semantics of operations on `LLVM.Int` and on `RISCV.Reg` to
   bitvectors, such that `bv_decide` can prove the correctness of the refinement relation
   over instruction selection patterns.
 -/
 macro "refine_bv_decide" : tactic =>
-  `(tactic| ((try simp only [llvm_toBitVec, reg_toBitVec]; try simp [LLVM.Int.getValue_eq_getValueD]; try bv_decide)))
+  `(tactic| ((try simp only [llvm_toBitVec, reg_toBitVec]; try simp [LLVM.Int.getValue_eq_getValueD, -BitVec.extractLsb_toNat]; try bv_decide)))
 
 
 /--
@@ -39,198 +56,155 @@ theorem constant_refinement {v : Int}:
 -/
 theorem add_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.add x y) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
+      (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
   refine_bv_decide
 
 /--
   Prove the correctness of the `and` lowering pattern.
 -/
-theorem and_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.and lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+theorem and_refinement{x y : LLVM.Int 64} :
+    (Data.LLVM.Int.and x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
   refine_bv_decide
 
 /--
   Prove the correctness of the `ashr` lowering pattern.
 -/
-theorem ashr_refinement {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.ashr lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.sra (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  simp
-  intros
-  rw [Nat.mod_eq_of_lt (by simp [BitVec.lt_def] at *; grind)]
+theorem ashr_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.ashr x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.sra (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `eq`.
 -/
-theorem icmp_refinement_eq {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.eq) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.sltiu 1#12 (Data.RISCV.xor (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs))) 1) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_eq {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.eq) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltiu 1#12 (Data.RISCV.xor (LLVM.Int.toReg y) (LLVM.Int.toReg x))) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `ne`.
 -/
-theorem icmp_refinement_ne {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ne) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.xor (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) (Data.RISCV.li 0#64)) 1) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  simp [BitVec.ult_zero_false]
-  bv_decide
+theorem icmp_refinement_ne {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ne) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.xor (LLVM.Int.toReg y) (LLVM.Int.toReg x)) (Data.RISCV.li 0#64)) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `slt`.
 -/
-theorem icmp_refinement_slt {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.slt) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.slt (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 1) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_slt {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.slt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.slt (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `sle`.
 -/
-theorem icmp_refinement_sle {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.sle) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.slt (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs))) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_sle {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.sle) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.slt (LLVM.Int.toReg x) (LLVM.Int.toReg y))) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `sgt`.
 -/
-theorem icmp_refinement_sgt {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.sgt) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.slt (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs)) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_sgt {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.sgt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.slt (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `sge`.
 -/
-theorem icmp_refinement_sge {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.sge) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.slt (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs))) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_sge {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.sge) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.slt (LLVM.Int.toReg y) (LLVM.Int.toReg x))) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `ult`.
 -/
-theorem icmp_refinement_ult {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ult) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.sltu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_ult {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ult) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `ule`.
 -/
-theorem icmp_refinement_ule {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ule) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.sltu (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs))) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_ule {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ule) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.sltu (LLVM.Int.toReg x) (LLVM.Int.toReg y))) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `ugt`.
 -/
-theorem icmp_refinement_ugt {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ugt) ⊒
-      (RISCV.Reg.toInt ((Data.RISCV.sltu (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs))) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_ugt {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ugt) ⊒
+      (RISCV.Reg.toInt ((Data.RISCV.sltu (LLVM.Int.toReg x) (LLVM.Int.toReg y))) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `icmp` lowering pattern with `uge`.
 -/
-theorem icmp_refinement_uge {lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.uge) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.sltu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs))) 1) := by
-  simp [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem icmp_refinement_uge {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.uge) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.sltu (LLVM.Int.toReg y) (LLVM.Int.toReg x))) 1) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `or` lowering pattern.
 -/
-theorem or_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.or lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem or_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.or x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `xor` lowering pattern.
 -/
-theorem xor_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.xor lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem xor_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.xor x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `mul` lowering pattern.
 -/
-theorem mul_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.mul lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.mul (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem mul_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.mul x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.mul (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `sdiv` lowering pattern.
 -/
-theorem sdiv_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.sdiv lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.div (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  simp
-  bv_decide
+theorem sdiv_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.sdiv x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.div (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `udiv` lowering pattern.
 -/
-theorem udiv_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.udiv lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  simp
-  bv_decide
+theorem udiv_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.udiv x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `udiv` lowering pattern.
 -/
-theorem srem_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.srem lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.rem (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem srem_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.srem x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.rem (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `udiv` lowering pattern.
 -/
-theorem urem_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.urem lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.remu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem urem_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.urem x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.remu (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide
 
 /--
   Prove the correctness of the `udiv` lowering pattern.
 -/
-theorem sub_refinement{lhs rhs : LLVM.Int 64} :
-    (Data.LLVM.Int.sub lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.sub (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
-  simp only [llvm_toBitVec, reg_toBitVec]
-  simp only [LLVM.Int.getValue_eq_getValueD]
-  bv_decide
+theorem sub_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.sub x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.sub (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  refine_bv_decide

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -41,3 +41,196 @@ theorem add_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.add x y) ⊒
       (RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg x) (LLVM.Int.toReg y)) 64) := by
   refine_bv_decide
+
+/--
+  Prove the correctness of the `and` lowering pattern.
+-/
+theorem and_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.and lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  refine_bv_decide
+
+/--
+  Prove the correctness of the `ashr` lowering pattern.
+-/
+theorem ashr_refinement {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.ashr lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.sra (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  simp
+  intros
+  rw [Nat.mod_eq_of_lt (by simp [BitVec.lt_def] at *; grind)]
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `eq`.
+-/
+theorem icmp_refinement_eq {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.eq) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltiu 1#12 (Data.RISCV.xor (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs))) 1) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `ne`.
+-/
+theorem icmp_refinement_ne {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ne) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.xor (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) (Data.RISCV.li 0#64)) 1) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  simp [BitVec.ult_zero_false]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `slt`.
+-/
+theorem icmp_refinement_slt {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.slt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.slt (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 1) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `sle`.
+-/
+theorem icmp_refinement_sle {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.sle) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.slt (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs))) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `sgt`.
+-/
+theorem icmp_refinement_sgt {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.sgt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.slt (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs)) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `sge`.
+-/
+theorem icmp_refinement_sge {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.sge) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.slt (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs))) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `ult`.
+-/
+theorem icmp_refinement_ult {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ult) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `ule`.
+-/
+theorem icmp_refinement_ule {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ule) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.sltu (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs))) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `ugt`.
+-/
+theorem icmp_refinement_ugt {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.ugt) ⊒
+      (RISCV.Reg.toInt ((Data.RISCV.sltu (LLVM.Int.toReg lhs) (LLVM.Int.toReg rhs))) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `icmp` lowering pattern with `uge`.
+-/
+theorem icmp_refinement_uge {lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.icmp lhs rhs LLVM.IntPred.uge) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12 (Data.RISCV.sltu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs))) 1) := by
+  simp [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `or` lowering pattern.
+-/
+theorem or_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.or lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `xor` lowering pattern.
+-/
+theorem xor_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.xor lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `mul` lowering pattern.
+-/
+theorem mul_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.mul lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.mul (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `sdiv` lowering pattern.
+-/
+theorem sdiv_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.sdiv lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.div (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  simp
+  bv_decide
+
+/--
+  Prove the correctness of the `udiv` lowering pattern.
+-/
+theorem udiv_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.udiv lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  simp
+  bv_decide
+
+/--
+  Prove the correctness of the `udiv` lowering pattern.
+-/
+theorem srem_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.srem lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.rem (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `udiv` lowering pattern.
+-/
+theorem urem_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.urem lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.remu (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide
+
+/--
+  Prove the correctness of the `udiv` lowering pattern.
+-/
+theorem sub_refinement{lhs rhs : LLVM.Int 64} :
+    (Data.LLVM.Int.sub lhs rhs) ⊒ (RISCV.Reg.toInt (Data.RISCV.sub (LLVM.Int.toReg rhs) (LLVM.Int.toReg lhs)) 64) := by
+  simp only [llvm_toBitVec, reg_toBitVec]
+  simp only [LLVM.Int.getValue_eq_getValueD]
+  bv_decide


### PR DESCRIPTION
Prove the correctness of all basic instruction selection patterns. Introduce `toInt_getValue` and update the `simp` set in the `refine_bv_decide` tactic to avoid a conversion `toNat` that was problematic (``BitVec.extractLsb_toNat`).
We do not prove the lemmas around sext/zext/trunc as we need to be careful with the widths we support for those ops.

In this PR, I am also fixing a mismatch in the `Reg` lemmas that was a consequence of #806. 

