### PR TITLE
feat: Add xDSL-style typing support for allocated registers

### DIFF
--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -287,6 +287,7 @@ macro "#assert " e:term : command =>
 
 /-! ## RISCV Register type -/
 #assert expectSuccessType "!riscv.reg" (RegisterType.mk)
+#assert expectSuccessType "!riscv.reg<x13>" (RegisterType.mk (some 13))
 
 /-! ## Flat symbol reference attribute -/
 #assert expectSuccessAttr "@foo" (FlatSymbolRefAttr.mk "@foo")

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -55,6 +55,7 @@ deriving Inhabited, Repr, DecidableEq, Hashable
   A register type is an integer type with width 64.
 -/
 structure RegisterType where
+  index: Option Nat := none
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
@@ -713,7 +714,10 @@ instance : ToString FloatAttr where
   toString attr := s!"{attr.value} : {attr.type}"
 
 instance : ToString RegisterType where
-  toString _ := s!"!riscv.reg"
+  toString type :=
+    match type.index with
+    | none => s!"!riscv.reg"
+    | some i => s!"!riscv.reg<x{i}>"
 
 instance : ToString RegisterAttr where
   toString attr := s!"{attr.value} : !riscv.reg"
@@ -1147,6 +1151,9 @@ instance : Coe FunctionType TypeAttr where
 
 instance : Coe ModArithType TypeAttr where
   coe type := ⟨.modArithType type, by rfl⟩
+
+instance : CoeDep (Option Nat → RegisterType) RegisterType.mk TypeAttr where
+  coe := ⟨.registerType (.mk none), by rfl⟩
 
 instance : Coe RegisterType TypeAttr where
   coe type := ⟨.registerType type, by rfl⟩

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -73,7 +73,8 @@ def parseOptionalFloatType : AttrParserM (Option FloatType) := do
 
 /--
   Parse an optional register type, which is fundamentally a wrapper for `i64`.
-  A register type is represented as `!riscv.reg`.
+  An unallocated register type is represented as `!riscv.reg`.
+  Allocated register types range from `!riscv.reg<x0>` to `!riscv.reg<x31>`.
 -/
 def parseOptionalRegisterType : AttrParserM (Option RegisterType) := do
   let token ← peekToken
@@ -82,7 +83,23 @@ def parseOptionalRegisterType : AttrParserM (Option RegisterType) := do
   let typeName := { token.slice with start := token.slice.start + 1 }.of input
   if typeName ≠ "riscv.reg".toByteArray then return none
   let _ ← consumeToken
-  return some RegisterType.mk
+  if ← parseOptionalPunctuation "<" then
+    match ← peekToken with
+    | { kind := .bareIdent, slice := slice } =>
+      if slice.size < 2 then
+        throwAtCurrentPos "expected RV64 register of the form xID"
+      if (← (getThe ParserState)).input.getD slice.start.byteOffset 0 == 'x'.toUInt8 then
+        let bitwidthSlice : Slice := {start := slice.start + 1, stop := slice.stop}
+        let identifier := bitwidthSlice.of (← (getThe ParserState)).input
+        let some reg := (String.fromUTF8? identifier).bind String.toNat? | return none
+        if reg > 31 then throwAtCurrentPos "RV64 registers range from x0 to x31"
+        let _ ← consumeToken
+        parsePunctuation ">"
+        return some (RegisterType.mk (some reg))
+      throwAtCurrentPos "expected RV64 register of the form xID"
+    | _ => throwAtCurrentPos "expected RV64 register of the form xID"
+  else
+    return some $ RegisterType.mk none
 
 /--
   Parse an integer type, throwing an error if it is not present.


### PR DESCRIPTION
Only the x0-x31 names are supported for now.
