### PR TITLE
test(cse): cover getelementptr incl. elemtype / noWrapFlags negative cases

### DIFF
--- a/Test/Passes/CSE/getelementptr.mlir
+++ b/Test/Passes/CSE/getelementptr.mlir
@@ -10,7 +10,11 @@
     %g_d1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     "test.test"(%g0, %g1, %g_d0, %g_d1) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
-    // CHECK-LABEL: TO DO 
+    // CHECK-LABEL: ^{{.*}}(%{{.*}} : !llvm.ptr, %{{.*}} : i64):
+    // CHECK-NEXT: %[[G0:.*]] = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    // CHECK-NEXT: %[[GD0:.*]] = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    // CHECK-NEXT: %[[GD1:.*]] = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = i32, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    // CHECK-NEXT: "test.test"(%[[G0]], %[[G0]], %[[GD0]], %[[GD1]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/CSE/getelementptr.mlir
+++ b/Test/Passes/CSE/getelementptr.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-opt %s -p=cse | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i64)>}> ({
+^bb0(%base : !llvm.ptr, %idx : i64):
+    %g0 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    %g1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    // the ones bellow are different and should not be eliminated
+    %g_d0 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    %g_d1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    "test.test"(%g0, %g1, %g_d0, %g_d1) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+    // CHECK-LABEL: TO DO 
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/CSE/getelementptr.mlir
+++ b/Test/Passes/CSE/getelementptr.mlir
@@ -5,7 +5,10 @@
 ^bb0(%base : !llvm.ptr, %idx : i64):
     %g0 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     %g1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-    // the ones bellow are different and should not be eliminated
+    // The GEPs below differ from %g0 and must not be eliminated:
+    // %g_d0 has a different elem_type; %g_d1 is a plain gep
+    // (noWrapFlags = 0) and must not merge with the inbounds gep %g0
+    // (noWrapFlags = 3, i.e. inbounds|nusw).
     %g_d0 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     %g_d1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     "test.test"(%g0, %g1, %g_d0, %g_d1) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()

--- a/Test/Passes/CSE/getelementptr.mlir
+++ b/Test/Passes/CSE/getelementptr.mlir
@@ -1,14 +1,14 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i64)>}> ({
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i64)>, sym_name = "gep"}> ({
 ^bb0(%base : !llvm.ptr, %idx : i64):
     %g0 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     %g1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     // The GEPs below differ from %g0 and must not be eliminated:
-    // %g_d0 has a different elem_type; %g_d1 is a plain gep
+    // %g_d0 has a different elem_type, %g_d1 is a plain gep
     // (noWrapFlags = 0) and must not merge with the inbounds gep %g0
-    // (noWrapFlags = 3, i.e. inbounds|nusw).
+    // (noWrapFlags = 3, i.e., inbounds|nusw).
     %g_d0 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     %g_d1 = "llvm.getelementptr"(%base, %idx) <{"elem_type" = i32, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
     "test.test"(%g0, %g1, %g_d0, %g_d1) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()

--- a/Veir/Passes/CSE.lean
+++ b/Veir/Passes/CSE.lean
@@ -7,8 +7,8 @@ import Veir.Data.LLVM.Int.Basic
 
   This pass implements a small, conservative CSE:
   * it only reasons within one basic block;
-  * it only considers arithmetic operations (including icmps, select,
-    and ext/trunc);
+  * it only considers pure operations (arithmetic, icmps, select,
+    ext/trunc, and getelementptr pointer arithmetic);
   * it only works for instructions that return a single result;
   * distinct UB flags are treated as distinct instructions;
   * it only supports the LLVM dialect (arith would be trivial to add);
@@ -119,6 +119,7 @@ def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
   | .llvm .shl | .llvm .lshr | .llvm .ashr
   | .llvm .sdiv | .llvm .udiv | .llvm .srem | .llvm .urem
   | .llvm .zext | .llvm .sext | .llvm .trunc
+  | .llvm .getelementptr
   | .llvm .select =>
       return ordinaryKey ctx op kind
   | _ => none


### PR DESCRIPTION
This PR adds missing test coverage for GEP in the CSE pass. GEP is pure pointer arithmetic (https://llvm.org/docs/GetElementPtr.html), so identical getelementptr ops (same base, index, elem_type, and noWrapFlags) within a block can be merged, which CSE already does since #867, but there was no test for it yet.

This PR adds tests that check:
- two identical inbounds GEPs get merged into one
- a GEP with a different elem_type is not merged
- a plain GEP (noWrapFlags = 0) is not merged with the inbounds one (noWrapFlags = 3), since they differ in UB semantics

