### PR TITLE
feat(riscv): introduce slti and sltiu

### DIFF
--- a/Test/Passes/Combines/slt_li_to_slti.mlir
+++ b/Test/Passes/Combines/slt_li_to_slti.mlir
@@ -1,0 +1,74 @@
+// RUN: veir-opt %s -p=riscv-combine | filecheck %s
+
+"builtin.module"() ({
+    // riscv.slt x (riscv.li imm) -> riscv.slti x imm
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[a:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = 7 : i64}>: () -> !riscv.reg
+        %r = "riscv.slt"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[r:%.*]] = "riscv.slti"([[a]]) <{"value" = 7 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // riscv.sltu x (riscv.li imm) -> riscv.sltiu x imm
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[a2:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = 2047 : i64}>: () -> !riscv.reg
+        %r = "riscv.sltu"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[r2:%.*]] = "riscv.sltiu"([[a2]]) <{"value" = 2047 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r2]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // riscv.slt x (riscv.li imm) -> riscv.slti x imm  (min in-range immediate)
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[a3:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = -2048 : i64}>: () -> !riscv.reg
+        %r = "riscv.slt"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[r3:%.*]] = "riscv.slti"([[a3]]) <{"value" = -2048 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r3]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // Non-commutative: li on the left is the lower bound, not rs1. For unsigned
+    // there is no profitable set-greater-than-immediate fold, so riscv.sltu
+    // (riscv.li imm) x must NOT fold.
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[a4:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = 4 : i64}>: () -> !riscv.reg
+        %r = "riscv.sltu"(%c, %a) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[v:%.*]] = "riscv.li"() <{"value" = 4 : i64}> : () -> !riscv.reg
+        // CHECK:             [[r4:%.*]] = "riscv.sltu"([[v]], [[a4]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r4]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // Out-of-range immediate: not folded (riscv.slt stays as-is).
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[a5:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = 2048 : i64}>: () -> !riscv.reg
+        %r = "riscv.slt"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[big:%.*]] = "riscv.li"() <{"value" = 2048 : i64}> : () -> !riscv.reg
+        // CHECK:             [[r5:%.*]] = "riscv.slt"([[a5]], [[big]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r5]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // Out-of-range immediate: not folded (riscv.sltu stays as-is).
+    "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%a : !riscv.reg):
+        // CHECK:             ^{{.*}}([[a6:%.*]] : !riscv.reg):
+        %c = "riscv.li"() <{"value" = -2049 : i64}>: () -> !riscv.reg
+        %r = "riscv.sltu"(%a, %c) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:             [[big2:%.*]] = "riscv.li"() <{"value" = -2049 : i64}> : () -> !riscv.reg
+        // CHECK:             [[r6:%.*]] = "riscv.sltu"([[a6]], [[big2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (!riscv.reg) -> ()
+        // CHECK:             "func.return"([[r6]]) : (!riscv.reg) -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Veir.lean
+++ b/Veir.lean
@@ -9,6 +9,7 @@ import Veir.Rewriter.InlineBlock
 import Veir.Rewriter.WfRewriter
 import Veir.Printer
 import Veir.PatternRewriter.Basic
+import Veir.Passes.RISCVCombines.Proofs
 import Veir.Benchmarks
 import Veir.Parser.Lexer
 import Veir.Interpreter

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -77,6 +77,10 @@ def fold_shift5_li (src dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediat
 def fold_shift6_li (src dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties) :
     LocalRewritePattern OpCode := fold_binop_li src dst h 0 63
 
+/-- Non-commutative signed imm12 operations: `imm ∈ [-2048, 2047]`. -/
+def fold_imm12_li (src dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties) :
+    LocalRewritePattern OpCode := fold_binop_li src dst h (-2048) 2047
+
 def fold_sllw_li_to_slliw := fold_shift5_li .sllw .slliw rfl
 def fold_srlw_li_to_srliw := fold_shift5_li .srlw .srliw rfl
 def fold_sraw_li_to_sraiw := fold_shift5_li .sraw .sraiw rfl
@@ -90,6 +94,9 @@ def fold_bclr_li_to_bclri := fold_shift6_li .bclr .bclri rfl
 def fold_bext_li_to_bexti := fold_shift6_li .bext .bexti rfl
 def fold_binv_li_to_binvi := fold_shift6_li .binv .binvi rfl
 def fold_bset_li_to_bseti := fold_shift6_li .bset .bseti rfl
+
+def fold_slt_li_to_slti   := fold_imm12_li .slt  .slti  rfl
+def fold_sltu_li_to_sltiu := fold_imm12_li .sltu .sltiu rfl
 
 set_option warn.sorry false in
 /-- riscv.slli (riscv.zextw x) shamt -> riscv.slliuw x shamt -/
@@ -126,6 +133,8 @@ def Combine.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds
       RewritePattern.fromLocalRewrite fold_bext_li_to_bexti,
       RewritePattern.fromLocalRewrite fold_binv_li_to_binvi,
       RewritePattern.fromLocalRewrite fold_bset_li_to_bseti,
+      RewritePattern.fromLocalRewrite fold_slt_li_to_slti,
+      RewritePattern.fromLocalRewrite fold_sltu_li_to_sltiu,
       RewritePattern.fromLocalRewrite fold_zextw_slli_to_slliuw]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"

--- a/Veir/Passes/RISCVCombines/Proofs.lean
+++ b/Veir/Passes/RISCVCombines/Proofs.lean
@@ -14,3 +14,28 @@ namespace Veir.Data.RISCV
 theorem right_identity_zero_add:
     (RISCV.add lhs (Data.RISCV.li (BitVec.ofInt 64 0))) = lhs := by
   simp [reg_toBitVec]
+
+/--
+  Soundness of:
+  `riscv.slt rs1 (riscv.li imm)` -> `riscv.slti rs1 imm`
+
+  This is stated directly over the RISCV register interpreter semantics. The
+  rewrite is valid when the original `li` value is the 64-bit sign extension of
+  the 12-bit immediate used by `slti`.
+-/
+theorem fold_slt_li_to_slti_sound (rs1 : Reg) (imm : BitVec 12) :
+    slt (li (imm.signExtend 64)) rs1 = slti imm rs1 := by
+  rw [val_inj]
+  simp only [val_slt, val_slti, val_li]
+
+/--
+  Soundness of:
+  `riscv.sltu rs1 (riscv.li imm)` -> `riscv.sltiu rs1 imm`
+
+  As in the ISA semantics for `sltiu`, the immediate is sign-extended before the
+  unsigned comparison.
+-/
+theorem fold_sltu_li_to_sltiu_sound (rs1 : Reg) (imm : BitVec 12) :
+    sltu (li (imm.signExtend 64)) rs1 = sltiu imm rs1 := by
+  rw [val_inj]
+  simp only [val_sltu, val_sltiu, val_li]


### PR DESCRIPTION
also add proofs of these. the proofs are for the specific rewrite, not for the code performing the rewrite, which must wait for us to build out some other infrastructure first.