### PR TITLE
chore(interpreter): add `OperationPtr.interpret` abbreviation

### DIFF
--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1208,6 +1208,13 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
     | _ , _ => none
   | _ => none
 
+/-- Wrapper around `interpretOp'` that retrieves the operation type, properties,
+result types, and successor blocks from the operation pointer. -/
+abbrev OperationPtr.interpret (op : OperationPtr) (ctx : IRContext OpCode)
+    (operandValues : Array RuntimeValue) (memory : MemoryState) :=
+    interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
+    (op.getResultTypes! ctx) operandValues (op.getSuccessors! ctx) memory
+
 /--
   Interpret a single operation given the current interpreter state.
   Return an updated interpreter state and a control flow action indicating how
@@ -1219,9 +1226,7 @@ def interpretOp (op : OperationPtr) {ctx : WfIRContext OpCode} (state : Interpre
     (inBounds : op.InBounds ctx.raw := by grind)
     : Interp (InterpreterState ctx × Option ControlFlowAction) := do
   let some operands := state.variables.getOperandValues op | none
-  let opType := op.getOpType! ctx
-  let (resultValues, mem, action) ← interpretOp' opType (op.getProperties! ctx opType)
-    (op.getResultTypes! ctx.raw) operands (op.getSuccessors! ctx.raw) state.memory
+  let (resultValues, mem, action) ← op.interpret ctx operands state.memory
   let newVars ← state.variables.setResultValues? op resultValues
   let newState := ⟨newVars, mem⟩
   return (newState, action)

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -97,7 +97,7 @@ theorem interpretOp_equationHolds_other
   subst state state'; simp_all only
   simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]
   simp only [VariableState.getOperandValues_setResultValues?_of_dominates ctxDom hDom hResValues₁]
-  simp only [hOperandValues₂]
+  simp only [hOperandValues₂, OperationPtr.interpret]
   rw [OperationPtr.Pure.interpretOp'_eq_interpretOp'_other_memory op₂Pure memory₂]
   simp only [hInterp₂', Interp.map, Option.map, UBOr.map]
   by_cases hOp : op₂ = op₁

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -155,9 +155,7 @@ theorem interpretOp_some_iff {ctx : WfIRContext OpCode} {state state' : Interpre
   interpretOp op state inBounds = some (.ok (state', cf)) ↔
   ∃ operandValues resValues mem' varState',
     (state.variables.getOperandValues op) = some operandValues ∧
-    interpretOp' (op.getOpType! ctx.raw) (op.getProperties! ctx.raw (op.getOpType! ctx.raw))
-      (op.getResultTypes! ctx.raw) operandValues (op.getSuccessors! ctx.raw) state.memory =
-      some (.ok (resValues, mem', cf)) ∧
+    op.interpret ctx operandValues state.memory = some (.ok (resValues, mem', cf)) ∧
     state.variables.setResultValues? op resValues = some varState' ∧
     state' = ⟨varState', mem'⟩ := by
   simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -83,3 +83,28 @@ theorem OperationPtr.isModuleRefinedBy_trans
     (h23 : isModuleRefinedBy mod₂ ctx₂ mod₃ ctx₃) :
     isModuleRefinedBy mod₁ ctx₁ mod₃ ctx₃ := by
   grind [isModuleRefinedBy, isRefinedByAsFunction_trans]
+
+/-! ## Interp refinements -/
+
+/-- `none` is refined by any value. -/
+@[simp, grind .]
+theorem Interp.isRefinedBy_none_target :
+    Interp.isRefinedBy R none target := by
+  simp [Interp.isRefinedBy]
+
+/-- `ub` is refined as long as interpretation succeeds. -/
+@[simp, grind =]
+theorem Interp.isRefinedBy_ub_target_iff :
+    Interp.isRefinedBy R (some .ub) target ↔
+    ∃ targetRes, target = some targetRes := by
+  simp only [Interp.isRefinedBy]
+  cases target <;> grind
+
+/-- `ok` is only refined by `ok` values that satisfy the given refinement relation. -/
+@[simp, grind =]
+theorem Interp.isRefinedBy_ok_target_iff :
+    Interp.isRefinedBy R (some (.ok sourceRes)) target ↔
+    ∃ targetRes, target = some (.ok targetRes) ∧ R sourceRes targetRes := by
+  simp only [Interp.isRefinedBy]
+  rcases target with _ | (_ | _) <;> grind
+


### PR DESCRIPTION
This makes it easier to write proofs about it, otherwise it becomes a mouthful.