### PR TITLE
feat: add a simple canonicalizer

### DIFF
--- a/Test/Passes/Canonicalize/commute_constant_arith.mlir
+++ b/Test/Passes/Canonicalize/commute_constant_arith.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-opt %s -p=canonicalize | filecheck %s
+
+// A commutative `arith` op with the constant on the left: the constant is
+// pushed to the right-hand side.
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "main"}> ({
+    ^bb0(%x : i32):
+      // CHECK:      ^{{.*}}(%[[X:.*]] : i32):
+      %c = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+      // CHECK-NEXT: %[[C:.*]] = "arith.constant"() <{"value" = 5 : i32}> : () -> i32
+      %add = "arith.addi"(%c, %x) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[ADD:.*]] = "arith.addi"(%[[X]], %[[C]]) : (i32, i32) -> i32
+      "func.return"(%add) : (i32) -> ()
+      // CHECK-NEXT: "func.return"(%[[ADD]]) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/Canonicalize/commute_constant_llvm.mlir
+++ b/Test/Passes/Canonicalize/commute_constant_llvm.mlir
@@ -1,0 +1,26 @@
+// RUN: veir-opt %s -p=canonicalize | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "main"}> ({
+    ^bb0(%x : i32):
+      // CHECK:      ^{{.*}}(%[[X:.*]] : i32):
+      %c = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
+      // CHECK-NEXT: %[[C:.*]] = "llvm.mlir.constant"() <{"value" = 5 : i32}> : () -> i32
+
+      // Commutative op with the constant on the left: operands are swapped
+      // so the constant is pushed to the right.
+      %add = "llvm.add"(%c, %x) : (i32, i32) -> i32
+      // CHECK-NEXT: %[[ADD:.*]] = "llvm.add"(%[[X]], %[[C]]) : (i32, i32) -> i32
+
+      // Non-commutative op: operands are left untouched.
+      %sub = "llvm.sub"(%c, %x) : (i32, i32) -> i32
+      // CHECK-NEXT: "llvm.sub"(%[[C]], %[[X]]) : (i32, i32) -> i32
+
+      // Already canonical (constant on the right): unchanged.
+      %ok = "llvm.add"(%x, %c) : (i32, i32) -> i32
+      // CHECK-NEXT: "llvm.add"(%[[X]], %[[C]]) : (i32, i32) -> i32
+
+      "func.return"(%add) : (i32) -> ()
+      // CHECK-NEXT: "func.return"(%[[ADD]]) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/Canonicalize/commute_constant_multi_result.mlir
+++ b/Test/Passes/Canonicalize/commute_constant_multi_result.mlir
@@ -1,0 +1,17 @@
+// RUN: veir-opt %s -p=canonicalize | filecheck %s
+
+// A commutative op with more than one result (`arith.mului_extended`
+// produces the low word and the high/overflow word): the constant is
+// still pushed to the right and all results are preserved.
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "main"}> ({
+    ^bb0(%x : i32):
+      // CHECK:      ^{{.*}}(%[[X:.*]] : i32):
+      %c = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
+      // CHECK-NEXT: %[[C:.*]] = "arith.constant"() <{"value" = 5 : i32}> : () -> i32
+      %lo, %hi = "arith.mului_extended"(%c, %x) : (i32, i32) -> (i32, i32)
+      // CHECK-NEXT: %[[R:.*]]:2 = "arith.mului_extended"(%[[X]], %[[C]]) : (i32, i32) -> (i32, i32)
+      "func.return"(%lo) : (i32) -> ()
+      // CHECK-NEXT: "func.return"(%[[R]]#0) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/Canonicalize/commute_constant_riscv.mlir
+++ b/Test/Passes/Canonicalize/commute_constant_riscv.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-opt %s -p=canonicalize | filecheck %s
+
+// A commutative `riscv` op with the `riscv.li` constant on the left: the
+// constant is pushed to the right-hand side.
+"builtin.module"() ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb0(%x : !riscv.reg):
+      // CHECK:      ^{{.*}}(%[[X:.*]] : !riscv.reg):
+      %c = "riscv.li"() <{"value" = 5 : i64}> : () -> !riscv.reg
+      // CHECK-NEXT: %[[C:.*]] = "riscv.li"() <{"value" = 5 : i64}> : () -> !riscv.reg
+      %add = "riscv.add"(%c, %x) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+      // CHECK-NEXT: %[[ADD:.*]] = "riscv.add"(%[[X]], %[[C]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+      "func.return"(%add) : (!riscv.reg) -> ()
+      // CHECK-NEXT: "func.return"(%[[ADD]]) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -410,7 +410,7 @@ def OperationPtr.hasSideEffects (op : OperationPtr) (ctx : IRContext OpCode) : B
   | _ => true
 
 /--
-  Does this OpCode materialize a literal constant value (i.e. an op
+  Does this `OpCode` materialize a literal constant value (i.e. an op
   whose result is a compile-time constant taken from its attributes,
   with no SSA operands)?
 -/

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -408,3 +408,35 @@ def OperationPtr.hasSideEffects (op : OperationPtr) (ctx : IRContext OpCode) : B
   | .llvm .load => (op.getProperties! ctx (.llvm .load)).volatile_
   -- For everything else: be conservative!
   | _ => true
+
+/--
+  Does this OpCode materialize a literal constant value (i.e. an op
+  whose result is a compile-time constant taken from its attributes,
+  with no SSA operands)?
+-/
+def OpCode.isConstantLike (opCode : OpCode) : Bool :=
+  match opCode with
+  | .arith .constant
+  | .llvm .mlir__constant
+  | .riscv .li => true
+  | _ => false
+
+/--
+  Is this OpCode commutative in its operands, i.e. `op x y` always
+  computes the same value as `op y x`?
+-/
+def OpCode.isCommutative (opCode : OpCode) : Bool :=
+  match opCode with
+  | .arith .addi | .arith .muli
+  | .arith .andi | .arith .ori | .arith .xori
+  | .arith .maxsi | .arith .maxui | .arith .minsi | .arith .minui
+  | .arith .addui_extended
+  | .arith .mulsi_extended | .arith .mului_extended
+  | .llvm .add | .llvm .mul
+  | .llvm .and | .llvm .or | .llvm .xor
+  | .llvm .fadd | .llvm .fmul
+  | .riscv .add | .riscv .and | .riscv .or | .riscv .xor | .riscv .xnor
+  | .riscv .mul | .riscv .mulh | .riscv .mulhu
+  | .riscv .max | .riscv .maxu | .riscv .min | .riscv .minu
+  | .riscv .addw | .riscv .mulw => true
+  | _ => false

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -422,7 +422,7 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | _ => false
 
 /--
-  Is this OpCode commutative in its operands, i.e. `op x y` always
+  Is this `OpCode` commutative in its operands, i.e. `op x y` always
   computes the same value as `op y x`?
 -/
 def OpCode.isCommutative (opCode : OpCode) : Bool :=

--- a/Veir/Passes/Canonicalize.lean
+++ b/Veir/Passes/Canonicalize.lean
@@ -1,0 +1,51 @@
+import Veir.Pass
+import Veir.PatternRewriter.Basic
+import Veir.Passes.Matching
+
+namespace Veir
+
+/-!
+  # Canonicalize pass
+
+  Currently, the only transformation it performs is to move constants
+  to the right side, for commutative operations.
+-/
+
+def isConstOperand (ctx : IRContext OpCode) (v : ValuePtr) : Bool :=
+  match v.getDefiningOp! ctx with
+  | some defOp => (defOp.getOpType! ctx).isConstantLike
+  | none => false
+
+set_option warn.sorry false in
+def commutativeConstantRHS (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let opType := op.getOpType! rewriter.ctx.raw
+  if ¬ opType.isCommutative then return rewriter
+  let operands := op.getOperands! rewriter.ctx.raw
+  /- Stable partition: non-constant operands first, then the constants. -/
+  let (nonConsts, consts) := operands.partition (!isConstOperand rewriter.ctx.raw ·)
+  let reordered := nonConsts ++ consts
+  if reordered == operands then return rewriter
+  let resultTypes := op.getResultTypes! rewriter.ctx.raw
+  let properties := op.getProperties! rewriter.ctx.raw opType
+  let (rewriter, newOp) ← rewriter.createOp opType resultTypes reordered
+    #[] #[] properties (some $ .before op) sorry sorry sorry sorry
+  rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
+
+/-! ## Pass implementation -/
+
+def CanonicalizePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
+    ExceptT String IO (WfIRContext OpCode) := do
+  let pattern := RewritePattern.GreedyRewritePattern #[
+    commutativeConstantRHS
+  ]
+  match RewritePattern.applyInContext pattern ctx with
+  | none => throw "Error while applying canonicalization patterns"
+  | some ctx => pure ctx
+
+public def CanonicalizePass : Pass OpCode :=
+  { name := "canonicalize"
+    description := "Rewrite operations into a canonical form."
+    run := CanonicalizePass.impl }
+
+end Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -15,6 +15,7 @@ import Veir.Passes.DCE.dce
 import Veir.Passes.CastsReconciliation.Reconciliation
 import Veir.Passes.RISCVCombines.Combine
 import Veir.Passes.ModArithToArith
+import Veir.Passes.Canonicalize
 
 open Veir.Parser
 open Veir.Parser.ParserError
@@ -34,6 +35,7 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
     |>.insert CastReconcilePass.name CastReconcilePass
     |>.insert RISCV.Combine.name RISCV.Combine
     |>.insert ModArithToArithPass.name ModArithToArithPass
+    |>.insert CanonicalizePass.name CanonicalizePass
 
 /--
   Arguments for the `veir-opt` command-line tool, parsed from the CLI.


### PR DESCRIPTION
all it does is move constants to the right of the operand list, for operations that are commutative

this mirrors upstream MLIR fairly closely!
