### PR TITLE
fix(llvm): make veir_bv_decide more robust

### DIFF
--- a/Veir/Data/LLVM/Int/Bitblast.lean
+++ b/Veir/Data/LLVM/Int/Bitblast.lean
@@ -12,6 +12,19 @@ namespace Veir.Data.LLVM.Int
 
 public section
 
+attribute [veir_bv_normalize] Bool.false_eq_true false_and or_self decide_false dite_eq_ite Bool.if_false_right
+  Bool.decide_or Bool.decide_eq_true Bool.and_true Bool.or_eq_false_iff implies_true
+  BitVec.truncate_eq_setWidth BitVec.setWidth_eq forall_const and_imp true_and
+  BitVec.natCast_eq_ofNat ge_iff_le Bool.or_false dite_eq_ite Bool.if_true_left
+  Bool.decide_or Bool.decide_eq_true Bool.or_eq_false_iff decide_eq_false_iff_not
+  BitVec.not_le Nat.sub_zero and_imp dite_eq_ite Bool.if_true_left
+  Bool.decide_or Bool.decide_eq_true Bool.or_eq_false_iff
+  decide_eq_false_iff_not BitVec.not_le and_imp
+
+attribute [veir_bv_normalize_post] dite_eq_ite Bool.if_true_left Bool.decide_or
+  Bool.decide_eq_true Bool.or_eq_false_iff decide_eq_false_iff_not
+  BitVec.not_le and_imp
+
 /-- Return true if the LLVM.Int `x` is poison. -/
 def isPoison {w : Nat} : (x : Int w) → Bool
   | .poison => true

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -1,11 +1,6 @@
 module
 
-public import Lean
-
-/-! ## Simpsets -/
-
-register_simp_attr veir_bv_normalize
-register_simp_attr veir_bv_normalize_post
+public import Veir.Meta.BVNormalizeSimp
 
 /-! ## Veir Bitblasting Tactic -/
 
@@ -23,8 +18,8 @@ contains `Int.getValue_eq_getValueD`, which rewrites the former into the latter.
 @[expose] macro "veir_bv_normalize" : tactic =>
   `(tactic| ((
       simp -failIfUnchanged only [veir_bv_normalize] <;>
-      simp +contextual -failIfUnchanged [veir_bv_normalize_post, -BitVec.extractLsb_toNat])))
-/- TODO: Tighten the last `simp` into a `simp only`.
+      simp +contextual -failIfUnchanged only [veir_bv_normalize_post])))
+/-
 The lack of `only` is copied from the previous version of this tactic, and indeed
 some of the tests seem to rely on certain simp-lemmas from the default simp-set.
 We should figure out which ones, and add just those to `veir_bv_normalize_post`.
@@ -37,3 +32,14 @@ then calls `bv_decide` to automatically close the goal.
 -/
 @[expose] macro "veir_bv_decide" : tactic =>
   `(tactic| ((veir_bv_normalize <;> bv_decide)))
+
+attribute [veir_bv_normalize] Bool.false_eq_true false_and or_self decide_false
+  dite_eq_ite Bool.if_false_right Bool.and_true implies_true
+  BitVec.truncate_eq_setWidth BitVec.setWidth_eq forall_const true_and
+  BitVec.natCast_eq_ofNat ge_iff_le Bool.or_false Bool.if_true_left
+  BitVec.not_le Nat.sub_zero Bool.decide_or Bool.decide_eq_true
+  Bool.or_eq_false_iff decide_eq_false_iff_not and_imp
+
+attribute [veir_bv_normalize_post] dite_eq_ite Bool.if_true_left Bool.decide_or
+  Bool.decide_eq_true Bool.or_eq_false_iff decide_eq_false_iff_not
+  BitVec.not_le and_imp

--- a/Veir/Meta/BVNormalizeSimp.lean
+++ b/Veir/Meta/BVNormalizeSimp.lean
@@ -1,0 +1,8 @@
+module
+
+public import Lean
+
+/-! ## Simpsets -/
+
+register_simp_attr veir_bv_normalize
+register_simp_attr veir_bv_normalize_post

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -234,8 +234,7 @@ theorem select_refinement {c : LLVM.Int 1} {t f : LLVM.Int 64} :
         (Data.RISCV.or
           (Data.RISCV.czeronez (LLVM.Int.toReg c) (LLVM.Int.toReg f))
           (Data.RISCV.czeroeqz (LLVM.Int.toReg c) (LLVM.Int.toReg t))) 64) := by
-  rcases c with cv | _ <;> rcases t with tv | _ <;> rcases f with fv | _ <;>
-    veir_bv_decide
+  veir_bv_decide
 
 /--
   Prove the correctness of the `orcb` lowering pattern (the `Y = 0` case).
@@ -532,22 +531,7 @@ theorem umin_refinement {x y : LLVM.Int 64} :
 theorem fshl_rol_refinement {a c : LLVM.Int 64} :
     (Data.LLVM.Int.fshl a a c) ⊒
       (RISCV.Reg.toInt (Data.RISCV.rol (LLVM.Int.toReg c) (LLVM.Int.toReg a)) 64) := by
-  rw [Data.LLVM.Int.isRefinedBy_iff]
-  refine ⟨fun _ => toInt_isPoison, fun h1 _ => ?_⟩
-  have hp := Data.LLVM.Int.isPoison_fshl a a c
-  rw [h1] at hp
-  have ha : a.isPoison = false := by grind
-  have hc : c.isPoison = false := by grind
-  rw [Data.LLVM.Int.getValue_fshl a a c h1, toInt_getValue]
-  cases a with
-  | poison => simp [Data.LLVM.Int.isPoison] at ha
-  | val av =>
-  cases c with
-  | poison => simp [Data.LLVM.Int.isPoison] at hc
-  | val cv =>
-    simp only [Data.LLVM.Int.getValue, Data.RISCV.rol, LLVM.Int.toReg,
-      BitVec.truncate_eq_setWidth]
-    bv_decide
+  veir_bv_decide
 
 /--
   Prove the correctness of the `fshr` rotate lowering: a funnel shift with
@@ -556,22 +540,7 @@ theorem fshl_rol_refinement {a c : LLVM.Int 64} :
 theorem fshr_ror_refinement {a c : LLVM.Int 64} :
     (Data.LLVM.Int.fshr a a c) ⊒
       (RISCV.Reg.toInt (Data.RISCV.ror (LLVM.Int.toReg c) (LLVM.Int.toReg a)) 64) := by
-  rw [Data.LLVM.Int.isRefinedBy_iff]
-  refine ⟨fun _ => toInt_isPoison, fun h1 _ => ?_⟩
-  have hp := Data.LLVM.Int.isPoison_fshr a a c
-  rw [h1] at hp
-  have ha : a.isPoison = false := by grind
-  have hc : c.isPoison = false := by grind
-  rw [Data.LLVM.Int.getValue_fshr a a c h1, toInt_getValue]
-  cases a with
-  | poison => simp [Data.LLVM.Int.isPoison] at ha
-  | val av =>
-  cases c with
-  | poison => simp [Data.LLVM.Int.isPoison] at hc
-  | val cv =>
-    simp only [Data.LLVM.Int.getValue, Data.RISCV.ror, LLVM.Int.toReg,
-      BitVec.truncate_eq_setWidth]
-    bv_decide
+  veir_bv_decide
 
 /--
   Prove the correctness of the constant-amount `fshr` lowering: a rotate-right is
@@ -582,22 +551,7 @@ theorem fshr_rori_refinement {a c : LLVM.Int 64} :
     (Data.LLVM.Int.fshr a a c) ⊒
       (RISCV.Reg.toInt
         (Data.RISCV.rori (BitVec.extractLsb 5 0 (LLVM.Int.toReg c).val) (LLVM.Int.toReg a)) 64) := by
-  rw [Data.LLVM.Int.isRefinedBy_iff]
-  refine ⟨fun _ => toInt_isPoison, fun h1 _ => ?_⟩
-  have hp := Data.LLVM.Int.isPoison_fshr a a c
-  rw [h1] at hp
-  have ha : a.isPoison = false := by grind
-  have hc : c.isPoison = false := by grind
-  rw [Data.LLVM.Int.getValue_fshr a a c h1, toInt_getValue]
-  cases a with
-  | poison => simp [Data.LLVM.Int.isPoison] at ha
-  | val av =>
-  cases c with
-  | poison => simp [Data.LLVM.Int.isPoison] at hc
-  | val cv =>
-    simp only [Data.LLVM.Int.getValue, Data.RISCV.rori, LLVM.Int.toReg,
-      BitVec.truncate_eq_setWidth]
-    bv_decide
+  veir_bv_decide
 
 /--
   Prove the correctness of the constant-amount `fshl` lowering: a rotate-left by
@@ -608,19 +562,4 @@ theorem fshl_rori_refinement {a c : LLVM.Int 64} :
     (Data.LLVM.Int.fshl a a c) ⊒
       (RISCV.Reg.toInt
         (Data.RISCV.rori (-(BitVec.extractLsb 5 0 (LLVM.Int.toReg c).val)) (LLVM.Int.toReg a)) 64) := by
-  rw [Data.LLVM.Int.isRefinedBy_iff]
-  refine ⟨fun _ => toInt_isPoison, fun h1 _ => ?_⟩
-  have hp := Data.LLVM.Int.isPoison_fshl a a c
-  rw [h1] at hp
-  have ha : a.isPoison = false := by grind
-  have hc : c.isPoison = false := by grind
-  rw [Data.LLVM.Int.getValue_fshl a a c h1, toInt_getValue]
-  cases a with
-  | poison => simp [Data.LLVM.Int.isPoison] at ha
-  | val av =>
-  cases c with
-  | poison => simp [Data.LLVM.Int.isPoison] at hc
-  | val cv =>
-    simp only [Data.LLVM.Int.getValue, Data.RISCV.rori, LLVM.Int.toReg,
-      BitVec.truncate_eq_setWidth]
-    bv_decide
+  veir_bv_decide


### PR DESCRIPTION
Do not use an open simp-set, but instead explicitly specify the theorems that we need. This allows us to bitblast more rewrite rules.

Initially, we used:

> simp +contextual -failIfUnchanged [veir_bv_normalize_post, -BitVec.extractLsb_toNat]

which pulled in the default simp-set, which sometimes turns a bitvector expression into an expression over Nat. Even though we dropped one of the offending theorems, this was not enough and other theorems introduced non-bitblastable expressions. We now tighten it to:

> simp only +contextual -failIfUnchanged [veir_bv_normalize_post]

plus an explicit list of attributes added to `veir_bv_normalize` and `veir_bv_normalize_post`. This will make our simplifications more controllable and immediately allows us to use `veir_bv_normalize` on a set of new theorems that were not bitblastable without this improved preprocessing.