### PR TITLE
fix(riscv): pick the right operand segment sizes for riscv_cf.bnez and riscv_cf.beqz

### DIFF
--- a/Test/Interpreter/RISCV_Cf/beqz_asymmetric.mlir
+++ b/Test/Interpreter/RISCV_Cf/beqz_asymmetric.mlir
@@ -1,0 +1,22 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      %t0 = "riscv.li"() <{"value" = 10 : i64}> : () -> !riscv.reg
+      %f0 = "riscv.li"() <{"value" = 20 : i64}> : () -> !riscv.reg
+      %f1 = "riscv.li"() <{"value" = 30 : i64}> : () -> !riscv.reg
+      %f2 = "riscv.li"() <{"value" = 40 : i64}> : () -> !riscv.reg
+      // cond = 1 (nonzero) => beqz NOT taken => successor 1 (^else), falseSize = 3.
+      // Segment layout [cond=1, trueSize=1, falseSize=3]; operands (cond, t0, f0, f1, f2).
+      "riscv_cf.beqz"(%cond, %t0, %f0, %f1, %f2) [^then, ^else]
+        <{"operandSegmentSizes" = array<i64: 1, 1, 3>}> : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+    ^then(%a : !riscv.reg):
+      "func.return"(%a) : (!riscv.reg) -> ()
+    ^else(%b0 : !riscv.reg, %b1 : !riscv.reg, %b2 : !riscv.reg):
+      "func.return"(%b2) : (!riscv.reg) -> ()   // expected: f2 = 40 = 0x28
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0000000000000028#64]

--- a/Test/Interpreter/RISCV_Cf/bnez.mlir
+++ b/Test/Interpreter/RISCV_Cf/bnez.mlir
@@ -2,15 +2,20 @@
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> !riscv.reg}> ({
-    ^1():
-      %neg1 = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
-      %one = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
-      "riscv_cf.bnez"(%one, %one, %neg1) [^3, ^2] <{"operandSegmentSizes" = array<i64: 1, 1, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg) -> ()
-    ^2(%t : !riscv.reg):
-      "func.return"(%t) : (!riscv.reg) -> ()
-    ^3(%f : !riscv.reg):
-      "func.return"(%f) : (!riscv.reg) -> ()
+    ^entry():
+      %cond = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+      %a = "riscv.li"() <{"value" = 7 : i64}> : () -> !riscv.reg
+      %b = "riscv.li"() <{"value" = 8 : i64}> : () -> !riscv.reg
+      %c = "riscv.li"() <{"value" = 9 : i64}> : () -> !riscv.reg
+      // cond = 1 (nonzero) => bnez taken => successor 0 (^taken).
+      // Segment layout [cond=1, trueSize=2, falseSize=1]; operands (cond, a, b, c).
+      "riscv_cf.bnez"(%cond, %a, %b, %c) [^taken, ^not_taken]
+        <{"operandSegmentSizes" = array<i64: 1, 2, 1>}> : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+    ^taken(%t0 : !riscv.reg, %t1 : !riscv.reg):
+      "func.return"(%t1) : (!riscv.reg) -> ()   // expected: b = 8 = 0x8
+    ^not_taken(%f0 : !riscv.reg):
+      "func.return"(%f0) : (!riscv.reg) -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0x0000000000000001#64]
+// CHECK: Program output: #[0x0000000000000008#64]

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1271,7 +1271,7 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInf
   | .beqz => do
     let [destTrue, destFalse] := blockOperands.toList | none
     let some (RuntimeValue.reg cond) := operands[0]? | none
-    let some trueSize := properties.operandSegmentSizes.values[2]? | none
+    let some trueSize := properties.operandSegmentSizes.values[1]? | none
     let trueSize := trueSize.toNat
     if cond.val = 0#64 then
       return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))
@@ -1280,7 +1280,7 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInf
   | .bnez => do
     let [destTrue, destFalse] := blockOperands.toList | none
     let some (RuntimeValue.reg cond) := operands[0]? | none
-    let some trueSize := properties.operandSegmentSizes.values[2]? | none
+    let some trueSize := properties.operandSegmentSizes.values[1]? | none
     let trueSize := trueSize.toNat
     if cond.val ≠ 0#64 then
       return (#[], some (.branch (operands.extract 1 (trueSize + 1)) destTrue))


### PR DESCRIPTION
also add some tests with asymmetical operandSegmentSizes, which is what was required to trigger the bug