### PR TITLE
feat(dataflow): sparse fact api

### DIFF
--- a/Veir/Analysis/DataFlow/Facts.lean
+++ b/Veir/Analysis/DataFlow/Facts.lean
@@ -83,6 +83,13 @@ structure RegionMetadataPayload where
   postOrderIndex : HashMap BlockPtr Nat := {}
 
 /--
+A sparse dataflow fact payload for one abstract domain.
+-/
+structure SparsePayload (Domain : Type) where
+  useDefSubscribers : Array AnalysisKind := #[]
+  latticeElement : Domain
+
+/--
 The fact specific data stored for each fact kind.
 -/
 @[expose] def FactPayload : FactKind → Type
@@ -94,8 +101,8 @@ A dataflow fact stored by the framework.
 
 Each fact associates with a lattice anchor (some location in the program), has
 an array of dependents (other facts that "depend" on this fact's current state in
-some fashion), has an array of analysis subscribers (similar to dependents except
-it's entire analyses that depend on this fact's current state), and has the fact
+some fashion), has an array of analysis subscribers (similar to dependents except 
+it's entire analyses that depend on this fact's current state), and has the fact 
 specific payload determined by its `FactKind`.
 -/
 structure Fact (kind : FactKind) where

--- a/Veir/Analysis/DataFlow/Facts.lean
+++ b/Veir/Analysis/DataFlow/Facts.lean
@@ -92,12 +92,15 @@ The fact specific data stored for each fact kind.
 /--
 A dataflow fact stored by the framework.
 
-Each fact associates with a lattice anchor (some location in the program), has 
+Each fact associates with a lattice anchor (some location in the program), has
 an array of dependents (other facts that "depend" on this fact's current state in
-some fashion), and has the fact specific payload determined by its `FactKind`.
+some fashion), has an array of analysis subscribers (similar to dependents except
+it's entire analyses that depend on this fact's current state), and has the fact
+specific payload determined by its `FactKind`.
 -/
 structure Fact (kind : FactKind) where
   dependents : Array WorkItem := #[]
+  subscribers : Array AnalysisKind := #[]
   payload : FactPayload kind
 
 namespace Fact
@@ -113,6 +116,15 @@ Add one dependent work item to the fact.
 -/
 def addDependent (fact : Fact kind) (workItem : WorkItem) : Fact kind :=
   fact.setDependents (fact.dependents.push workItem)
+
+/--
+Subscribe one analysis to changes of this fact.
+-/
+def subscribe (fact : Fact kind) (analysisKind : AnalysisKind) : Fact kind :=
+  if fact.subscribers.contains analysisKind then
+    fact
+  else
+    { fact with subscribers := (fact.subscribers.push analysisKind) }
 
 /--
 Enqueue all dependents of this fact.

--- a/Veir/Analysis/DataFlow/Facts.lean
+++ b/Veir/Analysis/DataFlow/Facts.lean
@@ -86,7 +86,6 @@ structure RegionMetadataPayload where
 A sparse dataflow fact payload for one abstract domain.
 -/
 structure SparsePayload (Domain : Type) where
-  useDefSubscribers : Array AnalysisKind := #[]
   latticeElement : Domain
 
 /--

--- a/Veir/Analysis/DataFlow/SparseFact.lean
+++ b/Veir/Analysis/DataFlow/SparseFact.lean
@@ -15,14 +15,11 @@ namespace SparseFact
 variable {kind : FactKind} {Domain : Type}
 variable [SparseFactSpec kind Domain]
 
-private theorem payloadEq : FactPayload kind = SparsePayload Domain :=
-  SparseFactSpec.payloadEq (kind := kind)
-
 def getPayload (fact : Fact kind) : SparsePayload Domain :=
-  cast payloadEq fact.payload
+  cast SparseFactSpec.payloadEq fact.payload
 
 def setPayload (fact : Fact kind) (payload : SparsePayload Domain) : Fact kind :=
-  { fact with payload := cast (Eq.symm payloadEq) payload }
+  { fact with payload := cast (Eq.symm SparseFactSpec.payloadEq) payload }
 
 def latticeElement (fact : Fact kind) : Domain :=
   (getPayload fact).latticeElement
@@ -43,12 +40,11 @@ def propagate (state : Fact kind) (anchor : LatticeAnchor)
     let mut maybeUse := ssaValue.getFirstUse! irCtx
     while let some use := maybeUse do
       let user := (use.get! irCtx).owner
-      for analysisKind in state.subscribers do
-        match InsertPoint.after? user irCtx with
-        | some point =>
+      match InsertPoint.after? user irCtx with
+      | some point =>
+        for analysisKind in state.subscribers do
           dfCtx := dfCtx.enqueue (point, analysisKind)
-        | none =>
-          pure ()
+      | none => pure ()
       maybeUse := (use.get! irCtx).nextUse
   | _ =>
     pure ()
@@ -60,7 +56,7 @@ variable [Bot Domain]
 
 /-- Default sparse lattice fact for the given anchor. -/
 def mkDefault : Fact kind :=
-  { payload := cast (Eq.symm payloadEq) { latticeElement := ⊥ } }
+  { payload := cast (Eq.symm SparseFactSpec.payloadEq) { latticeElement := ⊥ } }
 
 instance : FactSpec kind where
   mkDefault := SparseFact.mkDefault (kind := kind)

--- a/Veir/Analysis/DataFlow/SparseFact.lean
+++ b/Veir/Analysis/DataFlow/SparseFact.lean
@@ -24,9 +24,6 @@ def getPayload (fact : Fact kind) : SparsePayload Domain :=
 def setPayload (fact : Fact kind) (payload : SparsePayload Domain) : Fact kind :=
   { fact with payload := cast (Eq.symm payloadEq) payload }
 
-def useDefSubscribers (fact : Fact kind) : Array AnalysisKind :=
-  (getPayload fact).useDefSubscribers
-
 def latticeElement (fact : Fact kind) : Domain :=
   (getPayload fact).latticeElement
 
@@ -46,7 +43,7 @@ def propagate (state : Fact kind) (anchor : LatticeAnchor)
     let mut maybeUse := ssaValue.getFirstUse! irCtx
     while let some use := maybeUse do
       let user := (use.get! irCtx).owner
-      for analysisKind in useDefSubscribers state do
+      for analysisKind in state.subscribers do
         match InsertPoint.after? user irCtx with
         | some point =>
           dfCtx := dfCtx.enqueue (point, analysisKind)
@@ -57,24 +54,13 @@ def propagate (state : Fact kind) (anchor : LatticeAnchor)
     pure ()
   dfCtx
 
-def useDefSubscribe (state : Fact kind)
-    (analysisKind : AnalysisKind) : Fact kind :=
-  let payload := getPayload state
-  if payload.useDefSubscribers.contains analysisKind then
-    state
-  else
-    setPayload state { payload with useDefSubscribers := payload.useDefSubscribers.push analysisKind }
-
 section
 
 variable [Bot Domain]
 
 /-- Default sparse lattice fact for the given anchor. -/
 def mkDefault : Fact kind :=
-  { dependents := #[]
-    payload := cast (Eq.symm payloadEq)
-      { useDefSubscribers := #[]
-        latticeElement := ⊥ } }
+  { payload := cast (Eq.symm payloadEq) { latticeElement := ⊥ } }
 
 instance : FactSpec kind where
   mkDefault := SparseFact.mkDefault (kind := kind)

--- a/Veir/Analysis/DataFlow/SparseFact.lean
+++ b/Veir/Analysis/DataFlow/SparseFact.lean
@@ -1,0 +1,97 @@
+module
+
+public import Veir.Analysis.DataFlowFramework
+public import Veir.Analysis.DataFlow.Domains.AbstractDomain
+
+public section
+
+namespace Veir
+
+class SparseFactSpec (kind : FactKind) (Domain : outParam Type) where
+  payloadEq : FactPayload kind = SparsePayload Domain
+
+namespace SparseFact
+
+variable {kind : FactKind} {Domain : Type}
+variable [SparseFactSpec kind Domain]
+
+private theorem payloadEq : FactPayload kind = SparsePayload Domain :=
+  SparseFactSpec.payloadEq (kind := kind)
+
+def getPayload (fact : Fact kind) : SparsePayload Domain :=
+  cast payloadEq fact.payload
+
+def setPayload (fact : Fact kind) (payload : SparsePayload Domain) : Fact kind :=
+  { fact with payload := cast (Eq.symm payloadEq) payload }
+
+def useDefSubscribers (fact : Fact kind) : Array AnalysisKind :=
+  (getPayload fact).useDefSubscribers
+
+def latticeElement (fact : Fact kind) : Domain :=
+  (getPayload fact).latticeElement
+
+def setLatticeElement (fact : Fact kind) (latticeElement : Domain) : Fact kind :=
+  let payload := getPayload fact
+  setPayload fact { payload with latticeElement := latticeElement }
+
+/--
+Propagate a sparse lattice update by revisiting dependents and all users of the
+updated SSA value for subscribed analyses.
+-/
+def propagate (state : Fact kind) (anchor : LatticeAnchor) 
+  (dfCtx : DataFlowContext) (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
+  let mut dfCtx := { dfCtx with workList := state.enqueueDependents dfCtx.workList }
+  match anchor with
+  | .ValuePtr ssaValue =>
+    let mut maybeUse := ssaValue.getFirstUse! irCtx
+    while let some use := maybeUse do
+      let user := (use.get! irCtx).owner
+      for analysisKind in useDefSubscribers state do
+        match InsertPoint.after? user irCtx with
+        | some point =>
+          dfCtx := dfCtx.enqueue (point, analysisKind)
+        | none =>
+          pure ()
+      maybeUse := (use.get! irCtx).nextUse
+  | _ =>
+    pure ()
+  dfCtx
+
+def useDefSubscribe (state : Fact kind)
+    (analysisKind : AnalysisKind) : Fact kind :=
+  let payload := getPayload state
+  if payload.useDefSubscribers.contains analysisKind then
+    state
+  else
+    setPayload state { payload with useDefSubscribers := payload.useDefSubscribers.push analysisKind }
+
+section
+
+variable [Bot Domain]
+
+/-- Default sparse lattice fact for the given anchor. -/
+def mkDefault : Fact kind :=
+  { dependents := #[]
+    payload := cast (Eq.symm payloadEq)
+      { useDefSubscribers := #[]
+        latticeElement := ⊥ } }
+
+instance : FactSpec kind where
+  mkDefault := SparseFact.mkDefault (kind := kind)
+  propagate := SparseFact.propagate (kind := kind)
+
+end
+
+def getElement? (kind : FactKind) [SparseFactSpec kind Domain] [FactSpec kind]
+    (ssaValue : ValuePtr) (dfCtx : DataFlowContext) : Option Domain := do
+  let state ← dfCtx.getFact? kind (.ValuePtr ssaValue)
+  return latticeElement state
+
+def getElementD (kind : FactKind) [SparseFactSpec kind Domain] [FactSpec kind]
+    (ssaValue : ValuePtr) (fallback : Domain)
+    (dfCtx : DataFlowContext) : Domain :=
+  (getElement? kind ssaValue dfCtx).getD fallback
+
+end SparseFact
+
+end Veir

--- a/Veir/Analysis/DataFlow/SparseFact.lean
+++ b/Veir/Analysis/DataFlow/SparseFact.lean
@@ -7,6 +7,10 @@ public section
 
 namespace Veir
 
+/--
+Implement this class to register a custom type to be recognized as
+a sparse fact type by the dataflow framework.
+-/
 class SparseFactSpec (kind : FactKind) (Domain : outParam Type) where
   payloadEq : FactPayload kind = SparsePayload Domain
 


### PR DESCRIPTION
The following is a type that builds off of the generic `Fact` type. You can define "sparse facts" - facts that attach to `Value`s, using this type. It'll handle notifying dependents and subscribed analyses for you when it changes.