### PR TITLE
fix(riscv): remove commutative match 

### DIFF
--- a/Test/Passes/Combines/add_li_to_addi.mlir
+++ b/Test/Passes/Combines/add_li_to_addi.mlir
@@ -12,13 +12,14 @@
         // CHECK:             "func.return"([[r]]) : (!riscv.reg) -> ()
     }) : () -> ()
 
-    // riscv.add (riscv.li imm) x -> riscv.addi x imm  (li on the left)
+    // riscv.add (riscv.li imm) x -> riscv.add (riscv.li imm) x  (li on the left is not folded)
     "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
     ^bb(%a : !riscv.reg):
         // CHECK:             ^{{.*}}([[arg2:%.*]] : !riscv.reg):
         %c = "riscv.li"() <{"value" = -2048 : i64}>: () -> !riscv.reg
+        // CHECK:             [[r1:%.*]] = "riscv.li"() <{"value" = -2048 : i64}> : () -> !riscv.reg
         %add = "riscv.add"(%c, %a) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-        // CHECK:             [[r2:%.*]] = "riscv.addi"([[arg2]]) <{"value" = -2048 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:             [[r2:%.*]] = "riscv.add"([[r1]], [[arg2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         "func.return"(%add) : (!riscv.reg) -> ()
         // CHECK:             "func.return"([[r2]]) : (!riscv.reg) -> ()
     }) : () -> ()

--- a/Test/Passes/Combines/binop_li_to_binopi.mlir
+++ b/Test/Passes/Combines/binop_li_to_binopi.mlir
@@ -12,13 +12,14 @@
         // CHECK:             "func.return"([[r]]) : (!riscv.reg) -> ()
     }) : () -> ()
 
-    // riscv.or (riscv.li imm) x -> riscv.ori x imm  (li on the left)
+    // riscv.or (riscv.li imm) x -> riscv.ori x imm  (li on the left is not folded)
     "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
     ^bb(%a : !riscv.reg):
         // CHECK:             ^{{.*}}([[a2:%.*]] : !riscv.reg):
         %c = "riscv.li"() <{"value" = -1 : i64}>: () -> !riscv.reg
+        // CHECK:             [[r1:%.*]] = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
         %r = "riscv.or"(%c, %a) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-        // CHECK:             [[r2:%.*]] = "riscv.ori"([[a2]]) <{"value" = -1 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:             [[r2:%.*]] = "riscv.or"([[r1]], [[a2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         "func.return"(%r) : (!riscv.reg) -> ()
         // CHECK:             "func.return"([[r2]]) : (!riscv.reg) -> ()
     }) : () -> ()
@@ -56,13 +57,14 @@
         // CHECK:             "func.return"([[r5]]) : (!riscv.reg) -> ()
     }) : () -> ()
 
-    // riscv.addw (riscv.li imm) x -> riscv.addiw x imm  (li on the left)
+    // riscv.addw (riscv.li imm) x -> riscv.addiw x imm  (li on the left is not folded)
     "func.func"()  <{function_type = (!riscv.reg) -> !riscv.reg}> ({
     ^bb(%a : !riscv.reg):
         // CHECK:             ^{{.*}}([[a6:%.*]] : !riscv.reg):
         %c = "riscv.li"() <{"value" = -1 : i64}>: () -> !riscv.reg
+        // CHECK:             [[r7:%.*]] = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
         %r = "riscv.addw"(%c, %a) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-        // CHECK:             [[r6:%.*]] = "riscv.addiw"([[a6]]) <{"value" = -1 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:             [[r6:%.*]] = "riscv.addw"([[r7]], [[a6]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         "func.return"(%r) : (!riscv.reg) -> ()
         // CHECK:             "func.return"([[r6]]) : (!riscv.reg) -> ()
     }) : () -> ()

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -51,18 +51,13 @@ set_option warn.sorry false in
   so the immediate is only matched on the second operand.
 -/
 def fold_binop_li (src dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties)
-    (lo hi : Int) : LocalRewritePattern OpCode := fun ctx op =>
-  match matchRiscvBinop src op ctx with
-  | none => some (ctx, none)
-  | some (reg, rhs) =>
-    match matchLi rhs ctx with
-    | none => some (ctx, none)
-    | some imm =>
-      if imm.value.value < lo || imm.value.value > hi then some (ctx, none)
-      else do
-        let (ctx, newOp) ← WfRewriter.createOp ctx (.riscv dst) #[RegisterType.mk] #[reg]
-            #[] #[] (cast h.symm imm) none sorry
-        return (ctx, some (#[newOp], #[newOp.getResult 0]))
+    (lo hi : Int) : LocalRewritePattern OpCode := fun ctx op => do
+  let some (lhs, rhs) := matchRiscvBinop src op ctx | return (ctx, none)
+  let some imm :=  matchLi rhs ctx | return (ctx, none)
+  if imm.value.value < lo || imm.value.value > hi then return (ctx, none)
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.riscv dst) #[RegisterType.mk] #[lhs]
+      #[] #[] (cast h.symm imm) none sorry
+  return (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 /-- imm5 word shifts/rotates: `src rs1 (li imm) -> dst rs1 imm` for `imm ∈ [0,31]`. -/
 def fold_shift5_li (src dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties) :
@@ -95,16 +90,12 @@ def fold_sltu_li_to_sltiu := fold_imm12_li .sltu .sltiu rfl
 
 set_option warn.sorry false in
 /-- riscv.slli (riscv.zextw x) shamt -> riscv.slliuw x shamt -/
-def fold_zextw_slli_to_slliuw : LocalRewritePattern OpCode := fun ctx op =>
-  match matchOp op ctx (.riscv .slli) 1 with
-  | none => some (ctx, none)
-  | some (operands, shamt) =>
-    match matchZextw operands[0]! ctx with
-    | none => some (ctx, none)
-    | some x => do
-        let (ctx, newOp) ← WfRewriter.createOp ctx (.riscv .slliuw) #[RegisterType.mk] #[x]
-            #[] #[] shamt none sorry
-        return (ctx, some (#[newOp], #[newOp.getResult 0]))
+def fold_zextw_slli_to_slliuw : LocalRewritePattern OpCode := fun ctx op => do
+  let some (ops, shamt) := matchOp op ctx (.riscv .slli) 1 | return (ctx, none)
+  let some x :=  matchZextw ops[0]! ctx | return (ctx, none)
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.riscv .slliuw) #[RegisterType.mk] #[x]
+          #[] #[] shamt none sorry
+  return (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 /-! # Pass implementation -/
 

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -30,18 +30,13 @@ set_option warn.sorry false in
 -/
 def fold_commutative_binop_li (src dst : Riscv)
     (h : Riscv.propertiesOf dst = RISCVImmediateProperties) :
-    LocalRewritePattern OpCode := fun ctx op =>
-  match matchRiscvBinop src op ctx with
-  | none => some (ctx, none)
-  | some (lhs, rhs) =>
-    match (Prod.mk lhs <$> matchLi rhs ctx) <|> (Prod.mk rhs <$> matchLi lhs ctx) with
-    | none => some (ctx, none)
-    | some (reg, imm) =>
-      if imm.value.value < -2048 || imm.value.value > 2047 then some (ctx, none)
-      else do
-        let (ctx, newOp) ← WfRewriter.createOp ctx (.riscv dst) #[RegisterType.mk] #[reg]
-            #[] #[] (cast h.symm imm) none sorry
-        return (ctx, some (#[newOp], #[newOp.getResult 0]))
+    LocalRewritePattern OpCode := fun ctx op => do
+  let some (lhs, rhs) := matchRiscvBinop src op ctx | return (ctx, none)
+  let some imm :=  matchLi rhs ctx | return (ctx, none)
+  if imm.value.value < -2048 || imm.value.value > 2047 then return (ctx, none)
+  let (ctx, newOp) ← WfRewriter.createOp ctx (.riscv dst) #[RegisterType.mk] #[lhs]
+          #[] #[] (cast h.symm imm) none sorry
+  return (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 def fold_add_li_to_addi   := fold_commutative_binop_li .add  .addi  rfl
 def fold_or_li_to_ori     := fold_commutative_binop_li .or   .ori   rfl


### PR DESCRIPTION
Because we now canonicalize constants to be on the rhs of arithmetic operations, we can simplify the combines based on the assumption that this canonicalization has happened.