### PR TITLE
feat(riscv): isel for llvm.select

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
+// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
 

--- a/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
@@ -1,0 +1,33 @@
+// RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
+
+"builtin.module"() ({
+
+    // select c, t, 0 -> riscv.czeroeqz t, c
+    "func.func"()  <{function_type = (i1, i64) -> ()}> ({
+    ^bb0(%c: i1, %t: i64):
+        %zero = "llvm.mlir.constant"() <{ "value" = 0 : i64 }> : () -> i64
+        %r = "llvm.select"(%c, %t, %zero) : (i1, i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.czeroeqz"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // select c, 0, f -> riscv.czeronez f, c
+    "func.func"()  <{function_type = (i1, i64) -> ()}> ({
+    ^bb0(%c: i1, %f: i64):
+        %zero = "llvm.mlir.constant"() <{ "value" = 0 : i64 }> : () -> i64
+        %r = "llvm.select"(%c, %zero, %f) : (i1, i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.czeronez"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // general select c, t, f -> or (czero.eqz t, c) (czero.nez f, c)
+    "func.func"()  <{function_type = (i1, i64, i64) -> ()}> ({
+    ^bb0(%c: i1, %t: i64, %f: i64):
+        %r = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64
+        // CHECK-DAG: %{{.*}} = "riscv.czeroeqz"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-DAG: %{{.*}} = "riscv.czeronez"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-DAG: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+}) : () -> ()

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -207,6 +207,37 @@ theorem xnor_refinement {x y : LLVM.Int 64} :
   veir_bv_decide
 
 /--
+  Prove the correctness of the `select c t 0` -> `czero.eqz t c` lowering pattern.
+-/
+theorem select_czeroeqz_refinement {c : LLVM.Int 1} {t : LLVM.Int 64} :
+    (Data.LLVM.Int.select c t (LLVM.Int.constant 64 0)) ⊒
+      (RISCV.Reg.toInt
+        (Data.RISCV.czeroeqz (LLVM.Int.toReg c) (LLVM.Int.toReg t)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `select c 0 f` -> `czero.nez f c` lowering pattern.
+-/
+theorem select_czeronez_refinement {c : LLVM.Int 1} {f : LLVM.Int 64} :
+    (Data.LLVM.Int.select c (LLVM.Int.constant 64 0) f) ⊒
+      (RISCV.Reg.toInt
+        (Data.RISCV.czeronez (LLVM.Int.toReg c) (LLVM.Int.toReg f)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the general `select c t f` ->
+  `or (czero.eqz t c) (czero.nez f c)` lowering pattern.
+-/
+theorem select_refinement {c : LLVM.Int 1} {t f : LLVM.Int 64} :
+    (Data.LLVM.Int.select c t f) ⊒
+      (RISCV.Reg.toInt
+        (Data.RISCV.or
+          (Data.RISCV.czeronez (LLVM.Int.toReg c) (LLVM.Int.toReg f))
+          (Data.RISCV.czeroeqz (LLVM.Int.toReg c) (LLVM.Int.toReg t))) 64) := by
+  rcases c with cv | _ <;> rcases t with tv | _ <;> rcases f with fv | _ <;>
+    veir_bv_decide
+
+/--
   Prove the correctness of the `orcb` lowering pattern (the `Y = 0` case).
 
   The `and` with the per-byte bit-0 mask `0x0101_0101_0101_0101` is what makes the

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -1,6 +1,7 @@
 import Veir.Pass
 import Veir.PatternRewriter.Basic
 import Veir.Passes.Matching
+import Veir.Passes.InstructionSelection.Common
 
 namespace Veir
 
@@ -666,6 +667,74 @@ def getelementptr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
+/-! ## Zicond branchless `select` lowering
+
+  The Zicond extension lowers `llvm.select` branchlessly (mirroring LLVM's
+  SelectionDAG lowering of `ISD::SELECT` when `Zicond` is available):
+  ```
+    (select c, t, 0) -> (czero.eqz t, c)
+    (select c, 0, f) -> (czero.nez f, c)
+    (select c, t, f) -> (or (czero.eqz t, c), (czero.nez f, c))
+  ```
+  The single-instruction zero-arm cases take priority over the general form;
+  the greedy driver tries patterns in array order, so `selectCzeroeqz` and
+  `selectCzeronez` are registered before `selectGeneral`.
+-/
+
+set_option warn.sorry false in
+/--
+  `select c t 0` -> `riscv.czeroeqz t c`.
+-/
+def selectCzeroeqz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some _ := matchConstantZero fval rewriter.ctx | return rewriter
+  let (rewriter, tReg) ← castToReg rewriter op tval
+  let (rewriter, condReg) ← castToReg rewriter op cond
+  let (rewriter, czOp) ← rewriter.createOp (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (czOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  `select c 0 f` -> `riscv.czeronez f c`.
+-/
+def selectCzeronez (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some _ := matchConstantZero tval rewriter.ctx | return rewriter
+  let (rewriter, fReg) ← castToReg rewriter op fval
+  let (rewriter, condReg) ← castToReg rewriter op cond
+  let (rewriter, czOp) ← rewriter.createOp (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (czOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  General branchless select:
+  `select c t f` -> `or (czero.eqz t c) (czero.nez f c)`.
+-/
+def selectGeneral (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let (rewriter, tReg) ← castToReg rewriter op tval
+  let (rewriter, fReg) ← castToReg rewriter op fval
+  let (rewriter, condReg) ← castToReg rewriter op cond
+  let (rewriter, eqzOp) ← rewriter.createOp (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, nezOp) ← rewriter.createOp (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, orOp) ← rewriter.createOp (.riscv .or) #[RegisterType.mk]
+      #[eqzOp.getResult 0, nezOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (orOp.getResult 0)
+
 /-! # Pass implementation -/
 
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
@@ -673,7 +742,7 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   /- Early loop: multi-instruction fusion patterns that must run before the
      per-op lowerings consume their operands. -/
   /- Main loop: the existing per-op lowerings. -/
-  let pattern := RewritePattern.GreedyRewritePattern #[constant, add, and, ashr, icmp, or, xor, mul,
+  let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load, getelementptr, store]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -121,81 +121,13 @@ def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (orcbOp.getResult 0)
 
-/-! ## Zicond branchless `select` lowering
-
-  The Zicond extension lowers `llvm.select` branchlessly (mirroring LLVM's
-  SelectionDAG lowering of `ISD::SELECT` when `Zicond` is available):
-  ```
-    (select c, t, 0) -> (czero.eqz t, c)
-    (select c, 0, f) -> (czero.nez f, c)
-    (select c, t, f) -> (or (czero.eqz t, c), (czero.nez f, c))
-  ```
-  The single-instruction zero-arm cases take priority over the general form;
-  the greedy driver tries patterns in array order, so `selectCzeroeqz` and
-  `selectCzeronez` are registered before `selectGeneral`.
--/
-
-set_option warn.sorry false in
-/--
-  `select c t 0` -> `riscv.czeroeqz t c`.
--/
-def selectCzeroeqz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let some _ := matchConstantZero fval rewriter.ctx | return rewriter
-  let (rewriter, tReg) ← castToReg rewriter op tval
-  let (rewriter, condReg) ← castToReg rewriter op cond
-  let (rewriter, czOp) ← rewriter.createOp (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  replaceWithReg rewriter op (czOp.getResult 0)
-
-set_option warn.sorry false in
-/--
-  `select c 0 f` -> `riscv.czeronez f c`.
--/
-def selectCzeronez (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let some _ := matchConstantZero tval rewriter.ctx | return rewriter
-  let (rewriter, fReg) ← castToReg rewriter op fval
-  let (rewriter, condReg) ← castToReg rewriter op cond
-  let (rewriter, czOp) ← rewriter.createOp (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  replaceWithReg rewriter op (czOp.getResult 0)
-
-set_option warn.sorry false in
-/--
-  General branchless select:
-  `select c t f` -> `or (czero.eqz t c) (czero.nez f c)`.
--/
-def selectGeneral (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let (rewriter, tReg) ← castToReg rewriter op tval
-  let (rewriter, fReg) ← castToReg rewriter op fval
-  let (rewriter, condReg) ← castToReg rewriter op cond
-  let (rewriter, eqzOp) ← rewriter.createOp (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  let (rewriter, nezOp) ← rewriter.createOp (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  let (rewriter, orOp) ← rewriter.createOp (.riscv .or) #[RegisterType.mk]
-      #[eqzOp.getResult 0, nezOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  replaceWithReg rewriter op (orOp.getResult 0)
 
 
 /-! # Pass implementation -/
 
 def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern
-    #[andn, orn, xnor, orcb, selectCzeroeqz, selectCzeronez, selectGeneral]
+  let pattern := RewritePattern.GreedyRewritePattern #[andn, orn, xnor, orcb]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying SDAG patterns"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -121,13 +121,81 @@ def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (orcbOp.getResult 0)
 
+/-! ## Zicond branchless `select` lowering
+
+  The Zicond extension lowers `llvm.select` branchlessly (mirroring LLVM's
+  SelectionDAG lowering of `ISD::SELECT` when `Zicond` is available):
+  ```
+    (select c, t, 0) -> (czero.eqz t, c)
+    (select c, 0, f) -> (czero.nez f, c)
+    (select c, t, f) -> (or (czero.eqz t, c), (czero.nez f, c))
+  ```
+  The single-instruction zero-arm cases take priority over the general form;
+  the greedy driver tries patterns in array order, so `selectCzeroeqz` and
+  `selectCzeronez` are registered before `selectGeneral`.
+-/
+
+set_option warn.sorry false in
+/--
+  `select c t 0` -> `riscv.czeroeqz t c`.
+-/
+def selectCzeroeqz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some _ := matchConstantZero fval rewriter.ctx | return rewriter
+  let (rewriter, tReg) ← castToReg rewriter op tval
+  let (rewriter, condReg) ← castToReg rewriter op cond
+  let (rewriter, czOp) ← rewriter.createOp (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (czOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  `select c 0 f` -> `riscv.czeronez f c`.
+-/
+def selectCzeronez (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some _ := matchConstantZero tval rewriter.ctx | return rewriter
+  let (rewriter, fReg) ← castToReg rewriter op fval
+  let (rewriter, condReg) ← castToReg rewriter op cond
+  let (rewriter, czOp) ← rewriter.createOp (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (czOp.getResult 0)
+
+set_option warn.sorry false in
+/--
+  General branchless select:
+  `select c t f` -> `or (czero.eqz t c) (czero.nez f c)`.
+-/
+def selectGeneral (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (cond, tval, fval) := matchSelect op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let (rewriter, tReg) ← castToReg rewriter op tval
+  let (rewriter, fReg) ← castToReg rewriter op fval
+  let (rewriter, condReg) ← castToReg rewriter op cond
+  let (rewriter, eqzOp) ← rewriter.createOp (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, nezOp) ← rewriter.createOp (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, orOp) ← rewriter.createOp (.riscv .or) #[RegisterType.mk]
+      #[eqzOp.getResult 0, nezOp.getResult 0]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (orOp.getResult 0)
 
 
 /-! # Pass implementation -/
 
 def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern #[andn, orn, xnor, orcb]
+  let pattern := RewritePattern.GreedyRewritePattern
+    #[andn, orn, xnor, orcb, selectCzeroeqz, selectCzeronez, selectGeneral]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying SDAG patterns"
   | some ctx => pure ctx

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -61,6 +61,12 @@ def matchConstantIntVal (val : ValuePtr) (ctx : IRContext OpCode) : Option Integ
   let op := opResultPtr.op
   matchConstantIntOp op ctx
 
+/-- Match a constant integer with value zero, returning `val` itself. -/
+def matchConstantZero (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
+  let attr ← matchConstantIntVal val ctx
+  guard (attr.value = 0)
+  return val
+
 /--
   Return the operation that defines `val`, if `val` is the result of an operation
   (rather than a block argument). Used for matching multi-operation patterns.
@@ -86,6 +92,12 @@ def matchIcmp (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
 def matchOr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .or)) := do
   let (op, properties) ← matchOp op ctx (.llvm .or) 2
   return (op[0]!, op[1]!, properties)
+
+/-- Match `llvm.select cond, tval, fval`, returning `(cond, tval, fval)`. -/
+def matchSelect (op : OperationPtr) (ctx : IRContext OpCode) :
+    Option (ValuePtr × ValuePtr × ValuePtr) := do
+  let (op, _) ← matchOp op ctx (.llvm .select) 3
+  return (op[0]!, op[1]!, op[2]!)
 
 def matchXor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .xor)) := do
   let (op, properties) ← matchOp op ctx (.llvm .xor) 2


### PR DESCRIPTION
this implements the 3 patterns that seem the most relevant:
```
   (select c, t, 0) -> (czero.eqz t, c)
   (select c, 0, f) -> (czero.nez f, c)
   (select c, t, f) -> (or (czero.eqz t, c), (czero.nez f, c))
```
LLVM has more select-related isel rules, but let's worry about them later