### PR TITLE
feat(riscv): isel fastntt test 

### DIFF
--- a/Test/LLVM/fastntt.mlir
+++ b/Test/LLVM/fastntt.mlir
@@ -1,5 +1,5 @@
-// RUN: VEIR_ROUNDTRIP
-// RUN: MLIR_ROUNDTRIP
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+// RUN: MLIR_UNREGISTERED_ROUNDTRIP
 
 // This file contains a very naive implementation of the FastNTT algorithm, based on the heir pseudocode
 // (https://github.com/google/heir/blob/1210ad37dc9531d6e60d8ddbce81dbd79f7626a6/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp#L1060) and lowered using the `Vcc` tool (see `Test/Vcc/fastntt.c`).
@@ -7,277 +7,223 @@
 "builtin.module"() ({
   ^4():
     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
-    "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<i32 ()>, "linkage" = #llvm.linkage<external>, no_inline, no_unwind, "passthrough" = [["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "main", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
-      ^7():
-        %8 = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
-        %9 = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
+    "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, "passthrough" = [["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "fastNTT", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
+      ^7(%arg7_0 : !llvm.ptr, %arg7_1 : i64, %arg7_2 : i64, %arg7_3 : !llvm.ptr, %arg7_4 : i64, %arg7_5 : i64):
+        %8 = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
+        %9 = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
         %10 = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
-        %11 = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
-        %12 = "llvm.mlir.constant"() <{"value" = 3 : i64}> : () -> i64
-        %13 = "llvm.mlir.constant"() <{"value" = 4 : i64}> : () -> i64
-        %14 = "llvm.mlir.constant"() <{"value" = 8 : i64}> : () -> i64
-        %15 = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-        %16 = "llvm.mlir.constant"() <{"value" = 17 : i64}> : () -> i64
-        %17 = "llvm.alloca"(%8) <{"alignment" = 16 : i64, "elem_type" = !llvm.array<4 x i64>}> : (i32) -> !llvm.ptr
-        %18 = "llvm.alloca"(%8) <{"alignment" = 16 : i64, "elem_type" = !llvm.array<8 x i64>}> : (i32) -> !llvm.ptr
-        %19 = "llvm.getelementptr"(%17, %9, %9) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        "llvm.store"(%10, %19) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 16 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        %21 = "llvm.getelementptr"(%17, %9, %10) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        "llvm.store"(%11, %21) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        %23 = "llvm.getelementptr"(%17, %9, %11) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        "llvm.store"(%12, %23) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 16 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        %25 = "llvm.getelementptr"(%17, %9, %12) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        "llvm.store"(%13, %25) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        "llvm.br"(%10, %9) [^28] : (i64, i64) -> ()
-      ^28(%arg28_0 : i64, %arg28_1 : i64):
-        %30 = "llvm.icmp"(%arg28_1, %14) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%30) [^31, ^32] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^31():
-        %34 = "llvm.getelementptr"(%18, %9, %arg28_1) <{"elem_type" = !llvm.array<8 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        "llvm.store"(%arg28_0, %34) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        %36 = "llvm.mul"(%arg28_0, %12) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %37 = "llvm.srem"(%36, %16) : (i64, i64) -> i64
-        "llvm.br"() [^38] : () -> ()
-      ^38():
-        %40 = "llvm.add"(%arg28_1, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%37, %40) [^28] : (i64, i64) -> ()
+        %11 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%11) [^12, ^13] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^12():
+        "llvm.br"(%arg7_1) [^15] : (i64) -> ()
+      ^13():
+        "llvm.br"(%9) [^15] : (i64) -> ()
+      ^15(%arg15_0 : i64):
+        %18 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%18) [^19, ^20] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^19():
+        "llvm.br"(%10) [^22] : (i64) -> ()
+      ^20():
+        %24 = "llvm.sdiv"(%arg7_5, %9) : (i64, i64) -> i64
+        "llvm.br"(%24) [^22] : (i64) -> ()
+      ^22(%arg22_0 : i64):
+        %26 = "llvm.sdiv"(%arg7_1, %9) : (i64, i64) -> i64
+        "llvm.br"(%arg22_0, %26, %8, %arg15_0) [^27] : (i64, i64, i64, i64) -> ()
+      ^27(%arg27_0 : i64, %arg27_1 : i64, %arg27_2 : i64, %arg27_3 : i64):
+        "llvm.br"(%8, %arg7_1) [^29] : (i64, i64) -> ()
+      ^29(%arg29_0 : i64, %arg29_1 : i64):
+        %31 = "llvm.icmp"(%arg29_1, %10) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%31) [^32, ^33] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
       ^32():
-        %42 = "llvm.getelementptr"(%17, %9, %9) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        %43 = "llvm.getelementptr"(%18, %9, %9) <{"elem_type" = !llvm.array<8 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-        %44 = "llvm.icmp"(%9, %9) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%44) [^45, ^46] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^45():
-        "llvm.br"(%13) [^48] : (i64) -> ()
+        %35 = "llvm.ashr"(%arg29_1, %10) : (i64, i64) -> i64
+        %36 = "llvm.add"(%arg29_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%36, %35) [^29] : (i64, i64) -> ()
+      ^33():
+        %38 = "llvm.icmp"(%arg27_2, %arg29_0) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%38) [^39, ^40] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^39():
+        "llvm.br"(%8) [^42] : (i64) -> ()
+      ^42(%arg42_0 : i64):
+        %44 = "llvm.sdiv"(%arg7_1, %arg27_3) : (i64, i64) -> i64
+        %45 = "llvm.icmp"(%arg42_0, %44) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%45) [^46, ^47] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
       ^46():
-        "llvm.br"(%11) [^48] : (i64) -> ()
-      ^48(%arg48_0 : i64):
-        %51 = "llvm.icmp"(%9, %9) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%51) [^52, ^53] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^52():
-        "llvm.br"(%10) [^55] : (i64) -> ()
+        "llvm.br"(%8) [^49] : (i64) -> ()
+      ^49(%arg49_0 : i64):
+        %51 = "llvm.sdiv"(%arg27_3, %9) : (i64, i64) -> i64
+        %52 = "llvm.icmp"(%arg49_0, %51) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%52) [^53, ^54] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
       ^53():
-        %57 = "llvm.sdiv"(%13, %11) : (i64, i64) -> i64
-        "llvm.br"(%57) [^55] : (i64) -> ()
-      ^55(%arg55_0 : i64):
-        %59 = "llvm.sdiv"(%13, %11) : (i64, i64) -> i64
-        "llvm.br"(%9, %59, %arg55_0, %arg48_0) [^60] : (i64, i64, i64, i64) -> ()
-      ^60(%arg60_0 : i64, %arg60_1 : i64, %arg60_2 : i64, %arg60_3 : i64):
-        "llvm.br"(%9, %13) [^62] : (i64, i64) -> ()
-      ^62(%arg62_0 : i64, %arg62_1 : i64):
-        %64 = "llvm.icmp"(%arg62_1, %10) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%64) [^65, ^66] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^65():
-        %68 = "llvm.ashr"(%arg62_1, %10) : (i64, i64) -> i64
-        %69 = "llvm.add"(%arg62_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%69, %68) [^62] : (i64, i64) -> ()
-      ^66():
-        %71 = "llvm.icmp"(%arg60_0, %arg62_0) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%71) [^72, ^73] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^72():
-        "llvm.br"(%9) [^75] : (i64) -> ()
-      ^75(%arg75_0 : i64):
-        %77 = "llvm.sdiv"(%13, %arg60_3) : (i64, i64) -> i64
-        %78 = "llvm.icmp"(%arg75_0, %77) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%78) [^79, ^80] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^79():
-        "llvm.br"(%9) [^82] : (i64) -> ()
-      ^82(%arg82_0 : i64):
-        %84 = "llvm.sdiv"(%arg60_3, %11) : (i64, i64) -> i64
-        %85 = "llvm.icmp"(%arg82_0, %84) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%85) [^86, ^87] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^86():
-        %89 = "llvm.mul"(%arg75_0, %arg60_3) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %90 = "llvm.add"(%89, %arg82_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %91 = "llvm.getelementptr"(%42, %90) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-        %92 = "llvm.load"(%91) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-        %95 = "llvm.sdiv"(%arg60_3, %11) : (i64, i64) -> i64
-        %96 = "llvm.add"(%90, %95) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %97 = "llvm.getelementptr"(%42, %96) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-        %98 = "llvm.load"(%97) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-        %99 = "llvm.mul"(%11, %arg82_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %100 = "llvm.add"(%99, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %101 = "llvm.mul"(%100, %arg60_1) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %102 = "llvm.getelementptr"(%43, %101) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-        %103 = "llvm.load"(%102) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-        %104 = "llvm.mul"(%103, %98) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %105 = "llvm.srem"(%104, %16) : (i64, i64) -> i64
-        %106 = "llvm.add"(%92, %105) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %107 = "llvm.srem"(%106, %16) : (i64, i64) -> i64
-        %110 = "llvm.sub"(%92, %105) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %111 = "llvm.add"(%110, %16) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        %112 = "llvm.srem"(%111, %16) : (i64, i64) -> i64
-        %115 = "llvm.getelementptr"(%42, %90) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-        "llvm.store"(%107, %115) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        %121 = "llvm.getelementptr"(%42, %96) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-        "llvm.store"(%112, %121) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-        %123 = "llvm.add"(%arg82_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%123) [^82] : (i64) -> ()
-      ^87():
-        %125 = "llvm.add"(%arg75_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%125) [^75] : (i64) -> ()
-      ^80():
-        %127 = "llvm.sdiv"(%arg60_1, %11) : (i64, i64) -> i64
-        %128 = "llvm.icmp"(%9, %9) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%128) [^129, ^130] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^129():
-        %132 = "llvm.sdiv"(%arg60_3, %11) : (i64, i64) -> i64
-        "llvm.br"(%132) [^133] : (i64) -> ()
-      ^130():
-        %152 = "llvm.add"(%arg60_3, %arg60_3) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%152) [^133] : (i64) -> ()
-      ^133(%arg133_0 : i64):
-        %137 = "llvm.icmp"(%9, %9) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-        "llvm.cond_br"(%137) [^138, ^139] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-      ^138():
-        %151 = "llvm.add"(%arg60_2, %arg60_2) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%151) [^142] : (i64) -> ()
-      ^139():
-        %144 = "llvm.sdiv"(%arg60_2, %11) : (i64, i64) -> i64
-        "llvm.br"(%144) [^142] : (i64) -> ()
-      ^142(%arg142_0 : i64):
-        %146 = "llvm.add"(%arg60_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-        "llvm.br"(%146, %127, %arg142_0, %arg133_0) [^60] : (i64, i64, i64, i64) -> ()
-      ^73():
-        "llvm.return"(%15) : (i32) -> ()
+        %56 = "llvm.mul"(%arg42_0, %arg27_3) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %57 = "llvm.add"(%56, %arg49_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %58 = "llvm.getelementptr"(%arg7_0, %57) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %59 = "llvm.load"(%58) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+        %62 = "llvm.sdiv"(%arg27_3, %9) : (i64, i64) -> i64
+        %63 = "llvm.add"(%57, %62) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %64 = "llvm.getelementptr"(%arg7_0, %63) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %65 = "llvm.load"(%64) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+        %66 = "llvm.mul"(%9, %arg49_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %67 = "llvm.add"(%66, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %68 = "llvm.mul"(%67, %arg27_1) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %69 = "llvm.getelementptr"(%arg7_3, %68) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %70 = "llvm.load"(%69) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+        %71 = "llvm.mul"(%70, %65) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %72 = "llvm.srem"(%71, %arg7_2) : (i64, i64) -> i64
+        %73 = "llvm.add"(%59, %72) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %74 = "llvm.srem"(%73, %arg7_2) : (i64, i64) -> i64
+        %77 = "llvm.sub"(%59, %72) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %78 = "llvm.add"(%77, %arg7_2) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %79 = "llvm.srem"(%78, %arg7_2) : (i64, i64) -> i64
+        %82 = "llvm.getelementptr"(%arg7_0, %57) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        "llvm.store"(%74, %82) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+        %88 = "llvm.getelementptr"(%arg7_0, %63) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        "llvm.store"(%79, %88) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+        "llvm.br"() [^90] : () -> ()
+      ^90():
+        %92 = "llvm.add"(%arg49_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%92) [^49] : (i64) -> ()
+      ^54():
+        "llvm.br"() [^94] : () -> ()
+      ^94():
+        %96 = "llvm.add"(%arg42_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%96) [^42] : (i64) -> ()
+      ^47():
+        %98 = "llvm.sdiv"(%arg27_1, %9) : (i64, i64) -> i64
+        %99 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%99) [^100, ^101] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^100():
+        %103 = "llvm.sdiv"(%arg27_3, %9) : (i64, i64) -> i64
+        "llvm.br"(%103) [^104] : (i64) -> ()
+      ^101():
+        %125 = "llvm.add"(%arg27_3, %arg27_3) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%125) [^104] : (i64) -> ()
+      ^104(%arg104_0 : i64):
+        %108 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%108) [^109, ^110] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^109():
+        %124 = "llvm.add"(%arg27_0, %arg27_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%124) [^113] : (i64) -> ()
+      ^110():
+        %115 = "llvm.sdiv"(%arg27_0, %9) : (i64, i64) -> i64
+        "llvm.br"(%115) [^113] : (i64) -> ()
+      ^113(%arg113_0 : i64):
+        "llvm.br"() [^117] : () -> ()
+      ^117():
+        %119 = "llvm.add"(%arg27_2, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%arg113_0, %98, %119, %arg104_0) [^27] : (i64, i64, i64, i64) -> ()
+      ^40():
+        "llvm.return"() : () -> ()
     }) : () -> ()
 }) {"dlti.dl_spec" = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, "llvm.ident" = "Ubuntu clang version 18.1.3 (1ubuntu1)", "llvm.module_asm" = [], "llvm.target_triple" = "x86_64-pc-linux-gnu"} : () -> ()
 
-
-
-// CHECK:      "builtin.module"() ({
-// CHECK-NEXT: ^[[BB4:[0-9]+]]():
-// CHECK-NEXT:   "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
-// CHECK-NEXT:   "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<i32 ()>, "linkage" = #llvm.linkage<external>, no_inline, no_unwind, "passthrough" = [["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "{{.*}}"]], "sym_name" = "main", "target_cpu" = "{{.*}}", "target_features" = #llvm.target_features<[{{.*}}]>, "tune_cpu" = "{{.*}}", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
-// CHECK-NEXT:   ^[[BB7:[0-9]+]]():
-// CHECK-NEXT:     %[[M_C1:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
-// CHECK-NEXT:     %[[M_C0:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C1_64:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C2:.*]] = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C3:.*]] = "llvm.mlir.constant"() <{"value" = 3 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C4:.*]] = "llvm.mlir.constant"() <{"value" = 4 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C8:.*]] = "llvm.mlir.constant"() <{"value" = 8 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C0_32:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-// CHECK-NEXT:     %[[M_C17:.*]] = "llvm.mlir.constant"() <{"value" = 17 : i64}> : () -> i64
-// CHECK-NEXT:     %[[ALLOC17:.*]] = "llvm.alloca"(%[[M_C1]]) <{"alignment" = 16 : i64, "elem_type" = !llvm.array<4 x i64>}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:     %[[ALLOC18:.*]] = "llvm.alloca"(%[[M_C1]]) <{"alignment" = 16 : i64, "elem_type" = !llvm.array<8 x i64>}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:     %[[GEP19:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C0]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C1_64]], %[[GEP19]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 16 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP21:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C1_64]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C2]], %[[GEP21]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP23:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C2]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C3]], %[[GEP23]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 16 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP25:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C3]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C4]], %[[GEP25]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     "llvm.br"(%[[M_C1_64]], %[[M_C0]]) [^[[BB28:[0-9]+]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB28]](%[[ARG28_0:.*]] : i64, %[[ARG28_1:.*]] : i64):
-// CHECK-NEXT:     %[[CMP30:.*]] = "llvm.icmp"(%[[ARG28_1]], %[[M_C8]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP30]]) [^[[BB31:[0-9]+]], ^[[BB32:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB31]]():
-// CHECK-NEXT:     %[[GEP34:.*]] = "llvm.getelementptr"(%[[ALLOC18]], %[[M_C0]], %[[ARG28_1]]) <{"elem_type" = !llvm.array<8 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[ARG28_0]], %[[GEP34]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[MUL36:.*]] = "llvm.mul"(%[[ARG28_0]], %[[M_C3]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM37:.*]] = "llvm.srem"(%[[MUL36]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"() [^[[BB38:[0-9]+]]] : () -> ()
-// CHECK-NEXT:   ^[[BB38]]():
-// CHECK-NEXT:     %[[ADD40:.*]] = "llvm.add"(%[[ARG28_1]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[SREM37]], %[[ADD40]]) [^[[BB28]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB32]]():
-// CHECK-NEXT:     %[[GEP42:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C0]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[GEP43:.*]] = "llvm.getelementptr"(%[[ALLOC18]], %[[M_C0]], %[[M_C0]]) <{"elem_type" = !llvm.array<8 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[CMP44:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP44]]) [^[[BB45:[0-9]+]], ^[[BB46:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB45]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C4]]) [^[[BB48:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB46]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C2]]) [^[[BB48]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB48]](%[[ARG48_0:.*]] : i64):
-// CHECK-NEXT:     %[[CMP51:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP51]]) [^[[BB52:[0-9]+]], ^[[BB53:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB52]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C1_64]]) [^[[BB55:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB53]]():
-// CHECK-NEXT:     %[[DIV57:.*]] = "llvm.sdiv"(%[[M_C4]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[DIV57]]) [^[[BB55]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB55]](%[[ARG55_0:.*]] : i64):
-// CHECK-NEXT:     %[[DIV59:.*]] = "llvm.sdiv"(%[[M_C4]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]], %[[DIV59]], %[[ARG55_0]], %[[ARG48_0]]) [^[[BB60:[0-9]+]]] : (i64, i64, i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB60]](%[[ARG60_0:.*]] : i64, %[[ARG60_1:.*]] : i64, %[[ARG60_2:.*]] : i64, %[[ARG60_3:.*]] : i64):
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]], %[[M_C4]]) [^[[BB62:[0-9]+]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB62]](%[[ARG62_0:.*]] : i64, %[[ARG62_1:.*]] : i64):
-// CHECK-NEXT:     %[[CMP64:.*]] = "llvm.icmp"(%[[ARG62_1]], %[[M_C1_64]]) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP64]]) [^[[BB65:[0-9]+]], ^[[BB66:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB65]]():
-// CHECK-NEXT:     %[[ASHR68:.*]] = "llvm.ashr"(%[[ARG62_1]], %[[M_C1_64]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD69:.*]] = "llvm.add"(%[[ARG62_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD69]], %[[ASHR68]]) [^[[BB62]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB66]]():
-// CHECK-NEXT:     %[[CMP71:.*]] = "llvm.icmp"(%[[ARG60_0]], %[[ARG62_0]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP71]]) [^[[BB72:[0-9]+]], ^[[BB73:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB72]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]]) [^[[BB75:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB75]](%[[ARG75_0:.*]] : i64):
-// CHECK-NEXT:     %[[DIV77:.*]] = "llvm.sdiv"(%[[M_C4]], %[[ARG60_3]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[CMP78:.*]] = "llvm.icmp"(%[[ARG75_0]], %[[DIV77]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP78]]) [^[[BB79:[0-9]+]], ^[[BB80:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB79]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]]) [^[[BB82:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB82]](%[[ARG82_0:.*]] : i64):
-// CHECK-NEXT:     %[[DIV84:.*]] = "llvm.sdiv"(%[[ARG60_3]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[CMP85:.*]] = "llvm.icmp"(%[[ARG82_0]], %[[DIV84]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP85]]) [^[[BB86:[0-9]+]], ^[[BB87:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB86]]():
-// CHECK-NEXT:     %[[MUL89:.*]] = "llvm.mul"(%[[ARG75_0]], %[[ARG60_3]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD90:.*]] = "llvm.add"(%[[MUL89]], %[[ARG82_0]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP91:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD90]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[LOAD92:.*]] = "llvm.load"(%[[GEP91]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-// CHECK-NEXT:     %[[DIV95:.*]] = "llvm.sdiv"(%[[ARG60_3]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD96:.*]] = "llvm.add"(%[[ADD90]], %[[DIV95]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP97:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD96]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[LOAD98:.*]] = "llvm.load"(%[[GEP97]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-// CHECK-NEXT:     %[[MUL99:.*]] = "llvm.mul"(%[[M_C2]], %[[ARG82_0]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD100:.*]] = "llvm.add"(%[[MUL99]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[MUL101:.*]] = "llvm.mul"(%[[ADD100]], %[[ARG60_1]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP102:.*]] = "llvm.getelementptr"(%[[GEP43]], %[[MUL101]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[LOAD103:.*]] = "llvm.load"(%[[GEP102]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-// CHECK-NEXT:     %[[MUL104:.*]] = "llvm.mul"(%[[LOAD103]], %[[LOAD98]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM105:.*]] = "llvm.srem"(%[[MUL104]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD106:.*]] = "llvm.add"(%[[LOAD92]], %[[SREM105]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM107:.*]] = "llvm.srem"(%[[ADD106]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SUB110:.*]] = "llvm.sub"(%[[LOAD92]], %[[SREM105]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD111:.*]] = "llvm.add"(%[[SUB110]], %[[M_C17]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM112:.*]] = "llvm.srem"(%[[ADD111]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP115:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD90]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[SREM107]], %[[GEP115]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP121:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD96]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[SREM112]], %[[GEP121]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[ADD123:.*]] = "llvm.add"(%[[ARG82_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD123]]) [^[[BB82]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB87]]():
-// CHECK-NEXT:     %[[ADD125:.*]] = "llvm.add"(%[[ARG75_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD125]]) [^[[BB75]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB80]]():
-// CHECK-NEXT:     %[[DIV127:.*]] = "llvm.sdiv"(%[[ARG60_1]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[CMP128:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP128]]) [^[[BB129:[0-9]+]], ^[[BB130:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB129]]():
-// CHECK-NEXT:     %[[DIV132:.*]] = "llvm.sdiv"(%[[ARG60_3]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[DIV132]]) [^[[BB133:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB130]]():
-// CHECK-NEXT:     %[[ADD152:.*]] = "llvm.add"(%[[ARG60_3]], %[[ARG60_3]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD152]]) [^[[BB133]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB133]](%[[ARG133_0:.*]] : i64):
-// CHECK-NEXT:     %[[CMP137:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP137]]) [^[[BB138:[0-9]+]], ^[[BB139:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB138]]():
-// CHECK-NEXT:     %[[ADD151:.*]] = "llvm.add"(%[[ARG60_2]], %[[ARG60_2]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD151]]) [^[[BB142:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB139]]():
-// CHECK-NEXT:     %[[DIV144:.*]] = "llvm.sdiv"(%[[ARG60_2]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[DIV144]]) [^[[BB142]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB142]](%[[ARG142_0:.*]] : i64):
-// CHECK-NEXT:     %[[ADD146:.*]] = "llvm.add"(%[[ARG60_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD146]], %[[DIV127]], %[[ARG142_0]], %[[ARG133_0]]) [^[[BB60]]] : (i64, i64, i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB73]]():
-// CHECK-NEXT:     "llvm.return"(%[[M_C0_32]]) : (i32) -> ()
-// CHECK-NEXT:   }) : () -> ()
-// CHECK-NEXT: }) {{.*}} : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   ^4():
+// CHECK-NEXT:     "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, "passthrough" = {{\[\[}}"min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "fastNTT", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:       ^7(%[[VAL_0:.*]] : !llvm.ptr, %[[VAL_1:.*]] : i64, %[[VAL_2:.*]] : i64, %[[VAL_3:.*]] : !llvm.ptr, %[[VAL_4:.*]] : i64, %[[VAL_5:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_6:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
+// CHECK-NEXT:         %[[VAL_7:.*]] = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
+// CHECK-NEXT:         %[[VAL_8:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
+// CHECK-NEXT:         %[[VAL_9:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_9]]) [^12, ^13] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^12():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_1]]) [^15] : (i64) -> ()
+// CHECK-NEXT:       ^13():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_7]]) [^15] : (i64) -> ()
+// CHECK-NEXT:       ^15(%[[VAL_10:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_11:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_11]]) [^19, ^20] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^19():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_8]]) [^22] : (i64) -> ()
+// CHECK-NEXT:       ^20():
+// CHECK-NEXT:         %[[VAL_12:.*]] = "llvm.sdiv"(%[[VAL_5]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_12]]) [^22] : (i64) -> ()
+// CHECK-NEXT:       ^22(%[[VAL_13:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_14:.*]] = "llvm.sdiv"(%[[VAL_1]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_13]], %[[VAL_14]], %[[VAL_6]], %[[VAL_10]]) [^27] : (i64, i64, i64, i64) -> ()
+// CHECK-NEXT:       ^27(%[[VAL_15:.*]] : i64, %[[VAL_16:.*]] : i64, %[[VAL_17:.*]] : i64, %[[VAL_18:.*]] : i64):
+// CHECK-NEXT:         "llvm.br"(%[[VAL_6]], %[[VAL_1]]) [^29] : (i64, i64) -> ()
+// CHECK-NEXT:       ^29(%[[VAL_19:.*]] : i64, %[[VAL_20:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_21:.*]] = "llvm.icmp"(%[[VAL_20]], %[[VAL_8]]) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_21]]) [^32, ^33] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^32():
+// CHECK-NEXT:         %[[VAL_22:.*]] = "llvm.ashr"(%[[VAL_20]], %[[VAL_8]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_23:.*]] = "llvm.add"(%[[VAL_19]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_23]], %[[VAL_22]]) [^29] : (i64, i64) -> ()
+// CHECK-NEXT:       ^33():
+// CHECK-NEXT:         %[[VAL_24:.*]] = "llvm.icmp"(%[[VAL_17]], %[[VAL_19]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_24]]) [^39, ^40] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^39():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_6]]) [^42] : (i64) -> ()
+// CHECK-NEXT:       ^42(%[[VAL_25:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_26:.*]] = "llvm.sdiv"(%[[VAL_1]], %[[VAL_18]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_27:.*]] = "llvm.icmp"(%[[VAL_25]], %[[VAL_26]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_27]]) [^46, ^47] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^46():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_6]]) [^49] : (i64) -> ()
+// CHECK-NEXT:       ^49(%[[VAL_28:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_29:.*]] = "llvm.sdiv"(%[[VAL_18]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_30:.*]] = "llvm.icmp"(%[[VAL_28]], %[[VAL_29]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_30]]) [^53, ^54] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^53():
+// CHECK-NEXT:         %[[VAL_31:.*]] = "llvm.mul"(%[[VAL_25]], %[[VAL_18]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_32:.*]] = "llvm.add"(%[[VAL_31]], %[[VAL_28]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_33:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_32]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         %[[VAL_34:.*]] = "llvm.load"(%[[VAL_33]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         %[[VAL_35:.*]] = "llvm.sdiv"(%[[VAL_18]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_36:.*]] = "llvm.add"(%[[VAL_32]], %[[VAL_35]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_37:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_36]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         %[[VAL_38:.*]] = "llvm.load"(%[[VAL_37]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         %[[VAL_39:.*]] = "llvm.mul"(%[[VAL_7]], %[[VAL_28]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_40:.*]] = "llvm.add"(%[[VAL_39]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_41:.*]] = "llvm.mul"(%[[VAL_40]], %[[VAL_16]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_42:.*]] = "llvm.getelementptr"(%[[VAL_3]], %[[VAL_41]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         %[[VAL_43:.*]] = "llvm.load"(%[[VAL_42]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         %[[VAL_44:.*]] = "llvm.mul"(%[[VAL_43]], %[[VAL_38]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_45:.*]] = "llvm.srem"(%[[VAL_44]], %[[VAL_2]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_46:.*]] = "llvm.add"(%[[VAL_34]], %[[VAL_45]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_47:.*]] = "llvm.srem"(%[[VAL_46]], %[[VAL_2]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_48:.*]] = "llvm.sub"(%[[VAL_34]], %[[VAL_45]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_49:.*]] = "llvm.add"(%[[VAL_48]], %[[VAL_2]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_50:.*]] = "llvm.srem"(%[[VAL_49]], %[[VAL_2]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_51:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_32]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         "llvm.store"(%[[VAL_47]], %[[VAL_51]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+// CHECK-NEXT:         %[[VAL_52:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_36]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         "llvm.store"(%[[VAL_50]], %[[VAL_52]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+// CHECK-NEXT:         "llvm.br"() [^80] : () -> ()
+// CHECK-NEXT:       ^80():
+// CHECK-NEXT:         %[[VAL_53:.*]] = "llvm.add"(%[[VAL_28]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_53]]) [^49] : (i64) -> ()
+// CHECK-NEXT:       ^54():
+// CHECK-NEXT:         "llvm.br"() [^84] : () -> ()
+// CHECK-NEXT:       ^84():
+// CHECK-NEXT:         %[[VAL_54:.*]] = "llvm.add"(%[[VAL_25]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_54]]) [^42] : (i64) -> ()
+// CHECK-NEXT:       ^47():
+// CHECK-NEXT:         %[[VAL_55:.*]] = "llvm.sdiv"(%[[VAL_16]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_56:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_56]]) [^90, ^91] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^90():
+// CHECK-NEXT:         %[[VAL_57:.*]] = "llvm.sdiv"(%[[VAL_18]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_57]]) [^94] : (i64) -> ()
+// CHECK-NEXT:       ^91():
+// CHECK-NEXT:         %[[VAL_58:.*]] = "llvm.add"(%[[VAL_18]], %[[VAL_18]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_58]]) [^94] : (i64) -> ()
+// CHECK-NEXT:       ^94(%[[VAL_59:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_60:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_60]]) [^99, ^100] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^99():
+// CHECK-NEXT:         %[[VAL_61:.*]] = "llvm.add"(%[[VAL_15]], %[[VAL_15]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_61]]) [^103] : (i64) -> ()
+// CHECK-NEXT:       ^100():
+// CHECK-NEXT:         %[[VAL_62:.*]] = "llvm.sdiv"(%[[VAL_15]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_62]]) [^103] : (i64) -> ()
+// CHECK-NEXT:       ^103(%[[VAL_63:.*]] : i64):
+// CHECK-NEXT:         "llvm.br"() [^107] : () -> ()
+// CHECK-NEXT:       ^107():
+// CHECK-NEXT:         %[[VAL_64:.*]] = "llvm.add"(%[[VAL_17]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_63]], %[[VAL_55]], %[[VAL_64]], %[[VAL_59]]) [^27] : (i64, i64, i64, i64) -> ()
+// CHECK-NEXT:       ^40():
+// CHECK-NEXT:         "llvm.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) {"dlti.dl_spec" = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, "llvm.ident" = "Ubuntu clang version 18.1.3 (1ubuntu1)", "llvm.module_asm" = [], "llvm.target_triple" = "x86_64-pc-linux-gnu"} : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
@@ -1,0 +1,278 @@
+// RUN: veir-opt %s -p=isel-br-riscv64,isel-riscv64,reconcile-cast | filecheck %s
+
+"builtin.module"() ({
+  ^4():
+    "llvm.module_flags"() <{"flags" = [#llvm.mlir.module_flag<error, "wchar_size", 4 : i32>, #llvm.mlir.module_flag<min, "PIC Level", 2 : i32>, #llvm.mlir.module_flag<max, "PIE Level", 2 : i32>, #llvm.mlir.module_flag<max, "uwtable", 2 : i32>, #llvm.mlir.module_flag<max, "frame-pointer", 2 : i32>]}> : () -> ()
+    "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, "passthrough" = [["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "fastNTT", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
+      ^7(%arg7_0 : !llvm.ptr, %arg7_1 : i64, %arg7_2 : i64, %arg7_3 : !llvm.ptr, %arg7_4 : i64, %arg7_5 : i64):
+        %8 = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
+        %9 = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
+        %10 = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
+        %11 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%11) [^12, ^13] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^12():
+        "llvm.br"(%arg7_1) [^15] : (i64) -> ()
+      ^13():
+        "llvm.br"(%9) [^15] : (i64) -> ()
+      ^15(%arg15_0 : i64):
+        %18 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%18) [^19, ^20] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^19():
+        "llvm.br"(%10) [^22] : (i64) -> ()
+      ^20():
+        %24 = "llvm.sdiv"(%arg7_5, %9) : (i64, i64) -> i64
+        "llvm.br"(%24) [^22] : (i64) -> ()
+      ^22(%arg22_0 : i64):
+        %26 = "llvm.sdiv"(%arg7_1, %9) : (i64, i64) -> i64
+        "llvm.br"(%arg22_0, %26, %8, %arg15_0) [^27] : (i64, i64, i64, i64) -> ()
+      ^27(%arg27_0 : i64, %arg27_1 : i64, %arg27_2 : i64, %arg27_3 : i64):
+        "llvm.br"(%8, %arg7_1) [^29] : (i64, i64) -> ()
+      ^29(%arg29_0 : i64, %arg29_1 : i64):
+        %31 = "llvm.icmp"(%arg29_1, %10) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%31) [^32, ^33] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^32():
+        %35 = "llvm.ashr"(%arg29_1, %10) : (i64, i64) -> i64
+        %36 = "llvm.add"(%arg29_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%36, %35) [^29] : (i64, i64) -> ()
+      ^33():
+        %38 = "llvm.icmp"(%arg27_2, %arg29_0) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%38) [^39, ^40] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^39():
+        "llvm.br"(%8) [^42] : (i64) -> ()
+      ^42(%arg42_0 : i64):
+        %44 = "llvm.sdiv"(%arg7_1, %arg27_3) : (i64, i64) -> i64
+        %45 = "llvm.icmp"(%arg42_0, %44) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%45) [^46, ^47] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^46():
+        "llvm.br"(%8) [^49] : (i64) -> ()
+      ^49(%arg49_0 : i64):
+        %51 = "llvm.sdiv"(%arg27_3, %9) : (i64, i64) -> i64
+        %52 = "llvm.icmp"(%arg49_0, %51) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%52) [^53, ^54] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^53():
+        %56 = "llvm.mul"(%arg42_0, %arg27_3) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %57 = "llvm.add"(%56, %arg49_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %58 = "llvm.getelementptr"(%arg7_0, %57) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %59 = "llvm.load"(%58) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+        %62 = "llvm.sdiv"(%arg27_3, %9) : (i64, i64) -> i64
+        %63 = "llvm.add"(%57, %62) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %64 = "llvm.getelementptr"(%arg7_0, %63) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %65 = "llvm.load"(%64) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+        %66 = "llvm.mul"(%9, %arg49_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %67 = "llvm.add"(%66, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %68 = "llvm.mul"(%67, %arg27_1) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %69 = "llvm.getelementptr"(%arg7_3, %68) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %70 = "llvm.load"(%69) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+        %71 = "llvm.mul"(%70, %65) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %72 = "llvm.srem"(%71, %arg7_2) : (i64, i64) -> i64
+        %73 = "llvm.add"(%59, %72) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %74 = "llvm.srem"(%73, %arg7_2) : (i64, i64) -> i64
+        %77 = "llvm.sub"(%59, %72) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %78 = "llvm.add"(%77, %arg7_2) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        %79 = "llvm.srem"(%78, %arg7_2) : (i64, i64) -> i64
+        %82 = "llvm.getelementptr"(%arg7_0, %57) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        "llvm.store"(%74, %82) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+        %88 = "llvm.getelementptr"(%arg7_0, %63) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        "llvm.store"(%79, %88) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+        "llvm.br"() [^90] : () -> ()
+      ^90():
+        %92 = "llvm.add"(%arg49_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%92) [^49] : (i64) -> ()
+      ^54():
+        "llvm.br"() [^94] : () -> ()
+      ^94():
+        %96 = "llvm.add"(%arg42_0, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%96) [^42] : (i64) -> ()
+      ^47():
+        %98 = "llvm.sdiv"(%arg27_1, %9) : (i64, i64) -> i64
+        %99 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%99) [^100, ^101] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^100():
+        %103 = "llvm.sdiv"(%arg27_3, %9) : (i64, i64) -> i64
+        "llvm.br"(%103) [^104] : (i64) -> ()
+      ^101():
+        %125 = "llvm.add"(%arg27_3, %arg27_3) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%125) [^104] : (i64) -> ()
+      ^104(%arg104_0 : i64):
+        %108 = "llvm.icmp"(%arg7_4, %8) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+        "llvm.cond_br"(%108) [^109, ^110] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+      ^109():
+        %124 = "llvm.add"(%arg27_0, %arg27_0) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%124) [^113] : (i64) -> ()
+      ^110():
+        %115 = "llvm.sdiv"(%arg27_0, %9) : (i64, i64) -> i64
+        "llvm.br"(%115) [^113] : (i64) -> ()
+      ^113(%arg113_0 : i64):
+        "llvm.br"() [^117] : () -> ()
+      ^117():
+        %119 = "llvm.add"(%arg27_2, %10) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+        "llvm.br"(%arg113_0, %98, %119, %arg104_0) [^27] : (i64, i64, i64, i64) -> ()
+      ^40():
+        "llvm.return"() : () -> ()
+    }) : () -> ()
+}) {"dlti.dl_spec" = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, "llvm.ident" = "Ubuntu clang version 18.1.3 (1ubuntu1)", "llvm.module_asm" = [], "llvm.target_triple" = "x86_64-pc-linux-gnu"} : () -> ()
+
+
+// CHECK:       "builtin.module"() ({
+// CHECK-NEXT:    ^[[BB_ENTRY:[a-zA-Z0-9_]+]]():
+// CHECK-NEXT:      "llvm.module_flags"()
+// CHECK-NEXT:      "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, "passthrough" = [["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "fastNTT", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
+// CHECK-NEXT:        ^[[BB_FUNC_ENTRY:[a-zA-Z0-9_]+]](%{{.*}}: !llvm.ptr, %{{.*}}: i64, %{{.*}}: i64, %{{.*}}: !llvm.ptr, %{{.*}}: i64, %{{.*}}: i64):
+// CHECK-NEXT:          %[[REG_C0:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_C2:[0-9]+]] = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_C1:[0-9]+]] = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST0:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_XOR0:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_C0_2:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SLTU0:[0-9]+]] = "riscv.sltu"(%[[REG_C0_2]], %[[REG_XOR0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST1:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU0]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST2:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST1]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST2]]) [^[[BB_12:[0-9]+]], ^[[BB_13:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_12]]():
+// CHECK-NEXT:          %[[REG_CAST3:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_CAST3]]) [^[[BB_15:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_13]]():
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C2]]) [^[[BB_15]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_15]](%{{.*}}: !riscv.reg):
+// CHECK-NEXT:          %[[REG_CAST4:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_XOR1:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST4]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_C0_3:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SLTU1:[0-9]+]] = "riscv.sltu"(%[[REG_C0_3]], %[[REG_XOR1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST5:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU1]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST6:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST5]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST6]]) [^[[BB_19:[0-9]+]], ^[[BB_20:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_19]]():
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C1]]) [^[[BB_22:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_20]]():
+// CHECK-NEXT:          %[[REG_CAST7:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV0:[0-9]+]] = "riscv.div"(%[[REG_C2]], %[[REG_CAST7]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV0]]) [^[[BB_22]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_22]](%{{.*}}: !riscv.reg):
+// CHECK-NEXT:          %[[REG_CAST8:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV1:[0-9]+]] = "riscv.div"(%[[REG_C2]], %[[REG_CAST8]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"({{.*}}, %[[REG_C0]], %[[REG_DIV1]], {{.*}}) [^[[BB_27:[0-9]+]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_27]]({{.*}}):
+// CHECK-NEXT:          %[[REG_CAST9:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_CAST9]], %[[REG_C0]]) [^[[BB_29:[0-9]+]]] : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_29]]({{.*}}):
+// CHECK-NEXT:          %[[REG_SLT0:[0-9]+]] = "riscv.slt"({{.*}}, %[[REG_C1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST10:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT0]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST11:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST10]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST11]]) [^[[BB_32:[0-9]+]], ^[[BB_33:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_32]]():
+// CHECK-NEXT:          %[[REG_SRA0:[0-9]+]] = "riscv.sra"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD0:[0-9]+]] = "riscv.add"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_SRA0]], %[[REG_ADD0]]) [^[[BB_29]]] : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_33]]():
+// CHECK-NEXT:          %[[REG_SLT1:[0-9]+]] = "riscv.slt"({{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST12:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT1]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST13:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST12]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST13]]) [^[[BB_39:[0-9]+]], ^[[BB_40:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_39]]():
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]]) [^[[BB_42:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_42]](%[[ARG_42_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:          %[[REG_CAST14:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV2:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_CAST14]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SLT2:[0-9]+]] = "riscv.slt"(%[[REG_DIV2]], %[[ARG_42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST15:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT2]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST16:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST15]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST16]]) [^[[BB_46:[0-9]+]], ^[[BB_47:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_46]]():
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]]) [^[[BB_49:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_49]](%[[ARG_49_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:          %[[REG_DIV3:[0-9]+]] = "riscv.div"(%[[REG_C2]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SLT3:[0-9]+]] = "riscv.slt"(%[[REG_DIV3]], %[[ARG_49_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST17:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT3]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST18:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST17]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST18]]) [^[[BB_53:[0-9]+]], ^[[BB_54:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_53]]():
+// CHECK-NEXT:          %[[REG_MUL0:[0-9]+]] = "riscv.mul"({{.*}}, %[[ARG_42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD1:[0-9]+]] = "riscv.add"(%[[ARG_49_0]], %[[REG_MUL0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST19:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SH3ADD0:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD1]], %[[REG_CAST19]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST20:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD0]]) : (!riscv.reg) -> !llvm.ptr
+// CHECK-NEXT:          %[[REG_CAST21:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST20]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_LD0:[0-9]+]] = "riscv.ld"(%[[REG_CAST21]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV4:[0-9]+]] = "riscv.div"(%[[REG_C2]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD2:[0-9]+]] = "riscv.add"(%[[REG_DIV4]], %[[REG_ADD1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST22:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SH3ADD1:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD2]], %[[REG_CAST22]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST23:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD1]]) : (!riscv.reg) -> !llvm.ptr
+// CHECK-NEXT:          %[[REG_CAST24:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST23]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_LD1:[0-9]+]] = "riscv.ld"(%[[REG_CAST24]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_MUL1:[0-9]+]] = "riscv.mul"(%[[ARG_49_0]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD3:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[REG_MUL1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_MUL2:[0-9]+]] = "riscv.mul"({{.*}}, %[[REG_ADD3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST25:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SH3ADD2:[0-9]+]] = "riscv.sh3add"(%[[REG_MUL2]], %[[REG_CAST25]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST26:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD2]]) : (!riscv.reg) -> !llvm.ptr
+// CHECK-NEXT:          %[[REG_CAST27:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST26]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_LD2:[0-9]+]] = "riscv.ld"(%[[REG_CAST27]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_MUL3:[0-9]+]] = "riscv.mul"(%[[REG_LD1]], %[[REG_LD2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST28:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_REM0:[0-9]+]] = "riscv.rem"(%[[REG_CAST28]], %[[REG_MUL3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD4:[0-9]+]] = "riscv.add"(%[[REG_REM0]], %[[REG_LD0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST29:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_REM1:[0-9]+]] = "riscv.rem"(%[[REG_CAST29]], %[[REG_ADD4]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SUB0:[0-9]+]] = "riscv.sub"(%[[REG_REM0]], %[[REG_LD0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST30:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD5:[0-9]+]] = "riscv.add"(%[[REG_CAST30]], %[[REG_SUB0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST31:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_REM2:[0-9]+]] = "riscv.rem"(%[[REG_CAST31]], %[[REG_ADD5]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST32:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SH3ADD3:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD1]], %[[REG_CAST32]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST33:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD3]]) : (!riscv.reg) -> !llvm.ptr
+// CHECK-NEXT:          %[[REG_CAST34:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST33]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          "riscv.sd"(%[[REG_CAST34]], %[[REG_REM1]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:          %[[REG_CAST35:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SH3ADD4:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD2]], %[[REG_CAST35]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST36:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD4]]) : (!riscv.reg) -> !llvm.ptr
+// CHECK-NEXT:          %[[REG_CAST37:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST36]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:          "riscv.sd"(%[[REG_CAST37]], %[[REG_REM2]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_80:[0-9]+]]] : () -> ()
+// CHECK-NEXT:      ^[[BB_80]]():
+// CHECK-NEXT:          %[[REG_ADD6:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[ARG_49_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD6]]) [^[[BB_49]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_54]]():
+// CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_84:[0-9]+]]] : () -> ()
+// CHECK-NEXT:      ^[[BB_84]]():
+// CHECK-NEXT:          %[[REG_ADD7:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[ARG_42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD7]]) [^[[BB_42]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_47]]():
+// CHECK-NEXT:          %[[REG_DIV5:[0-9]+]] = "riscv.div"(%[[REG_C2]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST38:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_XOR2:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST38]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_C0_4:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SLTU2:[0-9]+]] = "riscv.sltu"(%[[REG_C0_4]], %[[REG_XOR2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST39:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU2]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST40:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST39]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST40]]) [^[[BB_90:[0-9]+]], ^[[BB_91:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_90]]():
+// CHECK-NEXT:          %[[REG_DIV6:[0-9]+]] = "riscv.div"(%[[REG_C2]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV6]]) [^[[BB_94:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_91]]():
+// CHECK-NEXT:          %[[REG_ADD8:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD8]]) [^[[BB_94]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_94]](%[[ARG_94_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:          %[[REG_CAST41:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_XOR3:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST41]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_C0_5:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SLTU3:[0-9]+]] = "riscv.sltu"(%[[REG_C0_5]], %[[REG_XOR3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_CAST42:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU3]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:          %[[REG_CAST43:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST42]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST43]]) [^[[BB_99:[0-9]+]], ^[[BB_100:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_99]]():
+// CHECK-NEXT:          %[[REG_ADD9:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD9]]) [^[[BB_103:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_100]]():
+// CHECK-NEXT:          %[[REG_DIV7:[0-9]+]] = "riscv.div"(%[[REG_C2]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV7]]) [^[[BB_103]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_103]](%[[ARG_103_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_107:[0-9]+]]] : () -> ()
+// CHECK-NEXT:      ^[[BB_107]]():
+// CHECK-NEXT:          %[[REG_ADD10:[0-9]+]] = "riscv.add"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          "riscv_cf.branch"(%[[ARG_94_0]], %[[REG_ADD10]], %[[REG_DIV5]], %[[ARG_103_0]]) [^[[BB_27]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:      ^[[BB_40]]():
+// CHECK-NEXT:          "llvm.return"() : () -> ()
+// CHECK-NEXT:    })
+// CHECK:         "llvm.target_triple" = "x86_64-pc-linux-gnu"

--- a/Test/Vcc/fastntt.c
+++ b/Test/Vcc/fastntt.c
@@ -41,8 +41,6 @@
     Reference: https://github.com/google/heir/blob/1210ad37dc9531d6e60d8ddbce81dbd79f7626a6/lib/Dialect/Polynomial/Conversions/PolynomialToModArith/PolynomialToModArith.cpp#L1060 
 */
 #include <stddef.h>
-#include <stdio.h>
-#include <stdlib.h>
 
 // log2(0) = 0
 // log2(1) = 0
@@ -72,7 +70,7 @@ __attribute__((always_inline)) static void bflyGS(long A, long B, long root, lon
     *outB = (A - B) * root % cmod;
 }
 
-__attribute__((always_inline)) static void fastNTT(long *coeffs, long n, long cmod, const long *roots, long inverse, long degree) {
+__attribute__((always_inline)) void fastNTT(long *coeffs, long n, long cmod, const long *roots, long inverse, long degree) {
     long m = inverse ? n : 2;
     long r = inverse ? 1 : degree / 2;
     long rootExp = n / 2;
@@ -95,166 +93,115 @@ __attribute__((always_inline)) static void fastNTT(long *coeffs, long n, long cm
     }
 }
 
-int main() {
-    long n = 4;
-    long cmod = 17;
-    long degree = 4; 
-    long inverse = 0; // 0 for forward NTT, 1 for inverse NTT
-    long coeffs[4];
-    coeffs[0] = 1;
-    coeffs[1] = 2;
-    coeffs[2] = 3;
-    coeffs[3] = 4;
 
-    long roots_size = n * 2; 
-    
-    long roots[8]; 
-    
-    long current_root = 1;
-    for (long i = 0; i < 8; i++) {
-        roots[i] = current_root;
-        current_root = (current_root * 3) % cmod;
-    }
-
-    fastNTT(coeffs, n, cmod, roots, inverse, degree);
-    
-    return 0;
-}
-
-// CHECK:      "builtin.module"() ({
-// CHECK-NEXT: ^[[BB4:[0-9]+]]():
-// CHECK-NEXT:   "llvm.module_flags"()
-// CHECK-NEXT:   "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, {{.*}}"function_type" = !llvm.func<i32 ()>, "linkage" = #llvm.linkage<external>, no_inline, no_unwind, {{.*}}"sym_name" = "main"{{.*}}}> ({
-// CHECK-NEXT:   ^[[BB7:[0-9]+]]():
-// CHECK-NEXT:     %[[M_C1:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
-// CHECK-NEXT:     %[[M_C0:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C1_64:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C2:.*]] = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C3:.*]] = "llvm.mlir.constant"() <{"value" = 3 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C4:.*]] = "llvm.mlir.constant"() <{"value" = 4 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C8:.*]] = "llvm.mlir.constant"() <{"value" = 8 : i64}> : () -> i64
-// CHECK-NEXT:     %[[M_C0_32:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i32}> : () -> i32
-// CHECK-NEXT:     %[[M_C17:.*]] = "llvm.mlir.constant"() <{"value" = 17 : i64}> : () -> i64
-// CHECK-NEXT:     %[[ALLOC17:.*]] = "llvm.alloca"(%[[M_C1]]) <{"alignment" = {{[0-9]+}} : i64, "elem_type" = !llvm.array<4 x i64>}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:     %[[ALLOC18:.*]] = "llvm.alloca"(%[[M_C1]]) <{"alignment" = {{[0-9]+}} : i64, "elem_type" = !llvm.array<8 x i64>}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:     %[[GEP19:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C0]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C1_64]], %[[GEP19]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = {{[0-9]+}} : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP21:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C1_64]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C2]], %[[GEP21]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP23:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C2]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C3]], %[[GEP23]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = {{[0-9]+}} : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP25:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C3]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[M_C4]], %[[GEP25]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     "llvm.br"(%[[M_C1_64]], %[[M_C0]]) [^[[BB28:[0-9]+]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB28]](%[[ARG28_0:.*]] : i64, %[[ARG28_1:.*]] : i64):
-// CHECK-NEXT:     %[[CMP30:.*]] = "llvm.icmp"(%[[ARG28_1]], %[[M_C8]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP30]]) [^[[BB31:[0-9]+]], ^[[BB32:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB31]]():
-// CHECK-NEXT:     %[[GEP34:.*]] = "llvm.getelementptr"(%[[ALLOC18]], %[[M_C0]], %[[ARG28_1]]) <{"elem_type" = !llvm.array<8 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[ARG28_0]], %[[GEP34]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[MUL36:.*]] = "llvm.mul"(%[[ARG28_0]], %[[M_C3]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM37:.*]] = "llvm.srem"(%[[MUL36]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"() [^[[BB38:[0-9]+]]] : () -> ()
-// CHECK-NEXT:   ^[[BB38]]():
-// CHECK-NEXT:     %[[ADD40:.*]] = "llvm.add"(%[[ARG28_1]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[SREM37]], %[[ADD40]]) [^[[BB28]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB32]]():
-// CHECK-NEXT:     %[[GEP42:.*]] = "llvm.getelementptr"(%[[ALLOC17]], %[[M_C0]], %[[M_C0]]) <{"elem_type" = !llvm.array<4 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[GEP43:.*]] = "llvm.getelementptr"(%[[ALLOC18]], %[[M_C0]], %[[M_C0]]) <{"elem_type" = !llvm.array<8 x i64>, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[CMP44:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP44]]) [^[[BB45:[0-9]+]], ^[[BB46:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB45]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C4]]) [^[[BB48:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB46]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C2]]) [^[[BB48]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB48]](%[[ARG48_0:.*]] : i64):
-// CHECK-NEXT:     %[[CMP51:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP51]]) [^[[BB52:[0-9]+]], ^[[BB53:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB52]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C1_64]]) [^[[BB55:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB53]]():
-// CHECK-NEXT:     %[[DIV57:.*]] = "llvm.sdiv"(%[[M_C4]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[DIV57]]) [^[[BB55]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB55]](%[[ARG55_0:.*]] : i64):
-// CHECK-NEXT:     %[[DIV59:.*]] = "llvm.sdiv"(%[[M_C4]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]], %[[DIV59]], %[[ARG55_0]], %[[ARG48_0]]) [^[[BB60:[0-9]+]]] : (i64, i64, i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB60]](%[[ARG60_0:.*]] : i64, %[[ARG60_1:.*]] : i64, %[[ARG60_2:.*]] : i64, %[[ARG60_3:.*]] : i64):
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]], %[[M_C4]]) [^[[BB62:[0-9]+]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB62]](%[[ARG62_0:.*]] : i64, %[[ARG62_1:.*]] : i64):
-// CHECK-NEXT:     %[[CMP64:.*]] = "llvm.icmp"(%[[ARG62_1]], %[[M_C1_64]]) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP64]]) [^[[BB65:[0-9]+]], ^[[BB66:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB65]]():
-// CHECK-NEXT:     %[[ASHR68:.*]] = "llvm.ashr"(%[[ARG62_1]], %[[M_C1_64]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD69:.*]] = "llvm.add"(%[[ARG62_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD69]], %[[ASHR68]]) [^[[BB62]]] : (i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB66]]():
-// CHECK-NEXT:     %[[CMP71:.*]] = "llvm.icmp"(%[[ARG60_0]], %[[ARG62_0]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP71]]) [^[[BB72:[0-9]+]], ^[[BB73:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB72]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]]) [^[[BB75:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB75]](%[[ARG75_0:.*]] : i64):
-// CHECK-NEXT:     %[[DIV77:.*]] = "llvm.sdiv"(%[[M_C4]], %[[ARG60_3]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[CMP78:.*]] = "llvm.icmp"(%[[ARG75_0]], %[[DIV77]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP78]]) [^[[BB79:[0-9]+]], ^[[BB80:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB79]]():
-// CHECK-NEXT:     "llvm.br"(%[[M_C0]]) [^[[BB82:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB82]](%[[ARG82_0:.*]] : i64):
-// CHECK-NEXT:     %[[DIV84:.*]] = "llvm.sdiv"(%[[ARG60_3]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[CMP85:.*]] = "llvm.icmp"(%[[ARG82_0]], %[[DIV84]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP85]]) [^[[BB86:[0-9]+]], ^[[BB87:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB86]]():
-// CHECK-NEXT:     %[[MUL89:.*]] = "llvm.mul"(%[[ARG75_0]], %[[ARG60_3]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD90:.*]] = "llvm.add"(%[[MUL89]], %[[ARG82_0]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP91:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD90]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[LOAD92:.*]] = "llvm.load"(%[[GEP91]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-// CHECK-NEXT:     %[[DIV95:.*]] = "llvm.sdiv"(%[[ARG60_3]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD96:.*]] = "llvm.add"(%[[ADD90]], %[[DIV95]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP97:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD96]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[LOAD98:.*]] = "llvm.load"(%[[GEP97]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-// CHECK-NEXT:     %[[MUL99:.*]] = "llvm.mul"(%[[M_C2]], %[[ARG82_0]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD100:.*]] = "llvm.add"(%[[MUL99]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[MUL101:.*]] = "llvm.mul"(%[[ADD100]], %[[ARG60_1]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP102:.*]] = "llvm.getelementptr"(%[[GEP43]], %[[MUL101]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     %[[LOAD103:.*]] = "llvm.load"(%[[GEP102]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
-// CHECK-NEXT:     %[[MUL104:.*]] = "llvm.mul"(%[[LOAD103]], %[[LOAD98]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM105:.*]] = "llvm.srem"(%[[MUL104]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD106:.*]] = "llvm.add"(%[[LOAD92]], %[[SREM105]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM107:.*]] = "llvm.srem"(%[[ADD106]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SUB110:.*]] = "llvm.sub"(%[[LOAD92]], %[[SREM105]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[ADD111:.*]] = "llvm.add"(%[[SUB110]], %[[M_C17]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     %[[SREM112:.*]] = "llvm.srem"(%[[ADD111]], %[[M_C17]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[GEP115:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD90]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[SREM107]], %[[GEP115]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[GEP121:.*]] = "llvm.getelementptr"(%[[GEP42]], %[[ADD96]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
-// CHECK-NEXT:     "llvm.store"(%[[SREM112]], %[[GEP121]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:     %[[ADD123:.*]] = "llvm.add"(%[[ARG82_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD123]]) [^[[BB82]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB87]]():
-// CHECK-NEXT:     %[[ADD125:.*]] = "llvm.add"(%[[ARG75_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD125]]) [^[[BB75]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB80]]():
-// CHECK-NEXT:     %[[DIV127:.*]] = "llvm.sdiv"(%[[ARG60_1]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     %[[CMP128:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP128]]) [^[[BB129:[0-9]+]], ^[[BB130:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB129]]():
-// CHECK-NEXT:     %[[DIV132:.*]] = "llvm.sdiv"(%[[ARG60_3]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[DIV132]]) [^[[BB133:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB130]]():
-// CHECK-NEXT:     %[[ADD152:.*]] = "llvm.add"(%[[ARG60_3]], %[[ARG60_3]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD152]]) [^[[BB133]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB133]](%[[ARG133_0:.*]] : i64):
-// CHECK-NEXT:     %[[CMP137:.*]] = "llvm.icmp"(%[[M_C0]], %[[M_C0]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
-// CHECK-NEXT:     "llvm.cond_br"(%[[CMP137]]) [^[[BB138:[0-9]+]], ^[[BB139:[0-9]+]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
-// CHECK-NEXT:   ^[[BB138]]():
-// CHECK-NEXT:     %[[ADD151:.*]] = "llvm.add"(%[[ARG60_2]], %[[ARG60_2]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD151]]) [^[[BB142:[0-9]+]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB139]]():
-// CHECK-NEXT:     %[[DIV144:.*]] = "llvm.sdiv"(%[[ARG60_2]], %[[M_C2]]) : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[DIV144]]) [^[[BB142]]] : (i64) -> ()
-// CHECK-NEXT:   ^[[BB142]](%[[ARG142_0:.*]] : i64):
-// CHECK-NEXT:     %[[ADD146:.*]] = "llvm.add"(%[[ARG60_0]], %[[M_C1_64]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
-// CHECK-NEXT:     "llvm.br"(%[[ADD146]], %[[DIV127]], %[[ARG142_0]], %[[ARG133_0]]) [^[[BB60]]] : (i64, i64, i64, i64) -> ()
-// CHECK-NEXT:   ^[[BB73]]():
-// CHECK-NEXT:     "llvm.return"(%[[M_C0_32]]) : (i32) -> ()
-// CHECK-NEXT:   }) : () -> ()
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:   ^4():
+// CHECK-NEXT:     "llvm.module_flags"()
+// CHECK-NEXT:     "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], {{.*}}"function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, {{.*}}"sym_name" = "fastNTT"{{.*}}}> ({
+// CHECK-NEXT:       ^7(%[[VAL_0:.*]] : !llvm.ptr, %[[VAL_1:.*]] : i64, %[[VAL_2:.*]] : i64, %[[VAL_3:.*]] : !llvm.ptr, %[[VAL_4:.*]] : i64, %[[VAL_5:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_6:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
+// CHECK-NEXT:         %[[VAL_7:.*]] = "llvm.mlir.constant"() <{"value" = 2 : i64}> : () -> i64
+// CHECK-NEXT:         %[[VAL_8:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
+// CHECK-NEXT:         %[[VAL_9:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_9]]) [^12, ^13] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^12():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_1]]) [^15] : (i64) -> ()
+// CHECK-NEXT:       ^13():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_7]]) [^15] : (i64) -> ()
+// CHECK-NEXT:       ^15(%[[VAL_10:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_11:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_11]]) [^19, ^20] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^19():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_8]]) [^22] : (i64) -> ()
+// CHECK-NEXT:       ^20():
+// CHECK-NEXT:         %[[VAL_12:.*]] = "llvm.sdiv"(%[[VAL_5]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_12]]) [^22] : (i64) -> ()
+// CHECK-NEXT:       ^22(%[[VAL_13:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_14:.*]] = "llvm.sdiv"(%[[VAL_1]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_13]], %[[VAL_14]], %[[VAL_6]], %[[VAL_10]]) [^27] : (i64, i64, i64, i64) -> ()
+// CHECK-NEXT:       ^27(%[[VAL_15:.*]] : i64, %[[VAL_16:.*]] : i64, %[[VAL_17:.*]] : i64, %[[VAL_18:.*]] : i64):
+// CHECK-NEXT:         "llvm.br"(%[[VAL_6]], %[[VAL_1]]) [^29] : (i64, i64) -> ()
+// CHECK-NEXT:       ^29(%[[VAL_19:.*]] : i64, %[[VAL_20:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_21:.*]] = "llvm.icmp"(%[[VAL_20]], %[[VAL_8]]) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_21]]) [^32, ^33] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^32():
+// CHECK-NEXT:         %[[VAL_22:.*]] = "llvm.ashr"(%[[VAL_20]], %[[VAL_8]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_23:.*]] = "llvm.add"(%[[VAL_19]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_23]], %[[VAL_22]]) [^29] : (i64, i64) -> ()
+// CHECK-NEXT:       ^33():
+// CHECK-NEXT:         %[[VAL_24:.*]] = "llvm.icmp"(%[[VAL_17]], %[[VAL_19]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_24]]) [^39, ^40] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^39():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_6]]) [^42] : (i64) -> ()
+// CHECK-NEXT:       ^42(%[[VAL_25:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_26:.*]] = "llvm.sdiv"(%[[VAL_1]], %[[VAL_18]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_27:.*]] = "llvm.icmp"(%[[VAL_25]], %[[VAL_26]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_27]]) [^46, ^47] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^46():
+// CHECK-NEXT:         "llvm.br"(%[[VAL_6]]) [^49] : (i64) -> ()
+// CHECK-NEXT:       ^49(%[[VAL_28:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_29:.*]] = "llvm.sdiv"(%[[VAL_18]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_30:.*]] = "llvm.icmp"(%[[VAL_28]], %[[VAL_29]]) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_30]]) [^53, ^54] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^53():
+// CHECK-NEXT:         %[[VAL_31:.*]] = "llvm.mul"(%[[VAL_25]], %[[VAL_18]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_32:.*]] = "llvm.add"(%[[VAL_31]], %[[VAL_28]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_33:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_32]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         %[[VAL_34:.*]] = "llvm.load"(%[[VAL_33]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         %[[VAL_35:.*]] = "llvm.sdiv"(%[[VAL_18]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_36:.*]] = "llvm.add"(%[[VAL_32]], %[[VAL_35]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_37:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_36]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         %[[VAL_38:.*]] = "llvm.load"(%[[VAL_37]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         %[[VAL_39:.*]] = "llvm.mul"(%[[VAL_7]], %[[VAL_28]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_40:.*]] = "llvm.add"(%[[VAL_39]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_41:.*]] = "llvm.mul"(%[[VAL_40]], %[[VAL_16]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_42:.*]] = "llvm.getelementptr"(%[[VAL_3]], %[[VAL_41]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         %[[VAL_43:.*]] = "llvm.load"(%[[VAL_42]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         %[[VAL_44:.*]] = "llvm.mul"(%[[VAL_43]], %[[VAL_38]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_45:.*]] = "llvm.srem"(%[[VAL_44]], %[[VAL_2]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_46:.*]] = "llvm.add"(%[[VAL_34]], %[[VAL_45]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_47:.*]] = "llvm.srem"(%[[VAL_46]], %[[VAL_2]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_48:.*]] = "llvm.sub"(%[[VAL_34]], %[[VAL_45]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_49:.*]] = "llvm.add"(%[[VAL_48]], %[[VAL_2]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_50:.*]] = "llvm.srem"(%[[VAL_49]], %[[VAL_2]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_51:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_32]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         "llvm.store"(%[[VAL_47]], %[[VAL_51]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+// CHECK-NEXT:         %[[VAL_52:.*]] = "llvm.getelementptr"(%[[VAL_0]], %[[VAL_36]]) <{"elem_type" = i64, "noWrapFlags" = 3 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+// CHECK-NEXT:         "llvm.store"(%[[VAL_50]], %[[VAL_52]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 8 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
+// CHECK-NEXT:         "llvm.br"() [^90] : () -> ()
+// CHECK-NEXT:       ^90():
+// CHECK-NEXT:         %[[VAL_53:.*]] = "llvm.add"(%[[VAL_28]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_53]]) [^49] : (i64) -> ()
+// CHECK-NEXT:       ^54():
+// CHECK-NEXT:         "llvm.br"() [^94] : () -> ()
+// CHECK-NEXT:       ^94():
+// CHECK-NEXT:         %[[VAL_54:.*]] = "llvm.add"(%[[VAL_25]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_54]]) [^42] : (i64) -> ()
+// CHECK-NEXT:       ^47():
+// CHECK-NEXT:         %[[VAL_55:.*]] = "llvm.sdiv"(%[[VAL_16]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         %[[VAL_56:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_56]]) [^100, ^101] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^100():
+// CHECK-NEXT:         %[[VAL_57:.*]] = "llvm.sdiv"(%[[VAL_18]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_57]]) [^104] : (i64) -> ()
+// CHECK-NEXT:       ^101():
+// CHECK-NEXT:         %[[VAL_58:.*]] = "llvm.add"(%[[VAL_18]], %[[VAL_18]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_58]]) [^104] : (i64) -> ()
+// CHECK-NEXT:       ^104(%[[VAL_59:.*]] : i64):
+// CHECK-NEXT:         %[[VAL_60:.*]] = "llvm.icmp"(%[[VAL_4]], %[[VAL_6]]) <{"predicate" = 1 : i64}> : (i64, i64) -> i1
+// CHECK-NEXT:         "llvm.cond_br"(%[[VAL_60]]) [^109, ^110] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+// CHECK-NEXT:       ^109():
+// CHECK-NEXT:         %[[VAL_61:.*]] = "llvm.add"(%[[VAL_15]], %[[VAL_15]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_61]]) [^113] : (i64) -> ()
+// CHECK-NEXT:       ^110():
+// CHECK-NEXT:         %[[VAL_62:.*]] = "llvm.sdiv"(%[[VAL_15]], %[[VAL_7]]) : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_62]]) [^113] : (i64) -> ()
+// CHECK-NEXT:       ^113(%[[VAL_63:.*]] : i64):
+// CHECK-NEXT:         "llvm.br"() [^117] : () -> ()
+// CHECK-NEXT:       ^117():
+// CHECK-NEXT:         %[[VAL_64:.*]] = "llvm.add"(%[[VAL_17]], %[[VAL_8]]) <{"overflowFlags" = 1 : i32}> : (i64, i64) -> i64
+// CHECK-NEXT:         "llvm.br"(%[[VAL_63]], %[[VAL_55]], %[[VAL_64]], %[[VAL_59]]) [^27] : (i64, i64, i64, i64) -> ()
+// CHECK-NEXT:       ^40():
+// CHECK-NEXT:         "llvm.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) {{.*}} : () -> ()


### PR DESCRIPTION
We remove the main from the vcc testing for fastntt and add it to the instruction selection benchmarks.