### PR TITLE
feat: Handle poison load/stores

### DIFF
--- a/Test/Interpreter/LLVM/load_poison.mlir
+++ b/Test/Interpreter/LLVM/load_poison.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i64, i64, i64)}> ({
+    %1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
+    %ptr = "llvm.alloca"(%1) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr
+    %6 = "llvm.load"(%ptr) : (!llvm.ptr) -> i64
+    "llvm.store"(%1, %ptr) : (i64, !llvm.ptr) -> ()
+    %7 = "llvm.load"(%ptr) : (!llvm.ptr) -> i64
+    "llvm.store"(%6, %ptr) : (i64, !llvm.ptr) -> ()
+    %8 = "llvm.load"(%ptr) : (!llvm.ptr) -> i64
+    "func.return"(%6, %7, %8) : (i64, i64, i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison, 0x0000000000000001#64, poison]

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -42,6 +42,9 @@ namespace ByteArray
 def extend (ba : ByteArray) (n : Nat) (val : UInt8) : ByteArray :=
   n.fold (init := ba) fun _ _ ba => ba.push val
 
+def replicate (n : Nat) (v : UInt8) : ByteArray :=
+  (ByteArray.emptyWithCapacity n).extend n v
+
 @[inline]
 def getD (ba : ByteArray) (i : Nat) (default : UInt8) : UInt8 :=
   if h : i < ba.size then ba[i] else default

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -39,11 +39,34 @@ def UInt64.toByteArrayLE (u : UInt64) : ByteArray :=
 
 namespace ByteArray
 
+@[simp, grind =]
+theorem size_emptyWithCapacity (n : Nat) :
+    (ByteArray.emptyWithCapacity n).size = 0 := by constructor
+
 def extend (ba : ByteArray) (n : Nat) (val : UInt8) : ByteArray :=
   n.fold (init := ba) fun _ _ ba => ba.push val
 
+@[simp, grind =]
+theorem extend_zero (ba : ByteArray) (val : UInt8) :
+    ba.extend 0 val = ba := by
+  simp [extend]
+
+@[simp, grind =]
+theorem extend_size (ba : ByteArray) (n : Nat) (val : UInt8) :
+    (ba.extend n val).size = ba.size + n := by
+  induction n
+  case zero => simp
+  case succ n h =>
+    grind [Nat.fold_succ, size_push, extend]
+
+@[simp]
 def replicate (n : Nat) (v : UInt8) : ByteArray :=
   (ByteArray.emptyWithCapacity n).extend n v
+
+@[simp, grind =]
+theorem replicate_size (n : Nat) (v : UInt8) :
+    (ByteArray.replicate n v).size = n := by
+  simp
 
 @[inline]
 def getD (ba : ByteArray) (i : Nat) (default : UInt8) : UInt8 :=

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -135,13 +135,16 @@ end RuntimeValue
 @[ext]
 structure MemoryState where
   contents : ByteArray
+  poisonMask : ByteArray
 
-def MemoryState.empty : MemoryState :=
-  { contents := (ByteArray.emptyWithCapacity 1024).extend 8 0xff }
+def MemoryState.empty : MemoryState := {
+  contents := (ByteArray.emptyWithCapacity 1024).extend 8 0xff,
+  poisonMask := (ByteArray.emptyWithCapacity 1024).extend 8 0xff
+}
 
 def MemoryState.ensureSize (mem : MemoryState) (size : Nat) : MemoryState :=
   if mem.contents.size < size then
-    { contents := mem.contents.extend (size - mem.contents.size) 0 }
+    ⟨mem.contents.extend (size - mem.contents.size) 0, mem.poisonMask.extend (size - mem.poisonMask.size) 0xff⟩
   else
     mem
 
@@ -330,16 +333,32 @@ instance : Inhabited (Interp α) := ⟨(none : Option (UBOr α))⟩
 -/
 def MemoryState.alloc (state : MemoryState) (size : UInt64)
     : MemoryState × UInt64 :=
-  ({ contents := state.contents.extend size.toNat 0 }, state.contents.size.toUInt64)
+  (⟨state.contents.extend size.toNat 0, state.poisonMask.extend size.toNat 0xff⟩, state.contents.size.toUInt64)
 
 /--
-  Store raw bytes to the given address in memory.
+  Store raw bytes to the given address in memory,
+  and unset the corresponding poison bits.
   Yields UB if the access is out of bounds.
 -/
 def MemoryState.store (state : MemoryState) (addr : UInt64) (val : ByteArray)
     : Interp MemoryState :=
   if addr.toNat + val.size ≤ state.contents.size then
-    return { state with contents := val.copySlice 0 state.contents addr.toNat val.size false }
+    let poison := ByteArray.replicate val.size 0
+    return ⟨val.copySlice 0 state.contents addr.toNat val.size false,
+      poison.copySlice 0 state.poisonMask addr.toNat val.size false⟩
+  else
+    Interp.ub
+
+/--
+  Poison the given number of bytes, starting from the given address in memory.
+  Yields UB if the access is out of bounds.
+-/
+def MemoryState.empoison (state : MemoryState) (addr : UInt64) (n : Nat)
+    : Interp MemoryState :=
+  if addr.toNat + n ≤ state.contents.size then
+    let mask := ByteArray.replicate n 0xff
+    return ⟨state.contents,
+      mask.copySlice 0 state.poisonMask addr.toNat n false⟩
   else
     Interp.ub
 
@@ -353,7 +372,7 @@ def MemoryState.storeValue (state : MemoryState) (addr : UInt64) (val : RuntimeV
   match val with
   | .int 8 (.val v) => state.store addr (ByteArray.empty.push (UInt8.ofBitVec v))
   | .int 64 (.val v) => state.store addr (UInt64.ofBitVec v).toByteArrayLE
-  | .int _ .poison => return state
+  | .int n .poison => state.empoison addr (n / 8)
   | .addr v => state.store addr v.toByteArrayLE
   | _ => none
 
@@ -369,6 +388,22 @@ def MemoryState.load (state : MemoryState) (addr size : UInt64)
     Interp.ub
 
 /--
+  Check if any bit at the given memory address is poison.
+  Yields UB if the access is out of bounds.
+-/
+def MemoryState.hasPoison (state : MemoryState) (addr size : UInt64)
+    : Interp Bool :=
+  if addr.toNat + size.toNat <= state.contents.size then do
+    let mut poison := false
+    for b in state.poisonMask.extract addr.toNat (addr + size).toNat do
+      if b ≠ 0 then
+        poison := true
+        break
+    return poison
+  else
+    Interp.ub
+
+/--
   Load an LLVM value from the given memory address.
   Yields UB if access is out of bounds or the address is 0.
 -/
@@ -378,12 +413,16 @@ def MemoryState.loadValue (state : MemoryState) (addr : UInt64) (type : TypeAttr
   match type.val with
   | Attribute.integerType { bitwidth := 8 } =>
       let ba ← state.load addr 1
+      if ← state.hasPoison addr 1 then return .int 8 .poison
       return .int 8 (.val ba[0]!.toNat)
   | Attribute.integerType { bitwidth := 64 } =>
       let ba ← state.load addr 8
+      if ← state.hasPoison addr 8 then return .int 64 .poison
       return .int 64 (.val (BitVec.ofNat 64 ba.toUInt64LE!.toNat))
   | Attribute.llvmPointerType _ =>
       let ba ← state.load addr 8
+      -- FIXME poison address
+      if ← state.hasPoison addr 8 then return .addr 0
       return .addr ba.toUInt64LE!
   | _ => none
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -2,7 +2,6 @@ import Veir.IR.Basic
 import Veir.Rewriter.Basic
 import Veir.ForLean
 import Veir.IR.WellFormed
-import Veir.PatternRewriter.Basic
 import Veir.Data.Comb.Basic
 import Veir.Data.LLVM.Int.Basic
 import Veir.Data.RISCV.Reg.Basic
@@ -130,21 +129,26 @@ theorem ArrayConforms.take_succ_eq {source : Array RuntimeValue} {target : Array
 end RuntimeValue
 
 /--
-  Memory state during interpretation
+  Memory state during interpretation.
+  Set bits in the poison mask represent poison bits.
 -/
 @[ext]
 structure MemoryState where
   contents : ByteArray
   poisonMask : ByteArray
+  consistentSize : contents.size = poisonMask.size
 
 def MemoryState.empty : MemoryState := {
   contents := (ByteArray.emptyWithCapacity 1024).extend 8 0xff,
-  poisonMask := (ByteArray.emptyWithCapacity 1024).extend 8 0xff
+  poisonMask := (ByteArray.emptyWithCapacity 1024).extend 8 0xff,
+  consistentSize := (by grind)
 }
 
 def MemoryState.ensureSize (mem : MemoryState) (size : Nat) : MemoryState :=
   if mem.contents.size < size then
-    ⟨mem.contents.extend (size - mem.contents.size) 0, mem.poisonMask.extend (size - mem.poisonMask.size) 0xff⟩
+    ⟨mem.contents.extend (size - mem.contents.size) 0,
+      mem.poisonMask.extend (size - mem.contents.size) 0xff,
+      (by simp [mem.consistentSize])⟩
   else
     mem
 
@@ -333,7 +337,9 @@ instance : Inhabited (Interp α) := ⟨(none : Option (UBOr α))⟩
 -/
 def MemoryState.alloc (state : MemoryState) (size : UInt64)
     : MemoryState × UInt64 :=
-  (⟨state.contents.extend size.toNat 0, state.poisonMask.extend size.toNat 0xff⟩, state.contents.size.toUInt64)
+  (⟨state.contents.extend size.toNat 0,
+    state.poisonMask.extend size.toNat 0xff,
+    by simp [state.consistentSize]⟩, state.contents.size.toUInt64)
 
 /--
   Store raw bytes to the given address in memory,
@@ -345,20 +351,31 @@ def MemoryState.store (state : MemoryState) (addr : UInt64) (val : ByteArray)
   if addr.toNat + val.size ≤ state.contents.size then
     let poison := ByteArray.replicate val.size 0
     return ⟨val.copySlice 0 state.contents addr.toNat val.size false,
-      poison.copySlice 0 state.poisonMask addr.toNat val.size false⟩
+      poison.copySlice 0 state.poisonMask addr.toNat val.size false,
+      by
+        have h : poison.size = val.size := by grind
+        simp [ByteArray.copySlice_eq_append, state.consistentSize, h]
+      ⟩
   else
     Interp.ub
 
 /--
-  Poison the given number of bytes, starting from the given address in memory.
+  Poison the given number n of bytes, starting from the given address in memory.
   Yields UB if the access is out of bounds.
 -/
 def MemoryState.empoison (state : MemoryState) (addr : UInt64) (n : Nat)
     : Interp MemoryState :=
-  if addr.toNat + n ≤ state.contents.size then
+  if h : addr.toNat + n ≤ state.poisonMask.size then
     let mask := ByteArray.replicate n 0xff
     return ⟨state.contents,
-      mask.copySlice 0 state.poisonMask addr.toNat n false⟩
+      mask.copySlice 0 state.poisonMask addr.toNat n false,
+      by
+        have h' : min n mask.size = n := by grind
+        have h'' : min addr.toNat state.poisonMask.size = addr.toNat := by grind
+        simp [ByteArray.copySlice_eq_append, state.consistentSize, h', h'']
+        grind
+
+      ⟩
   else
     Interp.ub
 
@@ -388,7 +405,7 @@ def MemoryState.load (state : MemoryState) (addr size : UInt64)
     Interp.ub
 
 /--
-  Check if any bit at the given memory address is poison.
+  Check if any of the `size` bytes at the given memory address `addr` is poison.
   Yields UB if the access is out of bounds.
 -/
 def MemoryState.hasPoison (state : MemoryState) (addr size : UInt64)


### PR DESCRIPTION
Memory is extended with a second ByteArray that serves as a poison mask.
RISCV memory accesses ignore the poison mask.

A limitation is that poison pointer reads become null addresses,
as we cannot represent poison addresses for now.
