### PR TITLE
feat: add `BlockPtr.OpChainSlice`

### DIFF
--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -2512,6 +2512,51 @@ theorem hasUses!_eq_false_iff_hasUses!_opResult_eq_false {op : OperationPtr}
 
 end OperationPtr
 
+/-- `ops` is a contiguous chain of operations in a block `parent` in context `ctx`: each operation's
+`.next` field points to the following operation in the list, and each operation's `.parent` field
+points to `parent`. -/
+def BlockPtr.OpChainSlice (ctx : IRContext OpInfo) (parent : BlockPtr) : List OperationPtr → Prop
+  | [] => True
+  | a :: l =>
+    a.InBounds ctx ∧
+    (a.get! ctx).parent = some parent ∧
+    (∀ b, l.head? = some b → (a.get! ctx).next = some b) ∧
+    BlockPtr.OpChainSlice ctx parent l
+
+namespace BlockPtr.OpChainSlice
+
+/-- All operations in an operation chain slice are in bounds. -/
+@[grind →]
+theorem inBounds_of_mem {ctx : IRContext OpInfo} {parent : BlockPtr} {ops : List OperationPtr}
+    (h : BlockPtr.OpChainSlice ctx parent ops) :
+    ∀ op, op ∈ ops → op.InBounds ctx := by
+  induction ops <;> simp [BlockPtr.OpChainSlice] at h <;> grind
+
+/-- All operations in an operation chain slice have the expected parent. -/
+@[grind →]
+theorem parent_of_mem {ctx : IRContext OpInfo} {parent : BlockPtr} {ops : List OperationPtr}
+    (h : BlockPtr.OpChainSlice ctx parent ops) :
+    ∀ op, op ∈ ops → (op.get! ctx).parent = some parent := by
+  induction ops <;> simp [BlockPtr.OpChainSlice] at h <;> grind
+
+/-- The empty list is always an operation chain slice. -/
+@[simp, grind .]
+theorem nil {ctx : IRContext OpInfo} {parent : BlockPtr} :
+    BlockPtr.OpChainSlice ctx parent [] := by
+  simp [BlockPtr.OpChainSlice]
+
+/-- An `head :: tail` list is an operation chain slice iff the tail is an operation chain slice,
+and the head is in bounds, has the same parent, and points to the tail. -/
+theorem cons_iff {ctx : IRContext OpInfo} {parent : BlockPtr} {head : OperationPtr} {tail : List OperationPtr} :
+    BlockPtr.OpChainSlice ctx parent (head :: tail) ↔
+    head.InBounds ctx ∧
+    (head.get! ctx).parent = some parent ∧
+    (∀ b, tail.head? = some b → (head.get! ctx).next = some b) ∧
+    BlockPtr.OpChainSlice ctx parent tail := by
+  simp [BlockPtr.OpChainSlice]
+
+end BlockPtr.OpChainSlice
+
 def IRContext.empty (OpInfo : Type) [HasOpInfo OpInfo] : IRContext OpInfo := {
     nextID := 0,
     operations := Std.HashMap.emptyWithCapacity,

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -225,3 +225,76 @@ theorem InterpreterState.DefinesDominating.interpretOp_ne_none
       (VariableState.setResultValues?_isSome_iff_conforms state.variables opInBounds).mp this
     simp [hv]
   · simp [Interp]
+
+/-- `interpretOpList` never fails (returns `none`) on a slice of an operation chain given a verified
+and well-dominated context, on an interpreter state containing all values dominating the first
+operation in the slice. -/
+theorem InterpreterState.DefinesDominating.interpretOpList_ne_none
+    (ctxVerif : ctx.Verified) (ctxDom : ctx.Dom) {block : BlockPtr}
+    (hChain : block.OpChainSlice ctx.raw ops)
+    {state : InterpreterState ctx}
+    (stateDom : ∀ head, (hhead : ops.head? = some head) →
+      state.DefinesDominating (.before head) (by grind [List.mem_of_head? hhead])) :
+    interpretOpList ops state ≠ none := by
+  induction ops generalizing state with
+  | nil => simp
+  | cons a l ih =>
+    have hDom : state.DefinesDominating (.before a) := stateDom a (by simp)
+    obtain ⟨headInBounds, headParent, headNext, hChainTail⟩ := hChain
+    simp only [interpretOpList_cons]
+    rcases hi : interpretOp a state (by grind) with _ | (⟨s, act⟩ | _)
+    · grind [InterpreterState.DefinesDominating.interpretOp_ne_none ctxDom]
+    · grind [interpretOp_DefinesDominating ctxDom hDom headParent hi]
+    · simp
+
+/-- If the equation lemma holds at the point *before* an operation chain, interpreting the chain
+keeps the equation lemma valid at the point *after* the chain. -/
+theorem interpretOpList_equationLemmaAt {ctx : WfIRContext OpCode}
+    {state state' : InterpreterState ctx} (ctxDom : ctx.Dom)
+    {block : BlockPtr} (hChain : block.OpChainSlice ctx.raw ops)
+    (hfstElem : ops.head? = some fstOp)
+    (eqLemma : state.EquationLemmaAt (.before fstOp) (by
+      grind [List.head?_eq_getElem?, hChain.inBounds_of_mem]))
+    (hLastElem : ops.getLast? = some lastOp)
+    (hrun : interpretOpList ops state (by grind) = some (.ok (state', none))) :
+    state'.EquationLemmaAt (InsertPoint.after lastOp ctx.raw block) := by
+  induction ops generalizing state fstOp with
+  | nil => grind
+  | cons head tail ih =>
+    obtain ⟨headInBounds, headParent, headNext, hChainTail⟩ := hChain
+    have : head = fstOp := by grind
+    subst head
+    simp only [interpretOpList_cons] at hrun
+    rcases hi : interpretOp fstOp state headInBounds with _ | (⟨s, act⟩ | _) <;>
+      simp only [hi] at hrun
+    · simp at hrun
+    · have hAfter := interpretOp_equationLemmaAt ctxDom eqLemma headParent hi
+      cases tail <;> grind
+    · grind
+
+/-- If `DefinesDominating` holds at the point *before* an operation chain, interpreting the chain
+keeps `DefinesDominating` at the point *after* the chain. -/
+theorem interpretOpList_DefinesDominating {ctx : WfIRContext OpCode}
+    {state state' : InterpreterState ctx} (ctxDom : ctx.Dom)
+    {block : BlockPtr} (hChain : block.OpChainSlice ctx.raw ops)
+    (head : ops.head? = some fstOp)
+    (stateDom : state.DefinesDominating (.before fstOp) (by
+      grind [List.head?_eq_getElem?, hChain.inBounds_of_mem]))
+    (hLastElem : ops.getLast? = some lastOp)
+    (hrun : interpretOpList ops state (by grind) = some (.ok (state', none))) :
+    state'.DefinesDominating (InsertPoint.after lastOp ctx.raw block) := by
+  induction ops generalizing state fstOp with
+  | nil => simp at hLastElem
+  | cons a tail ih =>
+    obtain ⟨headInBounds, headParent, headNext, hChainTail⟩ := hChain
+    obtain rfl : a = fstOp := by simpa using head
+    simp only [interpretOpList_cons] at hrun
+    rcases hi : interpretOp a state headInBounds with _ | (⟨s, act⟩ | _) <;>
+      simp only [hi] at hrun
+    · simp at hrun
+    · cases act
+      case none =>
+        have hAfter := interpretOp_DefinesDominating ctxDom stateDom headParent hi
+        cases tail <;> grind
+      case some cf => grind
+    · grind

--- a/Veir/Rewriter/InsertPoint.lean
+++ b/Veir/Rewriter/InsertPoint.lean
@@ -88,6 +88,14 @@ theorem InsertPoint.after_inBounds (ctxWf : ctx.WellFormed) :
     (InsertPoint.after op ctx blockPtr opHasParent opInBounds).InBounds ctx := by
   grind [InsertPoint.after]
 
+theorem InsertPoint.after_eq_of_some_next :
+    (op.get! ctx).next = some nextOp →
+    InsertPoint.after op ctx blockPtr opHasParent opInBounds = .before nextOp := by
+  grind [InsertPoint.after]
+
+grind_pattern InsertPoint.after_eq_of_some_next =>
+  (op.get! ctx).next, some nextOp, InsertPoint.after op ctx blockPtr opHasParent opInBounds
+
 @[grind]
 def InsertPoint.block! (insertionPoint : InsertPoint) (ctx : IRContext OpInfo) : Option BlockPtr :=
   match insertionPoint with


### PR DESCRIPTION
`BlockPtr.OpChainSlice ctx block ops` represents a slice of an operation chain, and means that `ops` is a list of contiguous operations that all have `block` as parent. 

This definition is quite useful to reason about the interpretation of a subset of a block for instance.