### PR TITLE
fix (mod_arith): make modulus an IntegerAttr

### DIFF
--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -203,11 +203,12 @@ macro "#assert " e:term : command =>
 
 /-! ## Modarith type -/
 
-#assert expectSuccessType "!mod_arith.int<17>" (ModArithType.mk 17 none)
-#assert expectSuccessType "!mod_arith.int<257 : i32>" (ModArithType.mk 257 (some (IntegerType.mk 32)))
-#assert expectSuccessAttr "!mod_arith.int<17>" (ModArithType.mk 17 none)
+#assert expectSuccessType "!mod_arith.int<17 : i64>" (ModArithType.mk (IntegerAttr.mk 17 (IntegerType.mk 64)))
+#assert expectSuccessType "!mod_arith.int<257 : i32>" (ModArithType.mk (IntegerAttr.mk 257 (IntegerType.mk 32)))
+#assert expectSuccessAttr "!mod_arith.int<17 : i64>" (ModArithType.mk (IntegerAttr.mk 17 (IntegerType.mk 64)))
 #assert expectErrorType "!mod_arith.int<>" "modarith type modulus expected" (some 15)
-#assert expectErrorType "!mod_arith.int<17 : x>" "integer type expected after ':' in modarith type" (some 20)
+#assert expectErrorType "!mod_arith.int<17>" "Expected punctuation ':'" (some 17)
+#assert expectErrorType "!mod_arith.int<17 : x>" "integer type expected after ':' in integer attribute" (some 20)
 
 /-! ## LLVM Pointer type -/
 #assert expectSuccessType "!llvm.ptr" (LLVM.PointerType.mk)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -219,11 +219,9 @@ deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
   The `!mod_arith.int` type from HEIR's modarith dialect.
-  The modulus type annotation is optional in syntax.
 -/
 structure ModArithType where
-  modulus : Int
-  modulusType : Option IntegerType
+  modulus : IntegerAttr
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 namespace LLVM
@@ -750,10 +748,7 @@ instance : ToString FlatSymbolRefAttr where
   toString attr := attr.value
 
 instance : ToString ModArithType where
-  toString type := s!"!mod_arith.int<{type.modulus}" ++
-    (match type.modulusType with
-    | some modulusType => s!" : {modulusType}"
-    | none => "") ++ ">"
+  toString type := s!"!mod_arith.int<{type.modulus}>"
 
 instance : ToString LLVM.VoidType where
   toString _ := "!llvm.void"

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -432,7 +432,7 @@ partial def parseOptionalCudaTilePointerType : AttrParserM (Option TypeAttr) := 
 
 /--
   Parse HEIR's modarith type, if present.
-  Its syntax is `!mod_arith.int<modulus>` or `!mod_arith.int<modulus : iN>`.
+  Its syntax is `!mod_arith.int<{IntegerAttr}>`, e.g., `!mod_arith.int<17 : i32>`.
 -/
 def parseOptionalModArithType : AttrParserM (Option TypeAttr) := do
   let token ← peekToken
@@ -443,15 +443,10 @@ def parseOptionalModArithType : AttrParserM (Option TypeAttr) := do
     return none
   let _ ← consumeToken
   parsePunctuation "<"
-  let some modulus ← parseOptionalInteger false false
+  let some modulus ← parseOptionalIntegerAttr
     | throwAtCurrentPos "modarith type modulus expected"
-  let modulusType ←
-    if ← parseOptionalPunctuation ":" then
-      some <$> parseIntegerType "integer type expected after ':' in modarith type"
-    else
-      pure none
   parsePunctuation ">"
-  return some (ModArithType.mk modulus modulusType)
+  return some (ModArithType.mk modulus)
 
 /--
   Parse CIRCT's HW dialect's `ModulePort::Direction` type.


### PR DESCRIPTION
Extracted from PR #799

This mirrors the construction of the type in HEIR more closely and means we do not have to handle optional types in passes/interpreter/etc. 

It does mean loosing the concise form w/o the type specified, as that's an MLIR IntegerAttr parser feature that VEIR doesn't (yet?) have. 

