### PR TITLE
fix(test): pass through some env vars to help clang find headers

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -7,6 +7,12 @@ from pathlib import Path
 
 config.test_source_root = os.path.dirname(__file__)
 config.name = "VeIR"
+
+# workaround lit scrubbing the environment -- on MacOS a non-Apple
+# clang needs these to find system headers
+for _v in ("SDKROOT", "CPATH"):
+    if os.environ.get(_v):
+        config.environment[_v] = os.environ[_v]
 config.suffixes = ['.mlir', '.c']
 
 for tool in ('clang', 'opt', 'mlir-translate', 'mlir-opt'):


### PR DESCRIPTION
without this, `Test/fastntt.c` fails on my Mac