### PR TITLE
feat(riscv_cf): add `beqz` and `bnez` instructions

### DIFF
--- a/Test/Interpreter/RISCV_Cf/beqz.mlir
+++ b/Test/Interpreter/RISCV_Cf/beqz.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^1():
+      %neg1 = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
+      %one = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.beqz"(%one, %neg1, %one) [^3, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+    ^2(%t : !riscv.reg):
+      "func.return"(%t) : (!riscv.reg) -> ()
+    ^3(%f : !riscv.reg):
+      "func.return"(%f) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0000000000000001#64]

--- a/Test/Interpreter/RISCV_Cf/bnez.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez.mlir
@@ -5,7 +5,7 @@
     ^1():
       %neg1 = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
       %one = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
-      "riscv_cf.cbr"(%one, %one, %neg1) [^3, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+      "riscv_cf.bnez"(%one, %one, %neg1) [^3, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
     ^2(%t : !riscv.reg):
       "func.return"(%t) : (!riscv.reg) -> ()
     ^3(%f : !riscv.reg):

--- a/Test/Interpreter/RISCV_Cf/cbr.mlir
+++ b/Test/Interpreter/RISCV_Cf/cbr.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^1():
+      %neg1 = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
+      %one = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.cbr"(%one, %one, %neg1) [^3, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+    ^2(%t : !riscv.reg):
+      "func.return"(%t) : (!riscv.reg) -> ()
+    ^3(%f : !riscv.reg):
+      "func.return"(%f) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0000000000000001#64]

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -17,6 +17,7 @@ match op with
 | .bge => RISCVBrProperties
 | .bltu => RISCVBrProperties
 | .bgeu => RISCVBrProperties
+| .cbr => RISCVBrProperties
 | _ => Unit
 
 instance : HasDialectOpInfo Riscv_Cf where

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -17,7 +17,8 @@ match op with
 | .bge => RISCVBrProperties
 | .bltu => RISCVBrProperties
 | .bgeu => RISCVBrProperties
-| .cbr => RISCVBrProperties
+| .beqz => RISCVBrProperties
+| .bnez => RISCVBrProperties
 | _ => Unit
 
 instance : HasDialectOpInfo Riscv_Cf where

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -100,6 +100,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case bge => exact (RISCVBrProperties.fromAttrDict attrDict)
     case bltu => exact (RISCVBrProperties.fromAttrDict attrDict)
     case bgeu => exact (RISCVBrProperties.fromAttrDict attrDict)
+    case cbr => exact (RISCVBrProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case riscv_stack op =>
     cases op
@@ -244,7 +245,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
     dict.insert "value_type".toUTF8 props.value_type
   | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .blt | .riscv_cf .bge
-  | .riscv_cf .bltu | .riscv_cf .bgeu =>
+  | .riscv_cf .bltu | .riscv_cf .bgeu | .riscv_cf .cbr =>
     (Std.HashMap.emptyWithCapacity 1).insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
   | .cf .cond_br =>
     let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
@@ -364,7 +365,7 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .cf .br | .cf .cond_br
   | .func .return
   | .llvm .br | .llvm .cond_br | .llvm .return | .llvm .unreachable
-  | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne
+  | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .cbr
   | .riscv_cf .blt | .riscv_cf .bge | .riscv_cf .bltu | .riscv_cf .bgeu
   | .hw .output => true
   | _ => false

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -100,7 +100,8 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     case bge => exact (RISCVBrProperties.fromAttrDict attrDict)
     case bltu => exact (RISCVBrProperties.fromAttrDict attrDict)
     case bgeu => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case cbr => exact (RISCVBrProperties.fromAttrDict attrDict)
+    case beqz => exact (RISCVBrProperties.fromAttrDict attrDict)
+    case bnez => exact (RISCVBrProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case riscv_stack op =>
     cases op
@@ -245,7 +246,7 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
     dict.insert "value_type".toUTF8 props.value_type
   | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .blt | .riscv_cf .bge
-  | .riscv_cf .bltu | .riscv_cf .bgeu | .riscv_cf .cbr =>
+  | .riscv_cf .bltu | .riscv_cf .bgeu | .riscv_cf .beqz | .riscv_cf .bnez =>
     (Std.HashMap.emptyWithCapacity 1).insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
   | .cf .cond_br =>
     let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
@@ -365,7 +366,8 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .cf .br | .cf .cond_br
   | .func .return
   | .llvm .br | .llvm .cond_br | .llvm .return | .llvm .unreachable
-  | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .cbr
+  | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne
+  | .riscv_cf .beqz | .riscv_cf .bnez
   | .riscv_cf .blt | .riscv_cf .bge | .riscv_cf .bltu | .riscv_cf .bgeu
   | .hw .output => true
   | _ => false

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1193,6 +1193,15 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInf
       return (#[], some (.branch (operands.extract 2 (trueSize + 2)) destTrue))
     else
       return (#[], some (.branch (operands.extract (trueSize + 2) operands.size) destFalse))
+  | .cbr => do
+    let [destTrue, destFalse] := blockOperands.toList | none
+    let some (RuntimeValue.reg cond) := operands[0]? | none
+    let some trueSize := properties.operandSegmentSizes.values[2]? | none
+    let trueSize := trueSize.toNat
+    if cond.val ≠ 0#64 then
+      return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
+    else
+      return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
 
 def Cf.interpretOp' (opType : Veir.Cf) (properties : HasDialectOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1193,7 +1193,16 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInf
       return (#[], some (.branch (operands.extract 2 (trueSize + 2)) destTrue))
     else
       return (#[], some (.branch (operands.extract (trueSize + 2) operands.size) destFalse))
-  | .cbr => do
+  | .beqz => do
+    let [destTrue, destFalse] := blockOperands.toList | none
+    let some (RuntimeValue.reg cond) := operands[0]? | none
+    let some trueSize := properties.operandSegmentSizes.values[2]? | none
+    let trueSize := trueSize.toNat
+    if cond.val = 0#64 then
+      return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
+    else
+      return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
+  | .bnez => do
     let [destTrue, destFalse] := blockOperands.toList | none
     let some (RuntimeValue.reg cond) := operands[0]? | none
     let some trueSize := properties.operandSegmentSizes.values[2]? | none

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -229,6 +229,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 @[opcodes]
 inductive Riscv_Cf where
 | branch
+| cbr
 | beq
 | bne
 | blt

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -229,7 +229,8 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 @[opcodes]
 inductive Riscv_Cf where
 | branch
-| cbr
+| beqz
+| bnez
 | beq
 | bne
 | blt

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -2220,9 +2220,9 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .cbr)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
+    if _ : sizes.values.size ≠ 3 then
       throw "Expected 1 operand plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
+    if sizes.values[0]! ≠ 1 then
       throw "Expected 1 operand plus 2 variadic operands"
     pure ()
   /- RISCV Stack -/

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -2212,6 +2212,19 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
       throw "Expected 2 operands plus 2 variadic operands"
     pure ()
+  | .riscv_cf .cbr => do
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 2 then
+      throw "Expected 2 successors"
+    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .cbr)).operandSegmentSizes
+    if _ : sizes.values.size ≠ 4 then
+      throw "Expected 1 operand plus 2 variadic operands"
+    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
+      throw "Expected 1 operand plus 2 variadic operands"
+    pure ()
   /- RISCV Stack -/
   | .riscv_stack .alloca => do
     if op.getNumOperands ctx.raw opIn ≠ 0 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -2212,18 +2212,31 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
       throw "Expected 2 operands plus 2 variadic operands"
     pure ()
-  | .riscv_cf .cbr => do
+  | .riscv_cf .beqz => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
       throw "Expected 0 results"
     if op.getNumRegions ctx.raw opIn ≠ 0 then
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .cbr)).operandSegmentSizes
+    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .beqz)).operandSegmentSizes
     if _ : sizes.values.size ≠ 3 then
       throw "Expected 1 operand plus 2 variadic operands"
     if sizes.values[0]! ≠ 1 then
+      throw "Expected one conditional operand (to be compared against zero)"
+    pure ()
+  | .riscv_cf .bnez => do
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 2 then
+      throw "Expected 2 successors"
+    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bnez)).operandSegmentSizes
+    if _ : sizes.values.size ≠ 3 then
       throw "Expected 1 operand plus 2 variadic operands"
+    if sizes.values[0]! ≠ 1 then
+      throw "Expected one conditional operand (to be compared against zero)"
     pure ()
   /- RISCV Stack -/
   | .riscv_stack .alloca => do


### PR DESCRIPTION
We add support for the pseudo operations `beqz` and `bneq`. Both take one conditional operand that is compared against zero, which makes for an easy lowering from LLVM's conditional branch operation.