### PR TITLE
feat(riscv): select riscv.andn, riscv.orn, riscv.xnor

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/andn_orn_xnor.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/andn_orn_xnor.mlir
@@ -1,0 +1,46 @@
+// RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
+
+// LLVM models `not y` as `xor y -1`. The Zbb logic-with-negate forms fuse a
+// `not` feeding an `and`/`or`/`xor` into a single instruction (mirroring LLVM's
+// TableGen patterns `(and X, (not Y)) -> ANDN`, etc.). These run in the SDAG
+// pass, before the bulk per-op lowering would otherwise consume the `not` and
+// the logic op separately. Each function should produce the fused op.
+
+"builtin.module"() ({
+    // and x (not y) -> riscv.andn
+    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    ^bb0(%x: i64, %y: i64):
+        %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
+        %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
+        %r = "llvm.and"(%x, %not) : (i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.andn"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+    // or x (not y) -> riscv.orn
+    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    ^bb0(%x: i64, %y: i64):
+        %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
+        %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
+        %r = "llvm.or"(%x, %not) : (i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.orn"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+    // xor x (not y) -> riscv.xnor  (i.e. ~(x ^ y))
+    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    ^bb0(%x: i64, %y: i64):
+        %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
+        %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
+        %r = "llvm.xor"(%x, %not) : (i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.xnor"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+    // The `not` is accepted on either operand: and (not y) x -> riscv.andn
+    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    ^bb0(%x: i64, %y: i64):
+        %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
+        %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
+        %r = "llvm.and"(%not, %x) : (i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.andn"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -178,15 +178,6 @@ def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op
     #[] #[] cstProp (some $ .before op) sorry sorry sorry sorry
   rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
 
-/-- Match `xor X, -1` (the canonical "not X"), returning `X`. -/
-def matchNot (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
-  let .opResult opResultPtr := val | none
-  let op := opResultPtr.op
-  let (lhs, rhs) ← matchXori op ctx
-  let cst ← matchConstantIntVal rhs ctx
-  guard (cst.value = -1)
-  return lhs
-
 set_option warn.sorry false in
 /-- Rewrites `~~x` to `x`. -/
 def notNotToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :

--- a/Veir/Passes/InstructionSelection/Common.lean
+++ b/Veir/Passes/InstructionSelection/Common.lean
@@ -1,0 +1,45 @@
+import Veir.Pass
+import Veir.PatternRewriter.Basic
+
+namespace Veir
+
+/-!
+  Shared helpers for the RISC-V instruction-selection lowering patterns.
+
+  Every per-op lowering is bracketed by the same boilerplate: a width check on
+  the operands/result, and the `unrealized_conversion_cast` plumbing that moves
+  values in and out of `!riscv.reg`. These helpers factor that out.
+-/
+
+/-- Every value in `vals` must have type `i64`. -/
+def allI64 (vals : Array ValuePtr) (ctx : IRContext OpCode) : Bool :=
+  vals.all fun v =>
+    match (v.getType! ctx).val with
+    | .integerType t => t.bitwidth == 64
+    | _ => false
+
+set_option warn.sorry false in
+/--
+  Insert `unrealized_conversion_cast : (typeof v) -> !riscv.reg` before `op`,
+  returning the updated rewriter and the register-typed result value.
+-/
+def castToReg (rewriter : PatternRewriter OpCode) (op : OperationPtr) (v : ValuePtr) :
+    Option (PatternRewriter OpCode × ValuePtr) := do
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast)
+      #[RegisterType.mk] #[v] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  return (rewriter, castOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  Cast the register value `reg` back to `op`'s result type and replace `op` with
+  the cast. The target type is read from `op`, so this is type-agnostic (it also
+  handles non-`i64` results, e.g. the `!llvm.ptr` produced by `getelementptr`).
+-/
+def replaceWithReg (rewriter : PatternRewriter OpCode) (op : OperationPtr) (reg : ValuePtr) :
+    Option (PatternRewriter OpCode) := do
+  let type := ((op.getResult 0).get! rewriter.ctx.raw).type
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast)
+      #[type] #[reg] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+
+end Veir

--- a/Veir/Passes/InstructionSelection/Common.lean
+++ b/Veir/Passes/InstructionSelection/Common.lean
@@ -5,18 +5,7 @@ namespace Veir
 
 /-!
   Shared helpers for the RISC-V instruction-selection lowering patterns.
-
-  Every per-op lowering is bracketed by the same boilerplate: a width check on
-  the operands/result, and the `unrealized_conversion_cast` plumbing that moves
-  values in and out of `!riscv.reg`. These helpers factor that out.
 -/
-
-/-- Every value in `vals` must have type `i64`. -/
-def allI64 (vals : Array ValuePtr) (ctx : IRContext OpCode) : Bool :=
-  vals.all fun v =>
-    match (v.getType! ctx).val with
-    | .integerType t => t.bitwidth == 64
-    | _ => false
 
 set_option warn.sorry false in
 /--

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -183,6 +183,30 @@ theorem sub_refinement {x y : LLVM.Int 64} :
   veir_bv_decide
 
 /--
+  Prove the correctness of the `andn` lowering pattern.
+-/
+theorem andn_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.and x (Data.LLVM.Int.xor y (LLVM.Int.constant 64 (-1)))) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.andn (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `orn` lowering pattern.
+-/
+theorem orn_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.or x (Data.LLVM.Int.xor y (LLVM.Int.constant 64 (-1)))) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.orn (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `xnor` lowering pattern.
+-/
+theorem xnor_refinement {x y : LLVM.Int 64} :
+    (Data.LLVM.Int.xor x (Data.LLVM.Int.xor y (LLVM.Int.constant 64 (-1)))) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xnor (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
   Prove the correctness of the `orcb` lowering pattern (the `Y = 0` case).
 
   The `and` with the per-byte bit-0 mask `0x0101_0101_0101_0101` is what makes the

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -1,6 +1,7 @@
 import Veir.Pass
 import Veir.PatternRewriter.Basic
 import Veir.Passes.Matching
+import Veir.Passes.InstructionSelection.Common
 
 namespace Veir
 
@@ -13,20 +14,79 @@ namespace Veir
 
 set_option warn.sorry false in
 /--
+  `and x (not y)` -> `riscv.andn x y`. The `not` may appear on either operand.
+-/
+def andn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
+    Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs) := matchAnd op rewriter.ctx | return rewriter
+  if !allI64 #[lhs, rhs, op.getResult 0] rewriter.ctx.raw then return rewriter
+  /- one operand must be `not y`; `x` is the other -/
+  let some (x, y) :=
+    (match matchNot rhs rewriter.ctx with
+     | some y => some (lhs, y)
+     | none => match matchNot lhs rewriter.ctx with
+               | some y => some (rhs, y)
+               | none => none) | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op x
+  let (rewriter, yReg) ← castToReg rewriter op y
+  /- result = x & ~y -/
+  let (rewriter, andnOp) ← rewriter.createOp (.riscv .andn) #[RegisterType.mk] #[xReg, yReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (andnOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  `or x (not y)` -> `riscv.orn x y`. The `not` may appear on either operand.
+-/
+def orn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
+    Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
+  if !allI64 #[lhs, rhs, op.getResult 0] rewriter.ctx.raw then return rewriter
+  /- one operand must be `not y`; `x` is the other -/
+  let some (x, y) :=
+    (match matchNot rhs rewriter.ctx with
+     | some y => some (lhs, y)
+     | none => match matchNot lhs rewriter.ctx with
+               | some y => some (rhs, y)
+               | none => none) | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op x
+  let (rewriter, yReg) ← castToReg rewriter op y
+  /- result = x | ~y -/
+  let (rewriter, ornOp) ← rewriter.createOp (.riscv .orn) #[RegisterType.mk] #[xReg, yReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (ornOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  `xor x (not y)` -> `riscv.xnor x y`. The `not` may appear on either operand.
+-/
+def xnor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
+    Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
+  if !allI64 #[lhs, rhs, op.getResult 0] rewriter.ctx.raw then return rewriter
+  /- one operand must be `not y`; `x` is the other -/
+  let some (x, y) :=
+    (match matchNot rhs rewriter.ctx with
+     | some y => some (lhs, y)
+     | none => match matchNot lhs rewriter.ctx with
+               | some y => some (rhs, y)
+               | none => none) | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op x
+  let (rewriter, yReg) ← castToReg rewriter op y
+  /- result = ~(x ^ y) -/
+  let (rewriter, xnorOp) ← rewriter.createOp (.riscv .xnor) #[RegisterType.mk] #[xReg, yReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (xnorOp.getResult 0)
+
+set_option warn.sorry false in
+/--
   `sub (shl M (8 - Y)) (lshr M Y)` -> `riscv.orcb M`,
   where `M = and Z (0x0101_0101_0101_0101 <<< Y)`
 -/
 def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (a, b, _) := matchSub op rewriter.ctx | return rewriter
-  /- only support `i64` -/
-  let .integerType atype := (a.getType! rewriter.ctx.raw).val | return rewriter
-  if atype.bitwidth ≠ 64 then return rewriter
-  let .integerType btype := (b.getType! rewriter.ctx.raw).val | return rewriter
-  if btype.bitwidth ≠ 64 then return rewriter
-  let type := ((op.getResult 0).get! rewriter.ctx.raw).type
-  let .integerType type' := type.val | return rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if !allI64 #[a, b, op.getResult 0] rewriter.ctx.raw then return rewriter
   /- left operand must be `shl M (8 - Y)` for some `0 ≤ Y < 8` -/
   let some aOp := getDefiningOp a rewriter.ctx | return rewriter
   let some (m, shamt, _) := matchShl aOp rewriter.ctx | return rewriter
@@ -57,16 +117,11 @@ def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
     | some attr => BitVec.ofInt 64 attr.value == maskBV
     | none => false
   if !(isMask mo0 || isMask mo1) then return rewriter
-  /- cast `M` to a register -/
-  let (rewriter, mCastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[m]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, mReg) ← castToReg rewriter op m
   /- actual `riscv.orcb` -/
-  let (rewriter, orcbOp) ← rewriter.createOp (.riscv .orcb) #[RegisterType.mk] #[mCastOp.getResult 0]
+  let (rewriter, orcbOp) ← rewriter.createOp (.riscv .orcb) #[RegisterType.mk] #[mReg]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- cast back result for type consistency -/
-  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[orcbOp.getResult 0]
-      #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
-  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+  replaceWithReg rewriter op (orcbOp.getResult 0)
 
 
 
@@ -74,7 +129,7 @@ def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
 
 def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern #[orcb]
+  let pattern := RewritePattern.GreedyRewritePattern #[andn, orn, xnor, orcb]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying SDAG patterns"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -19,8 +19,8 @@ set_option warn.sorry false in
 def andn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs) := matchAnd op rewriter.ctx | return rewriter
-  if !allI64 #[lhs, rhs, op.getResult 0] rewriter.ctx.raw then return rewriter
-  /- one operand must be `not y`; `x` is the other -/
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
   let some (x, y) :=
     (match matchNot rhs rewriter.ctx with
      | some y => some (lhs, y)
@@ -29,7 +29,6 @@ def andn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
                | none => none) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let (rewriter, yReg) ← castToReg rewriter op y
-  /- result = x & ~y -/
   let (rewriter, andnOp) ← rewriter.createOp (.riscv .andn) #[RegisterType.mk] #[xReg, yReg]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (andnOp.getResult 0)
@@ -41,8 +40,8 @@ set_option warn.sorry false in
 def orn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
-  if !allI64 #[lhs, rhs, op.getResult 0] rewriter.ctx.raw then return rewriter
-  /- one operand must be `not y`; `x` is the other -/
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
   let some (x, y) :=
     (match matchNot rhs rewriter.ctx with
      | some y => some (lhs, y)
@@ -51,7 +50,6 @@ def orn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
                | none => none) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let (rewriter, yReg) ← castToReg rewriter op y
-  /- result = x | ~y -/
   let (rewriter, ornOp) ← rewriter.createOp (.riscv .orn) #[RegisterType.mk] #[xReg, yReg]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (ornOp.getResult 0)
@@ -63,8 +61,8 @@ set_option warn.sorry false in
 def xnor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
-  if !allI64 #[lhs, rhs, op.getResult 0] rewriter.ctx.raw then return rewriter
-  /- one operand must be `not y`; `x` is the other -/
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
   let some (x, y) :=
     (match matchNot rhs rewriter.ctx with
      | some y => some (lhs, y)
@@ -73,7 +71,6 @@ def xnor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
                | none => none) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let (rewriter, yReg) ← castToReg rewriter op y
-  /- result = ~(x ^ y) -/
   let (rewriter, xnorOp) ← rewriter.createOp (.riscv .xnor) #[RegisterType.mk] #[xReg, yReg]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (xnorOp.getResult 0)
@@ -86,7 +83,8 @@ set_option warn.sorry false in
 def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (a, b, _) := matchSub op rewriter.ctx | return rewriter
-  if !allI64 #[a, b, op.getResult 0] rewriter.ctx.raw then return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
   /- left operand must be `shl M (8 - Y)` for some `0 ≤ Y < 8` -/
   let some aOp := getDefiningOp a rewriter.ctx | return rewriter
   let some (m, shamt, _) := matchShl aOp rewriter.ctx | return rewriter

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -91,6 +91,15 @@ def matchXor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × 
   let (op, properties) ← matchOp op ctx (.llvm .xor) 2
   return (op[0]!, op[1]!, properties)
 
+/-- Match `xor X, -1` (the canonical "not X"), returning `X`. -/
+def matchNot (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
+  let .opResult opResultPtr := val | none
+  let op := opResultPtr.op
+  let (lhs, rhs) ← matchXori op ctx
+  let cst ← matchConstantIntVal rhs ctx
+  guard (cst.value = -1)
+  return lhs
+
 def matchMul (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .mul)) := do
   let (op, properties) ← matchOp op ctx (.llvm .mul) 2
   return (op[0]!, op[1]!, properties)


### PR DESCRIPTION
a few little things to note about this:
- I noticed that the unrealized conversion casts were making the code annoying so I made some helpers to add those with less boilerplate
- since the LLVM dialect code has passed our verifier, checking only one of (input1, input2, result) for width 64 suffices
- I moved our existing `matchNot` function to a shared file. note that it already expected the literal constant to be on the RHS, even before we had a canonicalizer