### PR TITLE
Revert "chore(DataFlow): remove `anchor` from `Fact` (#688)"

### DIFF
--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -81,8 +81,9 @@ end RegionPtr
 
 namespace DominatorFact
 
-def mkDefault : DominatorFact :=
-  { dependents := #[]
+def mkDefault (anchor : LatticeAnchor) : DominatorFact :=
+  { anchor := anchor
+    dependents := #[]
     payload := { iDom := none } }
 
 def propagate (fact : DominatorFact) (dfCtx : DataFlowContext)
@@ -97,8 +98,9 @@ end DominatorFact
 
 namespace RegionMetadataFact
 
-def mkDefault : RegionMetadataFact :=
-  { dependents := #[]
+def mkDefault (anchor : LatticeAnchor) : RegionMetadataFact :=
+  { anchor := anchor
+    dependents := #[]
     payload := { postOrderIndex := {} } }
 
 def propagate (_fact : RegionMetadataFact) (dfCtx : DataFlowContext)

--- a/Veir/Analysis/DataFlow/Facts.lean
+++ b/Veir/Analysis/DataFlow/Facts.lean
@@ -98,6 +98,7 @@ current state in some fashion), and the fact specific payload determined by its
 `FactKind`.
 -/
 structure Fact (kind : FactKind) where
+  anchor : LatticeAnchor
   dependents : Array WorkItem := #[]
   payload : FactPayload kind
 

--- a/Veir/Analysis/DataFlowFramework.lean
+++ b/Veir/Analysis/DataFlowFramework.lean
@@ -34,7 +34,7 @@ class FactSpec (kind : FactKind) where
   /--
   Default state a fact starts in. Typically either bottom or top. 
   -/
-  mkDefault : Fact kind
+  mkDefault : LatticeAnchor -> Fact kind
   /--
   Hook that's called when the fact changes state. Typically used to
   enqueue a fact's dependents because it changed.
@@ -46,8 +46,8 @@ namespace Fact
 /--
 Construct the default fact for a given lattice anchor. 
 -/
-def mkDefault (kind : FactKind) [FactSpec kind] : Fact kind :=
-  FactSpec.mkDefault (kind := kind)
+def mkDefault (kind : FactKind) [FactSpec kind] (anchor : LatticeAnchor) : Fact kind :=
+  FactSpec.mkDefault (kind := kind) anchor
 
 /--
 Run the fact kind's propagation hook.
@@ -103,7 +103,7 @@ def getOrMkFact (kind : FactKind) [spec : FactSpec kind]
     (ctx : DataFlowContext) (anchor : LatticeAnchor) : Fact kind :=
   match ctx.getFact? kind anchor with
   | some fact => fact
-  | none => Fact.mkDefault kind
+  | none => Fact.mkDefault kind anchor
 
 /--
 Overwrite the stored fact of kind `kind` for `anchor`. 


### PR DESCRIPTION
This reverts commit 1db68dc83b0fb242386bfb3838a5077dfdb69048.

Despite it seeming useless, I'm going to need `anchor` for later analyses in the framework. We can remove this later if my usage of it can be circumvented, but as of right now it's been useful to have.