### PR TITLE
feat(rewriter): Require inBounds argument to rewrite patterns

### DIFF
--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -16,7 +16,7 @@ namespace Veir.Benchmarks
 
 namespace Pattern
 
-def addIConstantFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option (PatternRewriter OpCode) := do
+def addIConstantFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   -- Check that the operation is an arith.addi operation
   if op.getOpType rewriter.ctx.raw sorry ≠ .arith .addi then
     return rewriter
@@ -82,7 +82,7 @@ def addIConstantFoldingLocal (ctx: WfIRContext OpCode) (op: OperationPtr) :
   let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry
   return (ctx, some (#[newOp], #[newOp.getResult 0]))
 
-def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option (PatternRewriter OpCode)   := do
+def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   if op.getOpType rewriter.ctx.raw sorry ≠ .arith .addi then
     return rewriter
 
@@ -108,7 +108,7 @@ def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Opti
     rewriter ← rewriter.eraseOp rhsOp sorry sorry sorry
   return rewriter
 
-def mulITwoReduce (rewriter: PatternRewriter OpCode) (op: OperationPtr) : Option (PatternRewriter OpCode) := do
+def mulITwoReduce (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   if op.getOpType rewriter.ctx.raw sorry ≠ .arith .muli then
     return rewriter
 

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -30,7 +30,8 @@ def isPreservingIntegerTypeRoundTrip (inputType interType : TypeAttr) : Bool :=
 
 /- Reconciles round-trip casts of the form X->Y->X if allowed for these types by `legal X Y` -/
 set_option warn.sorry false in
-def reconcilePairingCast (legal : TypeAttr → TypeAttr → Bool) (rewriter : PatternRewriter OpCode) (op : OperationPtr) :
+def reconcilePairingCast (legal : TypeAttr → TypeAttr → Bool) (rewriter : PatternRewriter OpCode)
+    (op : OperationPtr) (opInBounds : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some cast := matchCastOp op rewriter.ctx.raw | return rewriter
   let input := op.getOperand! rewriter.ctx.raw 0
@@ -58,8 +59,8 @@ def reconcilePairingCast (legal : TypeAttr → TypeAttr → Bool) (rewriter : Pa
     return rewriter
 
 set_option warn.sorry false in
-def reconcileIdentityCast (rewriter : PatternRewriter OpCode) (op : OperationPtr) :
-    Option (PatternRewriter OpCode) := do
+def reconcileIdentityCast (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+  (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some cast := matchCastOp op rewriter.ctx.raw | return rewriter
   /- get the input and output types -/
   let input := op.getOperand! rewriter.ctx.raw 0

--- a/Veir/Passes/Combines/Combine.lean
+++ b/Veir/Passes/Combines/Combine.lean
@@ -12,8 +12,8 @@ namespace Veir.RISCV
 
 set_option warn.sorry false in
 /-- riscv.add x 0 -> x -/
-def right_identity_zero_add (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
-    Option (PatternRewriter OpCode) := do
+def right_identity_zero_add (rewriter: PatternRewriter OpCode) (op: OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAdd op rewriter.ctx | return rewriter
   let some cst := matchLi rhs rewriter.ctx | return rewriter
   if cst.value.value ≠ 0 then return rewriter
@@ -26,8 +26,8 @@ set_option warn.sorry false in
   riscv.add (riscv.li imm) x -> riscv.addi x imm
   But only when `imm` fits into a signed 12-bit immediate field.
 -/
-def fold_add_li_to_addi (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
-    Option (PatternRewriter OpCode) := do
+def fold_add_li_to_addi (rewriter: PatternRewriter OpCode) (op: OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAdd op rewriter.ctx | return rewriter
   let some (reg, imm) :=
       (Prod.mk lhs <$> matchLi rhs rewriter.ctx) <|>

--- a/Veir/Passes/DCE/dce.lean
+++ b/Veir/Passes/DCE/dce.lean
@@ -7,8 +7,8 @@ namespace Veir
 /-! We implement a dead code elimination pass. -/
 
 set_option warn.sorry false in
-def eliminateDeadOp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
-    Option (PatternRewriter OpCode) := do
+def eliminateDeadOp (rewriter: PatternRewriter OpCode) (op: OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   /- delete operations that are not used and have no side effects -/
   if ¬ op.hasUses! rewriter.ctx.raw && ¬ op.hasSideEffects rewriter.ctx.raw then
     rewriter.eraseOp op sorry sorry sorry

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -15,7 +15,7 @@ namespace Veir
 
 set_option warn.sorry false in
 /-- Rewrites `x * 2` to `x + x`. -/
-def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchMuli op rewriter.ctx
     | return rewriter
@@ -29,7 +29,7 @@ def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x * 0` to `0`. -/
-def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchMuli op rewriter.ctx
     | return rewriter
@@ -46,7 +46,7 @@ def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x + 0` to `x`. -/
-def addiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def addiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchAddi op rewriter.ctx
     | return rewriter
@@ -59,7 +59,7 @@ def addiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x * 1` to `x`. -/
-def mulIOneToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def mulIOneToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchMuli op rewriter.ctx
     | return rewriter
@@ -72,7 +72,7 @@ def mulIOneToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x - 0` to `x`. -/
-def subiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def subiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSubi op rewriter.ctx
     | return rewriter
@@ -85,7 +85,7 @@ def subiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x - x` to `0`. -/
-def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSubi op rewriter.ctx
     | return rewriter
@@ -100,7 +100,7 @@ def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x & x` to `x`. -/
-def andiSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def andiSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAndi op rewriter.ctx
     | return rewriter
@@ -111,7 +111,7 @@ def andiSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x & 0` to `0`. -/
-def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAndi op rewriter.ctx
     | return rewriter
@@ -128,7 +128,7 @@ def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x | 0` to `x`. -/
-def oriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def oriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOri op rewriter.ctx
     | return rewriter
@@ -141,7 +141,7 @@ def oriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x | x` to `x`. -/
-def oriSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def oriSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOri op rewriter.ctx
     | return rewriter
@@ -152,7 +152,7 @@ def oriSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x ^ 0` to `x`. -/
-def xoriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def xoriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchXori op rewriter.ctx
     | return rewriter
@@ -165,7 +165,7 @@ def xoriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- Rewrites `x ^ x` to `0`. -/
-def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchXori op rewriter.ctx
     | return rewriter
@@ -189,7 +189,7 @@ def matchNot (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
 
 set_option warn.sorry false in
 /-- Rewrites `~~x` to `x`. -/
-def notNotToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def notNotToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some outerNotted := matchNot (op.getResult 0) rewriter.ctx
     | return rewriter
@@ -201,7 +201,7 @@ def notNotToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 set_option warn.sorry false in
 /-- Rewrites `~(~a & ~b)` to `a | b` (DeMorgan). -/
 /- TODO: the precondition should be strengthened by some hasOneUse() checks -/
-def deMorganAndToOr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def deMorganAndToOr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some andVal := matchNot (op.getResult 0) rewriter.ctx
     | return rewriter
@@ -222,7 +222,7 @@ def deMorganAndToOr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 set_option warn.sorry false in
 /-- Rewrites `~(~a | ~b)` to `a & b` (DeMorgan). -/
 /- TODO: the precondition should be strengthened by some hasOneUse() checks -/
-def deMorganOrToAnd (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def deMorganOrToAnd (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some orVal := matchNot (op.getResult 0) rewriter.ctx
     | return rewriter

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -13,7 +13,7 @@ namespace Veir
 
 set_option warn.sorry false in
 /-- llvm.constant -> riscv.li -/
-def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some const := matchConstantIntOp op rewriter.ctx
       | return rewriter
@@ -29,7 +29,7 @@ def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.add -> riscv.add -/
-def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchAdd op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -55,7 +55,7 @@ def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.and -> riscv.and -/
-def and (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def and (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAnd op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -81,7 +81,7 @@ def and (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.ashr -> riscv.sra -/
-def ashr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def ashr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchAshr op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -118,7 +118,7 @@ set_option warn.sorry false in
     llvm.icmp ugt lhs rhs -> riscv.sltu rhs lhs
     llvm.icmp uge lhs rhs -> riscv.xori (riscv_sltu lhs rhs) 1
 -/
-def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, property) := matchIcmp op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -212,7 +212,7 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.or -> riscv.or -/
-def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -238,7 +238,7 @@ def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.xor -> riscv.xor -/
-def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -264,7 +264,7 @@ def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.mul -> riscv.mul -/
-def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchMul op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -290,7 +290,7 @@ def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.sdiv -> riscv.div -/
-def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSdiv op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -316,7 +316,7 @@ def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.udiv -> riscv.divu -/
-def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -342,7 +342,7 @@ def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.srem -> riscv.rem -/
-def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSrem op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -368,7 +368,7 @@ def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.urem -> riscv.remu -/
-def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchUrem op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -394,7 +394,7 @@ def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.sub -> riscv.sub -/
-def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSub op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -427,7 +427,7 @@ set_option warn.sorry false in
   For every other width:
   llvm.sext %x iX to iY-> riscv.srai (riscv.slli %x (64 - X)) (64 - X)
 -/
-def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchSext op rewriter.ctx | return rewriter
   /- Only support extensions fron `iX` to `iY` where both `X < 64` and `Y < 64`. -/
@@ -479,7 +479,7 @@ set_option warn.sorry false in
   For every other width:
   llvm.zext %x iX to iY-> riscv.srli (riscv.slli %x (64 - X)) (64 - X)
 -/
-def zext (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def zext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchZext op rewriter.ctx | return rewriter
   /- Only support extensions fron `iX` to `iY` where both `X < 64` and `Y < 64`. -/
@@ -526,7 +526,7 @@ set_option warn.sorry false in
 /--
   llvm.trunc %x iX to iY -> builtin_unrealized_conversion_cast (!riscv.reg) : iY
 -/
-def trunc (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def trunc (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchTrunc op rewriter.ctx | return rewriter
   /- Only support extensions fron `iX` to `iY` where both `X < 64` and `Y < 64`. -/
@@ -545,7 +545,7 @@ def trunc (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.shl -> riscv.sll -/
-def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchShl op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -571,7 +571,7 @@ def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.shl -> riscv.srl -/
-def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchLshr op rewriter.ctx | return rewriter
   /- only support `i64` -/
@@ -597,7 +597,7 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.load -> riscv.ld -/
-def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (ptr, _) := matchLoad op rewriter.ctx | return rewriter
   /- only support `i64` (the loaded value type) -/
@@ -617,7 +617,7 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
 
 set_option warn.sorry false in
 /-- llvm.store -> riscv.sd -/
-def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (arg, ptr, _) := matchStore op rewriter.ctx | return rewriter
   /- only support `i64` (the stored value type) -/
@@ -641,7 +641,7 @@ set_option warn.sorry false in
   Lower a single-dynamic-index `llvm.getelementptr` computing `ptr + idx * scale`,
   where `scale` is the byte size of the element type.
 -/
-def getelementptr (rewriter: PatternRewriter OpCode) (op: OperationPtr) :
+def getelementptr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (ptr, idx, properties) := matchGetelementptr op rewriter.ctx | return rewriter
   /- Bail unless it's a single dynamic index with no trailing constant indices. -/

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -108,7 +108,8 @@ set_option warn.sorry false in
     using intermediate Type iM given storage type iM, with M = `widen` N,
     and using Builder `build` to determine the exact `arith` operations to emit -/
 def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builder)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr) : Option (PatternRewriter OpCode) := do
+    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   -- match op and extract operands:
   let some (operands, _) := matchOp op rewriter.ctx (.mod_arith modOp) 2
     | return rewriter
@@ -157,7 +158,8 @@ def lowerModArithSubOp := lowerModArithBinOp .sub (· + 1) buildSub
 
 set_option warn.sorry false in
 /-- Lower `mod_arith.constant` to an `arith.constant` (assumes value is in `[0, q)` already). -/
-def lowerModArithConstant (rewriter : PatternRewriter OpCode) (op : OperationPtr) : Option (PatternRewriter OpCode) := do
+def lowerModArithConstant (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   -- match op and extract attribute:
   let some (_, props) := matchOp op rewriter.ctx (.mod_arith .constant) 0
     | return rewriter

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -234,7 +234,9 @@ def insertBlock (rewriter: PatternRewriter OpInfo) (block: BlockPtr) (ip : Block
 
 end PatternRewriter
 
-abbrev RewritePattern (OpInfo : Type) [HasOpInfo OpInfo] := (PatternRewriter OpInfo) → OperationPtr → Option (PatternRewriter OpInfo)
+abbrev RewritePattern (OpInfo : Type) [HasOpInfo OpInfo] :=
+  (rewriter : PatternRewriter OpInfo) → (op : OperationPtr) →
+  (opInBounds : op.InBounds rewriter.ctx.raw) → Option (PatternRewriter OpInfo)
 
 /--
   A local rewrite that can only replace a matched operation with a list of new operations.
@@ -246,7 +248,7 @@ abbrev LocalRewritePattern (OpInfo : Type) [HasOpInfo OpInfo] :=
 
 set_option warn.sorry false in
 def RewritePattern.fromLocalRewrite (pattern : LocalRewritePattern OpInfo) : RewritePattern OpInfo :=
-  fun rewriter op => do
+  fun rewriter op opInBounds => do
     match pattern rewriter.ctx op with
     -- error while applying pattern
     | none => none
@@ -265,21 +267,25 @@ def RewritePattern.fromLocalRewrite (pattern : LocalRewritePattern OpInfo) : Rew
       rewriter ← rewriter.eraseOp op (by sorry) (by sorry) (by sorry)
       return rewriter
 
+set_option warn.sorry false in
 /--
   Greedy pattern application: transforms a list of patterns into a single pattern that applies
   them repeatedly in order.
 -/
 def RewritePattern.GreedyRewritePattern (patterns : Array (RewritePattern OpInfo)) : RewritePattern OpInfo :=
-  fun rewriter op => do
+  fun rewriter op _ => do
     let hasDoneAction := rewriter.hasDoneAction
     let mut rewriter := { rewriter with hasDoneAction := false }
     for pattern in patterns do
-      match pattern rewriter op with
-      | some newRewriter =>
-        rewriter := newRewriter
-        if rewriter.hasDoneAction then
-          return rewriter
-      | none => failure
+      if opInBounds : op.InBounds rewriter.ctx.raw then
+        match pattern rewriter op opInBounds with
+        | some newRewriter =>
+          rewriter := newRewriter
+          if rewriter.hasDoneAction then
+            return rewriter
+        | none => failure
+      else
+        failure
     return { rewriter with hasDoneAction := hasDoneAction }
 
 /--
@@ -296,7 +302,10 @@ private partial def RewritePattern.applyOnceInContext
     let (opOpt, newWorklist) := rewriter.worklist.pop
     let op := opOpt.get!
     rewriter := { rewriter with worklist := newWorklist }
-    rewriter ← pattern rewriter op
+    if _ : op.InBounds rewriter.ctx.raw then
+      rewriter ← pattern rewriter op (by grind)
+    else
+      failure
   pure (rewriter.hasDoneAction, rewriter.ctx)
 
 def RewritePattern.applyInContext (pattern: RewritePattern OpInfo)


### PR DESCRIPTION
A lot of sorries cannot be removed in our rewrite patterns because rewrite patterns do not take `op.InBounds ctx` proofs as arguments.

This PR adds the `inBounds` argument in rewrite patterns, though it does not remove any sorries yet.