### PR TITLE
fix(arith): IntegerOverflowFlagsAttr as in MLIR

### DIFF
--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
   "func.func"() <{function_type = () -> (), sym_name = "main"}> ({

--- a/Test/Arith/identity.mlir
+++ b/Test/Arith/identity.mlir
@@ -5,9 +5,9 @@
     ^4():
       %5 = "arith.constant"() <{ "value" = 13 : i32 }> : () -> i32
       %addi = "arith.addi"(%5, %5) : (i32, i32) -> i32
-      %addi_nsw = "arith.addi"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
-      %addi_nuw = "arith.addi"(%5, %5) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
-      %addi_nsw_nuw = "arith.addi"(%5, %5) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
+      %addi_nsw = "arith.addi"(%5, %5) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32, i32) -> i32
+      %addi_nuw = "arith.addi"(%5, %5) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
+      %addi_nsw_nuw = "arith.addi"(%5, %5) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32, i32) -> i32
       %70, %71 = "arith.addui_extended"(%5, %5) : (i32, i32) -> (i32, i1)
       %8 = "arith.andi"(%5, %5) : (i32, i32) -> i32
       %9 = "arith.ceildivsi"(%5, %5) : (i32, i32) -> i32
@@ -22,9 +22,9 @@
       %18 = "arith.minsi"(%5, %5) : (i32, i32) -> i32
       %19 = "arith.minui"(%5, %5) : (i32, i32) -> i32
       %muli = "arith.muli"(%5, %5) : (i32, i32) -> i32
-      %muli_nsw = "arith.muli"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
-      %muli_nuw = "arith.muli"(%5, %5) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
-      %muli_nsw_nuw = "arith.muli"(%5, %5) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
+      %muli_nsw = "arith.muli"(%5, %5) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32, i32) -> i32
+      %muli_nuw = "arith.muli"(%5, %5) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
+      %muli_nsw_nuw = "arith.muli"(%5, %5) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32, i32) -> i32
       %210, %211 = "arith.mulsi_extended"(%5, %5) : (i32, i32) -> (i32, i32)
       %220, %221 = "arith.mului_extended"(%5, %5) : (i32, i32) -> (i32, i32)
       %23 = "arith.ori"(%5, %5) : (i32, i32) -> i32
@@ -47,9 +47,9 @@
 // CHECK-NEXT:       ^{{.*}}():
 // CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 13 : i32}> : () -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}}:2 = "arith.addui_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i1)
 // CHECK-NEXT:         %{{.*}} = "arith.andi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.ceildivsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
@@ -64,9 +64,9 @@
 // CHECK-NEXT:         %{{.*}} = "arith.minsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.minui"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
-// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = 3 : i32}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
+// CHECK-NEXT:         %{{.*}} = "arith.muli"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32, i32) -> i32
 // CHECK-NEXT:         %{{.*}}:2 = "arith.mulsi_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
 // CHECK-NEXT:         %{{.*}}:2 = "arith.mului_extended"(%{{.*}}, %{{.*}}) : (i32, i32) -> (i32, i32)
 // CHECK-NEXT:         %{{.*}} = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32

--- a/Test/Interpreter/Arith/addi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_signed_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/addi_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
     %none = "arith.addi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.addi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/divsi_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/Arith/divsi_poison_dividend_neg1.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.divsi"(%poison, %neg1) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/divsi_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/divsi_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.divsi"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/divui_poison_dividend.mlir
+++ b/Test/Interpreter/Arith/divui_poison_dividend.mlir
@@ -7,7 +7,7 @@
     %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.divui"(%poison, %five) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/divui_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/divui_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.divui"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/muli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 13 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_signed_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 150 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/muli_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 2 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %none = "arith.muli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.muli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/remsi_poison_dividend_neg1.mlir
+++ b/Test/Interpreter/Arith/remsi_poison_dividend_neg1.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.remsi"(%poison, %neg1) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/remsi_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/remsi_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.remsi"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/remui_poison_divisor.mlir
+++ b/Test/Interpreter/Arith/remui_poison_divisor.mlir
@@ -6,7 +6,7 @@
     %lhs  = "arith.constant"() <{ "value" = 130 : i32 }> : () -> i32
     %neg1 = "arith.constant"() <{ "value" = -1 : i32 }> : () -> i32
     %one  = "arith.constant"() <{ "value" = 1 : i32 }> : () -> i32
-    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = 2 : i32}> : (i32, i32) -> i32
+    %poison = "arith.addi"(%neg1, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %y = "arith.remui"(%lhs, %poison) : (i32, i32) -> i32
     "func.return"(%y) : (i32) -> ()
   }) : () -> ()

--- a/Test/Interpreter/Arith/shli_oversized_amount.mlir
+++ b/Test/Interpreter/Arith/shli_oversized_amount.mlir
@@ -4,9 +4,9 @@
   "func.func"() <{sym_name = "main", function_type = () -> (i66, i66, i66, i66)}> ({
     %c = "arith.constant"() <{ "value" = 18446744073709551616 : i66 }> : () -> i66
     %none = "arith.shli"(%c, %c) : (i66, i66) -> i66
-    %nsw = "arith.shli"(%c, %c) <{"overflowFlags" = 1 : i32}> : (i66, i66) -> i66
-    %nuw = "arith.shli"(%c, %c) <{"overflowFlags" = 2 : i32}> : (i66, i66) -> i66
-    %nsw_nuw = "arith.shli"(%c, %c) <{"overflowFlags" = 3 : i32}> : (i66, i66) -> i66
+    %nsw = "arith.shli"(%c, %c) <{"overflowFlags" = #arith.overflow<nsw>}> : (i66, i66) -> i66
+    %nuw = "arith.shli"(%c, %c) <{"overflowFlags" = #arith.overflow<nuw>}> : (i66, i66) -> i66
+    %nsw_nuw = "arith.shli"(%c, %c) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i66, i66) -> i66
     "func.return"(%none, %nsw, %nuw, %nsw_nuw) : (i66, i66, i66, i66) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_signed_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 6 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/shli_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
     %none = "arith.shli"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.shli"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/subi_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 200 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 80 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_signed_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 220 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/subi_unsigned_overflow.mlir
@@ -5,9 +5,9 @@
     %lhs = "arith.constant"() <{ "value" = -10 : i8 }> : () -> i8
     %rhs = "arith.constant"() <{ "value" = 127 : i8 }> : () -> i8
     %none = "arith.subi"(%lhs, %rhs) : (i8, i8) -> i8
-    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 1 : i32}> : (i8, i8) -> i8
-    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 2 : i32}> : (i8, i8) -> i8
-    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = 3 : i32}> : (i8, i8) -> i8
+    %nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw>}> : (i8, i8) -> i8
+    %nuw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %nuw_nsw = "arith.subi"(%lhs, %rhs) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_signed_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_signed_overflow.mlir
@@ -6,8 +6,8 @@
     %c127 = "arith.constant"() <{ "value" = 127 : i32 }> : () -> i32
     // 128 does not fit in i8 signed: sext(trunc(128)) == -128 != 128, poison
     %c128 = "arith.constant"() <{ "value" = 128 : i32 }> : () -> i32
-    %a = "arith.trunci"(%c127) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
-    %b = "arith.trunci"(%c128) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
+    %a = "arith.trunci"(%c127) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32) -> i8
+    %b = "arith.trunci"(%c128) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32) -> i8
     "func.return"(%a, %b) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_signed_unsigned_overflow.mlir
@@ -7,9 +7,9 @@
   "func.func"() <{sym_name = "main", function_type = () -> (i8, i8, i8, i8)}> ({
     %c384 = "arith.constant"() <{ "value" = 384 : i32 }> : () -> i32
     %none    = "arith.trunci"(%c384) : (i32) -> i8
-    %nsw     = "arith.trunci"(%c384) <{"overflowFlags" = 1 : i32}> : (i32) -> i8
-    %nuw     = "arith.trunci"(%c384) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
-    %nuw_nsw = "arith.trunci"(%c384) <{"overflowFlags" = 3 : i32}> : (i32) -> i8
+    %nsw     = "arith.trunci"(%c384) <{"overflowFlags" = #arith.overflow<nsw>}> : (i32) -> i8
+    %nuw     = "arith.trunci"(%c384) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32) -> i8
+    %nuw_nsw = "arith.trunci"(%c384) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32) -> i8
     "func.return"(%none, %nsw, %nuw, %nuw_nsw) : (i8, i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/trunci_unsigned_overflow.mlir
+++ b/Test/Interpreter/Arith/trunci_unsigned_overflow.mlir
@@ -6,8 +6,8 @@
     %c255 = "arith.constant"() <{ "value" = 255 : i32 }> : () -> i32
     // 256 does not fit in i8 unsigned: zext(trunc(256)) == 0 != 256, poison
     %c256 = "arith.constant"() <{ "value" = 256 : i32 }> : () -> i32
-    %a = "arith.trunci"(%c255) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
-    %b = "arith.trunci"(%c256) <{"overflowFlags" = 2 : i32}> : (i32) -> i8
+    %a = "arith.trunci"(%c255) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32) -> i8
+    %b = "arith.trunci"(%c256) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32) -> i8
     "func.return"(%a, %b) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Cf/cond_br_poison.mlir
+++ b/Test/Interpreter/Cf/cond_br_poison.mlir
@@ -6,7 +6,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     ^entry():
       %one    = "arith.constant"() <{"value" = 1 : i1}> : () -> i1
-      %poison = "arith.addi"(%one, %one) <{"overflowFlags" = 2 : i32}> : (i1, i1) -> i1
+      %poison = "arith.addi"(%one, %one) <{"overflowFlags" = #arith.overflow<nuw>}> : (i1, i1) -> i1
       %tval   = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
       %fval   = "arith.constant"() <{"value" = 99 : i32}> : () -> i32
       "cf.cond_br"(%poison, %tval, %fval) [^t, ^f]

--- a/Test/Passes/ModArithToArith/add.mlir
+++ b/Test/Passes/ModArithToArith/add.mlir
@@ -20,6 +20,6 @@
 // CHECK-NEXT:   [[Q:%.*]] = "arith.constant"() <{"value" = 7 : i33}> : () -> i33
 // CHECK-NEXT:   [[SUM:%.*]] = "arith.addi"([[E0]], [[E1]]) : (i33, i33) -> i33
 // CHECK-NEXT:   [[SUMR:%.*]] = "arith.remui"([[SUM]], [[Q]]) : (i33, i33) -> i33
-// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[SUMR]]) <{"overflowFlags" = 2 : i32}> : (i33) -> i32
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[SUMR]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i33) -> i32
 // CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i32) -> !mod_arith.int<7 : i32>
 // CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/Test/Passes/ModArithToArith/mul.mlir
+++ b/Test/Passes/ModArithToArith/mul.mlir
@@ -19,6 +19,6 @@
 // CHECK-NEXT:   [[Q:%.*]] = "arith.constant"() <{"value" = 7 : i64}> : () -> i64
 // CHECK-NEXT:   [[PROD:%.*]] = "arith.muli"([[E0]], [[E1]]) : (i64, i64) -> i64
 // CHECK-NEXT:   [[PRODR:%.*]] = "arith.remui"([[PROD]], [[Q]]) : (i64, i64) -> i64
-// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[PRODR]]) <{"overflowFlags" = 2 : i32}> : (i64) -> i32
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[PRODR]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i64) -> i32
 // CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i32) -> !mod_arith.int<7 : i32>
 // CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/Test/Passes/ModArithToArith/sub.mlir
+++ b/Test/Passes/ModArithToArith/sub.mlir
@@ -21,6 +21,6 @@
 // CHECK-NEXT:   [[AQ:%.*]] = "arith.addi"([[E0]], [[Q]]) : (i33, i33) -> i33
 // CHECK-NEXT:   [[DIFF:%.*]] = "arith.subi"([[AQ]], [[E1]]) : (i33, i33) -> i33
 // CHECK-NEXT:   [[DIFFR:%.*]] = "arith.remui"([[DIFF]], [[Q]]) : (i33, i33) -> i33
-// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[DIFFR]]) <{"overflowFlags" = 2 : i32}> : (i33) -> i32
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[DIFFR]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i33) -> i32
 // CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i32) -> !mod_arith.int<7 : i32>
 // CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -130,6 +130,15 @@ macro "#assert " e:term : command =>
 #assert expectSuccessAttr "false" (IntegerAttr.mk 0 (IntegerType.mk 1))
 #assert expectSuccessAttr "true" (IntegerAttr.mk 1 (IntegerType.mk 1))
 
+/-! ## Integer overflow flags attributes -/
+
+#assert expectSuccessAttr "#arith.overflow<none>" (ArithIntegerOverflowFlagsAttr.mk false false)
+#assert expectSuccessAttr "#arith.overflow<nsw>" (ArithIntegerOverflowFlagsAttr.mk true false)
+#assert expectSuccessAttr "#arith.overflow<nuw>" (ArithIntegerOverflowFlagsAttr.mk false true)
+#assert expectSuccessAttr "#arith.overflow<nsw, nuw>" (ArithIntegerOverflowFlagsAttr.mk true true)
+#assert expectErrorAttr "#arith.overflow<>"
+  "expected integer overflow flag to be one of: none, nsw, nuw" (some 16)
+
 /-! ## String attributes -/
 
 #assert expectSuccessAttr "\"hello\"" (StringAttr.mk "hello".toByteArray)

--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -112,6 +112,27 @@ def testParseOp (s : String) : IO Unit :=
 
 /--
   info: "builtin.module"() ({
+  ^4(%arg4_0 : i32, %arg4_1 : i32):
+    %5 = "arith.addi"(%arg4_0, %arg4_1) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32, i32) -> i32
+}) : () -> ()-/
+#guard_msgs in
+#eval! testParseOp "\"builtin.module\"() ({
+^bb0(%x : i32, %y : i32):
+  %a = \"arith.addi\"(%x, %y) <{ overflowFlags = #arith.overflow<nsw, nuw> }> : (i32, i32) -> i32
+}) : () -> ()"
+
+/--
+  error: expected 'overflowFlags' to be an arith integer overflow flags attribute, but got 1 : i32
+-/
+#guard_msgs in
+#eval! testParseOp "\"builtin.module\"() ({
+^bb0(%x : i32, %y : i32):
+  %a = \"arith.addi\"(%x, %y) <{ overflowFlags = 1 : i32 }> : (i32, i32) -> i32
+}) : () -> ()"
+
+
+/--
+  info: "builtin.module"() ({
   ^4():
     "builtin.module"() ({
       ^6():

--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -126,7 +126,7 @@ def mulITwoReduce (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option
   -- Get the lhs value
   let lhsValuePtr := op.getOperand rewriter.ctx.raw 0 (by sorry) (by sorry)
 
-  let (rewriter, newOp) ← rewriter.createOp (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (NswNuwProperties.mk false false) (some $ .before op) sorry sorry sorry sorry
+  let (rewriter, newOp) ← rewriter.createOp (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) (some $ .before op) sorry sorry sorry sorry
   let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
   if (rhsValuePtr.getFirstUse rewriter.ctx.raw (by sorry)).isNone then
@@ -221,7 +221,7 @@ def mulITwoReduce (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRCon
   -- Get the lhs value
   let lhsValuePtr := op.getOperand ctx.raw 0 (by sorry) (by sorry)
 
-  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (NswNuwProperties.mk false false) (some $ .before op) sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) (some $ .before op) sorry sorry sorry sorry
   let mut ctx ← WfRewriter.replaceOp? ctx op newOp sorry sorry sorry sorry sorry
 
   if (rhsValuePtr.getFirstUse ctx.raw (by sorry)).isNone then
@@ -299,13 +299,13 @@ def constFoldTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (
   (ctx, topOp)
 
 def addZeroTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
-  constFoldTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 0
+  constFoldTree (.arith .addi) (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) size pc 42 0
 
 def addOneTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
-  constFoldTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 1
+  constFoldTree (.arith .addi) (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) size pc 42 1
 
 def mulTwoTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
-  constFoldTree (.arith .muli) (NswNuwProperties.mk false false) size pc 42 2
+  constFoldTree (.arith .muli) (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) size pc 42 2
 
 
 -- Create a program that looks like:
@@ -338,7 +338,7 @@ def constReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) 
   (ctx, topOp)
 
 def addZeroReuseTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
-  constReuseTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 0
+  constReuseTree (.arith .addi) (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) size pc 42 0
 
 -- Create a program that looks like:
 -- func @main() -> u64 {
@@ -375,7 +375,7 @@ def constLotsOfReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc:
   (ctx, topOp)
 
 def addZeroLotsOfReuseTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
-  constLotsOfReuseTree (.arith .addi) (NswNuwProperties.mk false false) size pc 42 0
+  constLotsOfReuseTree (.arith .addi) (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) size pc 42 0
 
 end Program
 

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -12,17 +12,17 @@ public section
 def Arith.propertiesOf (op : Arith) : Type :=
 match op with
 | .constant => ArithConstantProperties
-| .addi => NswNuwProperties
-| .subi => NswNuwProperties
-| .muli => NswNuwProperties
+| .addi => ArithIntegerOverflowFlagsProperties
+| .subi => ArithIntegerOverflowFlagsProperties
+| .muli => ArithIntegerOverflowFlagsProperties
 | .divsi => ExactProperties
 | .divui => ExactProperties
 | .cmpi => IcmpProperties
-| .shli => NswNuwProperties
+| .shli => ArithIntegerOverflowFlagsProperties
 | .shrsi => ExactProperties
 | .shrui => ExactProperties
 | .ori => DisjointProperties
-| .trunci => NswNuwProperties
+| .trunci => ArithIntegerOverflowFlagsProperties
 | .extui => NnegProperties
 | _ => Unit
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -144,17 +144,17 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   case arith op =>
     cases op
     case constant => exact (ArithConstantProperties.fromAttrDict attrDict)
-    case addi => exact (NswNuwProperties.fromAttrDict attrDict)
-    case subi => exact (NswNuwProperties.fromAttrDict attrDict)
-    case muli => exact (NswNuwProperties.fromAttrDict attrDict)
+    case addi => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
+    case subi => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
+    case muli => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
     case divsi => exact (ExactProperties.fromAttrDict attrDict)
     case divui => exact (ExactProperties.fromAttrDict attrDict)
     case cmpi => exact (IcmpProperties.fromAttrDictFor "arith.cmpi" attrDict)
-    case shli => exact (NswNuwProperties.fromAttrDict attrDict)
+    case shli => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
     case shrsi => exact (ExactProperties.fromAttrDict attrDict)
     case shrui => exact (ExactProperties.fromAttrDict attrDict)
     case ori => exact (DisjointProperties.fromAttrDict attrDict)
-    case trunci => exact (NswNuwProperties.fromAttrDict attrDict)
+    case trunci => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
     case extui => exact (NnegProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
   case comb op =>
@@ -182,7 +182,11 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
       (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr intAttr)
     | .float floatAttr =>
       (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.floatAttr floatAttr)
-  | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci
+  | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 1
+    if props.attr.nsw || props.attr.nuw then
+      dict := dict.insert "overflowFlags".toUTF8 (Attribute.arithIntegerOverflowFlagsAttr props.attr)
+    dict
   | .llvm .add | .llvm .sub | .llvm .mul | .llvm .shl | .llvm .trunc => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 1
 

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -75,6 +75,15 @@ structure FastMathFlagsAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  Arith integer overflow flags attribute.
+-/
+structure ArithIntegerOverflowFlagsAttr where
+  nsw : Bool
+  nuw : Bool
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+
+/--
   LLVM calling convention attribute, e.g. `#llvm.cconv<ccc>`.
 -/
 structure CConvAttr where
@@ -341,6 +350,8 @@ inductive Attribute
 | floatAttr (attr : FloatAttr)
 /-- Float fast math flags attribute -/
 | fastMathFlagsAttr (attr : FastMathFlagsAttr)
+/-- Arith integer overflow flags attribute -/
+| arithIntegerOverflowFlagsAttr (attr : ArithIntegerOverflowFlagsAttr)
 /-- LLVM calling convention attribute -/
 | cconvAttr (attr : CConvAttr)
 /-- LLVM linkage attribute -/
@@ -567,6 +578,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case arithIntegerOverflowFlagsAttr.arithIntegerOverflowFlagsAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case stringAttr.stringAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -655,6 +670,17 @@ instance : ToString FastMathFlagsAttr where
       if type.nsz then array := array ++ ["nsz"]
       if !type.nnan && !type.ninf && !type.nsz then array := array ++ ["none"]
     s!"#llvm.fastmath<{String.intercalate ", " array}>"
+
+def integerOverflowFlagsString (dialect : String) (nsw nuw : Bool) : String :=
+  let flags :=
+    if nsw && nuw then ["nsw", "nuw"]
+    else if nsw then ["nsw"]
+    else if nuw then ["nuw"]
+    else ["none"]
+  s!"#{dialect}.overflow<{String.intercalate ", " flags}>"
+
+instance : ToString ArithIntegerOverflowFlagsAttr where
+  toString attr := integerOverflowFlagsString "arith" attr.nsw attr.nuw
 
 instance : ToString CConvAttr where
   toString attr := s!"#llvm.cconv<{attr.value}>"
@@ -830,6 +856,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .integerType type => ToString.toString type
   | .floatType type => ToString.toString type
   | .fastMathFlagsAttr attr => ToString.toString attr
+  | .arithIntegerOverflowFlagsAttr attr => ToString.toString attr
   | .cconvAttr attr => ToString.toString attr
   | .linkageAttr attr => ToString.toString attr
   | .framePointerKindAttr attr => ToString.toString attr
@@ -939,6 +966,9 @@ instance : Coe ArrayAttr Attribute where
 instance : Coe FloatAttr Attribute where
   coe attr := .floatAttr attr
 
+instance : Coe ArithIntegerOverflowFlagsAttr Attribute where
+  coe attr := .arithIntegerOverflowFlagsAttr attr
+
 instance : Coe DenseArrayAttr Attribute where
   coe attr := .denseArrayAttr attr
 
@@ -984,6 +1014,7 @@ def isType (attr : Attribute) : Bool :=
   | .integerType _ => true
   | .floatType _ => true
   | .fastMathFlagsAttr _ => false
+  | .arithIntegerOverflowFlagsAttr _ => false
   | .cconvAttr _ => false
   | .linkageAttr _ => false
   | .framePointerKindAttr _ => false

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -403,17 +403,17 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.add lhs rhs properties.nsw properties.nuw)], none)
+    return (#[.int bw (LLVM.Int.add lhs rhs properties.attr.nsw properties.attr.nuw)], none)
   | .subi => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.sub lhs rhs properties.nsw properties.nuw)], none)
+    return (#[.int bw (LLVM.Int.sub lhs rhs properties.attr.nsw properties.attr.nuw)], none)
   | .muli => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.mul lhs rhs properties.nsw properties.nuw)], none)
+    return (#[.int bw (LLVM.Int.mul lhs rhs properties.attr.nsw properties.attr.nuw)], none)
   | .divui => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -472,7 +472,7 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.shl lhs rhs properties.nsw properties.nuw)], none)
+    return (#[.int bw (LLVM.Int.shl lhs rhs properties.attr.nsw properties.attr.nuw)], none)
   | .shrsi => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -503,7 +503,7 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     let some resType := resultTypes[0]? | none
     let .integerType resBw := resType.val | none
     if h: resBw.bitwidth >= w then none else
-    return (#[.int resBw.bitwidth (LLVM.Int.trunc val resBw.bitwidth properties.nsw properties.nuw (by omega))], none)
+    return (#[.int resBw.bitwidth (LLVM.Int.trunc val resBw.bitwidth properties.attr.nsw properties.attr.nuw (by omega))], none)
   | .extui => do
     let [.int w val] := operands.toList | none
     let some resType := resultTypes[0]? | none

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -208,6 +208,26 @@ def parseFloatFastMathFlagsAttr : AttrParserM (Option FastMathFlagsAttr) := do
       nsz := floatFastMathFlags.nsz || flag.nsz }
   return some floatFastMathFlags
 
+def parseIntegerOverflowFlag : AttrParserM (Bool × Bool) := do
+  if ← parseOptionalKeyword "none".toByteArray then
+    return (false, false)
+  if ← parseOptionalKeyword "nsw".toByteArray then
+    return (true, false)
+  if ← parseOptionalKeyword "nuw".toByteArray then
+    return (false, true)
+  throwAtCurrentPos "expected integer overflow flag to be one of: none, nsw, nuw"
+
+def parseIntegerOverflowFlags : AttrParserM (Bool × Bool) := do
+  parsePunctuation "<"
+  let values ← parseList parseIntegerOverflowFlag
+  parsePunctuation ">"
+  let mut nsw := false
+  let mut nuw := false
+  for (flagNsw, flagNuw) in values do
+    nsw := nsw || flagNsw
+    nuw := nuw || flagNuw
+  return (nsw, nuw)
+
 def isClosingBracket (kind : TokenKind) : Bool :=
   kind = .greater || kind = .rParen || kind = .rSquare || kind = .rBrace
 
@@ -310,6 +330,10 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
 
   if dialectName = "llvm.fastmath".toByteArray then do
     return ← parseFloatFastMathFlagsAttr
+
+  if dialectName = "arith.overflow".toByteArray then do
+    let (nsw, nuw) ← parseIntegerOverflowFlags
+    return some (ArithIntegerOverflowFlagsAttr.mk nsw nuw : Attribute)
 
   if dialectName = "llvm.cconv".toByteArray then do
     parsePunctuation "<"

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -65,7 +65,7 @@ def packValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ty : ModArithT
   let storageType := ty.modulus.type
   if intermediateType.bitwidth > storageType.bitwidth then
     let (rewriter, narrowed) ← rewriter.createOp (.arith .trunci)
-      #[storageType] #[v] #[] #[] { nsw := false, nuw := true }
+      #[storageType] #[v] #[] #[] { attr := { nsw := false, nuw := true } }
       (some ip) sorry (by simp) (by simp) sorry
     castToModArith rewriter (narrowed.getResult 0 : ValuePtr) ty ip
   else
@@ -134,21 +134,22 @@ def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builde
 
 def buildAdd : Builder :=
   fun rewriter a b _ ip =>
-  emitArithBinOp rewriter .addi { nsw := false, nuw := false } a b ip
+  emitArithBinOp rewriter .addi { attr := { nsw := false, nuw := false } } a b ip
 
 def lowerModArithAddOp := lowerModArithBinOp .add (· + 1) buildAdd
 
 def buildMul : Builder :=
   fun rewriter a b _ ip =>
-  emitArithBinOp rewriter .muli { nsw := false, nuw := false } a b ip
+  emitArithBinOp rewriter .muli { attr := { nsw := false, nuw := false } } a b ip
 
 def lowerModArithMulOp := lowerModArithBinOp .mul (2 * ·) buildMul
 
 def buildSub : Builder :=
   fun (rewriter : PatternRewriter OpCode) (a b q : ValuePtr) (ip : InsertPoint) => do
     -- we compute a - b (mod q) as ((a+q) - b) % q to avoid unsigned underflow when a < b.
-    let (rewriter, aq) ← emitArithBinOp rewriter .addi { nsw := false, nuw := false } a q ip
-    emitArithBinOp rewriter .subi { nsw := false, nuw := false } aq b ip
+    let (rewriter, aq) ← emitArithBinOp rewriter .addi
+      { attr := { nsw := false, nuw := false } } a q ip
+    emitArithBinOp rewriter .subi { attr := { nsw := false, nuw := false } } aq b ip
 
 def lowerModArithSubOp := lowerModArithBinOp .sub (· + 1) buildSub
 

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -52,10 +52,26 @@ def ArithConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
     | throw s!"arith.constant: expected 'value' to be an integer attribute, but got {attr}"
   return { value := intAttr }
 
-/--
-  Properties of operations that can have `nsw` and `nuw` flags, such as `arith.addi`, `arith.muli`,
-  `llvm.add`, or `llvm.mul`.
--/
+/-- Properties of arith operations that can have `nsw` and `nuw` flags, such as `arith.addi` or `arith.muli`. -/
+structure ArithIntegerOverflowFlagsProperties where
+  attr : ArithIntegerOverflowFlagsAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def ArithIntegerOverflowFlagsProperties.fromAttrDict
+    (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String ArithIntegerOverflowFlagsProperties := do
+
+  let value ← match attrDict["overflowFlags".toUTF8]? with
+    | none => .ok { nsw := false, nuw := false }
+    | some (.arithIntegerOverflowFlagsAttr flags) => .ok flags
+    | some (.unregisteredAttr attr) =>
+        .error s!"expected 'overflowFlags' to be an arith integer overflow flags attribute, but got unregistered {attr}"
+    | some attr =>
+        .error s!"expected 'overflowFlags' to be an arith integer overflow flags attribute, but got {attr}"
+
+  return ⟨value⟩
+
+/-- Properties of LLVM operations that can have `nsw` and `nuw` flags, such as `llvm.add` or `llvm.mul`. -/
 structure NswNuwProperties where
   nsw : Bool
   nuw : Bool


### PR DESCRIPTION
Fixes #826  - veir's handling of nsw/nuw integer overflow flags did not match upstream MLIR, so IR with these flags would no longer-roundtrip.

This PR updates it from
```llvm
%addi_nsw = "arith.addi"(%5, %5) <{"overflowFlags" = 1 : i32}> : (i32, i32) -> i32
```
to
```llvm
%addi_nsw = "arith.addi"(%5, %5) <{overflowFlags = #arith.overflow<nsw>}> : (i32, i32) -> i32
```
by replacing the i32 `IntegerAttr` with `ArithIntegerOverflowFlagsAttr` mirroring MLIR.

To make reviewing easier, this is split into two commits: [the first one](https://github.com/opencompl/veir/pull/850/changes/9664e8b82b5e234fc94b0be9fe1c19e7fbad75e8) does all lean-side changes, [the second one](https://github.com/opencompl/veir/pull/850/changes/9853dc98a7e14c79052631714521c4228b84599c) applies the new syntax to the many *.mlir test files that use the overflow flags.
 