### PR TITLE
feat(riscv): make sure riscv instructions operate on riscv registers

### DIFF
--- a/Test/RISCV/add-non-reg-operand.mlir
+++ b/Test/RISCV/add-non-reg-operand.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = (i64) -> ()}> ({
+  ^bb0(%x : i64):
+    %a = "riscv.li"() <{ "value" = 1 : i64 }> : () -> !riscv.reg
+    %b = "riscv.add"(%x, %a) : (i64, !riscv.reg) -> !riscv.reg
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Error verifying input program: riscv.add: Expected operand 0 to have !riscv.reg type

--- a/Test/RISCV/add-non-reg-result.mlir
+++ b/Test/RISCV/add-non-reg-result.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    %a = "riscv.li"() <{ "value" = 1 : i64 }> : () -> !riscv.reg
+    %b = "riscv.add"(%a, %a) : (!riscv.reg, !riscv.reg) -> i64
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Error verifying input program: riscv.add: Expected result 0 to have !riscv.reg type

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -171,6 +171,25 @@ def OperationPtr.verifyIntegerExtTypes (op : OperationPtr) (ctx : WfIRContext Op
     pure ()
 
 /--
+  Ensure that every operand and result of a RISC-V register instruction has
+  type `!riscv.reg`. The caller is responsible for only invoking this on
+  `.riscv` operations.
+-/
+
+def OperationPtr.verifyRISCVRegisterTypes (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
+  let opTypes := op.getOperandTypes! ctx.raw
+  for i in [0:opTypes.size] do
+    match (opTypes[i]!).val with
+    | .registerType _ => pure ()
+    | _ => throw s!"{instrName}: Expected operand {i} to have !riscv.reg type"
+  for i in [0:op.getNumResults ctx.raw opIn] do
+    match ((op.getResult i).get! ctx.raw).type.val with
+    | .registerType _ => pure ()
+    | _ => throw s!"{instrName}: Expected result {i} to have !riscv.reg type"
+
+/--
   Verify local invariants of an operation.
   This typically includes checking that the number of operands, successors, results, and regions
   match the expected values for the given operation type.
@@ -2242,6 +2261,8 @@ public section
 def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
   ctx.raw.forOpsDepM (fun op opIn => do
     op.verifyLocalInvariants ctx opIn
+    if let .riscv _ := op.getOpType ctx.raw opIn then
+      op.verifyRISCVRegisterTypes ctx opIn
     match (op.get ctx.raw opIn).parent with
     | some _ => op.verifyTerminatorPosition ctx opIn
     | none => pure ())


### PR DESCRIPTION
I think this is the right invariant for riscv dialect operations-- easy!!!