### PR TITLE
feat(dataflow): Fix `propagate` to take in `LatticeAnchor`

### DIFF
--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -85,8 +85,8 @@ def mkDefault : DominatorFact :=
   { dependents := #[]
     payload := { iDom := none } }
 
-def propagate (fact : DominatorFact) (dfCtx : DataFlowContext)
-    (_irCtx : IRContext OpCode) : DataFlowContext :=
+def propagate (fact : DominatorFact) (_anchor : LatticeAnchor) 
+    (dfCtx : DataFlowContext) (_irCtx : IRContext OpCode) : DataFlowContext :=
   { dfCtx with workList := fact.enqueueDependents dfCtx.workList }
 
 instance : FactSpec .dominator where
@@ -101,8 +101,8 @@ def mkDefault : RegionMetadataFact :=
   { dependents := #[]
     payload := { postOrderIndex := {} } }
 
-def propagate (_fact : RegionMetadataFact) (dfCtx : DataFlowContext)
-    (_irCtx : IRContext OpCode) : DataFlowContext :=
+def propagate (_fact : RegionMetadataFact) (_anchor : LatticeAnchor) 
+    (dfCtx : DataFlowContext) (_irCtx : IRContext OpCode) : DataFlowContext :=
   dfCtx
 
 instance : FactSpec .regionMetadata where

--- a/Veir/Analysis/DataFlow/Facts.lean
+++ b/Veir/Analysis/DataFlow/Facts.lean
@@ -92,10 +92,9 @@ The fact specific data stored for each fact kind.
 /--
 A dataflow fact stored by the framework.
 
-Each fact carries a lattice anchor (some location in the program this fact
-associates with), an array of dependents (other facts that "depend" on this fact's
-current state in some fashion), and the fact specific payload determined by its
-`FactKind`.
+Each fact associates with a lattice anchor (some location in the program), has 
+an array of dependents (other facts that "depend" on this fact's current state in
+some fashion), and has the fact specific payload determined by its `FactKind`.
 -/
 structure Fact (kind : FactKind) where
   dependents : Array WorkItem := #[]

--- a/Veir/Analysis/DataFlowFramework.lean
+++ b/Veir/Analysis/DataFlowFramework.lean
@@ -39,7 +39,7 @@ class FactSpec (kind : FactKind) where
   Hook that's called when the fact changes state. Typically used to
   enqueue a fact's dependents because it changed.
   -/
-  propagate : Fact kind → DataFlowContext → IRContext OpCode → DataFlowContext
+  propagate : Fact kind → LatticeAnchor → DataFlowContext → IRContext OpCode → DataFlowContext
 
 namespace Fact
 
@@ -54,9 +54,10 @@ Run the fact kind's propagation hook.
 -/
 def propagate [FactSpec kind]
     (fact : Fact kind)
+    (anchor : LatticeAnchor)
     (ctx : DataFlowContext)
     (irCtx : IRContext OpCode) : DataFlowContext :=
-  FactSpec.propagate (kind := kind) fact ctx irCtx
+  FactSpec.propagate (kind := kind) fact anchor ctx irCtx
 
 end Fact
 
@@ -134,7 +135,7 @@ def modifyFactAndPropagate (kind : FactKind) [spec : FactSpec kind]
   let (fact, changed) := f current
   let ctx := ctx.setFact kind anchor fact
   if changed then
-    fact.propagate ctx irCtx
+    fact.propagate anchor ctx irCtx
   else
     ctx
 


### PR DESCRIPTION
Since facts do not store their anchors (see https://github.com/opencompl/veir/commit/1db68dc83b0fb242386bfb3838a5077dfdb69048), `propagate` needs to take it as a parameter.