### PR TITLE
fix(isel): poison instruction selection rule 

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/poison.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/poison.mlir
@@ -2,11 +2,9 @@
 
 "builtin.module"() ({
     "func.func"()  <{function_type = () -> ()}> ({
-        %one = "llvm.mlir.poison"() : () -> i64
-        %two = "llvm.mlir.poison"() : () -> i32
+        %one = "llvm.mlir.poison"() : () -> i1
         // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT: %{{.*}} = "llvm.mlir.poison"() : () -> i32
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i1
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -28,7 +28,7 @@ theorem constant_refinement {v : Int}:
   Prove the correctness of the `poisonConst` lowering pattern.
 -/
 theorem poisonConst_refinement :
-    (LLVM.Int.poison (w := 64)) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 0)) 64) := by
+    (LLVM.Int.poison (w := _)) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 0)) 64) := by
   veir_bv_decide
 
 /--

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -967,8 +967,6 @@ set_option warn.sorry false in
 def poisonConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some _ := matchPoison op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
   let (rewriter, liOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] imm (some $ .before op) (by simp) (by simp) (by simp) sorry


### PR DESCRIPTION
`llvm.mlir.poison` in LLVM is `i1`, not `i64`, and we previously could not lower it. I am therefore removing all checks on the width of the poison, such that it can always be lowered.