### PR TITLE
feat(llvm): support i32 for `constant` and arithmetic operations.

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/add.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add.mlir
@@ -25,4 +25,14 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
+
+    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    ^bb(%a: i32, %b: i32):
+        %add = "llvm.add"(%a, %b) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.addw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/add_ext_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add_ext_exec.mlir
@@ -1,0 +1,28 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t
+// RUN: veir-interpret %t >> %t
+// RUN: filecheck %s < %t
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i64, i64, i64, i64)}> ({
+    // 0x40000000 + 0x40000000 = 0x80000000 -- so bit 31  is set such that sext != zext.
+    %a = "llvm.mlir.constant"() <{value = 0x40000000 : i32}> : () -> i32
+    %b = "llvm.mlir.constant"() <{value = 0x40000000 : i32}> : () -> i32
+    %z = "llvm.add"(%a, %b) : (i32, i32) -> i32
+    %zs = "llvm.sext"(%z) : (i32) -> i64
+    %zz = "llvm.zext"(%z) : (i32) -> i64
+    // 0x10 + 0x20 = 0x30 -- so bit 31 clear, sext == zext.
+    %c = "llvm.mlir.constant"() <{value = 0x10 : i32}> : () -> i32
+    %d = "llvm.mlir.constant"() <{value = 0x20 : i32}> : () -> i32
+    %w = "llvm.add"(%c, %d) : (i32, i32) -> i32
+    %ws = "llvm.sext"(%w) : (i32) -> i64
+    %wz = "llvm.zext"(%w) : (i32) -> i64
+    "func.return"(%zs, %zz, %ws, %wz) : (i64, i64, i64, i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0xffffffff80000000#64, 0x0000000080000000#64, 0x0000000000000030#64, 0x0000000000000030#64]
+// CHECK:    "riscv.addw"
+// CHECK:    "riscv.sextw"
+// CHECK:    "riscv.zextw"
+// CHECK:    Program output: #[0xffffffff80000000#64, 0x0000000080000000#64, 0x0000000000000030#64, 0x0000000000000030#64]

--- a/Test/Passes/InstructionSelection/RISCV64/add_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add_invalid.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
-    ^bb(%a: i32, %b: i32):
-        %add = "llvm.add"(%a, %b) : (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    ^bb(%a: i16, %b: i16):
+        %add = "llvm.add"(%a, %b) : (i16, i16) -> i16
+        // CHECK: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/li.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/li.mlir
@@ -10,4 +10,11 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[B]]) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
+
+    "func.func"()  <{function_type = () -> ()}> ({
+        %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
+        // CHECK: [[C:%.*]] = "riscv.li"() <{"value" = 1 : i32}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[C]]) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/li_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/li_invalid.mlir
@@ -2,10 +2,10 @@
 
 "builtin.module"() ({
     "func.func"()  <{function_type = () -> ()}> ({
-        %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
-        %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-        // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i32}> : () -> i32
-        // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+        %one = "llvm.mlir.constant"() <{ "value" = 1 : i16 }> : () -> i16
+        %two = "llvm.mlir.constant"() <{ "value" = 2 : i16 }> : () -> i16
+        // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i16}> : () -> i16
+        // CHECK-NEXT: %{{.*}} = "llvm.mlir.constant"() <{"value" = 2 : i16}> : () -> i16
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
@@ -26,4 +26,14 @@
     
         "func.return"() : () -> ()
     }) : () -> ()
+
+    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    ^bb(%a: i32, %b: i32):
+        %lshr = "llvm.lshr"(%a, %b) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srlw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/lshr_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr_invalid.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
-    ^bb0(%a: i32, %b: i32):
-        %add = "llvm.lshr"(%a, %b) : (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.lshr"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    ^bb0(%a: i16, %b: i16):
+        %add = "llvm.lshr"(%a, %b) : (i16, i16) -> i16
+        // CHECK: %{{.*}} = "llvm.lshr"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
 
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/or.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or.mlir
@@ -15,5 +15,14 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
-    
+
+    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    ^bb(%a: i32, %b: i32):
+        %or = "llvm.or"(%a, %b) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
@@ -1,12 +1,12 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
-    ^bb0(%a: i32, %b: i32):
-        %add = "llvm.or"(%a, %b) : (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-        %add_disjoint = "llvm.or"(%a, %b) <{disjoint}>: (i32, i32) -> i32
-        // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) <{disjoint}> : (i32, i32) -> i32
+    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    ^bb0(%a: i16, %b: i16):
+        %add = "llvm.or"(%a, %b) : (i16, i16) -> i16
+        // CHECK: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
+        %add_disjoint = "llvm.or"(%a, %b) <{disjoint}>: (i16, i16) -> i16
+        // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) <{disjoint}> : (i16, i16) -> i16
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sext.mlir
@@ -1,28 +1,30 @@
 // RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i1, i16, i32) -> ()}> ({
-    ^bb0(%a: i1, %b: i16, %c: i32, %d: i42):
+    "func.func"()  <{function_type = (i1, i16, i32, i42, i8) -> ()}> ({
+    ^bb0(%a: i1, %b: i16, %c: i32, %d: i42, %e: i8):
         %sexta = "llvm.sext"(%b) : (i16) -> i64
         %sextb = "llvm.sext"(%b) : (i16) -> i32
         %sextc = "llvm.sext"(%c) : (i32) -> i64
         %sextd = "llvm.sext"(%a) : (i1) -> i64
-        
-        // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
-        // CHECK-NEXT:      %[[E:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
-        // CHECK-NEXT:      %[[F:.*]] = "riscv.sexth"(%[[E]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[G:.*]] = "builtin.unrealized_conversion_cast"(%[[F]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:      %[[H:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
-        // CHECK-NEXT:      %[[I:.*]] = "riscv.sexth"(%[[H]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[J:.*]] = "builtin.unrealized_conversion_cast"(%[[I]]) : (!riscv.reg) -> i32
-        // CHECK-NEXT:      %[[K:.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !riscv.reg
-        // CHECK-NEXT:      %[[L:.*]] = "riscv.sextw"(%[[K]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[M:.*]] = "builtin.unrealized_conversion_cast"(%[[L]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
-        // CHECK-NEXT:      %[[O:.*]] = "riscv.slli"(%[[N]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[P:.*]] = "riscv.srai"(%[[O]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[Q:.*]] = "builtin.unrealized_conversion_cast"(%[[P]]) : (!riscv.reg) -> i64
-        
+        %sexte = "llvm.sext"(%e) : (i8) -> i64
+        // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42, [[E:.*]] : i8):
+        // CHECK-NEXT:      %[[F:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
+        // CHECK-NEXT:      %[[G:.*]] = "riscv.sexth"(%[[F]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[H:.*]] = "builtin.unrealized_conversion_cast"(%[[G]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:      %[[I:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
+        // CHECK-NEXT:      %[[J:.*]] = "riscv.sexth"(%[[I]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[K:.*]] = "builtin.unrealized_conversion_cast"(%[[J]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:      %[[L:.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !riscv.reg
+        // CHECK-NEXT:      %[[M:.*]] = "riscv.sextw"(%[[L]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"(%[[M]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:      %[[O:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
+        // CHECK-NEXT:      %[[P:.*]] = "riscv.slli"(%[[O]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[Q:.*]] = "riscv.srai"(%[[P]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[R:.*]] = "builtin.unrealized_conversion_cast"(%[[Q]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:      %[[S:.*]] = "builtin.unrealized_conversion_cast"([[E]]) : (i8) -> !riscv.reg
+        // CHECK-NEXT:      %[[T:.*]] = "riscv.sextb"(%[[S]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[U:.*]] = "builtin.unrealized_conversion_cast"(%[[T]]) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sext_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sext_invalid.mlir
@@ -1,14 +1,12 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i128, i42, i8) -> ()}> ({
-    ^bb0(%a: i128, %b : i42, %c: i8):
+    "func.func"()  <{function_type = (i128, i42) -> ()}> ({
+    ^bb0(%a: i128, %b : i42):
         %sexta = "llvm.sext"(%a) : (i128) -> i256
         // CHECK:      %{{.*}} = "llvm.sext"(%{{.*}}) : (i128) -> i256
         %sextb = "llvm.sext"(%b) : (i42) -> i64
         // CHECK:      %{{.*}} = "llvm.sext"(%{{.*}}) : (i42) -> i64
-        %sextc = "llvm.sext"(%c) : (i8) -> i64
-        // CHECK:      %{{.*}} = "llvm.sext"(%{{.*}}) : (i8) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/shl.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl.mlir
@@ -26,4 +26,14 @@
     
         "func.return"() : () -> ()
     }) : () -> ()
+
+    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    ^bb(%a: i32, %b: i32):
+        %shl = "llvm.shl"(%a, %b) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sllw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/shl_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl_invalid.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
-    ^bb0(%a: i32, %b: i32):
-        %add = "llvm.shl"(%a, %b) : (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.shl"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    ^bb0(%a: i16, %b: i16):
+        %add = "llvm.shl"(%a, %b) : (i16, i16) -> i16
+        // CHECK: %{{.*}} = "llvm.shl"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
 
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sub.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub.mlir
@@ -26,4 +26,14 @@
     
         "func.return"() : () -> ()
     }) : () -> ()
+
+    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    ^bb(%a: i32, %b: i32):
+        %sub = "llvm.sub"(%a, %b) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.subw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sub_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub_invalid.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
-    ^bb0(%a: i32, %b: i32):
-        %add = "llvm.sub"(%a, %b) : (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.sub"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    ^bb0(%a: i16, %b: i16):
+        %add = "llvm.sub"(%a, %b) : (i16, i16) -> i16
+        // CHECK: %{{.*}} = "llvm.sub"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
 
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/xor.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/xor.mlir
@@ -11,5 +11,15 @@
     
         "func.return"() : () -> ()
     }) : () -> ()
-    
+
+    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    ^bb(%a: i32, %b: i32):
+        %xor = "llvm.xor"(%a, %b) : (i32, i32) -> i32
+        // i32 xor uses the plain `xor` (no `W` variant)
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.xor"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/xor_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/xor_invalid.mlir
@@ -1,10 +1,10 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
-    ^bb0(%a: i32, %b: i32):
-        %add = "llvm.xor"(%a, %b) : (i32, i32) -> i32
-        // CHECK: %{{.*}} = "llvm.xor"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    ^bb0(%a: i16, %b: i16):
+        %add = "llvm.xor"(%a, %b) : (i16, i16) -> i16
+        // CHECK: %{{.*}} = "llvm.xor"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
         
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/zext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/zext.mlir
@@ -1,29 +1,29 @@
 // RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i1, i16, i32) -> ()}> ({
-    ^bb0(%a: i1, %b: i16, %c: i32, %d: i42):
+    "func.func"()  <{function_type = (i1, i16, i32, i42, i8) -> ()}> ({
+    ^bb0(%a: i1, %b: i16, %c: i32, %d: i42, %e : i8):
         %sexta = "llvm.zext"(%b) : (i16) -> i64
         %sextb = "llvm.zext"(%b) : (i16) -> i32
         %sextc = "llvm.zext"(%c) : (i32) -> i64
         %sextd = "llvm.zext"(%a) : (i1) -> i64
-        %zextd = "llvm.zext"(%a) : (i8) -> i32
-        // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
-        // CHECK-NEXT:      %[[E:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
-        // CHECK-NEXT:      %[[F:.*]] = "riscv.zexth"(%[[E]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[G:.*]] = "builtin.unrealized_conversion_cast"(%[[F]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:      %[[H:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
-        // CHECK-NEXT:      %[[I:.*]] = "riscv.zexth"(%[[H]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[J:.*]] = "builtin.unrealized_conversion_cast"(%[[I]]) : (!riscv.reg) -> i32
-        // CHECK-NEXT:      %[[K:.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !riscv.reg
-        // CHECK-NEXT:      %[[L:.*]] = "riscv.zextw"(%[[K]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[M:.*]] = "builtin.unrealized_conversion_cast"(%[[L]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
-        // CHECK-NEXT:      %[[O:.*]] = "riscv.andi"(%[[N]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[P:.*]] = "builtin.unrealized_conversion_cast"(%[[O]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i8) -> !riscv.reg
-        // CHECK-NEXT:      %[[O:.*]] = "riscv.zextb"(%[[N]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[P:.*]] = "builtin.unrealized_conversion_cast"(%[[O]]) : (!riscv.reg) -> i32
+        %zextd = "llvm.zext"(%e) : (i8) -> i32
+          // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42, [[E:.*]] : i8):
+          // CHECK-NEXT:      %[[F:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
+          // CHECK-NEXT:      %[[G:.*]] = "riscv.zexth"(%[[F]]) : (!riscv.reg) -> !riscv.reg
+          // CHECK-NEXT:      %[[H:.*]] = "builtin.unrealized_conversion_cast"(%[[G]]) : (!riscv.reg) -> i64
+          // CHECK-NEXT:      %[[I:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
+          // CHECK-NEXT:      %[[J:.*]] = "riscv.zexth"(%[[I]]) : (!riscv.reg) -> !riscv.reg
+          // CHECK-NEXT:      %[[K:.*]] = "builtin.unrealized_conversion_cast"(%[[J]]) : (!riscv.reg) -> i32
+          // CHECK-NEXT:      %[[L:.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !riscv.reg
+          // CHECK-NEXT:      %[[M:.*]] = "riscv.zextw"(%[[L]]) : (!riscv.reg) -> !riscv.reg
+          // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"(%[[M]]) : (!riscv.reg) -> i64
+          // CHECK-NEXT:      %[[O:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
+          // CHECK-NEXT:      %[[P:.*]] = "riscv.andi"(%[[O]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+          // CHECK-NEXT:      %[[Q:.*]] = "builtin.unrealized_conversion_cast"(%[[P]]) : (!riscv.reg) -> i64
+          // CHECK-NEXT:      %[[R:.*]] = "builtin.unrealized_conversion_cast"([[E]]) : (i8) -> !riscv.reg
+          // CHECK-NEXT:      %[[S:.*]] = "riscv.zextb"(%[[R]]) : (!riscv.reg) -> !riscv.reg
+          // CHECK-NEXT:      %[[T:.*]] = "builtin.unrealized_conversion_cast"(%[[S]]) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/zext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/zext.mlir
@@ -7,7 +7,7 @@
         %sextb = "llvm.zext"(%b) : (i16) -> i32
         %sextc = "llvm.zext"(%c) : (i32) -> i64
         %sextd = "llvm.zext"(%a) : (i1) -> i64
-        
+        %zextd = "llvm.zext"(%a) : (i8) -> i32
         // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
         // CHECK-NEXT:      %[[E:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
         // CHECK-NEXT:      %[[F:.*]] = "riscv.zexth"(%[[E]]) : (!riscv.reg) -> !riscv.reg
@@ -21,7 +21,9 @@
         // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
         // CHECK-NEXT:      %[[O:.*]] = "riscv.andi"(%[[N]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[P:.*]] = "builtin.unrealized_conversion_cast"(%[[O]]) : (!riscv.reg) -> i64
-        
+        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i8) -> !riscv.reg
+        // CHECK-NEXT:      %[[O:.*]] = "riscv.zextb"(%[[N]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[P:.*]] = "builtin.unrealized_conversion_cast"(%[[O]]) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -424,3 +424,4 @@ namespace Rat
 def twoPow (k : Int) : Rat := 2 ^ k
 
 end Rat
+

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -2,7 +2,7 @@ module
 
 public import Std.Data.ExtHashSet
 public import Std.Data.HashMap
-public import Veir.Meta.BVNormalizeSimp -- registers the `veir_bv_normalize` simp attr
+public import Veir.Meta.BVNormalizeSimp
 import all Init.Data.Array.Basic -- unfold [Array.popWhile] in Array.getElem?_popWhile_of_false
 public section
 

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -2,6 +2,7 @@ module
 
 public import Std.Data.ExtHashSet
 public import Std.Data.HashMap
+public import Veir.Meta.BVNormalizeSimp -- registers the `veir_bv_normalize` simp attr
 import all Init.Data.Array.Basic -- unfold [Array.popWhile] in Array.getElem?_popWhile_of_false
 public section
 
@@ -407,6 +408,14 @@ theorem umulOverflow_comm {w : Nat} (x y : BitVec w) :
     x.umulOverflow y = y.umulOverflow x := by
   grind [BitVec.umulOverflow]
 
+@[veir_bv_normalize]
+theorem setWidth_ofInt_32_64 (v : Int) :
+    BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by
+  rw [← BitVec.toInt_inj]
+  simp only [BitVec.toInt_setWidth, BitVec.toNat_ofInt, Nat.reducePow, Int.cast_ofNat_Int, Int.ofNat_toNat,
+    BitVec.toInt_ofInt]
+  grind
+
 end BitVec
 
 namespace Rat
@@ -415,4 +424,3 @@ namespace Rat
 def twoPow (k : Int) : Rat := 2 ^ k
 
 end Rat
-

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -32,6 +32,18 @@ theorem poisonConst_refinement :
   veir_bv_decide
 
 /--
+  Prove the correctness of the `constant` lowering pattern at i32, currently using grind tactic.
+-/
+theorem constant_refinement_32 {v : Int} :
+    (LLVM.Int.constant 32 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 32) := by
+  have h : BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by
+      rw [← BitVec.toInt_inj]
+      simp only [BitVec.toInt_setWidth, BitVec.toNat_ofInt, Nat.reducePow, Int.cast_ofNat_Int, Int.ofNat_toNat,
+       BitVec.toInt_ofInt]
+      grind
+  veir_bv_decide
+
+/--
   Prove the correctness of the `add` lowering pattern.
 -/
 theorem add_refinement {x y : LLVM.Int 64} :

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -40,6 +40,15 @@ theorem add_refinement {x y : LLVM.Int 64} :
   veir_bv_decide
 
 /--
+  Prove the correctness of the `add` lowering pattern at i32, which selects the
+  32-bit `addw`.
+-/
+theorem addw_refinement {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.add x y) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.addw (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
+  veir_bv_decide
+
+/--
   Prove the correctness of the `and` lowering pattern.
 -/
 theorem and_refinement{x y : LLVM.Int 64} :

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -32,7 +32,7 @@ theorem poisonConst_refinement :
   veir_bv_decide
 
 /--
-  Prove the correctness of the `constant` lowering pattern at i32, currently using grind tactic.
+  Prove the correctness of the `constant` lowering pattern at i32 (similar to the `i64` case above), however currently using the grind tactic.
 -/
 theorem constant_refinement_32 {v : Int} :
     (LLVM.Int.constant 32 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 32) := by

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -36,11 +36,6 @@ theorem poisonConst_refinement :
 -/
 theorem constant_refinement_32 {v : Int} :
     (LLVM.Int.constant 32 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 32) := by
-  have h : BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by
-      rw [← BitVec.toInt_inj]
-      simp only [BitVec.toInt_setWidth, BitVec.toNat_ofInt, Nat.reducePow, Int.cast_ofNat_Int, Int.ofNat_toNat,
-       BitVec.toInt_ofInt]
-      grind
   veir_bv_decide
 
 /--

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -204,10 +204,24 @@ theorem or_refinement {x y : LLVM.Int 64} :
   veir_bv_decide
 
 /--
+  Prove the correctness of the `or` lowering pattern at i32 (plain `or`, no `W` variant).
+-/
+theorem or_refinement_32 {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.or x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
+  veir_bv_decide
+
+/--
   Prove the correctness of the `xor` lowering pattern.
 -/
 theorem xor_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.xor x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `xor` lowering pattern at i32.
+-/
+theorem xor_refinement_32 {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.xor x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
   veir_bv_decide
 
 /--
@@ -250,6 +264,27 @@ theorem urem_refinement {x y : LLVM.Int 64} :
 -/
 theorem sub_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.sub x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.sub (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `sub` lowering pattern at i32.
+-/
+theorem subw_refinement {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.sub x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.subw (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `shl` lowering pattern.
+-/
+theorem sllw_refinement {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.shl x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.sllw (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `lshr` lowering pattern.
+-/
+theorem srlw_refinement {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.lshr x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.srlw (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
   veir_bv_decide
 
 /--

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -325,14 +325,14 @@ set_option warn.sorry false in
 def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
-  /- only support `i64` -/
+  /- support `i64` and `i32` (bitwise ops need no `W` variant) -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if ltype.bitwidth ≠ 64 then return rewriter
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
-  if rtype.bitwidth ≠ 64 then return rewriter
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -351,14 +351,14 @@ set_option warn.sorry false in
 def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
-  /- only support `i64` -/
+  /- support `i64` and `i32` (bitwise ops need no `W` variant) -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if ltype.bitwidth ≠ 64 then return rewriter
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
-  if rtype.bitwidth ≠ 64 then return rewriter
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
@@ -507,22 +507,27 @@ set_option warn.sorry false in
 def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchSub op rewriter.ctx | return rewriter
-  /- only support `i64` -/
+  /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if ltype.bitwidth ≠ 64 then return rewriter
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
-  if rtype.bitwidth ≠ 64 then return rewriter
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Actual `riscv.remu` -/
-  let (rewriter, subOp) ← rewriter.createOp (.riscv .sub) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- 64-bit sub, or its 32-bit `W` variant for i32 -/
+  let (rewriter, subOp) ←
+    if type'.bitwidth = 32 then
+      rewriter.createOp (.riscv .subw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    else
+      rewriter.createOp (.riscv .sub) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[subOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
@@ -621,22 +626,27 @@ set_option warn.sorry false in
 def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchShl op rewriter.ctx | return rewriter
-  /- only support `i64` -/
+  /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if ltype.bitwidth ≠ 64 then return rewriter
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
-  if rtype.bitwidth ≠ 64 then return rewriter
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Actual `riscv.sll` -/
-  let (rewriter, mulOp) ← rewriter.createOp (.riscv .sll) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- 64-bit shift-left, or its 32-bit `W` variant for i32 -/
+  let (rewriter, mulOp) ←
+    if type'.bitwidth = 32 then
+      rewriter.createOp (.riscv .sllw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    else
+      rewriter.createOp (.riscv .sll) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
@@ -647,22 +657,27 @@ set_option warn.sorry false in
 def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchLshr op rewriter.ctx | return rewriter
-  /- only support `i64` -/
+  /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if ltype.bitwidth ≠ 64 then return rewriter
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
-  if rtype.bitwidth ≠ 64 then return rewriter
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Actual `riscv.srl` -/
-  let (rewriter, mulOp) ← rewriter.createOp (.riscv .srl) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- 64-bit logical shift-right, or its 32-bit `W` variant for i32 -/
+  let (rewriter, mulOp) ←
+    if type'.bitwidth = 32 then
+      rewriter.createOp (.riscv .srlw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    else
+      rewriter.createOp (.riscv .srl) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   /- Cast back result for type consistency-/
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -325,7 +325,7 @@ set_option warn.sorry false in
 def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
-  /- support `i64` and `i32` (bitwise ops need no `W` variant) -/
+  /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
   if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
@@ -351,7 +351,7 @@ set_option warn.sorry false in
 def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
-  /- support `i64` and `i32` (bitwise ops need no `W` variant) -/
+  /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
   if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -543,6 +543,7 @@ def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchSext op rewriter.ctx | return rewriter
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
+  if opType.bitwidth = 8 then return rewriter
   if ¬ isLegalExtOpWidth (opType.bitwidth) then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType retType := type.val | rewriter

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -137,22 +137,27 @@ set_option warn.sorry false in
 def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, properties) := matchAdd op rewriter.ctx | return rewriter
-  /- only support `i64` -/
+  /- support `i64` and `i32` (experiment) -/
   let .integerType ltype := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if ltype.bitwidth ≠ 64 then return rewriter
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return rewriter
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
-  if rtype.bitwidth ≠ 64 then return rewriter
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
   let (rewriter, lcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, rcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- Actual `riscv.add` -/
-  let (rewriter, addOp) ← rewriter.createOp (.riscv .add) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
-      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  /- 64-bit add, or its 32-bit `W` variant for i32 (keeps the result sign-extended) -/
+  let (rewriter, addOp) ←
+    if type'.bitwidth = 32 then
+      rewriter.createOp (.riscv .addw) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    else
+      rewriter.createOp (.riscv .add) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   /- Cast back result for type consistency-/
   let (rewriter, castAddOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[addOp.getResult 0]
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -122,10 +122,10 @@ def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBou
     Option (PatternRewriter OpCode) := do
   let some const := matchConstantIntOp op rewriter.ctx
       | return rewriter
-  if const.type.bitwidth ≠ 64 then return rewriter
+  if const.type.bitwidth ≠ 64 ∧ const.type.bitwidth ≠ 32 then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   let (rewriter, newOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] {value := const} (some $ .before op) (by simp) (by simp) (by simp) sorry
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type]

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -535,6 +535,8 @@ def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
 
 set_option warn.sorry false in
 /--
+  llvm.sext %x `i8`  to `i32` -> riscv.sextb %x
+  llvm.sext %x `i8`  to `i64` -> riscv.sextb %x
   llvm.sext %x `i16` to `i64` -> riscv.sexth %x
   llvm.sext %x `i16` to `i32` -> riscv.sexth %x
   llvm.sext %x `i32` to `i64` -> riscv.sextw %x
@@ -543,7 +545,6 @@ def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
     Option (PatternRewriter OpCode) := do
   let some (operand, _) := matchSext op rewriter.ctx | return rewriter
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
-  if opType.bitwidth = 8 then return rewriter
   if ¬ isLegalExtOpWidth (opType.bitwidth) then return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType retType := type.val | rewriter
@@ -552,6 +553,10 @@ def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let (rewriter, opCastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, retOp) ← match opType.bitwidth with
+    | 8 =>
+      let (rewriter, retOp) ← rewriter.createOp (.riscv .sextb) #[RegisterType.mk] #[opCastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+      pure (rewriter, retOp)
     | 16 =>
       let (rewriter, retOp) ← rewriter.createOp (.riscv .sexth) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -12,12 +12,12 @@ namespace Veir
 
 /-! # Lowering Patterns -/
 
-/-- Extension operations (`sext`/`zext`) in RISC-V 64 are only legal
-  from `i16` to `i64`, from `i16` to `i32`, and from `i32` to `i64`.
+/-- Extension operations (`sext`/`zext`) in RISC-V 64 are legal from `i8`, `i16`, and
+  `i32` source widths (`zext.b`/`zext.h`/`zext.w`, `sext.b`/`sext.h`/`sext.w`).
   See: https://github.com/llvm/llvm-project/blob/16a0a1042f7e4e5a0c667096fcdeb5803e06d120/llvm/lib/Target/RISCV/GISel/RISCVLegalizerInfo.cpp#L171-L179
 -/
 def isLegalExtOpWidth (w : Nat) : Bool :=
-  w = 16 ∨ w = 32
+  w = 8 ∨ w = 16 ∨ w = 32
 
 set_option warn.sorry false in
 /--
@@ -585,6 +585,10 @@ def zext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let (rewriter, opCastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, retOp) ← match opType.bitwidth with
+    | 8 =>
+      let (rewriter, retOp) ← rewriter.createOp (.riscv .zextb) #[RegisterType.mk] #[opCastOp.getResult 0]
+        #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+      pure (rewriter, retOp)
     | 16 =>
       let (rewriter, retOp) ← rewriter.createOp (.riscv .zexth) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry


### PR DESCRIPTION
This PR adds support for the llvm `i32` types needed in Chacha20.
Namely, it adds: i32 constant, add, lshr, or, shl, sub, xor, zext `i8` to `i32`, sext `i8` to `i64`  and their corresponding proof and registration into the rewriter.

Support for load and store will be added in a follow-up PR.