### PR TITLE
feat(refinement): Allows UB to be refined by `none`

### DIFF
--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -59,14 +59,13 @@ An interpretation result `source` is refined by `target` given a refinement rela
 on the underlying values. This asserts:
 * every well-defined outcome `some (.ok a)` of `source` must be matched by an outcome
   `some (.ok b)` of `target` with `R a b`;
-* when `source` is undefined behaviour (`some .ub`), `target` must succeed (i.e. not be `none`),
-  but may be either `some .ub` or `some (.ok _)`;
-* when `source` is `none`, `target` may be anything
+* when `source` is undefined behaviour (`some .ub`) or failed interpretation (`none`), `target`
+  is unconstrained
 -/
 def Interp.isRefinedBy (R : α → β → Prop) (source : Interp α) (target : Interp β) : Prop :=
   match source, target with
   | some (.ok a), some (.ok b) => R a b
-  | some .ub, some _ => True
+  | some .ub, _ => True
   | none, _ => True
   | _, _ => False
 

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -92,13 +92,11 @@ theorem Interp.isRefinedBy_none_target :
     Interp.isRefinedBy R none target := by
   simp [Interp.isRefinedBy]
 
-/-- `ub` is refined as long as interpretation succeeds. -/
-@[simp, grind =]
-theorem Interp.isRefinedBy_ub_target_iff :
-    Interp.isRefinedBy R (some .ub) target ↔
-    ∃ targetRes, target = some targetRes := by
+/-- `ub` is refined by any value. -/
+@[simp, grind .]
+theorem Interp.isRefinedBy_ub_target :
+    Interp.isRefinedBy R (some .ub) target := by
   simp only [Interp.isRefinedBy]
-  cases target <;> grind
 
 /-- `ok` is only refined by `ok` values that satisfy the given refinement relation. -/
 @[simp, grind =]

--- a/Veir/Interpreter/Refinement/Monotonicity.lean
+++ b/Veir/Interpreter/Refinement/Monotonicity.lean
@@ -130,25 +130,5 @@ theorem interpretOp_monotone
     simp only [Interp, hv, pure, Option.some.injEq, UBOr.ok.injEq, Prod.mk.injEq]
     have stateVarRef : state.variables.isRefinedBy state'.variables mapping := by grind [InterpreterState.isRefinedBy]
     grind [InterpreterState.isRefinedBy, VariableState.setResultValues?_isRefinedBy stateVarRef resValuesRef, cases ValueMapping.PreservesOperation]
-  · /- If the source interpretation returns UB, then we need to prove that the target
-       interpretation does not fail. -/
-    simp only [Interp.isRefinedBy_ub_target_iff]
-    rcases htgt : interpretOp op' state' opIn' with _ | (⟨state₂', act'⟩ | _)
-    /- If the target is either UB or a result, then the refinement is trivial. -/
-    rotate_left; grind; grind
-    have hinterp' := (interpretOp_ub_iff_op_interpret_of_getOperandValues_eq_some hSrcOps).mp hsrc
-    simp only [interpretOp, OperationPtr.interpret, hTgtOps, hPreserves.resultTypes, hPreserves.successors, ← hMem, liftM, monadLift,
-      MonadLift.monadLift] at htgt
-    simp only [Interp.isRefinedBy, hinterp'] at hPR1
-    split at hPR1; grind; rotate_left; grind; grind
-    rename_i _ _ interpTgtRes _ hInterpTgtRes
-    simp [interpretOp'_opType_cast hPreserves.opType hPreserves.props, hInterpTgtRes, bind] at htgt
-    cases interpTgtRes
-    · simp only [pure] at htgt
-      simp only [← hInterp'Eq] at hInterpTgtRes
-      have := interpretOp'_results_conform (opInBounds := opIn') opVerif' (VariableState.getOperandValues_conforms hTgtOps) hInterpTgtRes
-      split at htgt
-      · grind [VariableState.setResultValues?_isSome_iff_conforms (varState := state'.variables)]
-      · grind
-      · grind
-    · grind
+  · /- If the source interpretation returns UB, then the refinement holds trivially. -/
+    simp


### PR DESCRIPTION
With this change, a program that returns `ub` can be refined to a program that would have an interpretation error.

This is a major change of the semantics, that we are doing short-term to speed-up the writing of the lifting proof. While this is the same semantics used as vellvm, I believe we should instead strive of having a proof that the interpreter always return a value if the program is well-formed.