### PR TITLE
feat(riscv): enforce 5 and 6 bit immediate value constraints

### DIFF
--- a/Test/Interpreter/RISCV/rori.mlir
+++ b/Test/Interpreter/RISCV/rori.mlir
@@ -6,8 +6,8 @@
     %b = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !riscv.reg
     %d = "riscv.rori"(%a) <{ value = 3 : i6 }> : (!riscv.reg) -> !riscv.reg
-    %e = "riscv.rori"(%b) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
-    %f = "riscv.rori"(%c) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %e = "riscv.rori"(%b) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %f = "riscv.rori"(%c) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%d, %e, %f) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/roriw.mlir
+++ b/Test/Interpreter/RISCV/roriw.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %b = "riscv.roriw"(%a) <{ value = 3 : i6 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
-    %d = "riscv.roriw"(%c) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.roriw"(%c) <{ value = 29 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/roriw_overflow.mlir
+++ b/Test/Interpreter/RISCV/roriw_overflow.mlir
@@ -6,8 +6,8 @@
     %b = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !riscv.reg
     %d = "riscv.roriw"(%a) <{ value = 3 : i6 }> : (!riscv.reg) -> !riscv.reg
-    %e = "riscv.roriw"(%b) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
-    %f = "riscv.roriw"(%c) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %e = "riscv.roriw"(%b) <{ value = 29 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %f = "riscv.roriw"(%c) <{ value = 29 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%d, %e, %f) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/slli.mlir
+++ b/Test/Interpreter/RISCV/slli.mlir
@@ -6,8 +6,8 @@
     %b = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %c = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !riscv.reg
     %d = "riscv.slli"(%a) <{ value = 3 : i6 }> : (!riscv.reg) -> !riscv.reg
-    %e = "riscv.slli"(%b) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
-    %f = "riscv.slli"(%c) <{ value = -3 : i5 }> : (!riscv.reg) -> !riscv.reg
+    %e = "riscv.slli"(%b) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %f = "riscv.slli"(%c) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%d, %e, %f) : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/slliuw.mlir
+++ b/Test/Interpreter/RISCV/slliuw.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %b = "riscv.slliuw"(%a) <{ value = 3 : i5 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
-    %d = "riscv.slliuw"(%c) <{ value = -3 : i5 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.slliuw"(%c) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/slliuw_overflow.mlir
+++ b/Test/Interpreter/RISCV/slliuw_overflow.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
     %a = "riscv.li"() <{ value = 4294967298 : i64 }> : () -> !riscv.reg
-    %b = "riscv.slliuw"(%a) <{ value = -3 : i5 }> : (!riscv.reg) -> !riscv.reg
+    %b = "riscv.slliuw"(%a) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b) : (!riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/slliw.mlir
+++ b/Test/Interpreter/RISCV/slliw.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %b = "riscv.slliw"(%a) <{ value = 3 : i5 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
-    %d = "riscv.slliw"(%c) <{ value = -3 : i5 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.slliw"(%c) <{ value = 29 : i5 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/srai.mlir
+++ b/Test/Interpreter/RISCV/srai.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 23 : i64 }> : () -> !riscv.reg
     %b = "riscv.srai"(%a) <{ value = 1 : i6 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 23 : i64 }> : () -> !riscv.reg
-    %d = "riscv.srai"(%c) <{ value = -1 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.srai"(%c) <{ value = 63 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/sraiw.mlir
+++ b/Test/Interpreter/RISCV/sraiw.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 23 : i64 }> : () -> !riscv.reg
     %b = "riscv.sraiw"(%a) <{ value = 1 : i6 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 23 : i64 }> : () -> !riscv.reg
-    %d = "riscv.sraiw"(%c) <{ value = -1 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.sraiw"(%c) <{ value = 31 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/srli.mlir
+++ b/Test/Interpreter/RISCV/srli.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 11 : i64 }> : () -> !riscv.reg
     %b = "riscv.srli"(%a) <{ value = 3 : i6 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 11 : i64 }> : () -> !riscv.reg
-    %d = "riscv.srli"(%c) <{ value = -3 : i6 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.srli"(%c) <{ value = 61 : i6 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/RISCV/srliw.mlir
+++ b/Test/Interpreter/RISCV/srliw.mlir
@@ -5,7 +5,7 @@
     %a = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
     %b = "riscv.srliw"(%a) <{ value = 3 : i5 }> : (!riscv.reg) -> !riscv.reg
     %c = "riscv.li"() <{ value = 29 : i64 }> : () -> !riscv.reg
-    %d = "riscv.srliw"(%c) <{ value = -3 : i5 }> : (!riscv.reg) -> !riscv.reg
+    %d = "riscv.srliw"(%c) <{ value = 29 : i5 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%b, %d) : (!riscv.reg, !riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -100,6 +100,32 @@ def OperationPtr.verifyRISCVimm12 (op : OperationPtr) (ctx : WfIRContext OpCode)
   else
     pure ()
 
+/--
+  Check that a shift-amount/bit-index immediate fits in an unsigned 5-bit field
+  `[0, 31]`. Used by the word-width (`*w`) shift and rotate instructions, whose
+  shift amount operates on a 32-bit value.
+-/
+def OperationPtr.verifyRISCVuimm5 (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) (imm : Int) : Except String PUnit :=
+  if imm < 0 ∨ imm > 31 then
+    let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
+    throw s!"{instrName} immediate out of bounds: must fit in an unsigned 5-bit field [0, 31]"
+  else
+    pure ()
+
+/--
+  Check that a shift-amount/bit-index immediate fits in an unsigned 6-bit field
+  `[0, 63]`. Used by the full-width (64-bit) shift, rotate, and single-bit
+  instructions, whose immediate indexes a 64-bit register.
+-/
+def OperationPtr.verifyRISCVuimm6 (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) (imm : Int) : Except String PUnit :=
+  if imm < 0 ∨ imm > 63 then
+    let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
+    throw s!"{instrName} immediate out of bounds: must fit in an unsigned 6-bit field [0, 63]"
+  else
+    pure ()
+
 def OperationPtr.verifyOperandTypesMatch (op : OperationPtr) (ctx : WfIRContext OpCode)
     (firstIdx secondIdx : Nat) (errMsg : String) : Except String TypeAttr := do
   let firstType := (op.getOperand! ctx.raw firstIdx).getType! ctx.raw
@@ -1130,6 +1156,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .slli)).value.value
     pure ()
   | .riscv .srli => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1140,6 +1167,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .srli)).value.value
     pure ()
   | .riscv .srai => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1150,6 +1178,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .srai)).value.value
     pure ()
   | .riscv .add => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -1260,6 +1289,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .slliw)).value.value
     pure ()
   | .riscv .srliw => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1270,6 +1300,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .srliw)).value.value
     pure ()
   | .riscv .sraiw => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1280,6 +1311,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .sraiw)).value.value
     pure ()
   | .riscv .addw => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -1540,6 +1572,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .slliuw)).value.value
     pure ()
   | .riscv .andn => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -1770,6 +1803,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .roriw)).value.value
     pure ()
   | .riscv .rori => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1780,6 +1814,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .rori)).value.value
     pure ()
   | .riscv .bclr => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then
@@ -1830,6 +1865,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .bclri)).value.value
     pure ()
   | .riscv .bexti => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1840,6 +1876,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .bexti)).value.value
     pure ()
   | .riscv .binvi => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1850,6 +1887,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .binvi)).value.value
     pure ()
   | .riscv .bseti => do
     if op.getNumOperands ctx.raw opIn ≠ 1 then
@@ -1860,6 +1898,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .bseti)).value.value
     pure ()
   | .riscv .pack => do
     if op.getNumOperands ctx.raw opIn ≠ 2 then


### PR DESCRIPTION
I think this PR is actually relatively important. the reason is that it disallows negative values in 5/6-bit immediate fields, which are rejected by both the GNU and LLVM assemblers for 64-bit RISC-V, which we will eventually invoke to assemble code that we emit! so we must play by their rules.