### PR TITLE
feat(riscv): isel for `llvm.mlir.poison`

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/poison.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/poison.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+
+"builtin.module"() ({
+    "func.func"()  <{function_type = () -> ()}> ({
+        %one = "llvm.mlir.poison"() : () -> i64
+        %two = "llvm.mlir.poison"() : () -> i32
+        // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT: %{{.*}} = "llvm.mlir.poison"() : () -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -25,6 +25,13 @@ theorem constant_refinement {v : Int}:
   veir_bv_decide
 
 /--
+  Prove the correctness of the `poisonConst` lowering pattern.
+-/
+theorem poisonConst_refinement :
+    (LLVM.Int.poison (w := 64)) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 0)) 64) := by
+  veir_bv_decide
+
+/--
   Prove the correctness of the `add` lowering pattern.
 -/
 theorem add_refinement {x y : LLVM.Int 64} :

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -961,6 +961,19 @@ def fshlConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
       #[] #[] immProps (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (roriOp.getResult 0)
 
+
+set_option warn.sorry false in
+/-- llvm.mlir.poison -> riscv.li 0 -/
+def poisonConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some _ := matchPoison op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+  let (rewriter, liOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
+      #[] #[] imm (some $ .before op) (by simp) (by simp) (by simp) sorry
+  replaceWithReg rewriter op (liOp.getResult 0)
+
 /-! # Pass implementation -/
 
 def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
@@ -970,7 +983,7 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   /- Main loop: the existing per-op lowerings. -/
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral, ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load, getelementptr, store,
-    smax, smin, umax, umin, fshlConst, fshrConst, fshl, fshr]
+    smax, smin, umax, umin, fshlConst, fshrConst, fshl, fshr, poisonConst]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -218,6 +218,10 @@ def matchGetelementptr (op : OperationPtr) (ctx : IRContext OpCode) :
   let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 2
   return (op[0]!, op[1]!, properties)
 
+def matchPoison (op : OperationPtr) (ctx : IRContext OpCode) : Option ValuePtr := do
+  let (op, _) ← matchOp op ctx (.llvm .mlir__poison) 0
+  return op[0]!
+
 def matchStore (op : OperationPtr) (ctx : IRContext OpCode) :
     Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
   guard (op.getOpType! ctx = .llvm .store)


### PR DESCRIPTION
instruction selection of `llvm.mlir.poison` to `li 0`