### PR TITLE
chore(IR): rename `insertOp?`, and `insertBlock?` to `insertOp` and `insertBlock`

### DIFF
--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -200,9 +200,9 @@ def defineBlock (name : ByteArray) (ip : BlockInsertPoint) (loc : Location) : Ml
     modifyContextM fun ctx => do
       let ⟨hip⟩ ← checkBlockInsertPointInBounds ip ctx.raw
       let ⟨hblock⟩ ← checkBlockInBounds block ctx.raw
-      match hctx' : Rewriter.insertBlock? ctx block ip hblock hip with
+      match hctx' : Rewriter.insertBlock ctx block ip hblock hip with
       | none => throwAt loc "internal error: failed to insert block"
-      | some ctx' => pure ⟨ctx', by grind [Rewriter.insertBlock?_WellFormed]⟩
+      | some ctx' => pure ⟨ctx', by grind [Rewriter.insertBlock_WellFormed]⟩
     /- Notify the parsing context that the block is defined. -/
     modifyThe MlirParserState (fun state =>
     {state with

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -169,7 +169,7 @@ def createOp (rewriter: PatternRewriter OpInfo) (opType: OpInfo)
 def insertOp (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (ip : InsertPoint)
     (newOpIn: op.InBounds rewriter.ctx.raw := by grind) (insIn : ip.InBounds rewriter.ctx.raw)
     : Option (PatternRewriter OpInfo) := do
-  rlet newCtx ← WfRewriter.insertOp? rewriter.ctx op ip (by grind) (by grind)
+  rlet newCtx ← WfRewriter.insertOp rewriter.ctx op ip (by grind) (by grind)
   some { rewriter with
     ctx := newCtx,
     hasDoneAction := true,
@@ -226,7 +226,7 @@ def createBlock (rewriter: PatternRewriter OpInfo)
 def insertBlock (rewriter: PatternRewriter OpInfo) (block: BlockPtr) (ip : BlockInsertPoint)
     (newBlockIn: block.InBounds rewriter.ctx.raw := by grind)
     (ipIn : ip.InBounds rewriter.ctx.raw := by grind) : Option (PatternRewriter OpInfo) := do
-  rlet newCtx ← WfRewriter.insertBlock? rewriter.ctx block ip
+  rlet newCtx ← WfRewriter.insertBlock rewriter.ctx block ip
   some { rewriter with
     ctx := newCtx,
     hasDoneAction := true

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -14,7 +14,7 @@ variable {ctx : IRContext OpInfo}
 - Insert an operation at a given location.
 -/
 @[irreducible]
-def Rewriter.insertOp? (ctx: IRContext OpInfo) (newOp: OperationPtr) (insertionPoint: InsertPoint)
+def Rewriter.insertOp (ctx: IRContext OpInfo) (newOp: OperationPtr) (insertionPoint: InsertPoint)
     (newOpIn: newOp.InBounds ctx := by grind)
     (insIn : insertionPoint.InBounds ctx)
     (ctxInBounds: ctx.FieldsInBounds) : Option (IRContext OpInfo) :=
@@ -23,20 +23,20 @@ def Rewriter.insertOp? (ctx: IRContext OpInfo) (newOp: OperationPtr) (insertionP
     let next := insertionPoint.next
     newOp.linkBetweenWithParent ctx prev next parent (by grind) (by grind) (by grind) (by grind)
 
-theorem Rewriter.insertOp?_inBounds_mono (ptr : GenericPtr)
-    (heq : insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx) :
+theorem Rewriter.insertOp_inBounds_mono (ptr : GenericPtr)
+    (heq : insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx) :
     ptr.InBounds newCtx ↔ ptr.InBounds ctx := by
-  simp only [insertOp?] at heq
+  simp only [insertOp] at heq
   grind
 
-grind_pattern Rewriter.insertOp?_inBounds_mono =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, ptr.InBounds newCtx
+grind_pattern Rewriter.insertOp_inBounds_mono =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, ptr.InBounds newCtx
 
 @[grind .]
-theorem Rewriter.insertOp?_fieldsInBounds_mono
-    (heq : insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx) :
+theorem Rewriter.insertOp_fieldsInBounds_mono
+    (heq : insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx) :
     ctx.FieldsInBounds → newCtx.FieldsInBounds := by
-  simp only [insertOp?] at heq
+  simp only [insertOp] at heq
   grind
 
 /--
@@ -240,7 +240,7 @@ theorem Rewriter.eraseOp_inBounds (ptr : GenericPtr)
 - Insert a block at a given location.
 -/
 @[irreducible]
-def Rewriter.insertBlock? (ctx: IRContext OpInfo) (newBlock: BlockPtr)
+def Rewriter.insertBlock (ctx: IRContext OpInfo) (newBlock: BlockPtr)
     (insertionPoint: BlockInsertPoint)
     (newBlockIn: newBlock.InBounds ctx := by grind)
     (insIn : insertionPoint.InBounds ctx := by grind)
@@ -251,17 +251,17 @@ def Rewriter.insertBlock? (ctx: IRContext OpInfo) (newBlock: BlockPtr)
     newBlock.linkBetweenWithParent ctx prev next parent (by grind) (by grind) (by grind) (by grind)
 
 @[grind .]
-theorem Rewriter.insertBlock?_inBounds (ptr : GenericPtr)
-    (heq : insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx) :
+theorem Rewriter.insertBlock_inBounds (ptr : GenericPtr)
+    (heq : insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx) :
     ptr.InBounds ctx ↔ ptr.InBounds newCtx := by
-  simp only [insertBlock?] at heq
+  simp only [insertBlock] at heq
   grind
 
 @[grind .]
-theorem Rewriter.insertBlock?_fieldsInBounds_mono
-    (heq : insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx) :
+theorem Rewriter.insertBlock_fieldsInBounds_mono
+    (heq : insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx) :
     ctx.FieldsInBounds → newCtx.FieldsInBounds := by
-  simp only [insertBlock?] at heq
+  simp only [insertBlock] at heq
   grind
 
 def Rewriter.replaceUse (ctx: IRContext OpInfo) (use : OpOperandPtr) (newValue: ValuePtr)
@@ -534,7 +534,7 @@ def Rewriter.createBlock (ctx: IRContext OpInfo) (argTypes : Array TypeAttr)
   let ctx := Rewriter.initBlockArguments ctx newBlockPtr argTypes
   match h : insertionPoint with
   | some insertionPoint => do
-    let ctx ← Rewriter.insertBlock? ctx newBlockPtr insertionPoint
+    let ctx ← Rewriter.insertBlock ctx newBlockPtr insertionPoint
       (by grind) (by grind [cases BlockInsertPoint]) (by grind)
     (ctx, newBlockPtr)
   | none =>
@@ -927,7 +927,7 @@ def Rewriter.createOp (ctx: IRContext OpInfo) (opType: OpInfo)
   let ctx := Rewriter.initBlockOperands ctx newOpPtr blockOperands (hoperands := by grind (ematch := 10))
   match _ : insertionPoint with
   | some insertionPoint =>
-    rlet ctx ← Rewriter.insertOp? ctx newOpPtr insertionPoint (by grind)
+    rlet ctx ← Rewriter.insertOp ctx newOpPtr insertionPoint (by grind)
       (by cases insertionPoint <;> grind) (by grind) in
     some (ctx, newOpPtr)
   | none =>

--- a/Veir/Rewriter/GetSet/InsertBlock.lean
+++ b/Veir/Rewriter/GetSet/InsertBlock.lean
@@ -54,24 +54,24 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-section Rewriter.insertBlock?
+section Rewriter.insertBlock
 
-unseal Rewriter.insertBlock?
+unseal Rewriter.insertBlock
 
-attribute [local grind] Rewriter.insertBlock?
+attribute [local grind] Rewriter.insertBlock
 
 @[simp]
-theorem BlockPtr.firstUse!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.firstUse!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstUse = (block.get! ctx).firstUse := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockPtr.firstUse!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstUse
+grind_pattern BlockPtr.firstUse!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstUse
 
-theorem BlockPtr.prev!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.prev!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).prev =
       if block = ip.next then
         some newBlock
@@ -79,14 +79,14 @@ theorem BlockPtr.prev!_insertBlock? {block : BlockPtr} :
         ip.prev! ctx
       else
         (block.get! ctx).prev := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind [cases BlockInsertPoint]
 
-grind_pattern BlockPtr.prev!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).prev
+grind_pattern BlockPtr.prev!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).prev
 
-theorem BlockPtr.next!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.next!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).next =
       if block = ip.prev! ctx then
         some newBlock
@@ -94,269 +94,269 @@ theorem BlockPtr.next!_insertBlock? {block : BlockPtr} :
         ip.next
       else
         (block.get! ctx).next := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind [cases BlockInsertPoint]
 
-grind_pattern BlockPtr.next!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).next
+grind_pattern BlockPtr.next!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).next
 
-theorem BlockPtr.parent!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.parent!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).parent =
       if block = newBlock then
         ip.region! ctx
       else
       (block.get! ctx).parent := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockPtr.parent!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).parent
+grind_pattern BlockPtr.parent!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).parent
 
 @[simp]
-theorem BlockPtr.firstOp!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.firstOp!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstOp = (block.get! ctx).firstOp := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockPtr.firstOp!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstOp
+grind_pattern BlockPtr.firstOp!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstOp
 
 @[simp]
-theorem BlockPtr.lastOp!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.lastOp!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).lastOp = (block.get! ctx).lastOp := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockPtr.lastOp!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp
+grind_pattern BlockPtr.lastOp!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp
 
 @[simp]
-theorem OperationPtr.get!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.get!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.get! newCtx = operation.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.get! newCtx
+grind_pattern OperationPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.get! newCtx
 
 @[simp]
-theorem OperationPtr.getOpType!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getOpType!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getOpType! newCtx = operation.getOpType! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getOpType!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
+grind_pattern OperationPtr.getOpType!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
 
 @[simp]
-theorem OperationPtr.getNumResults!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumResults!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumResults! newCtx = operation.getNumResults! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getNumResults!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumResults! newCtx
+grind_pattern OperationPtr.getNumResults!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumResults! newCtx
 
 @[simp]
-theorem OpResultPtr.get!_insertBlock? {opResult : OpResultPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OpResultPtr.get!_insertBlock {opResult : OpResultPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     opResult.get! newCtx = opResult.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OpResultPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, opResult.get! newCtx
+grind_pattern OpResultPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, opResult.get! newCtx
 
 @[simp]
-theorem OperationPtr.getNumOperands!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumOperands!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumOperands! newCtx = operation.getNumOperands! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getNumOperands!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumOperands! newCtx
+grind_pattern OperationPtr.getNumOperands!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumOperands! newCtx
 
 @[simp]
-theorem OpOperandPtr.get!_insertBlock? {operand : OpOperandPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OpOperandPtr.get!_insertBlock {operand : OpOperandPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OpOperandPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
+grind_pattern OpOperandPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
 @[simp]
-theorem OperationPtr.getOperands!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getOperands!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getOperands! newCtx = operation.getOperands! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getOperands!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOperands! newCtx
+grind_pattern OperationPtr.getOperands!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOperands! newCtx
 
 @[simp]
-theorem OperationPtr.getNumSuccessors!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumSuccessors!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumSuccessors! newCtx = operation.getNumSuccessors! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getNumSuccessors!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumSuccessors! newCtx
+grind_pattern OperationPtr.getNumSuccessors!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumSuccessors! newCtx
 
 @[simp]
-theorem BlockOperandPtr.get!_insertBlock? {operand : BlockOperandPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockOperandPtr.get!_insertBlock {operand : BlockOperandPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockOperandPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
+grind_pattern BlockOperandPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
 @[simp]
-theorem OperationPtr.getSuccessor!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getSuccessor!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessor! newCtx index = operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-grind_pattern OperationPtr.getSuccessor!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getSuccessor! newCtx index
+grind_pattern OperationPtr.getSuccessor!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getSuccessor! newCtx index
 
 @[simp]
-theorem OperationPtr.getSuccessors!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getSuccessors!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessors! newCtx = operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-grind_pattern OperationPtr.getSuccessors!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getSuccessors! newCtx
+grind_pattern OperationPtr.getSuccessors!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getSuccessors! newCtx
 
 @[simp]
-theorem OperationPtr.getNumRegions!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumRegions!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumRegions! newCtx = operation.getNumRegions! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getNumRegions!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumRegions! newCtx
+grind_pattern OperationPtr.getNumRegions!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumRegions! newCtx
 
 @[simp]
-theorem OperationPtr.getRegion!_insertBlock? {operation : OperationPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getRegion!_insertBlock {operation : OperationPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getRegion! newCtx = operation.getRegion! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OperationPtr.getRegion!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getRegion! newCtx
+grind_pattern OperationPtr.getRegion!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getRegion! newCtx
 
 @[simp]
-theorem BlockOperandPtrPtr.get!_insertBlock? {operandPtr : BlockOperandPtrPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockOperandPtrPtr.get!_insertBlock {operandPtr : BlockOperandPtrPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operandPtr.get! newCtx = operandPtr.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockOperandPtrPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, operandPtr.get! newCtx
+grind_pattern BlockOperandPtrPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operandPtr.get! newCtx
 
 @[simp]
-theorem BlockPtr.getNumArguments!_insertBlock? {block : BlockPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.getNumArguments!_insertBlock {block : BlockPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     block.getNumArguments! newCtx = block.getNumArguments! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockPtr.getNumArguments!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, block.getNumArguments! newCtx
+grind_pattern BlockPtr.getNumArguments!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, block.getNumArguments! newCtx
 
 @[simp]
-theorem BlockArgumentPtr.get!_insertBlock? {blockArg : BlockArgumentPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem BlockArgumentPtr.get!_insertBlock {blockArg : BlockArgumentPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     blockArg.get! newCtx = blockArg.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern BlockArgumentPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, blockArg.get! newCtx
+grind_pattern BlockArgumentPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, blockArg.get! newCtx
 
-theorem RegionPtr.firstBlock!_insertBlock? {region : RegionPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem RegionPtr.firstBlock!_insertBlock {region : RegionPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (region.get! newCtx).firstBlock =
       if ip.region! ctx = region ∧ ip.prev! ctx = none then
         some newBlock
       else
         (region.get! ctx).firstBlock := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern RegionPtr.firstBlock!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).firstBlock
+grind_pattern RegionPtr.firstBlock!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).firstBlock
 
-theorem RegionPtr.lastBlock!_insertBlock? {region : RegionPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem RegionPtr.lastBlock!_insertBlock {region : RegionPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (region.get! newCtx).lastBlock =
       if ip.region! ctx = region ∧ ip.next = none then
         some newBlock
       else
         (region.get! ctx).lastBlock := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern RegionPtr.lastBlock!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).lastBlock
+grind_pattern RegionPtr.lastBlock!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).lastBlock
 
 @[simp]
-theorem RegionPtr.parent!_insertBlock? {region : RegionPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem RegionPtr.parent!_insertBlock {region : RegionPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (region.get! newCtx).parent = (region.get! ctx).parent := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern RegionPtr.parent!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).parent
+grind_pattern RegionPtr.parent!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).parent
 
 @[simp]
-theorem ValuePtr.getFirstUse!_insertBlock? {value : ValuePtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem ValuePtr.getFirstUse!_insertBlock {value : ValuePtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     value.getFirstUse! newCtx = value.getFirstUse! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern ValuePtr.getFirstUse!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, value.getFirstUse! newCtx
+grind_pattern ValuePtr.getFirstUse!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, value.getFirstUse! newCtx
 
 @[simp]
-theorem ValuePtr.getType!_insertBlock? {value : ValuePtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem ValuePtr.getType!_insertBlock {value : ValuePtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     value.getType! newCtx = value.getType! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern ValuePtr.getType!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, value.getType! newCtx
+grind_pattern ValuePtr.getType!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, value.getType! newCtx
 
 @[simp]
-theorem OpOperandPtrPtr.get!_insertBlock? {opOperandPtr : OpOperandPtrPtr} :
-    Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃ = some newCtx →
+theorem OpOperandPtrPtr.get!_insertBlock {opOperandPtr : OpOperandPtrPtr} :
+    Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     opOperandPtr.get! newCtx = opOperandPtr.get! ctx := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   grind
 
-grind_pattern OpOperandPtrPtr.get!_insertBlock? =>
-  Rewriter.insertBlock? ctx newBlock ip h₁ h₂ h₃, some newCtx, opOperandPtr.get! newCtx
+grind_pattern OpOperandPtrPtr.get!_insertBlock =>
+  Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, opOperandPtr.get! newCtx
 
-end Rewriter.insertBlock?
+end Rewriter.insertBlock
 
 end Veir

--- a/Veir/Rewriter/GetSet/InsertOp.lean
+++ b/Veir/Rewriter/GetSet/InsertOp.lean
@@ -54,80 +54,80 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-section Rewriter.insertOp?
+section Rewriter.insertOp
 
-unseal Rewriter.insertOp?
+unseal Rewriter.insertOp
 
-attribute [local grind] Rewriter.insertOp?
+attribute [local grind] Rewriter.insertOp
 
 @[simp]
-theorem BlockPtr.firstUse!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.firstUse!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstUse = (block.get! ctx).firstUse := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockPtr.firstUse!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstUse
+grind_pattern BlockPtr.firstUse!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstUse
 
 @[simp]
-theorem BlockPtr.prev!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.prev!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).prev = (block.get! ctx).prev := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockPtr.prev!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).prev
+grind_pattern BlockPtr.prev!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).prev
 
 @[simp]
-theorem BlockPtr.next!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.next!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).next = (block.get! ctx).next := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockPtr.next!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).next
+grind_pattern BlockPtr.next!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).next
 
 @[simp]
-theorem BlockPtr.parent!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.parent!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).parent = (block.get! ctx).parent := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockPtr.parent!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).parent
+grind_pattern BlockPtr.parent!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).parent
 
-theorem BlockPtr.firstOp!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.firstOp!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstOp =
     if ip.block! ctx = block ∧ ip.prev! ctx = none then
       some newOp
     else
       (block.get! ctx).firstOp := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind [cases InsertPoint]
 
-grind_pattern BlockPtr.firstOp!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstOp
+grind_pattern BlockPtr.firstOp!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstOp
 
-theorem BlockPtr.lastOp!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.lastOp!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).lastOp =
     if ip.block! ctx = block ∧ ip.next = none then
       some newOp
     else
       (block.get! ctx).lastOp := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockPtr.lastOp!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp
+grind_pattern BlockPtr.lastOp!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp
 
-theorem OperationPtr.prev!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.prev!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).prev =
     if operation = ip.next then
       some newOp
@@ -135,14 +135,14 @@ theorem OperationPtr.prev!_insertOp? {operation : OperationPtr} :
       ip.prev! ctx
     else
       (operation.get! ctx).prev := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind [cases InsertPoint]
 
-grind_pattern OperationPtr.prev!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).prev
+grind_pattern OperationPtr.prev!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).prev
 
-theorem OperationPtr.next!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.next!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).next =
     if operation = ip.prev! ctx then
       some newOp
@@ -150,230 +150,230 @@ theorem OperationPtr.next!_insertOp? {operation : OperationPtr} :
       ip.next
     else
       (operation.get! ctx).next := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind [cases InsertPoint]
 
-grind_pattern OperationPtr.next!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).next
+grind_pattern OperationPtr.next!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).next
 
-theorem OperationPtr.parent!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.parent!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).parent =
     if operation = newOp then
       ip.block! ctx
     else
       (operation.get! ctx).parent := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind (gen := 10)
 
-grind_pattern OperationPtr.parent!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).parent
+grind_pattern OperationPtr.parent!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).parent
 
 @[simp]
-theorem OperationPtr.getOpType!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getOpType!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getOpType! newCtx = operation.getOpType! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getOpType!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
+grind_pattern OperationPtr.getOpType!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
 
 @[simp]
-theorem OperationPtr.attrs!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.attrs!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).attrs = (operation.get! ctx).attrs := by
   grind
 
-grind_pattern OperationPtr.attrs!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).attrs
+grind_pattern OperationPtr.attrs!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).attrs
 
 @[simp]
-theorem OperationPtr.getProperties!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getProperties!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getProperties! newCtx opCode = operation.getProperties! ctx opCode := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getProperties!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getProperties! newCtx opCode
+grind_pattern OperationPtr.getProperties!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getProperties! newCtx opCode
 
 @[simp]
-theorem OperationPtr.getNumResults!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumResults!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumResults! newCtx = operation.getNumResults! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getNumResults!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumResults! newCtx
+grind_pattern OperationPtr.getNumResults!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumResults! newCtx
 
 @[simp]
-theorem OpResultPtr.get!_insertOp? {opResult : OpResultPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OpResultPtr.get!_insertOp {opResult : OpResultPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     opResult.get! newCtx = opResult.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OpResultPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, opResult.get! newCtx
+grind_pattern OpResultPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, opResult.get! newCtx
 
 @[simp]
-theorem OperationPtr.getNumOperands!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumOperands!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumOperands! newCtx = operation.getNumOperands! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getNumOperands!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumOperands! newCtx
+grind_pattern OperationPtr.getNumOperands!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumOperands! newCtx
 
 @[simp]
-theorem OpOperandPtr.get!_insertOp? {operand : OpOperandPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OpOperandPtr.get!_insertOp {operand : OpOperandPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OpOperandPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
+grind_pattern OpOperandPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
 @[simp]
-theorem OperationPtr.getOperands!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getOperands!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getOperands! newCtx = operation.getOperands! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getOperands!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOperands! newCtx
+grind_pattern OperationPtr.getOperands!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOperands! newCtx
 
 @[simp]
-theorem OperationPtr.getNumSuccessors!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumSuccessors!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumSuccessors! newCtx = operation.getNumSuccessors! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getNumSuccessors!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumSuccessors! newCtx
+grind_pattern OperationPtr.getNumSuccessors!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumSuccessors! newCtx
 
 @[simp]
-theorem BlockOperandPtr.get!_insertOp? {operand : BlockOperandPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockOperandPtr.get!_insertOp {operand : BlockOperandPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockOperandPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
+grind_pattern BlockOperandPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
 @[simp]
-theorem OperationPtr.getSuccessor!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getSuccessor!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessor! newCtx index = operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-grind_pattern OperationPtr.getSuccessor!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getSuccessor! newCtx index
+grind_pattern OperationPtr.getSuccessor!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getSuccessor! newCtx index
 
 @[simp]
-theorem OperationPtr.getSuccessors!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getSuccessors!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessors! newCtx = operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-grind_pattern OperationPtr.getSuccessors!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getSuccessors! newCtx
+grind_pattern OperationPtr.getSuccessors!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getSuccessors! newCtx
 
 @[simp]
-theorem OperationPtr.getNumRegions!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getNumRegions!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumRegions! newCtx = operation.getNumRegions! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getNumRegions!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumRegions! newCtx
+grind_pattern OperationPtr.getNumRegions!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumRegions! newCtx
 
 @[simp]
-theorem OperationPtr.getRegion!_insertOp? {operation : OperationPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OperationPtr.getRegion!_insertOp {operation : OperationPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getRegion! newCtx idx = operation.getRegion! ctx idx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OperationPtr.getRegion!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getRegion! newCtx idx
+grind_pattern OperationPtr.getRegion!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getRegion! newCtx idx
 
 @[simp]
-theorem BlockOperandPtrPtr.get!_insertOp? {operandPtr : BlockOperandPtrPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockOperandPtrPtr.get!_insertOp {operandPtr : BlockOperandPtrPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operandPtr.get! newCtx = operandPtr.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockOperandPtrPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, operandPtr.get! newCtx
+grind_pattern BlockOperandPtrPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operandPtr.get! newCtx
 
 @[simp]
-theorem BlockPtr.getNumArguments!_insertOp? {block : BlockPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockPtr.getNumArguments!_insertOp {block : BlockPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     block.getNumArguments! newCtx = block.getNumArguments! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockPtr.getNumArguments!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, block.getNumArguments! newCtx
+grind_pattern BlockPtr.getNumArguments!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, block.getNumArguments! newCtx
 
 @[simp]
-theorem BlockArgumentPtr.get!_insertOp? {blockArg : BlockArgumentPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem BlockArgumentPtr.get!_insertOp {blockArg : BlockArgumentPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     blockArg.get! newCtx = blockArg.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern BlockArgumentPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, blockArg.get! newCtx
+grind_pattern BlockArgumentPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, blockArg.get! newCtx
 
 @[simp]
-theorem RegionPtr.get!_insertOp? {region : RegionPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem RegionPtr.get!_insertOp {region : RegionPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     region.get! newCtx = region.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern RegionPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, region.get! newCtx
+grind_pattern RegionPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, region.get! newCtx
 
 @[simp]
-theorem ValuePtr.getFirstUse!_insertOp? {value : ValuePtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem ValuePtr.getFirstUse!_insertOp {value : ValuePtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     value.getFirstUse! newCtx = value.getFirstUse! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern ValuePtr.getFirstUse!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, value.getFirstUse! newCtx
+grind_pattern ValuePtr.getFirstUse!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, value.getFirstUse! newCtx
 
-theorem ValuePtr.getType!_insertOp? {value : ValuePtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem ValuePtr.getType!_insertOp {value : ValuePtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     value.getType! newCtx = value.getType! ctx := by
   grind
 
-grind_pattern ValuePtr.getType!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, value.getType! newCtx
+grind_pattern ValuePtr.getType!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, value.getType! newCtx
 
 @[simp]
-theorem OpOperandPtrPtr.get!_insertOp? {opOperandPtr : OpOperandPtrPtr} :
-    Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃ = some newCtx →
+theorem OpOperandPtrPtr.get!_insertOp {opOperandPtr : OpOperandPtrPtr} :
+    Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     opOperandPtr.get! newCtx = opOperandPtr.get! ctx := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   grind
 
-grind_pattern OpOperandPtrPtr.get!_insertOp? =>
-  Rewriter.insertOp? ctx newOp ip h₁ h₂ h₃, some newCtx, opOperandPtr.get! newCtx
+grind_pattern OpOperandPtrPtr.get!_insertOp =>
+  Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, opOperandPtr.get! newCtx
 
-end Rewriter.insertOp?
+end Rewriter.insertOp
 
 end Veir

--- a/Veir/Rewriter/InlineBlock.lean
+++ b/Veir/Rewriter/InlineBlock.lean
@@ -14,18 +14,18 @@ namespace Veir
 
 variable [HasOpInfo OpInfo] {ctx : IRContext OpInfo}
 
-theorem Rewriter.insertOp?.operationList {block : BlockPtr}
+theorem Rewriter.insertOp.operationList {block : BlockPtr}
   (blockIn : block.InBounds ctx) (ctxWf : ctx.WellFormed)
   (hwf : ip.block! ctx = some block')
-  (h : Rewriter.insertOp? ctx op ip opIn ipIn ctxIn = some ctx') :
-  block.operationList ctx' (by grind [Rewriter.insertOp?_WellFormed]) (by grind) =
+  (h : Rewriter.insertOp ctx op ip opIn ipIn ctxIn = some ctx') :
+  block.operationList ctx' (by grind [Rewriter.insertOp_WellFormed]) (by grind) =
   if h: block = block' then
     (block.operationList ctx ctxWf blockIn).insertIdx (ip.idxIn ctx block' (by grind) (by grind) (by grind)) op (by apply InsertPoint.idxIn.le_size_array; grind)
   else
     block.operationList ctx ctxWf blockIn := by
   have ⟨array, hArray⟩ := ctxWf.opChain block (by grind)
   have ⟨array', hArray'⟩ := ctxWf.opChain block' (by grind)
-  simp only [Rewriter.insertOp?] at h
+  simp only [Rewriter.insertOp] at h
   split at h; grind; rename_i parent hparent
   have : block' = parent := by grind
   subst parent
@@ -74,12 +74,12 @@ theorem InsertPoint.block!_detachOp_of_ne {ip : InsertPoint} (ipBlock : ip.block
   grind [cases InsertPoint]
 
 @[grind <=]
-theorem Rewriter.wellFormed_insertOp?_detachOp
+theorem Rewriter.wellFormed_insertOp_detachOp
     (ctxWf : ctx.WellFormed) :
-    Rewriter.insertOp? (Rewriter.detachOp ctx op hctx hin hparent) op ip opIn ipIn ctxIn = some ctx' →
+    Rewriter.insertOp (Rewriter.detachOp ctx op hctx hin hparent) op ip opIn ipIn ctxIn = some ctx' →
     ctx'.WellFormed := by
   intro h
-  apply Rewriter.insertOp?_WellFormed _ h <;> grind [Rewriter.detachOp_WellFormed]
+  apply Rewriter.insertOp_WellFormed _ h <;> grind [Rewriter.detachOp_WellFormed]
 
 theorem Rewriter.detachOp.operationList
   {block : BlockPtr}
@@ -103,12 +103,12 @@ theorem Rewriter.detachOp.operationList
     simp [BlockPtr.operationList_iff_BlockPtr_OpChain.mp hArray]
 
 set_option warn.sorry false in
-theorem Rewriter.insertOp?_detachOp_operationList {block : BlockPtr}
+theorem Rewriter.insertOp_detachOp_operationList {block : BlockPtr}
   (blockIn : block.InBounds ctx) (ctxWf : ctx.WellFormed)
   (ipIn' : ip.InBounds ctx)
   (hwf : ip.block! ctx = some block')
   (hparent' : (op.get! ctx).parent ≠ some block')
-  (h : Rewriter.insertOp? (Rewriter.detachOp ctx op hctx hin hparent) op ip opIn ipIn ctxIn = some ctx') :
+  (h : Rewriter.insertOp (Rewriter.detachOp ctx op hctx hin hparent) op ip opIn ipIn ctxIn = some ctx') :
   block.operationList ctx' (by grind) (by grind) =
   if h: block = block' then
     (block.operationList ctx ctxWf blockIn).insertIdx (ip.idxIn ctx block' (by grind) (by grind) (by grind)) op (by apply InsertPoint.idxIn.le_size_array; grind)
@@ -116,17 +116,17 @@ theorem Rewriter.insertOp?_detachOp_operationList {block : BlockPtr}
     (block.operationList ctx ctxWf blockIn).erase op
   else
     block.operationList ctx ctxWf blockIn := by
-  rw [Rewriter.insertOp?.operationList (h := h) (ctx := Rewriter.detachOp ctx op hctx hin hparent) (block' := block') (ctxWf := (by grind [Rewriter.detachOp_WellFormed])) (blockIn := by grind) (by grind)]
+  rw [Rewriter.insertOp.operationList (h := h) (ctx := Rewriter.detachOp ctx op hctx hin hparent) (block' := block') (ctxWf := (by grind [Rewriter.detachOp_WellFormed])) (blockIn := by grind) (by grind)]
   sorry
   --rw [Rewriter.detachOp.operationList]
 
 set_option warn.sorry false in
-theorem InsertPoint.idxIn_insertOp?_detachOp
+theorem InsertPoint.idxIn_insertOp_detachOp
   (ctxWf : ctx.WellFormed)
   (ipIn' : ip.InBounds ctx)
   (hwf : ip.block! ctx = some blockTo)
   (hparent' : (op.get! ctx).parent ≠ some blockTo)
-  (h : Rewriter.insertOp? (Rewriter.detachOp ctx op hctx hin hparent) op ip opIn ipIn ctxIn = some ctx') :
+  (h : Rewriter.insertOp (Rewriter.detachOp ctx op hctx hin hparent) op ip opIn ipIn ctxIn = some ctx') :
   ip.idxIn ctx' blockTo inBounds parent wf =
   (ip.idxIn ctx blockTo (by grind) (by grind) (by grind)) + 1 := by sorry
 
@@ -140,7 +140,7 @@ def Rewriter.inlineBlock (ctx : IRContext OpInfo) (block : BlockPtr)
   | none => some ctx
   | some firstOpPtr => do
   let ctx₀ := detachOp ctx firstOpPtr (by grind) (by grind) (by grind [IRContext.WellFormed])
-  rlet hctx: ctx₁ ← insertOp? ctx₀ firstOpPtr ip (by grind) (by cases ip <;> grind [cases InsertPoint]) (by grind)
+  rlet hctx: ctx₁ ← insertOp ctx₀ firstOpPtr ip (by grind) (by cases ip <;> grind [cases InsertPoint]) (by grind)
   inlineBlock ctx₁ block ip
     (by cases ip <;> grind [cases InsertPoint])
     (block' := block')
@@ -150,10 +150,10 @@ def Rewriter.inlineBlock (ctx : IRContext OpInfo) (block : BlockPtr)
     )
     (by grind)
     (by (have : block.InBounds ctx₀ := by grind); grind)
-    (by grind [Rewriter.insertOp?_WellFormed, Rewriter.detachOp_WellFormed])
+    (by grind [Rewriter.insertOp_WellFormed, Rewriter.detachOp_WellFormed])
 termination_by (block.operationList ctx ctxWf blockIn).size
 decreasing_by
-  rw [Rewriter.insertOp?.operationList (h := hctx) (block' := block')]
+  rw [Rewriter.insertOp.operationList (h := hctx) (block' := block')]
   · simp only [blockNe, ↓reduceDIte, ctx₀]
     rw [Rewriter.detachOp.operationList_size (block := block)]
     · have : (firstOpPtr.get! ctx).parent = block := by grind [IRContext.WellFormed]
@@ -164,7 +164,7 @@ decreasing_by
     · grind
     · grind
   · grind
-  · grind [Rewriter.insertOp?_WellFormed, Rewriter.detachOp_WellFormed]
+  · grind [Rewriter.insertOp_WellFormed, Rewriter.detachOp_WellFormed]
   · have : (firstOpPtr.get! ctx).parent = block := by grind [IRContext.WellFormed]
     grind
 
@@ -190,7 +190,7 @@ theorem Rewriter.inlineBlock_wellFormed :
       · grind
       · rename_i firstOpPtr heq ctx₁ h'
         apply @ih ctx₁ (by grind) (by grind) (by grind) (by grind) newCtx _ (by grind)
-        rw [Rewriter.insertOp?.operationList (h := h') (block' := block')]
+        rw [Rewriter.insertOp.operationList (h := h') (block' := block')]
         · simp only [blockNe, ↓reduceDIte]
           rw [Rewriter.detachOp.operationList_size]
           · have : (firstOpPtr.get! ctx).parent = block := by grind [BlockPtr.OpChain, IRContext.WellFormed]
@@ -226,7 +226,7 @@ theorem Rewriter.inlineBlock_inBounds_block :
         have : block₀.InBounds ctx ↔ block₀.InBounds ctx₁ := by grind
         simp only [this]
         apply @ih ctx₁ (by grind) (by grind) (by grind) (by grind) newCtx (by grind)
-        rw [Rewriter.insertOp?.operationList (h := h') (block' := block')]
+        rw [Rewriter.insertOp.operationList (h := h') (block' := block')]
         · simp only [blockNe, ↓reduceDIte]
           rw [Rewriter.detachOp.operationList_size]
           · have : (firstOpPtr.get! ctx).parent = block := by grind [BlockPtr.OpChain, IRContext.WellFormed]
@@ -267,7 +267,7 @@ theorem BlockPtr.operationList_Rewriter_inlineBlock_from
     apply @ih ctx₀ (by grind) (by grind) (by grind) (by grind) newCtx _ (by grind)
     · apply hNewCtx
     · apply hArrayFrom
-    · rw [Rewriter.insertOp?.operationList (h := h') (block' := blockTo)]
+    · rw [Rewriter.insertOp.operationList (h := h') (block' := blockTo)]
       · simp only [fromNeTo, ↓reduceDIte]
         rw [Rewriter.detachOp.operationList_size] <;> grind
       · grind
@@ -331,19 +331,19 @@ theorem BlockPtr.operationList_Rewriter_inlineBlock_to
     have ⟨arrayFrom, hArrayFrom⟩ := ctx₀Wf.opChain blockFrom (by grind)
     have hparent : (firstOpPtr.get! ctx).parent = some blockFrom := by grind
     have : (blockFrom.operationList ctx₀ (by grind) (by grind)).size = n := by
-      have := @Rewriter.insertOp?_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockFrom (by grind) (by grind) (by grind) (by grind) (by grind) h'
+      have := @Rewriter.insertOp_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockFrom (by grind) (by grind) (by grind) (by grind) (by grind) h'
       rw [this]
       simp [fromNeTo, hparent]
       have : firstOpPtr ∈ array := by grind [BlockPtr.OpChain]
       grind
     have ih := @ih ctx₀ (by grind) (by grind) (by grind) (by grind) newCtx (by grind) (by grind) hNewCtx (by grind)
     simp only [ih, Array.take_eq_extract, Array.drop_eq_extract, Array.append_assoc]
-    have := @Rewriter.insertOp?_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockTo (by grind) (by grind) (by grind) (by grind) (by grind) h'
+    have := @Rewriter.insertOp_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockTo (by grind) (by grind) (by grind) (by grind) (by grind) h'
     rw [this]
-    have := @Rewriter.insertOp?_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockFrom (by grind) (by grind) (by grind) (by grind) (by grind) h'
+    have := @Rewriter.insertOp_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockFrom (by grind) (by grind) (by grind) (by grind) (by grind) h'
     rw [this]
     simp only [↓reduceDIte, Array.size_insertIdx]
-    have := @InsertPoint.idxIn_insertOp?_detachOp _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ (by grind) (by grind) (by grind) (by grind) (by grind) (by grind) (by grind) h'
+    have := @InsertPoint.idxIn_insertOp_detachOp _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ (by grind) (by grind) (by grind) (by grind) (by grind) (by grind) (by grind) h'
     rw [this]
     simp only [Array.extract_insertIdx_zero_succ, Array.append_singleton, fromNeTo, ↓reduceDIte,
       hparent, ↓reduceIte, Array.extract_insertIdx_succ_ub, Nat.lt_add_one,
@@ -387,14 +387,14 @@ theorem BlockPtr.operationList_Rewriter_inlineBlock_other
     have ⟨arrayFrom, hArrayFrom⟩ := ctx₀Wf.opChain blockFrom (by grind)
     have hparent : (firstOpPtr.get! ctx).parent = some blockFrom := by grind
     have : (blockFrom.operationList ctx₀ (by grind) (by grind)).size = n := by
-      have := @Rewriter.insertOp?_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockFrom (by grind) (by grind) (by grind) (by grind) (by grind) h'
+      have := @Rewriter.insertOp_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ blockFrom (by grind) (by grind) (by grind) (by grind) (by grind) h'
       rw [this]
       simp [fromNeTo, hparent]
       have : firstOpPtr ∈ array := by grind [BlockPtr.OpChain]
       grind
     have ih := @ih ctx₀ (by grind) (by grind) newCtx (by grind) (by grind) (by grind) hNewCtx (by grind [Rewriter.inlineBlock_inBounds_block]) (by grind)
     rw [ih]
-    have := @Rewriter.insertOp?_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ block (by grind) (by grind) (by grind) (by grind) (by grind) h'
+    have := @Rewriter.insertOp_detachOp_operationList _ _ ctx blockTo firstOpPtr (by grind) (by grind) (by grind) ip (by grind) (by grind) (by grind) ctx₀ block (by grind) (by grind) (by grind) (by grind) (by grind) h'
     rw [this]
     grind
 

--- a/Veir/Rewriter/WellFormed/Block.lean
+++ b/Veir/Rewriter/WellFormed/Block.lean
@@ -18,30 +18,30 @@ namespace Veir
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
 
-/-- # Rewriter.insertBlock? -/
+/-- # Rewriter.insertBlock -/
 
-theorem Rewriter.insertBlock?_WellFormed (hctx : ctx.WellFormed) :
-    Rewriter.insertBlock? ctx newOp ip newOpIn insIn ctxInBounds = some newCtx →
+theorem Rewriter.insertBlock_WellFormed (hctx : ctx.WellFormed) :
+    Rewriter.insertBlock ctx newOp ip newOpIn insIn ctxInBounds = some newCtx →
     newCtx.WellFormed := by
-  simp only [Rewriter.insertBlock?]
+  simp only [Rewriter.insertBlock]
   split; grind; rename_i parent hparent
   intro h
   apply IRContext.wellFormed_BlockPtr_linkBetweenWithParent hctx h (ip := ip) <;>
     grind [Option.maybe₁_def]
 
-theorem BlockPtr.operationList_rewriter_insertBlock?
+theorem BlockPtr.operationList_rewriter_insertBlock
     {block : BlockPtr} {blockInBounds : block.InBounds newCtx}
-    (h : Rewriter.insertBlock? ctx newOp ip newOpIn insIn ctxInBounds = some newCtx)
+    (h : Rewriter.insertBlock ctx newOp ip newOpIn insIn ctxInBounds = some newCtx)
     (ctxWf : ctx.WellFormed) :
     block.operationList newCtx newCtxWf blockInBounds = block.operationList ctx ctxWf (by grind) := by
   simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
-  grind [BlockPtr.opChain_BlockPtr_linkBetweenWithParent, Rewriter.insertBlock?]
+  grind [BlockPtr.opChain_BlockPtr_linkBetweenWithParent, Rewriter.insertBlock]
 
-grind_pattern BlockPtr.operationList_rewriter_insertBlock? =>
-  Rewriter.insertBlock? ctx newOp ip newOpIn insIn ctxInBounds, newCtx.WellFormed, some newCtx,
+grind_pattern BlockPtr.operationList_rewriter_insertBlock =>
+  Rewriter.insertBlock ctx newOp ip newOpIn insIn ctxInBounds, newCtx.WellFormed, some newCtx,
   block.operationList newCtx newCtxWf blockInBounds
 
-/-- # Rewriter.insertBlock? -/
+/-- # Rewriter.insertBlock -/
 
 theorem BlockPtr.allocEmpty_wellFormed (hctx : ctx.WellFormed)
     (heq : BlockPtr.allocEmpty ctx = some (newCtx, bl)) :
@@ -114,7 +114,7 @@ theorem Rewriter.createBlock_WellFormed
   have : ctx₁.WellFormed := by grind [BlockPtr.allocEmpty_wellFormed]
   split at h
   · simp only [Option.bind_eq_bind, Option.bind] at h
-    grind [IRContext.wellFormed_Rewriter_initBlockArguments, Rewriter.insertBlock?_WellFormed]
+    grind [IRContext.wellFormed_Rewriter_initBlockArguments, Rewriter.insertBlock_WellFormed]
   · grind [IRContext.wellFormed_Rewriter_initBlockArguments]
 
 /-- Any block that already existed before `Rewriter.createBlock` keeps its operation chain. -/
@@ -131,7 +131,7 @@ theorem BlockPtr.opChain_rewriter_createBlock {block : BlockPtr} {array : Array 
     BlockPtr.opChain_Rewriter_initBlockArguments hc1
   split at h
   · simp only [Option.bind_eq_bind, Option.bind] at h
-    grind [Rewriter.insertBlock?, BlockPtr.opChain_BlockPtr_linkBetweenWithParent]
+    grind [Rewriter.insertBlock, BlockPtr.opChain_BlockPtr_linkBetweenWithParent]
   · grind
 
 /-- The block freshly created by `Rewriter.createBlock` has an empty operation chain. -/
@@ -146,7 +146,7 @@ theorem BlockPtr.opChain_rewriter_createBlock_new
     BlockPtr.opChain_Rewriter_initBlockArguments hc0
   split at h
   · simp only [Option.bind_eq_bind, Option.bind] at h
-    grind [BlockPtr.opChain_BlockPtr_linkBetweenWithParent, Rewriter.insertBlock?]
+    grind [BlockPtr.opChain_BlockPtr_linkBetweenWithParent, Rewriter.insertBlock]
   · grind
 
 theorem BlockPtr.operationList_rewriter_createBlock (ctxWf : ctx.WellFormed)

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -22,27 +22,27 @@ variable {ctx : IRContext OpInfo}
 
 section insertOp
 
-theorem Rewriter.insertOp?_WellFormed (hctx : ctx.WellFormed) :
-    Rewriter.insertOp? ctx newOp ip newOpIn insIn ctxInBounds = some newCtx →
+theorem Rewriter.insertOp_WellFormed (hctx : ctx.WellFormed) :
+    Rewriter.insertOp ctx newOp ip newOpIn insIn ctxInBounds = some newCtx →
     newCtx.WellFormed := by
-  simp only [Rewriter.insertOp?]
+  simp only [Rewriter.insertOp]
   split; grind; rename_i parent hparent
   intro h
   apply IRContext.wellFormed_OperationPtr_linkBetweenWithParent hctx h (ip := ip) <;>
     grind [Option.maybe₁_def]
 
-theorem BlockPtr.operationList_rewriter_insertOp?
-  (h : Rewriter.insertOp? ctx op ip opIn ipIn ctxIn = some ctx') (ctxWf : ctx.WellFormed) :
+theorem BlockPtr.operationList_rewriter_insertOp
+  (h : Rewriter.insertOp ctx op ip opIn ipIn ctxIn = some ctx') (ctxWf : ctx.WellFormed) :
   BlockPtr.operationList block ctx' ctx'Wf blockIn =
   if h: ip.block! ctx = some block then
     (BlockPtr.operationList block ctx ctxWf).insertIdx (ip.idxIn ctx block) op
       (by apply InsertPoint.idxIn.le_size_operationList)
   else
     BlockPtr.operationList block ctx ctxWf := by
-  have ⟨block', hBlock'⟩ : ∃ block', ip.block! ctx = some block' := by grind [Rewriter.insertOp?]
+  have ⟨block', hBlock'⟩ : ∃ block', ip.block! ctx = some block' := by grind [Rewriter.insertOp]
   have ⟨array, hArray⟩ := ctxWf.opChain block (by grind)
   have ⟨array', hArray'⟩ := ctxWf.opChain block' (by grind)
-  simp only [Rewriter.insertOp?] at h
+  simp only [Rewriter.insertOp] at h
   split at h; grind; rename_i parent hparent
   have : block' = parent := by grind
   subst parent
@@ -660,7 +660,7 @@ theorem Rewriter.createOp_WellFormed
   rename_i ctx₂ hctx₂
   have : ctx₂.WellFormed :=
     by grind [Rewriter.initOpRegions_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
-  grind [insertOp?_WellFormed, Rewriter.initOpOperands_WellFormed,
+  grind [insertOp_WellFormed, Rewriter.initOpOperands_WellFormed,
     Rewriter.initBlockOperands_WellFormed]
 
 theorem BlockPtr.operationList_rewriter_createOp
@@ -689,10 +689,10 @@ theorem BlockPtr.operationList_rewriter_createOp
     simp at h
     split at h; grind; rename_i ctx₄ hctx₄
     have ctx₄Wf : ctx₄.WellFormed := by
-      grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed, Rewriter.insertOp?_WellFormed]
+      grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed, Rewriter.insertOp_WellFormed]
     simp at h; have ⟨_, _⟩ := h; subst newCtx newOp'
     simp
-    rw [BlockPtr.operationList_rewriter_insertOp? hctx₄ (by grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed])]
+    rw [BlockPtr.operationList_rewriter_insertOp hctx₄ (by grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed])]
     cases ip
     case before op =>
       simp only [InsertPoint.block!_before_eq, OperationPtr.parent!_initBlockOperands,
@@ -701,11 +701,11 @@ theorem BlockPtr.operationList_rewriter_createOp
         OperationPtr.parent!_createEmptyOp hctx₂, show op ≠ newOp by grind, ↓reduceIte]
       split <;>
         grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed,
-          Rewriter.insertOp?_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+          Rewriter.insertOp_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
     case atEnd b =>
       simp only [InsertPoint.block!_atEnd_eq, Option.some.injEq]
       split <;>
         grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed,
-          Rewriter.insertOp?_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+          Rewriter.insertOp_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
 
 end Veir

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -14,13 +14,13 @@ variable {OpInfo : Type} [HasOpInfo OpInfo]
 
 /-- Insert an operation at a given location. -/
 @[inline]
-def WfRewriter.insertOp? (wfCtx : WfIRContext OpInfo) (newOp : OperationPtr)
+def WfRewriter.insertOp (wfCtx : WfIRContext OpInfo) (newOp : OperationPtr)
     (insertionPoint : InsertPoint)
     (newOpIn : newOp.InBounds wfCtx.raw := by grind)
     (insIn : insertionPoint.InBounds wfCtx.raw := by grind)
     : Option (WfIRContext OpInfo) := do
-  rlet ctx ← Rewriter.insertOp? wfCtx newOp insertionPoint newOpIn insIn (by grind)
-  return ⟨ctx, by grind [Rewriter.insertOp?_WellFormed]⟩
+  rlet ctx ← Rewriter.insertOp wfCtx newOp insertionPoint newOpIn insIn (by grind)
+  return ⟨ctx, by grind [Rewriter.insertOp_WellFormed]⟩
 
 /-- Detach an operation from its parent. -/
 @[inline]
@@ -54,13 +54,13 @@ def WfRewriter.eraseOp (wfCtx : WfIRContext OpInfo) (op : OperationPtr)
 
 /-- Insert a block at a given location. -/
 @[inline]
-def WfRewriter.insertBlock? (wfCtx : WfIRContext OpInfo) (newBlock : BlockPtr)
+def WfRewriter.insertBlock (wfCtx : WfIRContext OpInfo) (newBlock : BlockPtr)
     (insertionPoint : BlockInsertPoint)
     (newBlockIn : newBlock.InBounds wfCtx.raw := by grind)
     (insIn : insertionPoint.InBounds wfCtx.raw := by grind)
     : Option (WfIRContext OpInfo) := do
-  rlet h: ctx ← Rewriter.insertBlock? wfCtx newBlock insertionPoint newBlockIn insIn (by grind)
-  return ⟨ctx, by grind [Rewriter.insertBlock?_WellFormed]⟩
+  rlet h: ctx ← Rewriter.insertBlock wfCtx newBlock insertionPoint newBlockIn insIn (by grind)
+  return ⟨ctx, by grind [Rewriter.insertBlock_WellFormed]⟩
 
 /-- Replace the operand of an operation with a new value. -/
 @[inline]

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -310,49 +310,49 @@ theorem OperationPtr.getResultTypes!_WfRewriter_createOp :
 
 end WfRewriter.createOp
 
-/-! ## `WfRewriter.insertOp?` -/
+/-! ## `WfRewriter.insertOp` -/
 
-section WfRewriter.insertOp?
+section WfRewriter.insertOp
 
-attribute [local grind] WfRewriter.insertOp?
+attribute [local grind] WfRewriter.insertOp
 
 @[simp, grind =>, simp_getset]
-theorem BlockPtr.prev!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem BlockPtr.prev!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (block.get! ctx'.raw).prev = (block.get! ctx.raw).prev := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem BlockPtr.next!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem BlockPtr.next!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (block.get! ctx'.raw).next = (block.get! ctx.raw).next := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem BlockPtr.parent!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem BlockPtr.parent!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (block.get! ctx'.raw).parent = (block.get! ctx.raw).parent := by
   grind
 
 @[grind =>, simp_getset]
-theorem BlockPtr.firstOp!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem BlockPtr.firstOp!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (block.get! ctx'.raw).firstOp =
     if insertionPoint.block! ctx.raw = block ∧ insertionPoint.prev! ctx.raw = none then some newOp
     else (block.get! ctx.raw).firstOp := by
   grind
 
 @[grind =>, simp_getset]
-theorem BlockPtr.lastOp!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem BlockPtr.lastOp!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (block.get! ctx'.raw).lastOp =
     if insertionPoint.block! ctx.raw = block ∧ insertionPoint.next = none then some newOp
     else (block.get! ctx.raw).lastOp := by
   grind
 
 @[grind =>, simp_getset]
-theorem OperationPtr.prev!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.prev!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (operation.get! ctx'.raw).prev =
     if operation = insertionPoint.next then some newOp
     else if operation = newOp then insertionPoint.prev! ctx.raw
@@ -360,8 +360,8 @@ theorem OperationPtr.prev!_wfRewriter_insertOp? :
   grind
 
 @[grind =>, simp_getset]
-theorem OperationPtr.next!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.next!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (operation.get! ctx'.raw).next =
     if operation = insertionPoint.prev! ctx.raw then some newOp
     else if operation = newOp then insertionPoint.next
@@ -369,122 +369,122 @@ theorem OperationPtr.next!_wfRewriter_insertOp? :
   grind
 
 @[grind =>, simp_getset]
-theorem OperationPtr.parent!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.parent!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (operation.get! ctx'.raw).parent =
     if operation = newOp then insertionPoint.block! ctx.raw
     else (operation.get! ctx.raw).parent := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getOpType!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getOpType!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getOpType! ctx'.raw = operation.getOpType! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.attrs!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.attrs!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (operation.get! ctx'.raw).attrs = (operation.get! ctx.raw).attrs := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getProperties!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getProperties!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getProperties! ctx'.raw opType = operation.getProperties! ctx.raw opType := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getNumResults!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getNumResults!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getNumResults! ctx'.raw = operation.getNumResults! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getNumOperands!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getNumOperands!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getNumOperands! ctx'.raw = operation.getNumOperands! ctx.raw := by
   grind
 
 @[grind =>, simp_getset]
-theorem OperationPtr.getOperand!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getOperand!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getOperand! ctx'.raw index = operation.getOperand! ctx.raw index := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getOperands!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getOperands!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getOperands! ctx'.raw = operation.getOperands! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getNumSuccessors!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getNumSuccessors!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getNumSuccessors! ctx'.raw = operation.getNumSuccessors! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getSuccessor!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getSuccessor!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getSuccessor! ctx'.raw index = operation.getSuccessor! ctx.raw index := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getSuccessors!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getSuccessors!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getSuccessors! ctx'.raw = operation.getSuccessors! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getNumRegions!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getNumRegions!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getNumRegions! ctx'.raw = operation.getNumRegions! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem OperationPtr.getRegion!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getRegion!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getRegion! ctx'.raw idx = operation.getRegion! ctx.raw idx := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem BlockPtr.getNumArguments!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem BlockPtr.getNumArguments!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     block.getNumArguments! ctx'.raw = block.getNumArguments! ctx.raw := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem RegionPtr.firstBlock!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem RegionPtr.firstBlock!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (region.get! ctx'.raw).firstBlock = (region.get! ctx.raw).firstBlock := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem RegionPtr.lastBlock!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem RegionPtr.lastBlock!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (region.get! ctx'.raw).lastBlock = (region.get! ctx.raw).lastBlock := by
   grind
 
 @[simp, grind =>, simp_getset]
-theorem RegionPtr.parent!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem RegionPtr.parent!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     (region.get! ctx'.raw).parent = (region.get! ctx.raw).parent := by
   grind
 
 @[grind =>, simp_getset]
-theorem ValuePtr.getType!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem ValuePtr.getType!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     value.getType! ctx'.raw = value.getType! ctx.raw := by
   grind
 
 @[grind =>, simp_getset]
-theorem OperationPtr.getResultTypes!_wfRewriter_insertOp? :
-    WfRewriter.insertOp? ctx newOp insertionPoint newOpIn insIn = some ctx' →
+theorem OperationPtr.getResultTypes!_wfRewriter_insertOp :
+    WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
     operation.getResultTypes! ctx'.raw = operation.getResultTypes! ctx.raw := by
   grind
 
-end WfRewriter.insertOp?
+end WfRewriter.insertOp
 
 /-! ## `WfRewriter.eraseOp` -/
 

--- a/Veir/Rewriter/WfRewriter/InBounds.lean
+++ b/Veir/Rewriter/WfRewriter/InBounds.lean
@@ -21,13 +21,13 @@ variable {newOp operation : OperationPtr} {region : RegionPtr} {block blockPtr :
 variable {oldValue newValue : ValuePtr}
 variable {ptr : GenericPtr}
 
-/-! ## `WfRewriter.insertOp?` -/
+/-! ## `WfRewriter.insertOp` -/
 
 @[grind =>]
-theorem WfRewriter.insertOp?_inBounds_iff
-    (heq : WfRewriter.insertOp? ctx newOp ip h₁ h₂ = some ctx') :
+theorem WfRewriter.insertOp_inBounds_iff
+    (heq : WfRewriter.insertOp ctx newOp ip h₁ h₂ = some ctx') :
     ptr.InBounds ctx'.raw ↔ ptr.InBounds ctx.raw := by
-  grind [insertOp?]
+  grind [insertOp]
 
 /-! ## `WfRewriter.detachOp` -/
 
@@ -43,13 +43,13 @@ theorem WfRewriter.detachOpIfAttached_inBounds_iff :
     ptr.InBounds (WfRewriter.detachOpIfAttached ctx op h).raw ↔ ptr.InBounds ctx.raw := by
   grind [detachOpIfAttached]
 
-/-! ## `WfRewriter.insertBlock?` -/
+/-! ## `WfRewriter.insertBlock` -/
 
 @[grind =>]
-theorem WfRewriter.insertBlock?_inBounds_iff
-    (heq : WfRewriter.insertBlock? ctx newBlock ip h₁ h₂ = some ctx') :
+theorem WfRewriter.insertBlock_inBounds_iff
+    (heq : WfRewriter.insertBlock ctx newBlock ip h₁ h₂ = some ctx') :
     ptr.InBounds ctx.raw ↔ ptr.InBounds ctx'.raw := by
-  grind [insertBlock?]
+  grind [insertBlock]
 
 /-! ## `WfRewriter.replaceOperand` -/
 


### PR DESCRIPTION
These were badly named, as there was no `insertOp` or `insertBlock` equivalents.