### PR TITLE
feat(riscv): check that imm12 arguments are in bounds

### DIFF
--- a/Test/RISCV/ld-offset-oob.mlir
+++ b/Test/RISCV/ld-offset-oob.mlir
@@ -1,4 +1,5 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
+// MLIR_INVALID
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({

--- a/Test/RISCV/ld-offset-oob.mlir
+++ b/Test/RISCV/ld-offset-oob.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    %a = "riscv.li"() <{ "value" = 0 : i64 }> : () -> !riscv.reg
+    %y = "riscv.ld"(%a) <{ "value" = -2049 : i64 }> : (!riscv.reg) -> !riscv.reg
+    "func.return"(%y) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Error verifying input program: riscv.ld immediate out of bounds: must fit in a signed 12-bit field [-2048, 2047]

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -92,8 +92,10 @@ def TypeAttr.verifyI1 (ty : TypeAttr) (errMsg : String) : Except String PUnit :=
       pure ()
   | _ => throw errMsg
 
-def verifyRISCVimm12 (imm : Int) (instrName : String) : Except String PUnit :=
+def OperationPtr.verifyRISCVimm12 (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) (imm : Int) : Except String PUnit :=
   if imm < -2048 ∨ imm > 2047 then
+    let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
     throw s!"{instrName} immediate out of bounds: must fit in a signed 12-bit field [-2048, 2047]"
   else
     pure ()
@@ -1051,7 +1053,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .addi)).value.value "riscv.addi"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .addi)).value.value
     pure ()
   | .riscv .slti => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1062,7 +1064,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .slti)).value.value "riscv.slti"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .slti)).value.value
     pure ()
   | .riscv .sltiu => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1073,7 +1075,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .sltiu)).value.value "riscv.sltiu"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .sltiu)).value.value
     pure ()
   | .riscv .andi => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1084,7 +1086,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .andi)).value.value "riscv.andi"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .andi)).value.value
     pure ()
   | .riscv .ori => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1095,7 +1097,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .ori)).value.value "riscv.ori"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .ori)).value.value
     pure ()
   | .riscv .xori => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1106,7 +1108,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .xori)).value.value "riscv.xori"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .xori)).value.value
     pure ()
   | .riscv .addiw => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1117,7 +1119,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .addiw)).value.value "riscv.addiw"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .addiw)).value.value
     pure ()
   | .riscv .slli => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1898,7 +1900,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .ld)).value.value "riscv.ld"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .ld)).value.value
     pure ()
   | .riscv .sd => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -1909,7 +1911,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .sd)).value.value "riscv.sd"
+    op.verifyRISCVimm12 ctx opIn (op.getProperties! ctx.raw (.riscv .sd)).value.value
     pure ()
   | .riscv .mv => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -92,6 +92,12 @@ def TypeAttr.verifyI1 (ty : TypeAttr) (errMsg : String) : Except String PUnit :=
       pure ()
   | _ => throw errMsg
 
+def verifyRISCVimm12 (imm : Int) (instrName : String) : Except String PUnit :=
+  if imm < -2048 ∨ imm > 2047 then
+    throw s!"{instrName} immediate out of bounds: must fit in a signed 12-bit field [-2048, 2047]"
+  else
+    pure ()
+
 def OperationPtr.verifyOperandTypesMatch (op : OperationPtr) (ctx : WfIRContext OpCode)
     (firstIdx secondIdx : Nat) (errMsg : String) : Except String TypeAttr := do
   let firstType := (op.getOperand! ctx.raw firstIdx).getType! ctx.raw
@@ -1045,6 +1051,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .addi)).value.value "riscv.addi"
     pure ()
   | .riscv .slti => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1055,6 +1062,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .slti)).value.value "riscv.slti"
     pure ()
   | .riscv .sltiu => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1065,6 +1073,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .sltiu)).value.value "riscv.sltiu"
     pure ()
   | .riscv .andi => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1075,6 +1084,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .andi)).value.value "riscv.andi"
     pure ()
   | .riscv .ori => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1085,6 +1095,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .ori)).value.value "riscv.ori"
     pure ()
   | .riscv .xori => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1095,6 +1106,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .xori)).value.value "riscv.xori"
     pure ()
   | .riscv .addiw => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1105,6 +1117,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .addiw)).value.value "riscv.addiw"
     pure ()
   | .riscv .slli => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1885,6 +1898,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .ld)).value.value "riscv.ld"
     pure ()
   | .riscv .sd => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -1895,6 +1909,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    verifyRISCVimm12 (op.getProperties! ctx.raw (.riscv .sd)).value.value "riscv.sd"
     pure ()
   | .riscv .mv => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then


### PR DESCRIPTION
you might think that checking a signed range for riscv.sltiu (which is an unsigned comparison) is wrong, but I am emulating the behavior of other risc-v assemblers, such as LLVM's

there are other immediates that should be checked, this is just a start