### PR TITLE
fix(riscv): fix a crash during branch isel

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/cond_br_same_successor.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/cond_br_same_successor.mlir
@@ -1,0 +1,18 @@
+// RUN: veir-opt %s -p=isel-br-riscv64 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<void (i1)>}> ({
+    ^bb0(%cond : i1):
+      "llvm.cond_br"(%cond) [^bb1, ^bb1] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (i1) -> ()
+    ^bb1():
+      "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK-NOT: PANIC
+// CHECK-NOT: Error: index out of bounds
+// CHECK:      "builtin.module"()
+// CHECK:      "riscv_cf.bnez"(%{{.*}}) [^[[DEST:[0-9]+]], ^[[DEST]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK:      ^[[DEST]]():
+// CHECK-NEXT:   "llvm.return"() : () -> ()
+// CHECK-NOT: PANIC

--- a/Veir/Passes/InstructionSelection/RISCV64Branches.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Branches.lean
@@ -61,6 +61,8 @@ def convertBlock (ctx : WfIRContext OpCode) (block : BlockPtr)
   if (block.get! c.raw).firstUse == none then
     return c
 
+  -- convertBranch mutates the IR, so we build predOps first, to avoid
+  -- data structure invalidation issues
   let mut predOps : Array OperationPtr := #[]
   let mut currentPredUse := (block.get! c.raw).firstUse
   while let some blockop := currentPredUse do

--- a/Veir/Passes/InstructionSelection/RISCV64Branches.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Branches.lean
@@ -61,10 +61,16 @@ def convertBlock (ctx : WfIRContext OpCode) (block : BlockPtr)
   if (block.get! c.raw).firstUse == none then
     return c
 
+  let mut predOps : Array OperationPtr := #[]
   let mut currentPredUse := (block.get! c.raw).firstUse
   while let some blockop := currentPredUse do
-    have op := (blockop.get! c.raw).owner
-    currentPredUse := (blockop.get! c.raw).nextUse
+    let blockOperand := blockop.get! c.raw
+    let op := blockOperand.owner
+    currentPredUse := blockOperand.nextUse
+    if !predOps.contains op then
+      predOps := predOps.push op
+
+  for op in predOps do
     c := ← convertBranch c op block
 
   for i in List.range (block.getNumArguments! c.raw) do


### PR DESCRIPTION
I think this might be the right fix, but I'm not at all sure. the problem is that `convertBranch` mutates the IR causing a data structure invalidation bug, causing `isel-br-riscv64` to crash with an OOB index, for the provided test case, which simply has two branches both going to the same BB