### PR TITLE
feat(ir): add `BlockPtr.operationList` get-set lemmas for `Rewriter`

### DIFF
--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -249,6 +249,10 @@ theorem OpOperandPtr.dealloc.inBounds_dealloc_genericPtr {ptr : GenericPtr} :
     ptr.InBounds (OperationPtr.dealloc op' ctx inBounds) := by
   grind
 
+theorem OperationPtr.InBounds.ne_of_inBounds_OperationPtr_dealloc {op : OperationPtr} :
+    op.InBounds (OperationPtr.dealloc op' ctx inBounds) → op ≠ op' := by
+  grind
+
 theorem OpResultPtr.InBounds.op_ne_of_inBounds_OperationPtr_dealloc {opResult : OpResultPtr} :
     opResult.InBounds (OperationPtr.dealloc op' ctx inBounds) → opResult.op ≠ op' := by
   grind

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -217,6 +217,26 @@ example.
 -/
 
 /--
+`eraseOp` only deallocates `op` and the pointers belonging to it (its results,
+operands and block operands).  Hence, for any pointer that does not reference
+`op`, being in bounds is unaffected by `eraseOp`.
+-/
+@[grind .]
+theorem Rewriter.eraseOp_inBounds (ptr : GenericPtr)
+    (hPtr : match ptr with
+      | .operation op' => op' ≠ op
+      | .opResult or => or.op ≠ op
+      | .opOperand oo => oo.op ≠ op
+      | .blockOperand bo => bo.op ≠ op
+      | .value (.opResult or) => or.op ≠ op
+      | .opOperandPtr (.operandNextUse oo) => oo.op ≠ op
+      | .opOperandPtr (.valueFirstUse (.opResult or)) => or.op ≠ op
+      | .blockOperandPtr (.blockOperandNextUse oo) => oo.op ≠ op
+      | _ => True) :
+    ptr.InBounds (eraseOp ctx op hCtx hOp) ↔ ptr.InBounds ctx := by
+  grind [eraseOp]
+
+/--
 - Insert a block at a given location.
 -/
 @[irreducible]
@@ -398,6 +418,31 @@ def Rewriter.replaceOp? (ctx: IRContext OpInfo) (oldOp newOp: OperationPtr)
     rlet newCtx ← replaceOpResults ctx oldOp newOp numOldResults
     eraseOp newCtx oldOp
 
+/--
+`replaceOp?` do not allocate anything and only deallocates `op` and the pointers belonging to it
+(its results, operands and block operands).  Hence, for any pointer that does not reference
+`op`, being in bounds is unaffected by `eraseOp`.
+-/
+theorem Rewriter.replaceOp?_inBounds (ptr : GenericPtr)
+    (h : Rewriter.replaceOp? ctx oldOp newOp oldIn newIn ctxIn hpar = some newCtx)
+    (hPtr : match ptr with
+      | .operation op' => op' ≠ oldOp
+      | .opResult or => or.op ≠ oldOp
+      | .opOperand oo => oo.op ≠ oldOp
+      | .blockOperand bo => bo.op ≠ oldOp
+      | .value (.opResult or) => or.op ≠ oldOp
+      | .opOperandPtr (.operandNextUse oo) => oo.op ≠ oldOp
+      | .opOperandPtr (.valueFirstUse (.opResult or)) => or.op ≠ oldOp
+      | .blockOperandPtr (.blockOperandNextUse oo) => oo.op ≠ oldOp
+      | _ => True) :
+    ptr.InBounds newCtx ↔ ptr.InBounds ctx := by
+  simp only [Rewriter.replaceOp?] at h
+  grind
+
+grind_pattern Rewriter.replaceOp?_inBounds =>
+  Rewriter.replaceOp? ctx oldOp newOp oldIn newIn ctxIn hpar,
+  some newCtx, ptr.InBounds newCtx
+
 @[irreducible]
 protected def Rewriter.pushBlockArgument (ctx : IRContext OpInfo) (blockPtr : BlockPtr) (type : TypeAttr)
     (blockPtrInBounds : blockPtr.InBounds ctx := by grind) : IRContext OpInfo :=
@@ -505,6 +550,30 @@ theorem Rewriter.createBlock_inBounds_mono (ptr : GenericPtr) (heq : createBlock
     · simp [Option.bind] at heq
       split at heq <;> grind
     · grind
+
+/--
+`createBlock` allocate a new block with its arguments. Thus, the only new pointers that are in
+bounds in the new context and not in the old one are the block itself, its arguments, and links to
+the block arguments.
+-/
+@[grind =>]
+theorem Rewriter.createBlock_inBounds (ptr : GenericPtr)
+    (h : Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock)) :
+    ptr.InBounds newCtx ↔
+    match ptr with
+    | .blockArgument argPtr
+    | .value (.blockArgument argPtr)
+    | .opOperandPtr (.valueFirstUse (.blockArgument argPtr)) =>
+      if argPtr.block = newBlock then argPtr.index < types.size else argPtr.InBounds ctx
+    | _ =>
+      ptr.InBounds ctx ∨ ptr = .block newBlock ∨
+        ptr = .blockOperandPtr (BlockOperandPtrPtr.blockFirstUse newBlock) := by
+  simp only [Rewriter.createBlock] at h
+  simp only [Option.bind_eq_bind, Option.bind] at h
+  split at h; grind
+  split at h
+  · split at h <;> grind
+  · grind
 
 @[grind .]
 theorem Rewriter.createBlock_fieldsInBounds_mono

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -645,4 +645,41 @@ theorem OperationPtr.getNumOperands_iff_replaceValue?
     OperationPtr.getNumOperands op ctx (by grind) := by
   grind [OpOperandPtr.inBounds_if_operand_size_eq]
 
+/--
+`createOp` allocates a new operation with its results, operands, and block operands. Thus, the
+only new pointers that are in bounds in the new context and not in the old one are the operation
+itself, its results, its operands, its block operands, and the links to them.
+-/
+@[grind =>]
+theorem Rewriter.createOp_inBounds (ptr : GenericPtr)
+    (h : createOp ctx opType resultTypes operands blockOperands regions props ip h₁ h₂ h₃ h₄ h₅ = some (newCtx, newOp)) :
+    ptr.InBounds newCtx ↔
+    match ptr with
+    | .opResult resPtr
+    | .value (.opResult resPtr)
+    | .opOperandPtr (.valueFirstUse (.opResult resPtr)) =>
+      if resPtr.op = newOp then resPtr.index < resultTypes.size else resPtr.InBounds ctx
+    | .opOperand operandPtr
+    | .opOperandPtr (.operandNextUse operandPtr) =>
+      if operandPtr.op = newOp then operandPtr.index < operands.size else operandPtr.InBounds ctx
+    | .blockOperand blockOperandPtr
+    | .blockOperandPtr (.blockOperandNextUse blockOperandPtr) =>
+      if blockOperandPtr.op = newOp then
+        blockOperandPtr.index < blockOperands.size
+      else
+        blockOperandPtr.InBounds ctx
+    | _ => ptr.InBounds ctx ∨ ptr = .operation newOp := by
+  simp only [createOp] at h
+  split at h
+  · simp at h
+  · rename_i ctx₁ newOpPtr hnew
+    split at h
+    · simp at h
+    · rename_i ctx₂ hreg
+      split at h
+      · split at h
+        · simp at h
+        · cases ptr <;> grind [createEmptyOp]
+      · cases ptr <;> grind [createEmptyOp]
+
 end Veir

--- a/Veir/Rewriter/WellFormed/Block.lean
+++ b/Veir/Rewriter/WellFormed/Block.lean
@@ -29,6 +29,20 @@ theorem Rewriter.insertBlock?_WellFormed (hctx : ctx.WellFormed) :
   apply IRContext.wellFormed_BlockPtr_linkBetweenWithParent hctx h (ip := ip) <;>
     grind [Option.maybe₁_def]
 
+theorem BlockPtr.operationList_rewriter_insertBlock?
+    {block : BlockPtr} {blockInBounds : block.InBounds newCtx}
+    (h : Rewriter.insertBlock? ctx newOp ip newOpIn insIn ctxInBounds = some newCtx)
+    (ctxWf : ctx.WellFormed) :
+    block.operationList newCtx newCtxWf blockInBounds = block.operationList ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_BlockPtr_linkBetweenWithParent, Rewriter.insertBlock?]
+
+grind_pattern BlockPtr.operationList_rewriter_insertBlock? =>
+  Rewriter.insertBlock? ctx newOp ip newOpIn insIn ctxInBounds, newCtx.WellFormed, some newCtx,
+  block.operationList newCtx newCtxWf blockInBounds
+
+/-- # Rewriter.insertBlock? -/
+
 theorem BlockPtr.allocEmpty_wellFormed (hctx : ctx.WellFormed)
     (heq : BlockPtr.allocEmpty ctx = some (newCtx, bl)) :
     newCtx.WellFormed := by
@@ -76,15 +90,77 @@ theorem BlockPtr.allocEmpty_wellFormed (hctx : ctx.WellFormed)
     have := hctx.regions region (by grind)
     apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
 
-theorem Rewriter.createBlock_WellFormed (ctxWf : ctx.WellFormed) :
-    Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock) →
+theorem BlockPtr.operationList_blockPtr_allocEmpty
+    {block : BlockPtr} {blockInBounds : block.InBounds newCtx}
+    (h : BlockPtr.allocEmpty ctx = some (newCtx, bl)) (ctxWf : ctx.WellFormed) :
+    block.operationList newCtx newCtxWf blockInBounds =
+    if h : block = bl then #[] else block.operationList ctx ctxWf (by grind) := by
+  apply BlockPtr.operationList_iff_BlockPtr_OpChain.mp
+  by_cases hbb : block = bl
+  · grind [Block.empty, BlockPtr.OpChain]
+  · apply BlockPtr.OpChain_unchanged (ctx := ctx) <;>
+      grind [BlockPtr.operationListWF]
+
+grind_pattern BlockPtr.operationList_blockPtr_allocEmpty =>
+  BlockPtr.allocEmpty ctx, some (newCtx, bl), newCtx.WellFormed, some newCtx,
+  block.operationList newCtx newCtxWf blockInBounds
+
+theorem Rewriter.createBlock_WellFormed
+    (h : Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock))
+    (ctxWf : ctx.WellFormed) :
     newCtx.WellFormed := by
-  simp only [Rewriter.createBlock]
-  split; grind; rename_i ctx₁ newBlock₁ hctx₁
+  simp only [Rewriter.createBlock] at h
+  split at h; grind; rename_i ctx₁ newBlock₁ hctx₁
   have : ctx₁.WellFormed := by grind [BlockPtr.allocEmpty_wellFormed]
-  split
-  · simp only [Option.bind_eq_bind, Option.bind]
+  split at h
+  · simp only [Option.bind_eq_bind, Option.bind] at h
     grind [IRContext.wellFormed_Rewriter_initBlockArguments, Rewriter.insertBlock?_WellFormed]
   · grind [IRContext.wellFormed_Rewriter_initBlockArguments]
+
+/-- Any block that already existed before `Rewriter.createBlock` keeps its operation chain. -/
+theorem BlockPtr.opChain_rewriter_createBlock {block : BlockPtr} {array : Array OperationPtr}
+    (hWf : BlockPtr.OpChain block ctx array)
+    (h : Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock)) :
+    BlockPtr.OpChain block newCtx array := by
+  simp only [Rewriter.createBlock] at h
+  split at h; grind
+  rename_i ctx₁ newBlock₁ hAlloc
+  have hc1 : BlockPtr.OpChain block ctx₁ array := by
+    apply BlockPtr.OpChain_unchanged (ctx := ctx) hWf <;> grind
+  have hc2 : BlockPtr.OpChain block (Rewriter.initBlockArguments ctx₁ newBlock₁ types) array :=
+    BlockPtr.opChain_Rewriter_initBlockArguments hc1
+  split at h
+  · simp only [Option.bind_eq_bind, Option.bind] at h
+    grind [Rewriter.insertBlock?, BlockPtr.opChain_BlockPtr_linkBetweenWithParent]
+  · grind
+
+/-- The block freshly created by `Rewriter.createBlock` has an empty operation chain. -/
+theorem BlockPtr.opChain_rewriter_createBlock_new
+    (h : Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock)) :
+    BlockPtr.OpChain newBlock newCtx #[] := by
+  simp only [Rewriter.createBlock] at h
+  split at h; grind
+  rename_i ctx₁ newBlock₁ hAlloc
+  have hc0 : BlockPtr.OpChain newBlock₁ ctx₁ #[] := by grind [Block.empty, BlockPtr.OpChain]
+  have hc1 : BlockPtr.OpChain newBlock₁ (Rewriter.initBlockArguments ctx₁ newBlock₁ types) #[] :=
+    BlockPtr.opChain_Rewriter_initBlockArguments hc0
+  split at h
+  · simp only [Option.bind_eq_bind, Option.bind] at h
+    grind [BlockPtr.opChain_BlockPtr_linkBetweenWithParent, Rewriter.insertBlock?]
+  · grind
+
+theorem BlockPtr.operationList_rewriter_createBlock (ctxWf : ctx.WellFormed)
+    (newCtxWf : newCtx.WellFormed) {block : BlockPtr} {blockInBounds : block.InBounds newCtx}
+    (h : Rewriter.createBlock ctx types ip hctx hip = some (newCtx, newBlock)) :
+    block.operationList newCtx newCtxWf blockInBounds =
+    if hb : block = newBlock then #[] else block.operationList ctx ctxWf := by
+  by_cases hbb : block = newBlock
+  · grind [BlockPtr.opChain_rewriter_createBlock_new h]
+  · have hChain : BlockPtr.OpChain block ctx (block.operationList ctx ctxWf) := by grind
+    grind [BlockPtr.opChain_rewriter_createBlock hChain h]
+
+grind_pattern BlockPtr.operationList_rewriter_createBlock =>
+  Rewriter.createBlock ctx types ip hctx hip, some (newCtx, newBlock), newCtx.WellFormed,
+  block.operationList newCtx newCtxWf blockInBounds
 
 end Veir

--- a/Veir/Rewriter/WellFormed/BlockArguments.lean
+++ b/Veir/Rewriter/WellFormed/BlockArguments.lean
@@ -12,7 +12,7 @@ public section
 namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {ctx : IRContext OpInfo}
+variable {ctx newCtx : IRContext OpInfo}
 
 /-! ## Rewriter.pushBlockArgument -/
 
@@ -83,12 +83,42 @@ theorem IRContext.wellFormed_Rewriter_pushBlockArgument :
   case regions =>
     grind [RegionPtr.WellFormed_unchanged]
 
+theorem BlockPtr.operationList_rewriter_pushBlockArgument
+    (h : Rewriter.pushBlockArgument ctx block type blockInBounds = some newCtx)
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_Rewriter_pushBlockArgument]
+
+grind_pattern BlockPtr.operationList_rewriter_pushBlockArgument =>
+  Rewriter.pushBlockArgument ctx block type blockInBounds, newCtx.WellFormed, some newCtx,
+  block'.operationList newCtx newCtxWf blockInBounds'
+
 /-! ## Rewriter.initBlockArguments -/
 
 theorem IRContext.wellFormed_Rewriter_initBlockArguments :
     ctx.WellFormed →
     (Rewriter.initBlockArguments ctx opPtr resultTypes index hop hindex).WellFormed := by
   fun_induction Rewriter.initBlockArguments <;> grind [IRContext.wellFormed_Rewriter_pushBlockArgument]
+
+theorem BlockPtr.opChain_Rewriter_initBlockArguments
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' (Rewriter.initBlockArguments ctx block types index hblock hidx) array := by
+  fun_induction Rewriter.initBlockArguments <;>
+    grind [BlockPtr.opChain_Rewriter_pushBlockArgument]
+
+theorem BlockPtr.operationList_rewriter_initBlockArguments
+    (h : Rewriter.initBlockArguments ctx block types index hblock hidx = some newCtx)
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind [Rewriter.initBlockArguments_inBounds']) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_Rewriter_initBlockArguments]
+
+grind_pattern BlockPtr.operationList_rewriter_initBlockArguments =>
+  Rewriter.initBlockArguments ctx block types index hblock hidx, newCtx.WellFormed, some newCtx,
+  block'.operationList newCtx newCtxWf blockInBounds'
 
 /-! ## Rewriter.setBlockArguments -/
 
@@ -187,3 +217,15 @@ theorem IRContext.wellFormed_Rewriter_setBlockArguments
     constructor <;> grind
   case regions =>
     grind [RegionPtr.WellFormed_unchanged]
+
+theorem BlockPtr.operationList_rewriter_setBlockArguments
+    (h : Rewriter.setBlockArguments ctx block types hblock = some newCtx)
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_Rewriter_setBlockArguments]
+
+grind_pattern BlockPtr.operationList_rewriter_setBlockArguments =>
+  Rewriter.setBlockArguments ctx block types hblock, newCtx.WellFormed, some newCtx,
+  block'.operationList newCtx newCtxWf blockInBounds'

--- a/Veir/Rewriter/WellFormed/BlockOperands.lean
+++ b/Veir/Rewriter/WellFormed/BlockOperands.lean
@@ -133,6 +133,25 @@ info: 'Veir.Rewriter.pushBlockOperand_WellFormed' depends on axioms: [propext, C
 #guard_msgs in
 #print axioms Rewriter.pushBlockOperand_WellFormed
 
+theorem BlockPtr.opChain_rewriter_pushBlockOperand
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.pushBlockOperand ctx opPtr blockPtr opPtrInBounds blockPtrInBounds ctxInBounds)
+      array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_pushBlockOperand
+    (h : Rewriter.pushBlockOperand ctx opPtr blockPtr opPtrInBounds blockPtrInBounds ctxInBounds =
+      newCtx) (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_pushBlockOperand]
+
+grind_pattern BlockPtr.operationList_rewriter_pushBlockOperand =>
+  Rewriter.pushBlockOperand ctx opPtr blockPtr opPtrInBounds blockPtrInBounds ctxInBounds,
+  newCtx.WellFormed, block'.operationList newCtx newCtxWf blockInBounds'
+
 theorem Rewriter.initBlockOperands_WellFormed (hOpWf : ctx.WellFormed) :
     (Rewriter.initBlockOperands ctx opPtr operands n h₁ h₂ h₃ h₄).WellFormed := by
   induction n generalizing ctx
@@ -141,3 +160,21 @@ theorem Rewriter.initBlockOperands_WellFormed (hOpWf : ctx.WellFormed) :
   case succ n ih =>
     simp only [initBlockOperands]
     grind [Rewriter.pushBlockOperand_WellFormed]
+
+theorem BlockPtr.opChain_rewriter_initBlockOperands
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.initBlockOperands ctx opPtr operands n h₁ h₂ h₃ h₄) array := by
+  fun_induction Rewriter.initBlockOperands <;>
+    grind [BlockPtr.opChain_rewriter_pushBlockOperand]
+
+theorem BlockPtr.operationList_rewriter_initBlockOperands (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (Rewriter.initBlockOperands ctx opPtr operands n h₁ h₂ h₃ h₄)
+      newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_initBlockOperands]
+
+grind_pattern BlockPtr.operationList_rewriter_initBlockOperands =>
+  (Rewriter.initBlockOperands ctx opPtr operands n h₁ h₂ h₃ h₄).WellFormed,
+  block'.operationList (Rewriter.initBlockOperands ctx opPtr operands n h₁ h₂ h₃ h₄) newCtxWf blockInBounds'

--- a/Veir/Rewriter/WellFormed/OpOperands.lean
+++ b/Veir/Rewriter/WellFormed/OpOperands.lean
@@ -151,3 +151,43 @@ theorem Rewriter.initOpOperands_WellFormed (ctx: IRContext OpInfo) (opPtr: Opera
   case succ n ih =>
     simp only [initOpOperands]
     grind [Rewriter.pushOperand_WellFormed]
+
+theorem BlockPtr.opChain_rewriter_pushOperand
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.pushOperand ctx opPtr valuePtr opPtrInBounds valuePtrInBounds ctxInBounds)
+      array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_pushOperand
+    (h : Rewriter.pushOperand ctx opPtr valuePtr opPtrInBounds valuePtrInBounds ctxInBounds =
+      newCtx)
+    (ctxWf : ctx.WellFormed):
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_pushOperand]
+
+grind_pattern BlockPtr.operationList_rewriter_pushOperand =>
+  Rewriter.pushOperand ctx opPtr valuePtr opPtrInBounds valuePtrInBounds ctxInBounds,
+  newCtx.WellFormed,
+  block'.operationList newCtx newCtxWf blockInBounds'
+
+theorem BlockPtr.opChain_rewriter_initOpOperands
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.initOpOperands ctx opPtr opPtrInBounds operands hoperands hctx n hn) array := by
+  fun_induction Rewriter.initOpOperands <;>
+    grind [BlockPtr.opChain_rewriter_pushOperand]
+
+theorem BlockPtr.operationList_rewriter_initOpOperands (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block'
+      (Rewriter.initOpOperands ctx opPtr opPtrInBounds operands hoperands hctx n hn)
+      newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_initOpOperands]
+
+grind_pattern BlockPtr.operationList_rewriter_initOpOperands =>
+  (Rewriter.initOpOperands ctx opPtr opPtrInBounds operands hoperands hctx n hn).WellFormed,
+  block'.operationList (Rewriter.initOpOperands ctx opPtr opPtrInBounds operands hoperands hctx n hn) newCtxWf blockInBounds'

--- a/Veir/Rewriter/WellFormed/OpRegion.lean
+++ b/Veir/Rewriter/WellFormed/OpRegion.lean
@@ -86,3 +86,43 @@ theorem Rewriter.initOpRegions_WellFormed (opPtr: OperationPtr)
   case case1 => grind
   case case2 => grind [IRContext.wellFormed_Rewriter_pushRegion]
   case case3 => grind
+
+theorem BlockPtr.opChain_rewriter_pushRegion
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.pushRegion ctx op region hop hregion hregionParent) array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_pushRegion
+    (h : Rewriter.pushRegion ctx op region hop hregion hregionParent = newCtx)
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_pushRegion]
+
+grind_pattern BlockPtr.operationList_rewriter_pushRegion =>
+  Rewriter.pushRegion ctx op region hop hregion hregionParent,
+  newCtx.WellFormed,
+  block'.operationList newCtx newCtxWf blockInBounds'
+
+theorem BlockPtr.opChain_rewriter_initOpRegions
+    (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx')
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' ctx' array := by
+  fun_induction Rewriter.initOpRegions generalizing array
+  case case1 => grind
+  case case2 => grind [BlockPtr.opChain_rewriter_pushRegion]
+  case case3 => grind
+
+theorem BlockPtr.operationList_rewriter_initOpRegions
+    (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx')
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' ctx' newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_initOpRegions]
+
+grind_pattern BlockPtr.operationList_rewriter_initOpRegions =>
+  Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄, some ctx',
+  block'.operationList ctx' newCtxWf blockInBounds'

--- a/Veir/Rewriter/WellFormed/OpResults.lean
+++ b/Veir/Rewriter/WellFormed/OpResults.lean
@@ -89,9 +89,39 @@ theorem IRContext.wellFormed_Rewriter_pushResult :
   case regions =>
     grind [RegionPtr.WellFormed_unchanged]
 
+theorem BlockPtr.operationList_rewriter_pushResult
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (Rewriter.pushResult ctx op type hop) newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_Rewriter_pushResult]
+
+grind_pattern BlockPtr.operationList_rewriter_pushResult =>
+  Rewriter.pushResult ctx op type hop,
+  (Rewriter.pushResult ctx op type hop).WellFormed,
+  block'.operationList (Rewriter.pushResult ctx op type hop) (by grind) (by grind)
+
 /-! ## Rewriter.initOpResults -/
 
-theorem IRContext.wellFormed_Rewriter_initOpResults :
+theorem IRContext.wellFormed_rewriter_initOpResults :
     ctx.WellFormed →
     (Rewriter.initOpResults ctx opPtr resultTypes index hop hindex).WellFormed := by
   fun_induction Rewriter.initOpResults <;> grind [IRContext.wellFormed_Rewriter_pushResult]
+
+theorem BlockPtr.opChain_rewriter_initOpResults
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.initOpResults ctx op resultTypes index hop hidx) array := by
+  fun_induction Rewriter.initOpResults <;>
+    grind [BlockPtr.opChain_Rewriter_pushResult]
+
+theorem BlockPtr.operationList_rewriter_initOpResults (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block'
+      (Rewriter.initOpResults ctx op resultTypes index hop hidx) newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_initOpResults]
+
+grind_pattern BlockPtr.operationList_rewriter_initOpResults =>
+  (Rewriter.initOpResults ctx op resultTypes index hop hidx).WellFormed,
+  block'.operationList (Rewriter.initOpResults ctx op resultTypes index hop hidx) newCtxWf blockInBounds'

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -31,6 +31,36 @@ theorem Rewriter.insertOp?_WellFormed (hctx : ctx.WellFormed) :
   apply IRContext.wellFormed_OperationPtr_linkBetweenWithParent hctx h (ip := ip) <;>
     grind [Option.maybe₁_def]
 
+theorem BlockPtr.operationList_rewriter_insertOp?
+  (h : Rewriter.insertOp? ctx op ip opIn ipIn ctxIn = some ctx') (ctxWf : ctx.WellFormed) :
+  BlockPtr.operationList block ctx' ctx'Wf blockIn =
+  if h: ip.block! ctx = some block then
+    (BlockPtr.operationList block ctx ctxWf).insertIdx (ip.idxIn ctx block) op
+      (by apply InsertPoint.idxIn.le_size_operationList)
+  else
+    BlockPtr.operationList block ctx ctxWf := by
+  have ⟨block', hBlock'⟩ : ∃ block', ip.block! ctx = some block' := by grind [Rewriter.insertOp?]
+  have ⟨array, hArray⟩ := ctxWf.opChain block (by grind)
+  have ⟨array', hArray'⟩ := ctxWf.opChain block' (by grind)
+  simp only [Rewriter.insertOp?] at h
+  split at h; grind; rename_i parent hparent
+  have : block' = parent := by grind
+  subst parent
+  by_cases heq : block = block'
+  · subst block'
+    simp only [hBlock', ↓reduceDIte]
+    have := BlockPtr.opChain_OperationPtr_linkBetweenWithParent_self (ctx := ctx) (by grind)
+      h (ip := ip) (by grind) (by grind) (by grind) (by grind) hArray
+    simp [BlockPtr.operationList_iff_BlockPtr_OpChain.mp this,
+          BlockPtr.operationList_iff_BlockPtr_OpChain.mp hArray]
+  · have h := BlockPtr.opChain_OperationPtr_linkBetweenWithParent_other (ctx := ctx) h (array := array) (block' := block)
+    simp only [← InsertPoint.prev!_eq_prev] at h
+    have h := h (by grind [InsertPoint.prev.maybe₁_parent_of_opChain])
+    have h := h (by grind [InsertPoint.next.maybe₁_parent_of_opChain])
+    have h := h (by grind) (by grind)
+    grind [BlockPtr.operationList_iff_BlockPtr_OpChain.mp h,
+          BlockPtr.operationList_iff_BlockPtr_OpChain.mp hArray]
+
 end insertOp
 
 section detachOp
@@ -196,6 +226,33 @@ theorem Rewriter.detachOpIfAttached_WellFormed (ctx : IRContext OpInfo) (wf : ct
   simp only [Rewriter.detachOpIfAttached]
   grind [Rewriter.detachOp_WellFormed]
 
+theorem BlockPtr.operationList_rewriter_detachOpIfAttached (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block (Rewriter.detachOpIfAttached ctx op hctx hIn)
+      (by grind [Rewriter.detachOpIfAttached_WellFormed]) (by grind) =
+    if (op.get! ctx).parent = block then
+      (BlockPtr.operationList block ctx ctxWf blockIn).erase op
+    else
+      BlockPtr.operationList block ctx ctxWf blockIn := by
+  have ⟨array, hArray⟩ := ctxWf.opChain block (by grind)
+  cases hparent : (op.get! ctx).parent with
+  | none =>
+    simp only [BlockPtr.operationList_iff_BlockPtr_OpChain.mp
+        (BlockPtr.opChain_detachOpIfAttached_none hArray hparent),
+      BlockPtr.operationList_iff_BlockPtr_OpChain.mp hArray]
+    grind
+  | some block' =>
+    by_cases heq : block' = block
+    · subst block'
+      simp only [↓reduceIte]
+      simp only [BlockPtr.operationList_iff_BlockPtr_OpChain.mp
+        (BlockPtr.opChain_detachOpIfAttached_self hArray hparent)]
+      simp only [BlockPtr.operationList_iff_BlockPtr_OpChain.mp hArray]
+    · simp only [Option.some.injEq, heq, ↓reduceIte]
+      have ⟨array', hArray'⟩ := ctxWf.opChain block' (by grind [IRContext.WellFormed])
+      simp only [BlockPtr.operationList_iff_BlockPtr_OpChain.mp
+        (BlockPtr.opChain_detachOpIfAttached_other hArray hArray' hparent (by grind))]
+      simp [BlockPtr.operationList_iff_BlockPtr_OpChain.mp hArray]
+
 end detachOpIfAttached
 
 section setAttributes
@@ -233,6 +290,20 @@ theorem OperationPtr.setAttributes_WellFormed (ctx : IRContext OpInfo) (op : Ope
   · intro reg hreg
     have h_wf := h₈ reg (by grind)
     apply RegionPtr.WellFormed_unchanged h_wf (ctx' := op.setAttributes ctx newAttrs hop) <;> grind
+
+theorem BlockPtr.opChain_OperationPtr_setAttributes
+    (hWf : BlockPtr.OpChain block' ctx array)
+    {op : OperationPtr} (hop : op.InBounds ctx) (newAttrs : DictionaryAttr) :
+    BlockPtr.OpChain block' (op.setAttributes ctx newAttrs hop) array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+@[grind =]
+theorem BlockPtr.operationList_operationPtr_setAttributes
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (OperationPtr.setAttributes op ctx newAttrs hop) newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_OperationPtr_setAttributes]
 
 end setAttributes
 
@@ -310,6 +381,92 @@ theorem Rewriter.detachBlockOperands_wellFormed
     have := @Rewriter.detachBlockOperands.loop_wellFormed _ _ ctx missingOperands missingSuccessors
       (op.getNumSuccessors ctx - 1) op hCtx hOp (by grind) wf (by grind)
     grind [Nat.toList_rcc_eq_toList_rco]
+
+theorem BlockPtr.opChain_rewriter_detachOperands_loop
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.detachOperands.loop ctx op index hCtx hOp hIndex) array := by
+  induction index generalizing ctx
+  case zero =>
+    simp only [Rewriter.detachOperands.loop]
+    apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+  case succ index ih =>
+    simp only [Rewriter.detachOperands.loop]
+    apply ih
+    apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_detachOperands_loop (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (Rewriter.detachOperands.loop ctx op index hCtx hOp hIndex)
+      newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_detachOperands_loop]
+
+grind_pattern BlockPtr.operationList_rewriter_detachOperands_loop =>
+  (Rewriter.detachOperands.loop ctx op index hCtx hOp hIndex).WellFormed,
+  block'.operationList (Rewriter.detachOperands.loop ctx op index hCtx hOp hIndex) newCtxWf blockInBounds'
+
+theorem BlockPtr.opChain_rewriter_detachOperands
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' (Rewriter.detachOperands ctx op hCtx hOp) array := by
+  simp only [Rewriter.detachOperands]
+  split
+  · exact hWf
+  · exact BlockPtr.opChain_rewriter_detachOperands_loop hWf
+
+theorem BlockPtr.operationList_rewriter_detachOperands (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (Rewriter.detachOperands ctx op hCtx hOp)
+      newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_detachOperands]
+
+grind_pattern BlockPtr.operationList_rewriter_detachOperands =>
+  (Rewriter.detachOperands ctx op hCtx hOp).WellFormed,
+  block'.operationList (Rewriter.detachOperands ctx op hCtx hOp) newCtxWf blockInBounds'
+
+theorem BlockPtr.opChain_rewriter_detachBlockOperands_loop
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.detachBlockOperands.loop ctx op index hCtx hOp hIndex) array := by
+  induction index generalizing ctx
+  case zero =>
+    simp only [Rewriter.detachBlockOperands.loop]
+    apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+  case succ index ih =>
+    simp only [Rewriter.detachBlockOperands.loop]
+    apply ih
+    apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_detachBlockOperands_loop (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (Rewriter.detachBlockOperands.loop ctx op index hCtx hOp hIndex)
+      newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_detachBlockOperands_loop]
+
+grind_pattern BlockPtr.operationList_rewriter_detachBlockOperands_loop =>
+  (Rewriter.detachBlockOperands.loop ctx op index hCtx hOp hIndex).WellFormed,
+  block'.operationList (Rewriter.detachBlockOperands.loop ctx op index hCtx hOp hIndex) newCtxWf blockInBounds'
+
+theorem BlockPtr.opChain_rewriter_detachBlockOperands
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' (Rewriter.detachBlockOperands ctx op hCtx hOp) array := by
+  simp only [Rewriter.detachBlockOperands]
+  split
+  · exact hWf
+  · exact BlockPtr.opChain_rewriter_detachBlockOperands_loop hWf
+
+theorem BlockPtr.operationList_rewriter_detachBlockOperands (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' (Rewriter.detachBlockOperands ctx op hCtx hOp)
+      newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_detachBlockOperands]
+
+grind_pattern BlockPtr.operationList_rewriter_detachBlockOperands =>
+  (Rewriter.detachBlockOperands ctx op hCtx hOp).WellFormed,
+  block'.operationList (Rewriter.detachBlockOperands ctx op hCtx hOp) newCtxWf blockInBounds'
 
 theorem OpResultPtr.firstUse!_OpOperandPtr_removeFromCurrent_eq_none_of_firstUse!_eq_none
     (hctx : ctx.WellFormed missingUses missingSuccessors) :
@@ -390,15 +547,33 @@ theorem Rewriter.eraseOp_WellFormed (ctx : IRContext OpInfo) (wf : ctx.WellForme
   · grind
   · grind
 
-set_option warn.sorry false in
-theorem BlockPtr.operationList_Rewriter_eraseOp
-    (hWf : BlockPtr.operationList blockPtr ctx ctxWellFormed blockInBounds = array) :
-      BlockPtr.operationList blockPtr (Rewriter.eraseOp ctx op hctx hop) ctxWellFormed' blockInBounds' =
-      if blockPtr = blockPtr' then
-        array.erase op
-      else
-        array := by
-  sorry
+theorem BlockPtr.operationList_rewriter_eraseOp
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block (Rewriter.eraseOp ctx op hctx hop) hctx' hblock =
+    if (op.get! ctx).parent = block then
+      (BlockPtr.operationList block ctx ctxWf).erase op
+    else
+      BlockPtr.operationList block ctx ctxWf := by
+  -- The op-chain change happens entirely in the first step (`detachOpIfAttached`); the remaining
+  -- steps (`detachOperands`, `detachBlockOperands`, `dealloc`) leave every block's chain untouched.
+  have hWf0 := Rewriter.detachOpIfAttached_WellFormed ctx ctxWf (by grind) op (by grind)
+  have hWf1 := Rewriter.detachOperands_wellFormed (op := op) (hOp := by grind) hWf0 (by grind)
+    (hCtx := by grind)
+  have hWf2 := Rewriter.detachBlockOperands_wellFormed (op := op) (hOp := by grind) hWf1 (by grind)
+    (hCtx := by grind)
+  apply BlockPtr.operationList_iff_BlockPtr_OpChain.mp
+  simp only [Rewriter.eraseOp]
+  refine BlockPtr.opChain_OperationPtr_dealloc ?wf ?chain (by grind) (by grind)
+  case wf =>
+    apply cast (a := hWf2); congr
+    · simp only [Std.ExtHashSet.fromOperands]
+      grind [Std.ExtHashSet.insertMany_empty_eq_ofList, OperationPtr.getOpOperand_def]
+    · simp only [Std.ExtHashSet.fromSuccessors]
+      grind [Std.ExtHashSet.insertMany_empty_eq_ofList, OperationPtr.getBlockOperand_def]
+  case chain =>
+    grind [BlockPtr.operationList_rewriter_detachOpIfAttached,
+      BlockPtr.opChain_rewriter_detachOperands,
+      BlockPtr.opChain_rewriter_detachBlockOperands]
 
 set_option warn.sorry false in
 theorem OperationPtr.getOperand_Rewriter_eraseOp
@@ -452,6 +627,26 @@ theorem Rewriter.createEmptyOp_wellFormed  (hctx : IRContext.WellFormed ctx) :
     have := hctx.regions reg (by grind)
     apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> try grind
 
+theorem BlockPtr.opChain_rewriter_createEmptyOp
+    (hWf : BlockPtr.OpChain block' ctx array)
+    (h : Rewriter.createEmptyOp ctx opType properties = some (newCtx, newOp)) :
+    BlockPtr.OpChain block' newCtx array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_createEmptyOp
+    (h : Rewriter.createEmptyOp ctx opType properties = some (newCtx, newOp))
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  have := BlockPtr.opChain_rewriter_createEmptyOp (block' := block')
+    (array := block'.operationList ctx ctxWf (by grind))
+    (by grind [BlockPtr.operationListWF]) h
+  grind
+
+grind_pattern BlockPtr.operationList_rewriter_createEmptyOp =>
+  Rewriter.createEmptyOp ctx opType properties, some (newCtx, newOp),
+  block'.operationList newCtx newCtxWf blockInBounds'
+
 theorem Rewriter.createOp_WellFormed
     (hctx : IRContext.WellFormed ctx) :
     Rewriter.createOp ctx opType resultTypes operands blockOperands
@@ -464,6 +659,53 @@ theorem Rewriter.createOp_WellFormed
   split; grind
   rename_i ctx₂ hctx₂
   have : ctx₂.WellFormed :=
-    by grind [Rewriter.initOpRegions_WellFormed, IRContext.wellFormed_Rewriter_initOpResults]
+    by grind [Rewriter.initOpRegions_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
   grind [insertOp?_WellFormed, Rewriter.initOpOperands_WellFormed,
     Rewriter.initBlockOperands_WellFormed]
+
+theorem BlockPtr.operationList_rewriter_createOp
+    (h : Rewriter.createOp ctx opType resultTypes operands blockOperands
+      regions properties insertionPoint h₁ h₂ h₃ h₄ h₅ = some (newCtx, newOp))
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block newCtx newCtxWf blockIn =
+    match insertionPoint with
+    | none => BlockPtr.operationList block ctx ctxWf (by grind)
+    | some ip =>
+      if hb : ip.block! ctx = some block then
+        (BlockPtr.operationList block ctx ctxWf (by grind)).insertIdx
+          (ip.idxIn ctx block (by grind [Option.maybe_def]) (by grind [Option.maybe_def]) ctxWf)
+          newOp (by apply InsertPoint.idxIn.le_size_operationList)
+      else
+        BlockPtr.operationList block ctx ctxWf (by grind) := by
+  simp only [Rewriter.createOp] at h
+  split at h; grind; rename_i ctx₂ newOp' hctx₂
+  have ctx₂Wf : ctx₂.WellFormed := by grind [Rewriter.createEmptyOp_wellFormed]
+  split at h; grind; rename_i ctx₃ hctx₃
+  have ctx₃Wf : ctx₃.WellFormed := by grind [Rewriter.initOpRegions_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+  cases insertionPoint with
+  | none =>
+    grind [Rewriter.initOpOperands_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+  | some ip =>
+    simp at h
+    split at h; grind; rename_i ctx₄ hctx₄
+    have ctx₄Wf : ctx₄.WellFormed := by
+      grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed, Rewriter.insertOp?_WellFormed]
+    simp at h; have ⟨_, _⟩ := h; subst newCtx newOp'
+    simp
+    rw [BlockPtr.operationList_rewriter_insertOp? hctx₄ (by grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed])]
+    cases ip
+    case before op =>
+      simp only [InsertPoint.block!_before_eq, OperationPtr.parent!_initBlockOperands,
+        OperationPtr.parent!_initOpOperands, InsertPoint.idxIn_before_eq]
+      simp only [OperationPtr.parent!_initOpRegions hctx₃, OperationPtr.parent!_initOpResults,
+        OperationPtr.parent!_createEmptyOp hctx₂, show op ≠ newOp by grind, ↓reduceIte]
+      split <;>
+        grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed,
+          Rewriter.insertOp?_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+    case atEnd b =>
+      simp only [InsertPoint.block!_atEnd_eq, Option.some.injEq]
+      split <;>
+        grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed,
+          Rewriter.insertOp?_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+
+end Veir

--- a/Veir/Rewriter/WellFormed/Region.lean
+++ b/Veir/Rewriter/WellFormed/Region.lean
@@ -49,3 +49,23 @@ theorem IRContext.wellFormed_Rewriter_createRegion (hctx : ctx.WellFormed) :
     · constructor <;> grind
     · have := hctx.regions region' (by grind)
       apply RegionPtr.WellFormed_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.opChain_rewriter_createRegion
+    (hWf : BlockPtr.OpChain block' ctx array)
+    (h : Rewriter.createRegion ctx = some (newCtx, region)) :
+    BlockPtr.OpChain block' newCtx array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_createRegion
+    (h : Rewriter.createRegion ctx = some (newCtx, region))
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  have := BlockPtr.opChain_rewriter_createRegion (block' := block')
+    (array := block'.operationList ctx ctxWf (by grind))
+    (by grind [BlockPtr.operationListWF]) h
+  grind
+
+grind_pattern BlockPtr.operationList_rewriter_createRegion =>
+  Rewriter.createRegion ctx, some (newCtx, region), newCtx.WellFormed,
+  block'.operationList newCtx newCtxWf blockInBounds'

--- a/Veir/Rewriter/WellFormed/ReplaceOp.lean
+++ b/Veir/Rewriter/WellFormed/ReplaceOp.lean
@@ -133,4 +133,46 @@ theorem IRContext.wellFormed_replaceOp? (ctxWf : ctx.WellFormed)
   · grind
   · grind [OperationPtr.hasUses_replaceOpResults]
 
+theorem BlockPtr.opChain_rewriter_replaceOpResults
+    (h : Rewriter.replaceOpResults ctx fromOp toOp idx fromOpIB toOpIB hNumFrom hNumTo
+      ctxInBounds = some newCtx)
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' newCtx array := by
+  induction idx generalizing ctx
+  case zero => grind [Rewriter.replaceOpResults]
+  case succ idx ih =>
+    simp only [Rewriter.replaceOpResults] at h
+    grind [Option.maybe₁_def, BlockPtr.opChain_Rewriter_replaceValue?]
+
+theorem BlockPtr.operationList_rewriter_replaceOpResults
+    (h : Rewriter.replaceOpResults ctx fromOp toOp idx fromOpIB toOpIB hNumFrom hNumTo
+      ctxInBounds = some newCtx)
+    (ctxWf : ctx.WellFormed) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf (by grind) := by
+  have := BlockPtr.opChain_rewriter_replaceOpResults (block' := block')
+    (array := block'.operationList ctx ctxWf (by grind))
+    h (by grind [BlockPtr.operationListWF])
+  grind
+
+grind_pattern BlockPtr.operationList_rewriter_replaceOpResults =>
+  Rewriter.replaceOpResults ctx fromOp toOp idx fromOpIB toOpIB hNumFrom hNumTo ctxInBounds,
+  some newCtx,
+  block'.operationList newCtx newCtxWf blockInBounds'
+
+theorem BlockPtr.operationList_rewriter_replaceOp?
+    (hNewCtx : Rewriter.replaceOp? ctx oldOp newOp oldIn newIn ctxIn hpar = some newCtx)
+    (ctxWf : ctx.WellFormed)
+    (neOps : oldOp ≠ newOp) :
+    BlockPtr.operationList block newCtx newCtxWf blockIn =
+    if h : (oldOp.get! ctx).parent = block then
+      (BlockPtr.operationList block ctx ctxWf).erase oldOp
+    else
+      BlockPtr.operationList block ctx (by grind) (by grind) := by
+  simp only [Rewriter.replaceOp?] at hNewCtx
+  split at hNewCtx; grind
+  split at hNewCtx; grind
+  grind [IRContext.wellFormed_replaceOpResults, BlockPtr.operationList_rewriter_eraseOp]
+
+
 end Veir

--- a/Veir/Rewriter/WellFormed/Value.lean
+++ b/Veir/Rewriter/WellFormed/Value.lean
@@ -354,16 +354,46 @@ theorem OperationPtr.getOperand_replaceOp?
     | _ => operand := by
   sorry
 
-set_option warn.sorry false in
-theorem BlockPtr.operationList_replaceOp?
-    (hWf : BlockPtr.operationList blockPtr ctx ctxWellFormed blockInBounds = array)
-    (hnewCtx : Rewriter.replaceOp? ctx oldOp newOp oldIn newIn ctxIn depth = some newCtx) :
-      BlockPtr.operationList blockPtr newCtx ctxWellFormed' blockInBounds' =
-      if blockPtr = blockPtr' then
-        array.erase oldOp
-      else
-        array := by
-  sorry
+theorem BlockPtr.opChain_rewriter_replaceUse
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block'
+      (Rewriter.replaceUse ctx use newValue useIn newIn ctxIn) array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+theorem BlockPtr.operationList_rewriter_replaceUse
+    (ctxWf : ctx.WellFormed)
+    (h : Rewriter.replaceUse ctx use newValue useIn newIn ctxIn = newCtx) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf := by
+  simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_rewriter_replaceUse]
+
+grind_pattern BlockPtr.operationList_rewriter_replaceUse =>
+  Rewriter.replaceUse ctx use newValue useIn newIn ctxIn,
+  newCtx.WellFormed,
+  block'.operationList newCtx newCtxWf blockInBounds'
+
+theorem BlockPtr.opChain_Rewriter_replaceValue?
+    (h : Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx)
+    (hWf : BlockPtr.OpChain block' ctx array) :
+    BlockPtr.OpChain block' newCtx array := by
+  induction depth generalizing ctx
+  case zero => simp [Rewriter.replaceValue?] at h
+  case succ depth ih =>
+    simp only [Rewriter.replaceValue?] at h
+    grind [BlockPtr.opChain_rewriter_replaceUse]
+
+theorem BlockPtr.operationList_rewriter_replaceValue?
+    (ctxWf : ctx.WellFormed)
+    (h : Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx) :
+    BlockPtr.operationList block' newCtx newCtxWf blockInBounds' =
+    BlockPtr.operationList block' ctx ctxWf := by
+  grind [BlockPtr.opChain_Rewriter_replaceValue? h
+    (BlockPtr.operationListWF ctx block' (by grind) (by grind))]
+
+grind_pattern BlockPtr.operationList_rewriter_replaceValue? =>
+  Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth, some newCtx,
+  block'.operationList newCtx newCtxWf blockInBounds'
 
 /--
 info: 'Veir.Rewriter.replaceValue?_WellFormed' depends on axioms: [propext, Classical.choice, Quot.sound]


### PR DESCRIPTION
This PR adds new get-set lemmas about `BlockPtr.operationList`. These lemmas are very useful to reason at a high-level about operations. For instance, in the rewriter, this should allow us to prove that a rewrite pattern transform a block `beforeOps ++ #[op] ++ afterOps` into `beforeOps ++ newOps ++ afterOps`. This will allow us to reason at the level of operation arrays, rather than doubly linked lists.

While this is a large PR, these lemmas have almost the same structure, starting with an `BlockPtr.OpChain` proof, then a `BlockPtr.operationList` proof.