### PR TITLE
feat(ir): add new lemmas about inBounds and the rewriter

### DIFF
--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -249,6 +249,10 @@ theorem OpOperandPtr.dealloc.inBounds_dealloc_genericPtr {ptr : GenericPtr} :
     ptr.InBounds (OperationPtr.dealloc op' ctx inBounds) := by
   grind
 
+theorem OperationPtr.InBounds.ne_of_inBounds_OperationPtr_dealloc {op : OperationPtr} :
+    op.InBounds (OperationPtr.dealloc op' ctx inBounds) → op ≠ op' := by
+  grind
+
 theorem OpResultPtr.InBounds.op_ne_of_inBounds_OperationPtr_dealloc {opResult : OpResultPtr} :
     opResult.InBounds (OperationPtr.dealloc op' ctx inBounds) → opResult.op ≠ op' := by
   grind

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -217,6 +217,26 @@ example.
 -/
 
 /--
+`eraseOp` only deallocates `op` and the pointers belonging to it (its results,
+operands and block operands).  Hence, for any pointer that does not reference
+`op`, being in bounds is unaffected by `eraseOp`.
+-/
+@[grind .]
+theorem Rewriter.eraseOp_inBounds (ptr : GenericPtr)
+    (hPtr : match ptr with
+      | .operation op' => op' ≠ op
+      | .opResult or => or.op ≠ op
+      | .opOperand oo => oo.op ≠ op
+      | .blockOperand bo => bo.op ≠ op
+      | .value (.opResult or) => or.op ≠ op
+      | .opOperandPtr (.operandNextUse oo) => oo.op ≠ op
+      | .opOperandPtr (.valueFirstUse (.opResult or)) => or.op ≠ op
+      | .blockOperandPtr (.blockOperandNextUse oo) => oo.op ≠ op
+      | _ => True) :
+    ptr.InBounds (eraseOp ctx op hCtx hOp) ↔ ptr.InBounds ctx := by
+  grind [eraseOp]
+
+/--
 - Insert a block at a given location.
 -/
 @[irreducible]
@@ -398,6 +418,31 @@ def Rewriter.replaceOp? (ctx: IRContext OpInfo) (oldOp newOp: OperationPtr)
     rlet newCtx ← replaceOpResults ctx oldOp newOp numOldResults
     eraseOp newCtx oldOp
 
+/--
+`replaceOp?` do not allocate anything and only deallocates `op` and the pointers belonging to it
+(its results, operands and block operands).  Hence, for any pointer that does not reference
+`op`, being in bounds is unaffected by `eraseOp`.
+-/
+theorem Rewriter.replaceOp?_inBounds (ptr : GenericPtr)
+    (h : Rewriter.replaceOp? ctx oldOp newOp oldIn newIn ctxIn hpar = some newCtx)
+    (hPtr : match ptr with
+      | .operation op' => op' ≠ oldOp
+      | .opResult or => or.op ≠ oldOp
+      | .opOperand oo => oo.op ≠ oldOp
+      | .blockOperand bo => bo.op ≠ oldOp
+      | .value (.opResult or) => or.op ≠ oldOp
+      | .opOperandPtr (.operandNextUse oo) => oo.op ≠ oldOp
+      | .opOperandPtr (.valueFirstUse (.opResult or)) => or.op ≠ oldOp
+      | .blockOperandPtr (.blockOperandNextUse oo) => oo.op ≠ oldOp
+      | _ => True) :
+    ptr.InBounds newCtx ↔ ptr.InBounds ctx := by
+  simp only [Rewriter.replaceOp?] at h
+  grind
+
+grind_pattern Rewriter.replaceOp?_inBounds =>
+  Rewriter.replaceOp? ctx oldOp newOp oldIn newIn ctxIn hpar,
+  some newCtx, ptr.InBounds newCtx
+
 @[irreducible]
 protected def Rewriter.pushBlockArgument (ctx : IRContext OpInfo) (blockPtr : BlockPtr) (type : TypeAttr)
     (blockPtrInBounds : blockPtr.InBounds ctx := by grind) : IRContext OpInfo :=
@@ -505,6 +550,30 @@ theorem Rewriter.createBlock_inBounds_mono (ptr : GenericPtr) (heq : createBlock
     · simp [Option.bind] at heq
       split at heq <;> grind
     · grind
+
+/--
+`createBlock` allocate a new block with its arguments. Thus, the only new pointers that are in
+bounds in the new context and not in the old one are the block itself, its arguments, and links to
+the block arguments.
+-/
+@[grind =>]
+theorem Rewriter.createBlock_inBounds (ptr : GenericPtr)
+    (h : Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock)) :
+    ptr.InBounds newCtx ↔
+    match ptr with
+    | .blockArgument argPtr
+    | .value (.blockArgument argPtr)
+    | .opOperandPtr (.valueFirstUse (.blockArgument argPtr)) =>
+      if argPtr.block = newBlock then argPtr.index < types.size else argPtr.InBounds ctx
+    | _ =>
+      ptr.InBounds ctx ∨ ptr = .block newBlock ∨
+        ptr = .blockOperandPtr (BlockOperandPtrPtr.blockFirstUse newBlock) := by
+  simp only [Rewriter.createBlock] at h
+  simp only [Option.bind_eq_bind, Option.bind] at h
+  split at h; grind
+  split at h
+  · split at h <;> grind
+  · grind
 
 @[grind .]
 theorem Rewriter.createBlock_fieldsInBounds_mono

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -645,4 +645,41 @@ theorem OperationPtr.getNumOperands_iff_replaceValue?
     OperationPtr.getNumOperands op ctx (by grind) := by
   grind [OpOperandPtr.inBounds_if_operand_size_eq]
 
+/--
+`createOp` allocates a new operation with its results, operands, and block operands. Thus, the
+only new pointers that are in bounds in the new context and not in the old one are the operation
+itself, its results, its operands, its block operands, and the links to them.
+-/
+@[grind =>]
+theorem Rewriter.createOp_inBounds (ptr : GenericPtr)
+    (h : createOp ctx opType resultTypes operands blockOperands regions props ip h₁ h₂ h₃ h₄ h₅ = some (newCtx, newOp)) :
+    ptr.InBounds newCtx ↔
+    match ptr with
+    | .opResult resPtr
+    | .value (.opResult resPtr)
+    | .opOperandPtr (.valueFirstUse (.opResult resPtr)) =>
+      if resPtr.op = newOp then resPtr.index < resultTypes.size else resPtr.InBounds ctx
+    | .opOperand operandPtr
+    | .opOperandPtr (.operandNextUse operandPtr) =>
+      if operandPtr.op = newOp then operandPtr.index < operands.size else operandPtr.InBounds ctx
+    | .blockOperand blockOperandPtr
+    | .blockOperandPtr (.blockOperandNextUse blockOperandPtr) =>
+      if blockOperandPtr.op = newOp then
+        blockOperandPtr.index < blockOperands.size
+      else
+        blockOperandPtr.InBounds ctx
+    | _ => ptr.InBounds ctx ∨ ptr = .operation newOp := by
+  simp only [createOp] at h
+  split at h
+  · simp at h
+  · rename_i ctx₁ newOpPtr hnew
+    split at h
+    · simp at h
+    · rename_i ctx₂ hreg
+      split at h
+      · split at h
+        · simp at h
+        · cases ptr <;> grind [createEmptyOp]
+      · cases ptr <;> grind [createEmptyOp]
+
 end Veir


### PR DESCRIPTION
These lemmas were missing, and were necessary to prove some get-set lemmas about the rewriter.