### PR TITLE
feat(riscv): tighten up the riscv-dialect verifier for branch operations

### DIFF
--- a/Test/Interpreter/RISCV_Cf/bnez_arg_type_mismatch.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_arg_type_mismatch.mlir
@@ -1,0 +1,22 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// The forwarded operand is !riscv.reg, but the taken successor's block argument
+// is i32. Segment sizes and successor-argument counts match, yet the types do
+// not, so the verifier must reject this.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      %argT = "riscv.li"() <{"value" = 9 : i64}> : () -> !riscv.reg
+      %argF = "riscv.li"() <{"value" = 7 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond, %argT, %argF) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
+    ^taken(%yt : i32):
+      "func.return"(%yt) : (i32) -> ()
+    ^not_taken(%yf : i32):
+      "func.return"(%yf) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: true successor argument 0 type mismatch: operand has type !riscv.reg, block argument has type i32

--- a/Test/Interpreter/RISCV_Cf/bnez_bad_segment_count.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_bad_segment_count.mlir
@@ -1,0 +1,16 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, 0>}> : (!riscv.reg) -> ()
+    ^taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+    ^not_taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: operandSegmentSizes expected 3 entries, got 2

--- a/Test/Interpreter/RISCV_Cf/bnez_bad_segment_sizes.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_bad_segment_sizes.mlir
@@ -1,0 +1,17 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      %fallback = "riscv.li"() <{"value" = 42 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, 0, 0>}> : (!riscv.reg) -> ()
+    ^taken(%x : !riscv.reg):
+      "func.return"(%x) : (!riscv.reg) -> ()
+    ^not_taken():
+      "func.return"(%fallback) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: true operand segment expected operand count 1, got 0

--- a/Test/Interpreter/RISCV_Cf/bnez_false_segment_mismatch.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_false_segment_mismatch.mlir
@@ -1,0 +1,16 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, 0, 0>}> : (!riscv.reg) -> ()
+    ^taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+    ^not_taken(%x : !riscv.reg):
+      "func.return"(%x) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: false operand segment expected operand count 1, got 0

--- a/Test/Interpreter/RISCV_Cf/bnez_negative_segment_size.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_negative_segment_size.mlir
@@ -1,0 +1,17 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      %arg = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond, %arg) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, -1, 2>}> : (!riscv.reg, !riscv.reg) -> ()
+    ^taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+    ^not_taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: operandSegmentSizes contains negative size -1

--- a/Test/Interpreter/RISCV_Cf/bnez_segment_sum_mismatch.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_segment_sum_mismatch.mlir
@@ -1,0 +1,16 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 0>}> : (!riscv.reg) -> ()
+    ^taken(%x : !riscv.reg):
+      "func.return"(%x) : (!riscv.reg) -> ()
+    ^not_taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: operandSegmentSizes describes 2 operands, got 1

--- a/Test/Interpreter/RISCV_Cf/bnez_wrong_fixed_operand_count.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez_wrong_fixed_operand_count.mlir
@@ -1,0 +1,16 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.bnez"(%cond) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 0, 0, 0>}> : (!riscv.reg) -> ()
+    ^taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+    ^not_taken():
+      "func.return"(%cond) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.bnez: fixed operand segment 0 expected size 1, got 0

--- a/Test/Interpreter/RISCV_Cf/branch_arg_type_mismatch.mlir
+++ b/Test/Interpreter/RISCV_Cf/branch_arg_type_mismatch.mlir
@@ -1,0 +1,17 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// The branch operand is !riscv.reg, but the successor block argument is i32.
+// Operand and successor-argument counts match, yet the types do not, so the
+// verifier must reject this.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    ^entry():
+      %x = "riscv.li"() <{"value" = 9 : i64}> : () -> !riscv.reg
+      "riscv_cf.branch"(%x) [^dest] : (!riscv.reg) -> ()
+    ^dest(%y : i32):
+      "func.return"(%y) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_cf.branch: successor argument 0 type mismatch: operand has type !riscv.reg, block argument has type i32

--- a/Test/Interpreter/RISCV_Cf/branch_operand_count_mismatch.mlir
+++ b/Test/Interpreter/RISCV_Cf/branch_operand_count_mismatch.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %x = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      "riscv_cf.branch"(%x) [^dest] : (!riscv.reg) -> ()
+    ^dest(%a : !riscv.reg, %b : !riscv.reg):
+      "func.return"(%a) : (!riscv.reg) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: RISCV branch expected operand count 2, got 1

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -92,6 +92,24 @@ def TypeAttr.verifyI1 (ty : TypeAttr) (errMsg : String) : Except String PUnit :=
       pure ()
   | _ => throw errMsg
 
+/--
+  Check that the operands forwarded to a successor block match the types of that
+  block's arguments. `operandBase` is the index of the first forwarded operand;
+  the forwarded operands are `operandBase .. operandBase + dest.numArguments`,
+  mapped positionally onto `dest`'s arguments. Callers must have already verified
+  that this operand range is in bounds (i.e. the relevant segment size equals the
+  successor's argument count).
+-/
+def OperationPtr.verifyBranchSuccessorArgTypes
+    (op : OperationPtr) (ctx : WfIRContext OpCode)
+    (operandBase : Nat) (dest : BlockPtr) (errPrefix : String) :
+    Except String PUnit := do
+  for j in [0:dest.getNumArguments! ctx.raw] do
+    let opTy := (op.getOperand! ctx.raw (operandBase + j)).getType! ctx.raw
+    let argTy := ((dest.getArgument j).get! ctx.raw).type
+    if opTy.val ≠ argTy.val then
+      throw s!"{errPrefix} argument {j} type mismatch: operand has type {opTy}, block argument has type {argTy}"
+
 def OperationPtr.verifyRISCVBranchOperandSegmentSizes
     (op : OperationPtr) (ctx : WfIRContext OpCode) (opIn : op.InBounds ctx.raw)
     (sizes : DenseArrayAttr) (fixedOperands : Nat) :
@@ -118,6 +136,8 @@ def OperationPtr.verifyRISCVBranchOperandSegmentSizes
     throw s!"{instrName}: true operand segment expected operand count {trueDest.getNumArguments! ctx.raw}, got {trueArgCount}"
   if falseArgCount ≠ falseDest.getNumArguments! ctx.raw then
     throw s!"{instrName}: false operand segment expected operand count {falseDest.getNumArguments! ctx.raw}, got {falseArgCount}"
+  op.verifyBranchSuccessorArgTypes ctx fixedOperands trueDest s!"{instrName}: true successor"
+  op.verifyBranchSuccessorArgTypes ctx (fixedOperands + trueArgCount) falseDest s!"{instrName}: false successor"
 
 def OperationPtr.verifyRISCVimm12 (op : OperationPtr) (ctx : WfIRContext OpCode)
     (opIn : op.InBounds ctx.raw) (imm : Int) : Except String PUnit :=
@@ -2163,6 +2183,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     let dest := op.getSuccessor! ctx.raw 0
     if op.getNumOperands ctx.raw opIn ≠ dest.getNumArguments! ctx.raw then
       throw s!"RISCV branch expected operand count {dest.getNumArguments! ctx.raw}, got {op.getNumOperands ctx.raw opIn}"
+    let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
+    op.verifyBranchSuccessorArgTypes ctx 0 dest s!"{instrName}: successor"
     pure ()
   | .riscv_cf .beq => do
     if op.getNumResults ctx.raw opIn ≠ 0 then

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -92,6 +92,33 @@ def TypeAttr.verifyI1 (ty : TypeAttr) (errMsg : String) : Except String PUnit :=
       pure ()
   | _ => throw errMsg
 
+def OperationPtr.verifyRISCVBranchOperandSegmentSizes
+    (op : OperationPtr) (ctx : WfIRContext OpCode) (opIn : op.InBounds ctx.raw)
+    (sizes : DenseArrayAttr) (fixedOperands : Nat) :
+    Except String PUnit := do
+  let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
+  if _ : sizes.values.size ≠ fixedOperands + 2 then
+    throw s!"{instrName}: operandSegmentSizes expected {fixedOperands + 2} entries, got {sizes.values.size}"
+  let mut operandSegmentSizes : Array Nat := #[]
+  for size in sizes.values do
+    if size < 0 then
+      throw s!"{instrName}: operandSegmentSizes contains negative size {size}"
+    operandSegmentSizes := operandSegmentSizes.push size.toNat
+  for i in [0:fixedOperands] do
+    if operandSegmentSizes[i]! ≠ 1 then
+      throw s!"{instrName}: fixed operand segment {i} expected size 1, got {operandSegmentSizes[i]!}"
+  let operandSegmentSum := operandSegmentSizes.foldl (init := 0) fun acc size => acc + size
+  if operandSegmentSum ≠ op.getNumOperands ctx.raw opIn then
+    throw s!"{instrName}: operandSegmentSizes describes {operandSegmentSum} operands, got {op.getNumOperands ctx.raw opIn}"
+  let trueArgCount := operandSegmentSizes[fixedOperands]!
+  let falseArgCount := operandSegmentSizes[fixedOperands + 1]!
+  let trueDest := op.getSuccessor! ctx.raw 0
+  let falseDest := op.getSuccessor! ctx.raw 1
+  if trueArgCount ≠ trueDest.getNumArguments! ctx.raw then
+    throw s!"{instrName}: true operand segment expected operand count {trueDest.getNumArguments! ctx.raw}, got {trueArgCount}"
+  if falseArgCount ≠ falseDest.getNumArguments! ctx.raw then
+    throw s!"{instrName}: false operand segment expected operand count {falseDest.getNumArguments! ctx.raw}, got {falseArgCount}"
+
 def OperationPtr.verifyRISCVimm12 (op : OperationPtr) (ctx : WfIRContext OpCode)
     (opIn : op.InBounds ctx.raw) (imm : Int) : Except String PUnit :=
   if imm < -2048 ∨ imm > 2047 then
@@ -2133,6 +2160,9 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 1 then
       throw "Expected 1 successor"
+    let dest := op.getSuccessor! ctx.raw 0
+    if op.getNumOperands ctx.raw opIn ≠ dest.getNumArguments! ctx.raw then
+      throw s!"RISCV branch expected operand count {dest.getNumArguments! ctx.raw}, got {op.getNumOperands ctx.raw opIn}"
     pure ()
   | .riscv_cf .beq => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2142,10 +2172,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .beq)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
-      throw "Expected 2 operands plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
-      throw "Expected 2 operands plus 2 variadic operands"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 2
     pure ()
   | .riscv_cf .bne => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2155,10 +2182,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bne)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
-      throw "Expected 2 operands plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
-      throw "Expected 2 operands plus 2 variadic operands"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 2
     pure ()
   | .riscv_cf .blt => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2168,10 +2192,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .blt)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
-      throw "Expected 2 operands plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
-      throw "Expected 2 operands plus 2 variadic operands"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 2
     pure ()
   | .riscv_cf .bge => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2181,10 +2202,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bge)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
-      throw "Expected 2 operands plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
-      throw "Expected 2 operands plus 2 variadic operands"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 2
     pure ()
   | .riscv_cf .bltu => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2194,10 +2212,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bltu)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
-      throw "Expected 2 operands plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
-      throw "Expected 2 operands plus 2 variadic operands"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 2
     pure ()
   | .riscv_cf .bgeu => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2207,10 +2222,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bgeu)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 4 then
-      throw "Expected 2 operands plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 || sizes.values[1]! ≠ 1 then
-      throw "Expected 2 operands plus 2 variadic operands"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 2
     pure ()
   | .riscv_cf .beqz => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2220,10 +2232,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .beqz)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 3 then
-      throw "Expected 1 operand plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 then
-      throw "Expected one conditional operand (to be compared against zero)"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 1
     pure ()
   | .riscv_cf .bnez => do
     if op.getNumResults ctx.raw opIn ≠ 0 then
@@ -2233,10 +2242,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     if op.getNumSuccessors ctx.raw opIn ≠ 2 then
       throw "Expected 2 successors"
     let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bnez)).operandSegmentSizes
-    if _ : sizes.values.size ≠ 3 then
-      throw "Expected 1 operand plus 2 variadic operands"
-    if sizes.values[0]! ≠ 1 then
-      throw "Expected one conditional operand (to be compared against zero)"
+    op.verifyRISCVBranchOperandSegmentSizes ctx opIn sizes 1
     pure ()
   /- RISCV Stack -/
   | .riscv_stack .alloca => do


### PR DESCRIPTION
it was possible to crash the interpreter by parsing in MLIR containing malformed riscv-dialect branches. this tightens that up as much as possible

as a side effect, the riscv branch part of the verifier becomes more concise