### PR TITLE
feat(riscv): introduce riscv.addi when possible

### DIFF
--- a/Test/Passes/Combines/add_li_to_addi.mlir
+++ b/Test/Passes/Combines/add_li_to_addi.mlir
@@ -1,0 +1,37 @@
+// RUN: veir-opt %s -p=riscv-combine | filecheck %s
+
+"builtin.module"() ({
+    // riscv.add x (riscv.li imm) -> riscv.addi x imm
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[arg:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = 1 : i64}>: () -> !riscv.reg
+        %add = "riscv.add"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[r:%.*]] = "riscv.addi"([[arg]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%add) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // riscv.add (riscv.li imm) x -> riscv.addi x imm  (li on the left)
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[arg2:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = -2048 : i64}>: () -> !riscv.reg
+        %add = "riscv.add"(%c, %a) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[r2:%.*]] = "riscv.addi"([[arg2]]) <{"value" = -2048 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%add) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r2]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // Immediate does not fit addi's signed 12-bit field: not folded.
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[arg3:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = -2049 : i64}>: () -> !riscv.reg
+        %add = "riscv.add"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[big:%.*]] = "riscv.li"() <{"value" = -2049 : i64}> : () -> !riscv.reg
+        // CHECK:             [[r3:%.*]] = "riscv.add"([[arg3]], [[big]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%add) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r3]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/Combines/right_identity_op_add.mlir
+++ b/Test/Passes/Combines/right_identity_op_add.mlir
@@ -10,8 +10,9 @@
         // CHECK-NEXT:       [[zero:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
         %c1 = "riscv.li"() <{"value" = 1 : i64}>: () -> !riscv.reg
         %add1 = "riscv.add"(%a, %c1) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:       [[one:%.*]] = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
-        // CHECK-NEXT:       %{{.*}} =  "riscv.add"([[arg]], [[one]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // A non-zero `riscv.li` operand is folded into a `riscv.addi`.
+        // CHECK-NEXT:       %{{.*}} = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT:       %{{.*}} = "riscv.addi"([[arg]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Veir/Passes/Combines/Combine.lean
+++ b/Veir/Passes/Combines/Combine.lean
@@ -15,17 +15,34 @@ set_option warn.sorry false in
 def right_identity_zero_add (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAdd op rewriter.ctx | return rewriter
-  let some rhsOp := rhs.getDefiningOp! rewriter.ctx.raw | return rewriter
-  let some cst := matchLi rhsOp rewriter.ctx | return rewriter
+  let some cst := matchLi rhs rewriter.ctx | return rewriter
   if cst.value.value ≠ 0 then return rewriter
   let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
+
+set_option warn.sorry false in
+/--
+  riscv.add x (riscv.li imm) -> riscv.addi x imm
+  riscv.add (riscv.li imm) x -> riscv.addi x imm
+  But only when `imm` fits into a signed 12-bit immediate field.
+-/
+def fold_add_li_to_addi (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+    Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs) := matchAdd op rewriter.ctx | return rewriter
+  let some (reg, imm) :=
+      (Prod.mk lhs <$> matchLi rhs rewriter.ctx) <|>
+      (Prod.mk rhs <$> matchLi lhs rewriter.ctx)
+    | return rewriter
+  if imm.value.value < -2048 || imm.value.value > 2047 then return rewriter
+  let (rewriter, addiOp) ← rewriter.createOp (.riscv .addi) #[RegisterType.mk] #[reg]
+      #[] #[] imm (some $ .before op) sorry (by simp) (by simp) sorry
+  rewriter.replaceOp op addiOp sorry sorry sorry sorry sorry
 
 /-! # Pass implementation -/
 
 def Combine.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern #[right_identity_zero_add]
+  let pattern := RewritePattern.GreedyRewritePattern #[right_identity_zero_add, fold_add_li_to_addi]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx

--- a/Veir/Passes/RISCVMatching.lean
+++ b/Veir/Passes/RISCVMatching.lean
@@ -10,7 +10,7 @@ def matchAdd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × 
   let (op, _) ← matchOp op ctx (.riscv .add) 2
   return (op[0]!, op[1]!)
 
-
-def matchLi (op : OperationPtr) (ctx : IRContext OpCode) : Option ( propertiesOf (.riscv .li)) := do
+def matchLi (val : ValuePtr) (ctx : IRContext OpCode) : Option (propertiesOf (.riscv .li)) := do
+  let op ← val.getDefiningOp! ctx
   let (_, properties) ← matchOp op ctx (.riscv .li) 0
-  return (properties)
+  return properties


### PR DESCRIPTION
also tweaked the signature of `matchLi` since this saves a line of code in both of its current clients, hopefully that's a good general improvement