### PR TITLE
feat(interpreter): Add InterpreterState.DefinesDominating

### DIFF
--- a/Veir/Dominance.lean
+++ b/Veir/Dominance.lean
@@ -120,8 +120,10 @@ SSA dominance.
   A predicate that states that the values in the IR context are used in operations that
   are dominated by the operation or block that defines them.
 -/
-axiom WfIRContext.Dom (ctx : WfIRContext OpInfo) : Prop
-
+def WfIRContext.Dom (ctx : WfIRContext OpInfo) : Prop :=
+  ∀ {op : OperationPtr} (_opInBounds : op.InBounds ctx.raw) {value : ValuePtr},
+  value ∈ op.getOperands! ctx.raw →
+  value.dominatesIp (InsertPoint.before op) ctx
 
 /--
 Operands of an operation are not results of dominated operations.
@@ -142,3 +144,18 @@ axiom OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands! (ctxD
 
 grind_pattern OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands! =>
   ctx.Dom, value.getDefiningOp! ctx.raw, some op₂, op₁.getOperands! ctx.raw
+
+/-- In a well-dominated IR context, any value that is an operand of an operation `op` is
+dominating the program point before `op`. -/
+@[grind →]
+theorem WfIRContext.Dom.operand_dominates_op (ctxDom : ctx.Dom)
+    (opInBounds : op.InBounds ctx.raw) :
+    value ∈ op.getOperands! ctx.raw →
+    value.dominatesIp (InsertPoint.before op) ctx := by
+  grind [WfIRContext.Dom]
+
+/-- In a well-dominated IR context, a value dominates the program point after an operation iff
+it dominates the program point before the operation, or it is a result of the operation. -/
+axiom WfIRContext.Dom.value_dominatesIp_after_iff (ctxDom : ctx.Dom) :
+  value.dominatesIp (InsertPoint.after op ctx.raw block blockIsParent opInBounds) ctx ↔
+  value.dominatesIp (InsertPoint.before op) ctx ∨ value ∈ op.getResults! ctx.raw

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -167,6 +167,15 @@ theorem Array.mapM_eq_some_iff_of_size_eq [Inhabited α] [Inhabited β] {a₁ : 
     suffices r = a₂ by grind
     grind [Array.mapM_option_eq_some_implies]
 
+theorem Array.exists_mapM_option_eq_some_iff {f : α → Option β} {l : Array α} :
+    (∃ r, l.mapM f = some r) ↔ (∀ i (hi : i < l.size), ∃ v, f l[i] = some v) := by
+  constructor
+  · rintro ⟨r, hr⟩ i hi
+    grind [Array.mapM_option_eq_some_implies hr i (by grind)]
+  · intro h
+    apply Array.mapM_option_isSome
+    grind
+
 namespace ForLean.List
 
 theorem idxOf_getElem [DecidableEq α] {l : List α} (H : l.Nodup) (i : Nat) (h : i < l.length) :

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -139,3 +139,89 @@ theorem interpretOp_equationLemmaAt {ctx : WfIRContext OpCode} {opInBounds} {sta
     · grind [interpretOp_equationHolds_other]
     · grind
   · grind [interpretOp_equationHolds_self]
+
+/-- An interpreter state satisfies the `DefinesDominating` invariant at a program point if it
+defines all values that dominate that program point. This should be satisfied by any state in the
+interpreter. -/
+def InterpreterState.DefinesDominating {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
+    (location : InsertPoint) (_locInBounds : location.InBounds ctx.raw := by grind) : Prop :=
+  ∀ (value : ValuePtr) (_valueInBounds : value.InBounds ctx.raw),
+  value.dominatesIp location ctx →
+  (state.variables.getVar? value).isSome
+
+/-- Getting a dominating value from a state satisfying `DefinesDominating` at a program point is
+always successful. -/
+theorem InterpreterState.DefinesDominating.isSome_getVar_of_dominatesIp
+    {state : InterpreterState ctx}
+    (eqLemma : state.DefinesDominating location locInBounds)
+    {value : ValuePtr} (valueInBounds : value.InBounds ctx.raw)
+    (valueDom : value.dominatesIp location ctx) :
+    (state.variables.getVar? value).isSome := by
+  grind [InterpreterState.DefinesDominating]
+
+/-- Getting a dominating value from a state satisfying `DefinesDominating` at a program point is
+always successful. -/
+theorem InterpreterState.DefinesDominating.exists_getVar_of_dominatesIp
+    {state : InterpreterState ctx}
+    (eqLemma : state.DefinesDominating location locInBounds)
+    {value : ValuePtr} (valueInBounds : value.InBounds ctx.raw)
+    (valueDom : value.dominatesIp location ctx) :
+    ∃ val, state.variables.getVar? value = some val := by
+  simp only [← Option.isSome_iff_exists]
+  grind [InterpreterState.DefinesDominating.isSome_getVar_of_dominatesIp]
+
+/-- All operands operation in a well-dominated program exist in a state that is `DefinesDominating`
+right before the operation. -/
+theorem InterpreterState.DefinesDominating.exists_getOperandValues_eq_some
+    {ctx : WfIRContext OpCode} (ctxDom : ctx.Dom) {state : InterpreterState ctx}
+    {op : OperationPtr} (opInBounds : op.InBounds ctx.raw)
+    (stateDom : state.DefinesDominating (InsertPoint.before op) opInBounds) :
+    ∃ val, state.variables.getOperandValues op = some val := by
+  simp only [VariableState.getOperandValues, Array.exists_mapM_option_eq_some_iff]
+  intro i hi
+  apply InterpreterState.DefinesDominating.exists_getVar_of_dominatesIp stateDom (by grind)
+  grind [WfIRContext.Dom.operand_dominates_op]
+
+/-- `InterpreterState.DefinesDominating` is preserved when interpreting an operation: if every value
+dominating the program point *before* `op` is available in `state`, then after running `op` every
+value dominating the point *after* `op` is available in the resulting state. -/
+theorem interpretOp_DefinesDominating {ctx : WfIRContext OpCode} {opInBounds}
+    (ctxDom : ctx.Dom) {state state' : InterpreterState ctx}
+    (stateDom : state.DefinesDominating (InsertPoint.before op) opInBounds)
+    (opHasParent : (op.get! ctx.raw).parent = some block) :
+    interpretOp op state = some (.ok (state', controlFlow)) →
+    state'.DefinesDominating (InsertPoint.after op ctx.raw block) := by
+  intro hinterp
+  simp only [InterpreterState.DefinesDominating] at stateDom ⊢
+  simp only [interpretOp_some_iff] at hinterp
+  have ⟨operandValues, resValues, mem', varState', hoperand, hinterp, hresValues, hstate⟩ := hinterp
+  subst state'
+  intro value valueInBounds valueDom
+  cases (WfIRContext.Dom.value_dominatesIp_after_iff ctxDom).mp valueDom
+  case inl =>
+    have := stateDom value (by grind) (by grind)
+    grind
+  case inr =>
+    grind [OperationPtr.getResults!.mem_iff_exists_index]
+
+/-- Interpreting a verified operation never fails on a state satisfying `DefinesDominating` at the
+operation's location. -/
+theorem InterpreterState.DefinesDominating.interpretOp_ne_none
+    (ctxDom : ctx.Dom) (opInBounds : op.InBounds ctx.raw) {state : InterpreterState ctx}
+    (stateDom : state.DefinesDominating (InsertPoint.before op) opInBounds)
+    (opVerif : op.Verified ctx opInBounds) :
+    ∃ state', interpretOp op state opInBounds = some state' := by
+  simp only [interpretOp]
+  have ⟨operandValues, hOperandValues⟩ := stateDom.exists_getOperandValues_eq_some ctxDom opInBounds
+  simp only [hOperandValues]
+  have hconforms : RuntimeValue.ArrayConforms operandValues (op.getOperandTypes! ctx.raw) := by
+    grind [VariableState.getOperandValues_conforms]
+  have ⟨resValues, hresValues⟩ := exists_interpretOp'_eq_some opVerif hconforms state.memory
+  simp only [hresValues, bind]
+  rcases resValues with ⟨resValues, mem', act⟩ | _
+  · simp only [liftM, monadLift, MonadLift.monadLift, pure, Interp]
+    have := interpretOp'_results_conform opVerif hconforms hresValues
+    have ⟨v, hv⟩ :=
+      (VariableState.setResultValues?_isSome_iff_conforms state.variables opInBounds).mp this
+    simp [hv]
+  · simp [Interp]


### PR DESCRIPTION
This proposition asserts that the variable state should contain all variables that are dominating the current location. From this definition, we can now have a proof that `interpretOp` is never return `none` whenever the state is `DefinesDominating`