### PR TITLE
feat(interpreter): add useful `ValueMapping` methods

### DIFF
--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -144,6 +144,21 @@ def OperationPtr.isModuleRefinedBy (mod₁ : OperationPtr) (ctx₁ : WfIRContext
 abbrev ValueMapping (ctx ctx' : WfIRContext OpInfo) : Type :=
   {v : ValuePtr // v.InBounds ctx.raw} → {v : ValuePtr // v.InBounds ctx'.raw}
 
+/-- Apply the value mapping to an array of values with separately their bounds information. -/
+def ValueMapping.applyToArray {ctx ctx' : WfIRContext OpInfo} (mapping : ValueMapping ctx ctx')
+    (vals : Array ValuePtr) (valsIn : ∀ v ∈ vals, v.InBounds ctx.raw := by grind) : Array ValuePtr :=
+  vals.attach.map (fun ⟨v, hv⟩ => (mapping ⟨v, valsIn v hv⟩).val)
+
+/--
+`mapping` *reflects* `op'`'s result pointers back to `op`'s if the only value it sends onto `op'`'s
+`i`-th result pointer is `op`'s `i`-th result pointer. Paired with the "fixes" equation
+`mapping.applyToArray (op.getResults! ..) = op'.getResults! ..`, this says `mapping` matches the two
+operations' results index-by-index without mapping any other value onto them. -/
+def ValueMapping.ReflectsResults {ctx ctx' : WfIRContext OpInfo} (mapping : ValueMapping ctx ctx')
+    (op op' : OperationPtr) : Prop :=
+  ∀ (val : ValuePtr) (valIn : val.InBounds ctx.raw) (i : Nat),
+    (mapping ⟨val, valIn⟩).val = op'.getResult i → val = op.getResult i
+
 /--
 A variable state `state` is refined by `state'` through the value renaming `mapping`: every
 variable defined in `state` is, after renaming through `mapping`, also defined in `state'` with a

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -108,3 +108,39 @@ theorem Interp.isRefinedBy_ok_target_iff :
   simp only [Interp.isRefinedBy]
   rcases target with _ | (_ | _) <;> grind
 
+/-! ## ValueMapping -/
+
+/-- Applying a value mapping to an array preserves its size. -/
+@[simp, grind =]
+theorem ValueMapping.applyToArray_size {ctx ctx' : WfIRContext OpInfo} (mapping : ValueMapping ctx ctx')
+    (vals : Array ValuePtr) (valsIn : ∀ v ∈ vals, v.InBounds ctx.raw) :
+    (mapping.applyToArray vals valsIn).size = vals.size := by
+  simp [ValueMapping.applyToArray]
+
+/-- Extensibility theorem for value mappings mapping `op` results to `op'` results. -/
+theorem ValueMapping.applyToArray_getResults!_ext
+    {ctx ctx' : WfIRContext OpInfo} {op op' : OperationPtr}
+    {mapping : ValueMapping ctx ctx'}
+    (opIn : op.InBounds ctx.raw)
+    (hResults : mapping.applyToArray (op.getResults! ctx.raw) = op'.getResults! ctx'.raw) :
+    ∀ (i : Nat) (hi : i < op.getNumResults! ctx.raw),
+      (mapping ⟨op.getResult i, (by grind)⟩).val = op'.getResult i := by
+  intro i hi
+  simp only [applyToArray, Array.ext_iff, Array.size_map, Array.size_attach,
+    OperationPtr.getResults!.size_eq_getNumResults!, Array.getElem_map,
+    Array.getElem_attach] at hResults
+  grind
+
+/-- If a value mapping reflects results from `op` to `op'`, then values that are not in
+`op` results are not mapped to values in `op'` results. -/
+@[grind .]
+theorem ValueMapping.ReflectsResults.not_mem_getResults
+    {ctx ctx' : WfIRContext OpInfo} {mapping : ValueMapping ctx ctx'} {op op' : OperationPtr}
+    {val : ValuePtr} (valIn : val.InBounds ctx.raw)
+    (hReflect : mapping.ReflectsResults op op')
+    (hNotMem : val ∉ op.getResults! ctx.raw) :
+    (mapping ⟨val, valIn⟩).val ∉ op'.getResults! ctx'.raw := by
+  intro hmem
+  simp only [OperationPtr.getResults!.mem_iff_exists_index] at hmem
+  have ⟨index, hindex, heq⟩ := hmem
+  grind [OperationPtr.getResults!.mem_iff_exists_index, hReflect val valIn index heq.symm]


### PR DESCRIPTION
These methods are useful to talk about the effect of a value mapping on an operation.  `ValueMapping.applyToArray` applies the mapping to an entire array (which is often used on operation operands).

`ValueMapping.ReflectsResults` is used to show that `op` results map directly to `op'`, and that all values mapping to `op'` results are exactly the results of `op`. This is necessary to prove some of the refinement proofs later on.