### PR TITLE
feat: Parse and interpret xDSL-style zero register access

### DIFF
--- a/Test/Interpreter/RISCV/zero.mlir
+++ b/Test/Interpreter/RISCV/zero.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (!riscv.reg)}> ({
+    %a = "rv64.get_register"() : () -> !riscv.reg<x0>
+    %b = "riscv.addi"(%a) <{ value = 5 : i12 }> : (!riscv.reg<x0>) -> !riscv.reg
+    "func.return"(%b) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0000000000000005#64]

--- a/Test/RV64/identity.mlir
+++ b/Test/RV64/identity.mlir
@@ -1,0 +1,18 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %0 = "rv64.get_register"() : () -> !riscv.reg<x0>
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "rv64.get_register"() : () -> !riscv.reg<x0>
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -1,0 +1,20 @@
+module
+
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Rv64.propertiesOf (op : Rv64) : Type :=
+match op with
+| _ => Unit
+
+instance : HasDialectOpInfo Rv64 where
+  propertiesOf := Rv64.propertiesOf
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -5,6 +5,7 @@ public import Veir.Dialects.LLVM.OpInfo
 public import Veir.Dialects.RISCV.OpInfo
 public import Veir.Dialects.RISCV_Cf.OpInfo
 public import Veir.Dialects.RISCV_Stack.OpInfo
+public import Veir.Dialects.RV64.OpInfo
 public import Veir.Dialects.ModArith.OpInfo
 public import Veir.Dialects.Cf.OpInfo
 public import Veir.Dialects.Comb.OpInfo
@@ -27,6 +28,7 @@ match opCode with
 | .riscv op => Riscv.propertiesOf op
 | .riscv_cf op => Riscv_Cf.propertiesOf op
 | .riscv_stack op => Riscv_Stack.propertiesOf op
+| .rv64 op => Rv64.propertiesOf op
 | .mod_arith op => Mod_Arith.propertiesOf op
 | .cf op => Cf.propertiesOf op
 | .comb op => Comb.propertiesOf op
@@ -107,6 +109,8 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
     cases op
     case alloca => exact (RISCVStackAllocaProperties.fromAttrDict attrDict)
     all_goals exact (Except.ok ())
+  case rv64 =>
+    exact Except.ok ()
   case llvm op =>
     cases op
     case mlir__constant => exact (LLVMConstantProperties.fromAttrDict attrDict)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1281,6 +1281,17 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInf
     else
       return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
 
+def Rv64.interpretOp' (opType : Veir.Rv64) (properties : HasDialectOpInfo.propertiesOf opType)
+    (resultTypes : Array TypeAttr) (_operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
+    : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
+  match opType with
+  | .get_register => do
+    let [⟨.registerType reg, _⟩] := resultTypes.toList | none
+    if reg.index = some 0 then
+      return (#[.reg ⟨0⟩], none)
+    else
+      none
+
 def Cf.interpretOp' (opType : Veir.Cf) (properties : HasDialectOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
@@ -1353,6 +1364,9 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
     return (vals, mem, act)
   | .riscv_stack riscvStackOp =>
     Riscv_Stack.interpretOp' riscvStackOp properties resultTypes operands blockOperands mem
+  | .rv64 rv64Op => do
+    let (vals, act) ← Rv64.interpretOp' rv64Op properties resultTypes operands blockOperands
+    return (vals, mem, act)
   | .cf cfOp => do
     let (vals, act) ← Cf.interpretOp' cfOp properties resultTypes operands blockOperands
     return (vals, mem, act)

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -245,6 +245,11 @@ inductive Riscv_Stack where
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[opcodes]
+inductive Rv64 where
+| get_register
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[opcodes]
 inductive Mod_Arith where
 | add
 | constant

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -2249,6 +2249,17 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+  /- RISCV 64-bit -/
+  | .rv64 .get_register => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
   /- Comb -/
   | .comb .add | .comb .and | .comb .mul | .comb .or | .comb .xor => do
     if op.getNumOperands ctx.raw opIn < 1 then


### PR DESCRIPTION
This adds an `rv64.get_register` operation.
