### PR TITLE
feat(dataflow): sparse forward dataflow analysis api

### DIFF
--- a/Veir.lean
+++ b/Veir.lean
@@ -27,6 +27,7 @@ import Veir.Passes.Legalization.Proofs
 
 -- FIXME: These modules are otherwise orphans and would not be compiled.
 import Veir.Analysis.DataFlow.SparseFact
+import Veir.Analysis.DataFlow.SparseForwardDataFlowAnalysis
 import Veir.Data.FP.EScientificBV
 import Veir.Data.FP.EScientificBV.Basic
 import Veir.Data.FP.EScientificBV.ToExtRat

--- a/Veir/Analysis/DataFlow/SparseAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseAnalysis.lean
@@ -80,9 +80,7 @@ private def getSuccessorOperand?
     | _ =>
       panic! "SparseForwardDataFlowAnalysis.getSuccessorOperand?: non-branch op"
 
-/--
-Conservatively treat blocks as live when no liveness facts exist.
--/
+/-- Conservatively treat blocks as live when no liveness facts exist. -/
 private def isBlockLive
     (block : BlockPtr)
     (dfCtx : DataFlowContext)
@@ -105,7 +103,7 @@ private def isEdgeLive
   let _ := dfCtx
   true
 
-/-- Subscribe to block liveness updates if dead code analysis is registered. -/
+/-- No-op when no liveness analysis is registered. -/
 private def subscribeToBlockLiveness
     (analysisKind : AnalysisKind)
     (block : BlockPtr)
@@ -116,7 +114,7 @@ private def subscribeToBlockLiveness
   let _ := irCtx
   dfCtx
 
-/-- Subscribe to edge liveness updates if dead code analysis is registered. -/
+/-- No-op when no liveness analysis is registered. -/
 private def subscribeToEdgeLiveness
     (analysisKind : AnalysisKind)
     (edge : CFGEdge)

--- a/Veir/Analysis/DataFlow/SparseAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseAnalysis.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Analysis.DataFlow.SparseFact
+public import Veir.Interfaces.ControlFlowInterfaces
 
 public section
 
@@ -44,41 +45,6 @@ def joinAndPropagate
     return dfCtx
   dfCtx.modifyFactAndPropagate kind (.ValuePtr target) 
     (SparseFact.setLatticeElement · newValue, true) irCtx
-
-/--
-Return whether the given operation is a branch op.
--/
-private def isBranchOp
-    (op : OperationPtr)
-    (irCtx : WfIRContext OpCode) : Bool :=
-  -- TODO: Replace this `.test .test` check once VeIR has proper branch ops.
-  match (op.get! irCtx.raw).opType with
-  | .test .test =>
-    true
-  | _ =>
-    false
-
-/--
-Return the SSA value forwarded to the given successor's block argument, if any.
--/
-private def getSuccessorOperand?
-    (op : OperationPtr)
-    (successorIndex : Nat)
-    (argumentIndex : Nat)
-    (irCtx : WfIRContext OpCode) : Option ValuePtr :=
-  if successorIndex >= op.getNumSuccessors! irCtx.raw then
-    panic! s!"SparseForwardDataFlowAnalysis.getSuccessorOperand?: successor index {successorIndex} out of range"
-  else
-    match (op.get! irCtx.raw).opType with
-    -- TODO: Replace this `.test .test` check once VeIR has proper branch ops.
-    -- `successorIndex` will become relevant then.
-    | .test .test =>
-      if argumentIndex < op.getNumOperands! irCtx.raw then
-        some (op.getOperand! irCtx.raw argumentIndex)
-      else
-        none
-    | _ =>
-      panic! "SparseForwardDataFlowAnalysis.getSuccessorOperand?: non-branch op"
 
 /-- Conservatively treat blocks as live when no liveness facts exist. -/
 private def isBlockLive
@@ -174,14 +140,20 @@ private def visitBlock
       continue
 
     -- Check if we can reason about the dataflow from the predecessor.
-    if !isBranchOp predecessorOp irCtx then
+    if !(predecessorOp.getOpType! irCtx.raw).isTerminator then
       for target in block.getArguments! irCtx.raw do
         dfCtx := joinAndPropagate kind target ⊤ dfCtx irCtx
       return dfCtx
 
+    let some successorOperands :=
+        BranchOpInterface.getSuccessorOperands? predecessorOp predUse.index irCtx.raw
+      | for target in block.getArguments! irCtx.raw do
+          dfCtx := joinAndPropagate kind target ⊤ dfCtx irCtx
+        return dfCtx
+
     for i in [0:block.getNumArguments! irCtx.raw] do
       let arg := block.getArgument i
-      match getSuccessorOperand? predecessorOp predUse.index i irCtx with
+      match successorOperands[i]? with
       | some operand =>
         -- Add the current block start program point as a dependency of the
         -- predecessor block's successor operand lattice state, so this block

--- a/Veir/Analysis/DataFlow/SparseAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseAnalysis.lean
@@ -1,0 +1,371 @@
+module
+
+public import Veir.Analysis.DataFlow.SparseFact
+
+public section
+
+namespace Veir
+
+namespace SparseForwardDataFlowAnalysis
+
+variable {kind : FactKind} {Domain : Type}
+
+-- TODO: When this is verified, we will need something stronger than this for `Domain`
+variable [Top Domain] [Bot Domain] [Join Domain] [DecidableEq Domain]
+
+/--
+The transfer function signature used for custom sparse analyses.
+
+The framework handles operand subscriptions, invokes this hook with the current
+operand lattice elements, and then joins any returned updates into the result
+facts. Returning `none` for a result means the transfer contributes no new fact
+for that result.
+-/
+abbrev VisitOperationFn (Domain : Type) :=
+  OperationPtr -> Array Domain -> WfIRContext OpCode -> Array (Option Domain)
+
+/--
+Join a sparse lattice fact into the target value state and propagate updates
+when it changes.
+
+This is the generic sparse analysis primitive that merges an incoming lattice
+element into the stored state for an SSA value.
+-/
+def joinAndPropagate
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (target : ValuePtr)
+    (incoming : Domain)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext := Id.run do
+  let oldValue := SparseFact.getElement kind target dfCtx
+  let newValue := oldValue ⊔ incoming
+  if newValue = oldValue then
+    return dfCtx
+  dfCtx.modifyFactAndPropagate kind (.ValuePtr target) 
+    (SparseFact.setLatticeElement · newValue, true) irCtx
+
+/--
+Return whether the given operation is a branch op.
+-/
+private def isBranchOp
+    (op : OperationPtr)
+    (irCtx : WfIRContext OpCode) : Bool :=
+  -- TODO: Replace this `.test .test` check once VeIR has proper branch ops.
+  match (op.get! irCtx.raw).opType with
+  | .test .test =>
+    true
+  | _ =>
+    false
+
+/--
+Return the SSA value forwarded to the given successor's block argument, if any.
+-/
+private def getSuccessorOperand?
+    (op : OperationPtr)
+    (successorIndex : Nat)
+    (argumentIndex : Nat)
+    (irCtx : WfIRContext OpCode) : Option ValuePtr :=
+  if successorIndex >= op.getNumSuccessors! irCtx.raw then
+    panic! s!"SparseForwardDataFlowAnalysis.getSuccessorOperand?: successor index {successorIndex} out of range"
+  else
+    match (op.get! irCtx.raw).opType with
+    -- TODO: Replace this `.test .test` check once VeIR has proper branch ops.
+    -- `successorIndex` will become relevant then.
+    | .test .test =>
+      if argumentIndex < op.getNumOperands! irCtx.raw then
+        some (op.getOperand! irCtx.raw argumentIndex)
+      else
+        none
+    | _ =>
+      panic! "SparseForwardDataFlowAnalysis.getSuccessorOperand?: non-branch op"
+
+/--
+Conservatively treat blocks as live when no liveness facts exist.
+-/
+private def isBlockLive
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : Bool :=
+  let _ := block
+  let _ := dfCtx
+  let _ := irCtx
+  true
+
+/--
+Conservatively treat CFG edges as live when dead code analysis is
+not registered. Otherwise consult the liveness lattice, where points are
+not live by default.
+-/
+private def isEdgeLive
+    (edge : CFGEdge)
+    (dfCtx : DataFlowContext)
+    (_irCtx : WfIRContext OpCode) : Bool :=
+  let _ := edge
+  let _ := dfCtx
+  true
+
+/-- Subscribe to block liveness updates if dead code analysis is registered. -/
+private def subscribeToBlockLiveness
+    (analysisKind : AnalysisKind)
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext :=
+  let _ := analysisKind
+  let _ := block
+  let _ := irCtx
+  dfCtx
+
+/-- Subscribe to edge liveness updates if dead code analysis is registered. -/
+private def subscribeToEdgeLiveness
+    (analysisKind : AnalysisKind)
+    (edge : CFGEdge)
+    (dfCtx : DataFlowContext) : DataFlowContext :=
+  let _ := analysisKind
+  let _ := edge
+  dfCtx
+
+/--
+Visit a block during sparse initialization.
+-/
+private def visitBlock
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext := Id.run do
+  -- Exit early on blocks with no arguments.
+  if block.getNumArguments! irCtx.raw = 0 then
+    return dfCtx 
+
+  -- If the block is not live, bail out.
+  if !isBlockLive block dfCtx irCtx then
+    return dfCtx
+
+  let some parentRegion := (block.get! irCtx.raw).parent
+    | return dfCtx
+
+  -- The argument lattices of entry blocks are set by region control flow or
+  -- the callgraph.
+  if (parentRegion.get! irCtx.raw).firstBlock = some block then
+    -- TODO: Mirror MLIR's handling of `visitCallableOperation` and
+    -- `visitRegionSuccessors` and `visitNonControlFlowArgumentsImpl`
+    -- for entry blocks.
+    return dfCtx
+
+  let mut dfCtx := dfCtx
+
+  -- Iterate over the predecessors of the non-entry block.
+  let mut maybePredUse := (block.get! irCtx.raw).firstUse
+
+  while let some predUse := maybePredUse do
+    let predUseStruct := predUse.get! irCtx.raw
+    maybePredUse := predUseStruct.nextUse
+
+    let predecessorOp := predUseStruct.owner
+    let some predecessorBlock := (predecessorOp.get! irCtx.raw).parent
+      | continue
+
+    let edge : CFGEdge := { source := predecessorBlock, target := block }
+    dfCtx := subscribeToEdgeLiveness analysisKind edge dfCtx
+
+    -- If the edge from the predecessor block to the current block is not live,
+    -- bail out.
+    if !isEdgeLive edge dfCtx irCtx then
+      continue
+
+    -- Check if we can reason about the dataflow from the predecessor.
+    if !isBranchOp predecessorOp irCtx then
+      for target in block.getArguments! irCtx.raw do
+        dfCtx := joinAndPropagate kind target ⊤ dfCtx irCtx
+      return dfCtx
+
+    for i in [0:block.getNumArguments! irCtx.raw] do
+      let arg := block.getArgument i
+      match getSuccessorOperand? predecessorOp predUse.index i irCtx with
+      | some operand =>
+        -- Add the current block start program point as a dependency of the
+        -- predecessor block's successor operand lattice state, so this block
+        -- is revisited when that operand lattice changes.
+        let dependentPoint := InsertPoint.atStart! block irCtx.raw
+        let workItem : WorkItem := (dependentPoint, analysisKind)
+        dfCtx := dfCtx.modifyFact kind (.ValuePtr operand) (fun state =>
+          if state.dependents.any (fun dependent =>
+              dependent.1 = dependentPoint && dependent.2 = analysisKind) then
+            -- Do not add dependent again if it's already added.
+            state
+          else
+            state.addDependent workItem)
+
+        -- Call transfer function
+        let incoming :=
+          SparseFact.getElement kind operand dfCtx
+        dfCtx := joinAndPropagate kind arg incoming dfCtx irCtx
+      | none =>
+        -- Conservatively consider internally produced arguments to be at the
+        -- pessimistic sparse state.
+        dfCtx := joinAndPropagate kind arg ⊤ dfCtx irCtx
+
+  return dfCtx
+
+mutual
+
+/--
+Ensure an operand has a sparse lattice state and subscribe the current sparse
+analysis to its updates. This is what makes use-def driven revisitation work.
+-/
+partial def subscribeToOperand
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (operand : ValuePtr)
+    (dfCtx : DataFlowContext) : DataFlowContext :=
+  dfCtx.modifyFact kind (.ValuePtr operand) (fun state =>
+    state.subscribe analysisKind)
+
+/--
+Visit one operation in the sparse analysis.
+We first subscribe to operand lattices, then hand the operation and current
+operand lattice elements to the user provided transfer function. The framework
+applies any returned result updates itself.
+-/
+partial def visitOperation
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn Domain)
+    (op : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext := Id.run do
+  -- Exit early on operations with no results.
+  if op.getNumResults! irCtx.raw = 0 then
+    return dfCtx
+
+  -- If the containing block is not live, bail out. Liveness is by default
+  -- unreachable until proven live, so a missing state is treated as dead.
+  if let some parentBlock := (op.get! irCtx.raw).parent then
+    if !isBlockLive parentBlock dfCtx irCtx then
+      return dfCtx
+
+  -- TODO: Mirror MLIR more closely by `visitRegionSuccessors`
+  -- Comment: The results of a region branch operation are determined by control-flow.
+
+  -- TODO: Mirror MLIR more closely by `visitCallOperation`
+
+  let mut dfCtx := dfCtx
+  for operand in op.getOperands! irCtx.raw do
+    dfCtx := subscribeToOperand kind analysisKind operand dfCtx
+
+  let operandLatticeElements := (op.getOperands! irCtx.raw).map (fun operand =>
+    SparseFact.getElement kind operand dfCtx)
+  let resultUpdates := visitOperationImpl op operandLatticeElements irCtx
+
+  for (result, incoming?) in (op.getResults! irCtx.raw).zip resultUpdates do
+    if let some incoming := incoming? then
+      dfCtx := joinAndPropagate kind result incoming dfCtx irCtx
+  return dfCtx
+
+/--
+Recursively initialize an operation tree for sparse analysis.
+Visit the current operation first, then walk its nested regions, 
+blocks, and nested operations.
+-/
+partial def initializeRecursively
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn Domain)
+    (op : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext := Id.run do
+  -- Initialize the analysis by visiting every owner of an SSA value (all
+  -- operations and blocks).
+  let mut dfCtx := dfCtx
+  dfCtx := visitOperation kind analysisKind visitOperationImpl op dfCtx irCtx
+
+  for regionPtr in (op.get! irCtx.raw).regions do
+    let region := regionPtr.get! irCtx.raw
+    let mut maybeBlock := region.firstBlock
+
+    while let some block := maybeBlock do
+      dfCtx := subscribeToBlockLiveness analysisKind block dfCtx irCtx
+      dfCtx := visitBlock kind analysisKind block dfCtx irCtx
+      let mut maybeOp := (block.get! irCtx.raw).firstOp
+
+      while let some nestedOp := maybeOp do
+        dfCtx := initializeRecursively kind analysisKind visitOperationImpl nestedOp dfCtx irCtx
+        maybeOp := (nestedOp.get! irCtx.raw).next
+
+      maybeBlock := (block.get! irCtx.raw).next
+  dfCtx
+
+end
+
+/--
+Initialize the analysis by visiting every owner of an SSA value: all
+operations and blocks.
+-/
+private def init
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn Domain)
+    (top : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext := Id.run do
+  -- Mark the entry block arguments as having reached their pessimistic
+  -- fixpoints.
+  let mut dfCtx := dfCtx
+  for regionPtr in (top.get! irCtx.raw).regions do
+    let region := regionPtr.get! irCtx.raw
+    if let some firstBlock := region.firstBlock then
+      for arg in firstBlock.getArguments! irCtx.raw do
+        dfCtx := joinAndPropagate kind arg ⊤ dfCtx irCtx
+
+  initializeRecursively kind analysisKind visitOperationImpl top dfCtx irCtx
+
+/--
+Visit an insertion point. If this is at beginning of block and all
+control flow predecessors or callsites are known, then the arguments'
+lattices are propagated from them. If this is after call operation or an
+operation with region control-flow, then its result lattices are set
+accordingly. Otherwise, the operation transfer function is invoked.
+-/
+private def visit
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn Domain)
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : WfIRContext OpCode) : DataFlowContext :=
+  match point.prev! irCtx.raw with
+  | some prevOp =>
+    visitOperation kind analysisKind visitOperationImpl prevOp dfCtx irCtx
+  | none =>
+    match point.block! irCtx.raw with
+    | some block =>
+      visitBlock kind analysisKind block dfCtx irCtx
+    | none =>
+      dfCtx
+
+/--
+Build a sparse forward analysis over one abstract value domain.
+
+Sparse facts default to `⊥`. Whenever control flow or transfer functions lose
+precision, the framework conservatively joins `⊤` into the affected values.
+-/
+def new
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn Domain)
+    : DataFlowAnalysis :=
+  { kind := analysisKind
+    init := init kind analysisKind visitOperationImpl
+    visit := visit kind analysisKind visitOperationImpl }
+
+end SparseForwardDataFlowAnalysis
+
+end Veir

--- a/Veir/Analysis/DataFlow/SparseAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseAnalysis.lean
@@ -16,11 +16,13 @@ variable [Top Domain] [Bot Domain] [Join Domain] [DecidableEq Domain]
 /--
 The transfer function signature used for custom sparse analyses.
 
-The framework handles operand subscriptions before invoking this hook, and
-analysis code can recover operands/results directly from the operation pointer.
+The framework handles operand subscriptions, invokes this hook with the current
+operand lattice elements, and then joins any returned updates into the result
+facts. Returning `none` for a result means the transfer contributes no new fact
+for that result.
 -/
-abbrev VisitOperationFn :=
-  OperationPtr -> DataFlowContext -> IRContext OpCode -> DataFlowContext
+abbrev VisitOperationFn (Domain : Type) :=
+  OperationPtr -> Array Domain -> IRContext OpCode -> Array (Option Domain)
 
 /--
 Join a sparse lattice fact into the target value state and propagate updates
@@ -78,8 +80,8 @@ private def getSuccessorOperand?
     | _ =>
       panic! "SparseForwardDataFlowAnalysis.getSuccessorOperand?: non-branch op"
 
-/-- Conservatively treat blocks as executable when no liveness facts exist. -/
-private def isBlockExecutable
+/-- Conservatively treat blocks as live when no liveness facts exist. -/
+private def isBlockLive
     (block : BlockPtr)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : Bool :=
@@ -88,8 +90,8 @@ private def isBlockExecutable
   let _ := irCtx
   true
 
-/-- Conservatively treat CFG edges as executable when no liveness facts exist. -/
-private def isEdgeExecutable
+/-- Conservatively treat CFG edges as live when no liveness facts exist. -/
+private def isEdgeLive
     (edge : CFGEdge)
     (dfCtx : DataFlowContext)
     (_irCtx : IRContext OpCode) : Bool :=
@@ -97,7 +99,7 @@ private def isEdgeExecutable
   let _ := dfCtx
   true
 
-/-- No-op when no external executability provider is registered. -/
+/-- No-op when no liveness analysis is registered. -/
 private def subscribeToBlockLiveness
     (analysisKind : AnalysisKind)
     (block : BlockPtr)
@@ -108,7 +110,7 @@ private def subscribeToBlockLiveness
   let _ := irCtx
   dfCtx
 
-/-- No-op when no external executability provider is registered. -/
+/-- No-op when no liveness analysis is registered. -/
 private def subscribeToEdgeLiveness
     (analysisKind : AnalysisKind)
     (edge : CFGEdge)
@@ -131,8 +133,8 @@ private def visitBlock
   if block.getNumArguments! irCtx = 0 then
     return dfCtx 
 
-  -- If the block is not executable, bail out.
-  if !isBlockExecutable block dfCtx irCtx then
+  -- If the block is not live, bail out.
+  if !isBlockLive block dfCtx irCtx then
     return dfCtx
 
   let some parentRegion := (block.get! irCtx).parent
@@ -164,7 +166,7 @@ private def visitBlock
 
     -- If the edge from the predecessor block to the current block is not live,
     -- bail out.
-    if !isEdgeExecutable edge dfCtx irCtx then
+    if !isEdgeLive edge dfCtx irCtx then
       continue
 
     -- Check if we can reason about the dataflow from the predecessor.
@@ -218,14 +220,15 @@ partial def subscribeToOperand
 
 /--
 Visit one operation in the sparse analysis.
-We first subscribe to operand lattices, then hand the operation to the user
-provided transfer function.
+We first subscribe to operand lattices, then hand the operation and current
+operand lattice elements to the user provided transfer function. The framework
+applies any returned result updates itself.
 -/
 partial def visitOperation
     (kind : FactKind)
     [SparseFactSpec kind Domain]
     (analysisKind : AnalysisKind)
-    (visitOperationImpl : VisitOperationFn)
+    (visitOperationImpl : VisitOperationFn Domain)
     (op : OperationPtr)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
@@ -233,10 +236,10 @@ partial def visitOperation
   if op.getNumResults! irCtx = 0 then
     return dfCtx
 
-  -- If the containing block is not executable, bail out. Executability is
+  -- If the containing block is not live, bail out. Liveness is by default
   -- unreachable until proven live, so a missing state is treated as dead.
   if let some parentBlock := (op.get! irCtx).parent then
-    if !isBlockExecutable parentBlock dfCtx irCtx then
+    if !isBlockLive parentBlock dfCtx irCtx then
       return dfCtx
 
   -- TODO: Mirror MLIR more closely by `visitRegionSuccessors`
@@ -248,8 +251,14 @@ partial def visitOperation
   for operand in op.getOperands! irCtx do
     dfCtx := subscribeToOperand kind analysisKind operand dfCtx
 
-  -- Invoke the operation transfer function.
-  visitOperationImpl op dfCtx irCtx
+  let operandLatticeElements := (op.getOperands! irCtx).map (fun operand =>
+    SparseFact.getElement kind operand dfCtx)
+  let resultUpdates := visitOperationImpl op operandLatticeElements irCtx
+
+  for (result, incoming?) in (op.getResults! irCtx).zip resultUpdates do
+    if let some incoming := incoming? then
+      dfCtx := joinAndPropagate kind result incoming dfCtx irCtx
+  return dfCtx
 
 /--
 Recursively initialize an operation tree for sparse analysis.
@@ -260,7 +269,7 @@ partial def initializeRecursively
     (kind : FactKind)
     [SparseFactSpec kind Domain]
     (analysisKind : AnalysisKind)
-    (visitOperationImpl : VisitOperationFn)
+    (visitOperationImpl : VisitOperationFn Domain)
     (op : OperationPtr)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
@@ -295,7 +304,7 @@ private def init
     (kind : FactKind)
     [SparseFactSpec kind Domain]
     (analysisKind : AnalysisKind)
-    (visitOperationImpl : VisitOperationFn)
+    (visitOperationImpl : VisitOperationFn Domain)
     (top : OperationPtr)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
@@ -321,7 +330,7 @@ private def visit
     (kind : FactKind)
     [SparseFactSpec kind Domain]
     (analysisKind : AnalysisKind)
-    (visitOperationImpl : VisitOperationFn)
+    (visitOperationImpl : VisitOperationFn Domain)
     (point : InsertPoint)
     (dfCtx : DataFlowContext)
     (irCtx : IRContext OpCode) : DataFlowContext :=
@@ -345,7 +354,7 @@ def new
     (kind : FactKind)
     [SparseFactSpec kind Domain]
     (analysisKind : AnalysisKind)
-    (visitOperationImpl : VisitOperationFn)
+    (visitOperationImpl : VisitOperationFn Domain)
     : DataFlowAnalysis :=
   { kind := analysisKind
     init := init kind analysisKind visitOperationImpl

--- a/Veir/Analysis/DataFlow/SparseAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseAnalysis.lean
@@ -1,0 +1,356 @@
+module
+
+public import Veir.Analysis.DataFlow.SparseFact
+
+public section
+
+namespace Veir
+
+namespace SparseForwardDataFlowAnalysis
+
+variable {kind : FactKind} {Domain : Type}
+
+-- TODO: When this is verified, we will need something stronger than this for `Domain`
+variable [Top Domain] [Bot Domain] [Join Domain] [DecidableEq Domain]
+
+/--
+The transfer function signature used for custom sparse analyses.
+
+The framework handles operand subscriptions before invoking this hook, and
+analysis code can recover operands/results directly from the operation pointer.
+-/
+abbrev VisitOperationFn :=
+  OperationPtr -> DataFlowContext -> IRContext OpCode -> DataFlowContext
+
+/--
+Join a sparse lattice fact into the target value state and propagate updates
+when it changes.
+
+This is the generic sparse analysis primitive that merges an incoming lattice
+element into the stored state for an SSA value.
+-/
+def joinAndPropagate
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (target : ValuePtr)
+    (incoming : Domain)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
+  let oldValue := SparseFact.getElement kind target dfCtx
+  let newValue := oldValue ⊔ incoming
+  if newValue = oldValue then
+    return dfCtx
+  dfCtx.modifyFactAndPropagate kind (.ValuePtr target) 
+    (SparseFact.setLatticeElement · newValue, true) irCtx
+
+/--
+Return whether the given operation is a branch op.
+-/
+private def isBranchOp
+    (op : OperationPtr)
+    (irCtx : IRContext OpCode) : Bool :=
+  -- TODO: Replace this `.test .test` check once VeIR has proper branch ops.
+  match (op.get! irCtx).opType with
+  | .test .test =>
+    true
+  | _ =>
+    false
+
+/--
+Return the SSA value forwarded to the given successor's block argument, if any.
+-/
+private def getSuccessorOperand?
+    (op : OperationPtr)
+    (successorIndex : Nat)
+    (argumentIndex : Nat)
+    (irCtx : IRContext OpCode) : Option ValuePtr :=
+  if successorIndex >= op.getNumSuccessors! irCtx then
+    panic! s!"SparseForwardDataFlowAnalysis.getSuccessorOperand?: successor index {successorIndex} out of range"
+  else
+    match (op.get! irCtx).opType with
+    -- TODO: Replace this `.test .test` check once VeIR has proper branch ops.
+    -- `successorIndex` will become relevant then.
+    | .test .test =>
+      if argumentIndex < op.getNumOperands! irCtx then
+        some (op.getOperand! irCtx argumentIndex)
+      else
+        none
+    | _ =>
+      panic! "SparseForwardDataFlowAnalysis.getSuccessorOperand?: non-branch op"
+
+/-- Conservatively treat blocks as executable when no liveness facts exist. -/
+private def isBlockExecutable
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : Bool :=
+  let _ := block
+  let _ := dfCtx
+  let _ := irCtx
+  true
+
+/-- Conservatively treat CFG edges as executable when no liveness facts exist. -/
+private def isEdgeExecutable
+    (edge : CFGEdge)
+    (dfCtx : DataFlowContext)
+    (_irCtx : IRContext OpCode) : Bool :=
+  let _ := edge
+  let _ := dfCtx
+  true
+
+/-- No-op when no external executability provider is registered. -/
+private def subscribeToBlockLiveness
+    (analysisKind : AnalysisKind)
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext :=
+  let _ := analysisKind
+  let _ := block
+  let _ := irCtx
+  dfCtx
+
+/-- No-op when no external executability provider is registered. -/
+private def subscribeToEdgeLiveness
+    (analysisKind : AnalysisKind)
+    (edge : CFGEdge)
+    (dfCtx : DataFlowContext) : DataFlowContext :=
+  let _ := analysisKind
+  let _ := edge
+  dfCtx
+
+/--
+Visit a block during sparse initialization.
+-/
+private def visitBlock
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (block : BlockPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
+  -- Exit early on blocks with no arguments.
+  if block.getNumArguments! irCtx = 0 then
+    return dfCtx 
+
+  -- If the block is not executable, bail out.
+  if !isBlockExecutable block dfCtx irCtx then
+    return dfCtx
+
+  let some parentRegion := (block.get! irCtx).parent
+    | return dfCtx
+
+  -- The argument lattices of entry blocks are set by region control flow or
+  -- the callgraph.
+  if (parentRegion.get! irCtx).firstBlock = some block then
+    -- TODO: Mirror MLIR's handling of `visitCallableOperation` and
+    -- `visitRegionSuccessors` and `visitNonControlFlowArgumentsImpl`
+    -- for entry blocks.
+    return dfCtx
+
+  let mut dfCtx := dfCtx
+
+  -- Iterate over the predecessors of the non-entry block.
+  let mut maybePredUse := (block.get! irCtx).firstUse
+
+  while let some predUse := maybePredUse do
+    let predUseStruct := predUse.get! irCtx
+    maybePredUse := predUseStruct.nextUse
+
+    let predecessorOp := predUseStruct.owner
+    let some predecessorBlock := (predecessorOp.get! irCtx).parent
+      | continue
+
+    let edge : CFGEdge := { source := predecessorBlock, target := block }
+    dfCtx := subscribeToEdgeLiveness analysisKind edge dfCtx
+
+    -- If the edge from the predecessor block to the current block is not live,
+    -- bail out.
+    if !isEdgeExecutable edge dfCtx irCtx then
+      continue
+
+    -- Check if we can reason about the dataflow from the predecessor.
+    if !isBranchOp predecessorOp irCtx then
+      for target in block.getArguments! irCtx do
+        dfCtx := joinAndPropagate kind target ⊤ dfCtx irCtx
+      return dfCtx
+
+    for i in [0:block.getNumArguments! irCtx] do
+      let arg := block.getArgument i
+      match getSuccessorOperand? predecessorOp predUse.index i irCtx with
+      | some operand =>
+        -- Add the current block start program point as a dependency of the
+        -- predecessor block's successor operand lattice state, so this block
+        -- is revisited when that operand lattice changes.
+        let dependentPoint := InsertPoint.atStart! block irCtx
+        let workItem : WorkItem := (dependentPoint, analysisKind)
+        dfCtx := dfCtx.modifyFact kind (.ValuePtr operand) (fun state =>
+          if state.dependents.any (fun dependent =>
+              dependent.1 = dependentPoint && dependent.2 = analysisKind) then
+            -- Do not add dependent again if it's already added.
+            state
+          else
+            state.addDependent workItem)
+
+        -- Call transfer function
+        let incoming :=
+          SparseFact.getElement kind operand dfCtx
+        dfCtx := joinAndPropagate kind arg incoming dfCtx irCtx
+      | none =>
+        -- Conservatively consider internally produced arguments to be at the
+        -- pessimistic sparse state.
+        dfCtx := joinAndPropagate kind arg ⊤ dfCtx irCtx
+
+  return dfCtx
+
+mutual
+
+/--
+Ensure an operand has a sparse lattice state and subscribe the current sparse
+analysis to its updates. This is what makes use-def driven revisitation work.
+-/
+partial def subscribeToOperand
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (operand : ValuePtr)
+    (dfCtx : DataFlowContext) : DataFlowContext :=
+  dfCtx.modifyFact kind (.ValuePtr operand) (fun state =>
+    state.subscribe analysisKind)
+
+/--
+Visit one operation in the sparse analysis.
+We first subscribe to operand lattices, then hand the operation to the user
+provided transfer function.
+-/
+partial def visitOperation
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn)
+    (op : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
+  -- Exit early on operations with no results.
+  if op.getNumResults! irCtx = 0 then
+    return dfCtx
+
+  -- If the containing block is not executable, bail out. Executability is
+  -- unreachable until proven live, so a missing state is treated as dead.
+  if let some parentBlock := (op.get! irCtx).parent then
+    if !isBlockExecutable parentBlock dfCtx irCtx then
+      return dfCtx
+
+  -- TODO: Mirror MLIR more closely by `visitRegionSuccessors`
+  -- Comment: The results of a region branch operation are determined by control-flow.
+
+  -- TODO: Mirror MLIR more closely by `visitCallOperation`
+
+  let mut dfCtx := dfCtx
+  for operand in op.getOperands! irCtx do
+    dfCtx := subscribeToOperand kind analysisKind operand dfCtx
+
+  -- Invoke the operation transfer function.
+  visitOperationImpl op dfCtx irCtx
+
+/--
+Recursively initialize an operation tree for sparse analysis.
+Visit the current operation first, then walk its nested regions, 
+blocks, and nested operations.
+-/
+partial def initializeRecursively
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn)
+    (op : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
+  -- Initialize the analysis by visiting every owner of an SSA value (all
+  -- operations and blocks).
+  let mut dfCtx := dfCtx
+  dfCtx := visitOperation kind analysisKind visitOperationImpl op dfCtx irCtx
+
+  for regionPtr in (op.get! irCtx).regions do
+    let region := regionPtr.get! irCtx
+    let mut maybeBlock := region.firstBlock
+
+    while let some block := maybeBlock do
+      dfCtx := subscribeToBlockLiveness analysisKind block dfCtx irCtx
+      dfCtx := visitBlock kind analysisKind block dfCtx irCtx
+      let mut maybeOp := (block.get! irCtx).firstOp
+
+      while let some nestedOp := maybeOp do
+        dfCtx := initializeRecursively kind analysisKind visitOperationImpl nestedOp dfCtx irCtx
+        maybeOp := (nestedOp.get! irCtx).next
+
+      maybeBlock := (block.get! irCtx).next
+  dfCtx
+
+end
+
+/--
+Initialize the analysis by visiting every owner of an SSA value: all
+operations and blocks.
+-/
+private def init
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn)
+    (top : OperationPtr)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
+  -- Mark the entry block arguments as having reached their pessimistic
+  -- fixpoints.
+  let mut dfCtx := dfCtx
+  for regionPtr in (top.get! irCtx).regions do
+    let region := regionPtr.get! irCtx
+    if let some firstBlock := region.firstBlock then
+      for arg in firstBlock.getArguments! irCtx do
+        dfCtx := joinAndPropagate kind arg ⊤ dfCtx irCtx
+
+  initializeRecursively kind analysisKind visitOperationImpl top dfCtx irCtx
+
+/--
+Visit an insertion point. If this is at beginning of block and all
+control flow predecessors or callsites are known, then the arguments
+lattices are propagated from them. If this is after call operation or an
+operation with region control-flow, then its result lattices are set
+accordingly. Otherwise, the operation transfer function is invoked.
+-/
+private def visit
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn)
+    (point : InsertPoint)
+    (dfCtx : DataFlowContext)
+    (irCtx : IRContext OpCode) : DataFlowContext :=
+  match point.prev! irCtx with
+  | some prevOp =>
+    visitOperation kind analysisKind visitOperationImpl prevOp dfCtx irCtx
+  | none =>
+    match point.block! irCtx with
+    | some block =>
+      visitBlock kind analysisKind block dfCtx irCtx
+    | none =>
+      dfCtx
+
+/--
+Build a sparse forward analysis over one abstract value domain.
+
+Sparse facts default to `⊥`. Whenever control flow or transfer functions lose
+precision, the framework conservatively joins `⊤` into the affected values.
+-/
+def new
+    (kind : FactKind)
+    [SparseFactSpec kind Domain]
+    (analysisKind : AnalysisKind)
+    (visitOperationImpl : VisitOperationFn)
+    : DataFlowAnalysis :=
+  { kind := analysisKind
+    init := init kind analysisKind visitOperationImpl
+    visit := visit kind analysisKind visitOperationImpl }
+
+end SparseForwardDataFlowAnalysis
+
+end Veir

--- a/Veir/Analysis/DataFlow/SparseFact.lean
+++ b/Veir/Analysis/DataFlow/SparseFact.lean
@@ -68,15 +68,11 @@ instance : FactSpec kind where
 
 end
 
-def getElement? (kind : FactKind) [SparseFactSpec kind Domain] [FactSpec kind]
-    (ssaValue : ValuePtr) (dfCtx : DataFlowContext) : Option Domain := do
-  let state ← dfCtx.getFact? kind (.ValuePtr ssaValue)
-  return latticeElement state
-
-def getElementD (kind : FactKind) [SparseFactSpec kind Domain] [FactSpec kind]
-    (ssaValue : ValuePtr) (fallback : Domain)
-    (dfCtx : DataFlowContext) : Domain :=
-  (getElement? kind ssaValue dfCtx).getD fallback
+def getElement (kind : FactKind) [SparseFactSpec kind Domain] [FactSpec kind]
+    [Bot Domain] (ssaValue : ValuePtr) (dfCtx : DataFlowContext) : Domain :=
+  match dfCtx.getFact? kind (.ValuePtr ssaValue) with
+  | some state => latticeElement state
+  | none => ⊥
 
 end SparseFact
 

--- a/Veir/Analysis/DataFlow/SparseForwardDataFlowAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseForwardDataFlowAnalysis.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.Analysis.DataFlow.SparseFact
 public import Veir.Interfaces.ControlFlowInterfaces
+public import Veir.Analysis.DataFlow.DeadCodeAnalysis
 
 public section
 
@@ -46,15 +47,22 @@ def joinAndPropagate
   dfCtx.modifyFactAndPropagate kind (.ValuePtr target) 
     (SparseFact.setLatticeElement · newValue, true) irCtx
 
-/-- Conservatively treat blocks as live when no liveness facts exist. -/
+/--
+Conservatively treat blocks as live when dead code analysis is
+not registered. Otherwise consult the liveness lattice, where points
+are not live by default.
+-/
 private def isBlockLive
     (block : BlockPtr)
     (dfCtx : DataFlowContext)
     (irCtx : WfIRContext OpCode) : Bool :=
-  let _ := block
-  let _ := dfCtx
-  let _ := irCtx
-  true
+  if !dfCtx.hasAnalysis .deadCode then
+    true
+  else
+    let blockPoint := InsertPoint.atStart! block irCtx.raw
+    match dfCtx.getFact? .liveness (.InsertPoint blockPoint) with
+    | some liveFact => liveFact.live
+    | none => false
 
 /--
 Conservatively treat CFG edges as live when dead code analysis is
@@ -65,29 +73,36 @@ private def isEdgeLive
     (edge : CFGEdge)
     (dfCtx : DataFlowContext)
     (_irCtx : WfIRContext OpCode) : Bool :=
-  let _ := edge
-  let _ := dfCtx
-  true
+  if !dfCtx.hasAnalysis .deadCode then
+    true
+  else
+    match dfCtx.getFact? .liveness (.CFGEdge edge) with
+    | some liveFact => liveFact.live
+    | none => false
 
-/-- No-op when no liveness analysis is registered. -/
+/-- Subscribe to block liveness updates if dead code analysis is registered. -/
 private def subscribeToBlockLiveness
     (analysisKind : AnalysisKind)
     (block : BlockPtr)
     (dfCtx : DataFlowContext)
     (irCtx : WfIRContext OpCode) : DataFlowContext :=
-  let _ := analysisKind
-  let _ := block
-  let _ := irCtx
-  dfCtx
+  if !dfCtx.hasAnalysis .deadCode then
+    dfCtx
+  else
+    let blockPoint := InsertPoint.atStart! block irCtx.raw
+    dfCtx.modifyFact .liveness (.InsertPoint blockPoint) (fun state =>
+      state.subscribe analysisKind)
 
-/-- No-op when no liveness analysis is registered. -/
+/-- Subscribe to edge liveness updates if dead code analysis is registered. -/
 private def subscribeToEdgeLiveness
     (analysisKind : AnalysisKind)
     (edge : CFGEdge)
     (dfCtx : DataFlowContext) : DataFlowContext :=
-  let _ := analysisKind
-  let _ := edge
-  dfCtx
+  if !dfCtx.hasAnalysis .deadCode then
+    dfCtx
+  else
+    dfCtx.modifyFact .liveness (.CFGEdge edge) (fun state =>
+      state.subscribe analysisKind)
 
 /--
 Visit a block during sparse initialization.

--- a/Veir/Analysis/DataFlow/SparseForwardDataFlowAnalysis.lean
+++ b/Veir/Analysis/DataFlow/SparseForwardDataFlowAnalysis.lean
@@ -71,8 +71,7 @@ not live by default.
 -/
 private def isEdgeLive
     (edge : CFGEdge)
-    (dfCtx : DataFlowContext)
-    (_irCtx : WfIRContext OpCode) : Bool :=
+    (dfCtx : DataFlowContext) : Bool :=
   if !dfCtx.hasAnalysis .deadCode then
     true
   else
@@ -151,7 +150,7 @@ private def visitBlock
 
     -- If the edge from the predecessor block to the current block is not live,
     -- bail out.
-    if !isEdgeLive edge dfCtx irCtx then
+    if !isEdgeLive edge dfCtx then
       continue
 
     -- Check if we can reason about the dataflow from the predecessor.

--- a/Veir/Analysis/DataFlowFramework.lean
+++ b/Veir/Analysis/DataFlowFramework.lean
@@ -1,9 +1,10 @@
 module
 
+public import Std.Data.HashSet
 public import Veir.Analysis.DataFlow.Facts
 public import Veir.IR.WellFormed
 
-open Std (DHashMap HashMap)
+open Std (DHashMap HashMap HashSet)
 
 public section
 
@@ -19,10 +20,12 @@ to call transfer functions on.
 -/
 structure DataFlowContext where
   lattice : HashMap LatticeAnchor (DHashMap FactKind Fact)
+  registeredAnalyses : HashSet AnalysisKind
   workList : WorkList
 
 def DataFlowContext.empty : DataFlowContext :=
   { lattice := ∅
+    registeredAnalyses := ∅
     workList := .empty }
 
 /--
@@ -86,6 +89,10 @@ Enqueue one transfer problem onto the worklist.
 -/
 def enqueue (ctx : DataFlowContext) (workItem : WorkItem) : DataFlowContext :=
   { ctx with workList := ctx.workList.enqueue workItem }
+
+/-- Return whether the given analysis is registered in the current fixpoint loop. -/
+def hasAnalysis (ctx : DataFlowContext) (analysisKind : AnalysisKind) : Bool :=
+  ctx.registeredAnalyses.contains analysisKind
 
 /--
 Read the fact of kind `kind` stored at `anchor`, if any.
@@ -175,6 +182,7 @@ def fixpointSolve (top : OperationPtr) (analyses : Array DataFlowAnalysis)
   let mut registeredAnalyses : RegisteredAnalyses := ∅
   for analysis in analyses do
     registeredAnalyses := registeredAnalyses.insert analysis.kind analysis
+    ctx := { ctx with registeredAnalyses := ctx.registeredAnalyses.insert analysis.kind }
   for analysis in analyses do
     ctx := analysis.init top ctx irCtx
   run registeredAnalyses ctx irCtx


### PR DESCRIPTION
Any transfer function that works on `OperationPtr` will use this API. Simply implementing a (transfer) function of the form `OperationPtr -> DataFlowContext -> IRContext OpCode -> DataFlowContext` gets you a sparse forward analysis plugged into the dataflow framework for free. This API handles most of the stuff the implementer of a transfer function shouldn't concern themselves with.