### PR TITLE
fix(sqlite): parse zeroed array initializers

### DIFF
--- a/Test/Builtin/parse_zeroed_array_initializers.mlir
+++ b/Test/Builtin/parse_zeroed_array_initializers.mlir
@@ -1,0 +1,8 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+    %1 = "llvm.mlir.constant"() <{value = dense<0> : tensor<4xi8>}> : () -> !llvm.array<4 x i8>
+    // CHECK: "llvm.mlir.constant"() <{"value" = dense<0> : tensor<4xi8>}> : () -> !llvm.array<4 x i8>
+}) : () -> ()
+

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -196,6 +196,8 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
       (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr intAttr)
     | .float floatAttr =>
       (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.floatAttr floatAttr)
+    | .dense denseAttr =>
+      (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.denseElementsAttr denseAttr)
   | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 1
     if props.attr.nsw || props.attr.nuw then

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -211,6 +211,16 @@ structure DenseArrayAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  An array of dense elements, e.g., `!llvm.array<4 x i32>`.
+  The values are stored as a string, and an associated type.
+  The string is expected to be a valid MLIR representation of the array elements.
+-/
+structure DenseElementsAttr where
+  value : String
+  type : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   An attribute from an unknown dialect.
   It can be either a type attribute or a non-type attribute.
 -/
@@ -383,6 +393,8 @@ inductive Attribute
 | arrayAttr (attr : ArrayAttr)
 /-- Dense array attribute -/
 | denseArrayAttr (attr : DenseArrayAttr)
+/-- Dense elements attribute -/
+| denseElementsAttr (attr : DenseElementsAttr)
 /-- Dictionary attribute -/
 | dictionaryAttr (attr : DictionaryAttr)
 /-- Function type -/
@@ -627,6 +639,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case denseElementsAttr.denseElementsAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case denseArrayAttr.denseArrayAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -746,6 +762,9 @@ instance : ToString DenseArrayAttr where
     let values := if attr.values.isEmpty then ""
       else ": " ++ String.intercalate ", " (attr.values.toList.map ToString.toString)
     s!"array<{attr.elementType}{values}>"
+
+instance : ToString DenseElementsAttr where
+  toString attr := s!"dense<{attr.value}> : {attr.type}"
 
 instance : ToString UnregisteredAttr where
   toString attr := attr.value
@@ -877,6 +896,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .unitAttr attr => ToString.toString attr
   | .locationAttr attr => ToString.toString attr
   | .arrayAttr attr => attr.toString
+  | .denseElementsAttr attr => ToString.toString attr
   | .denseArrayAttr attr => ToString.toString attr
   | .dictionaryAttr attr => attr.toString
   | .unregisteredAttr attr => ToString.toString attr
@@ -976,6 +996,9 @@ instance : Coe ArithIntegerOverflowFlagsAttr Attribute where
 instance : Coe DenseArrayAttr Attribute where
   coe attr := .denseArrayAttr attr
 
+instance : Coe DenseElementsAttr Attribute where
+  coe attr := .denseElementsAttr attr
+
 instance : Coe DictionaryAttr Attribute where
   coe attr := .dictionaryAttr attr
 
@@ -1034,6 +1057,7 @@ def isType (attr : Attribute) : Bool :=
   | .locationAttr _ => false
   | .arrayAttr _ => false
   | .denseArrayAttr _ => false
+  | .denseElementsAttr _ => false
   | .dictionaryAttr _ => false
   | .unregisteredAttr attr => attr.isType
   | .flatSymbolRefAttr _ => false

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -597,6 +597,8 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
       if bw.bitwidth ≠ 64 then
         none
       return (#[.float 64 floatAttr.value], mem, none)
+    | .dense denseAttr =>
+      none
   | .mlir__poison => do
     let some resType := resultTypes[0]? | none
     let .integerType bw := resType.val | none

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -667,6 +667,30 @@ partial def parseType (errorMsg : String := "type expected") : AttrParserM TypeA
   | none => throwAtCurrentPos errorMsg
 
 /--
+  Parse a dense elements attribute, if present.
+  Its syntax is `dense<value> : type`, e.g. `dense<0> : tensor<4xi8>`.
+  Both the value body and the type are stored as raw strings pending full
+  tensor/vector type support.
+-/
+partial def parseOptionalDenseElementsAttr : AttrParserM (Option DenseElementsAttr) := do
+  if !(← parseOptionalKeyword "dense".toByteArray) then
+    return none
+  parsePunctuation "<"
+  let value ← parseUnregisteredAttrBody
+  parsePunctuation ">"
+  parsePunctuation ":"
+  -- tensor<4xi8> is an unregistered type: capture it as a balanced string
+  -- using the same scheme as parseOptionalDialectAttr's fallback case.
+  let typeStartPos ← getPos
+  parseKeyword "tensor".toByteArray
+  parsePunctuation "<"
+  let _ ← parseUnregisteredAttrBody
+  let typeEndPos := (← peekToken).slice.stop
+  parsePunctuation ">"
+  let typeStr := (Slice.mk typeStartPos typeEndPos).of (← getThe ParserState).input
+  return some (DenseElementsAttr.mk value (String.fromUTF8! typeStr))
+
+/--
   Parse an entry in an attribute dictionary, which has the form `name = value`
   or the shorthand `name` (equivalent to `name = unit`).
 -/
@@ -730,6 +754,8 @@ partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
     return some stringAttr
   else if let some denseArrayAttr ← parseOptionalDenseArrayAttr then
     return some denseArrayAttr
+  else if let some denseElementsAttr ← parseOptionalDenseElementsAttr then
+    return some denseElementsAttr
   else if let some unitAttr ← parseOptionalUnitAttr then
     return some unitAttr
   else if let some arrayAttr ← parseOptionalArrayAttr then

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -177,11 +177,12 @@ def FastMathFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attri
   return ⟨value⟩
 
 /--
-The two types of constants an LLVM constant can store.
+The types of constants an LLVM constant can store.
 -/
 inductive LLVMConstantValue where
 | integer (value : IntegerAttr)
 | float (value : FloatAttr)
+| dense (value : DenseElementsAttr)
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 /--
@@ -202,8 +203,10 @@ def LLVMConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attrib
     return { value := .integer intAttr }
   | .floatAttr floatAttr =>
     return { value := .float floatAttr }
+  | .denseElementsAttr denseAttr =>
+    return { value := .dense denseAttr }
   | _ =>
-    throw s!"llvm.constant: expected 'value' to be an integer or float attribute, but got {attr}"
+    throw s!"llvm.constant: expected 'value' to be an integer, float, or dense elements attribute, but got {attr}"
 
 /-- Properties of integer comparison operations in the LLVM and arith dialects. -/
 structure IcmpProperties where

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -496,6 +496,10 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
         if intType.bitwidth ≠ floatAttr.type.bitwidth then
           throw s!"llvm.mlir.constant: Expected integer result type with bitwidth {floatAttr.type.bitwidth}"
       | _ => throw "llvm.mlir.constant: Expected float or integer result type for a float constant"
+    | .dense _ =>
+      match resultType with
+      | .llvmArrayType _ => pure ()
+      | _ => throw "llvm.mlir.constant: Expected array result type for a dense elements constant"
     pure ()
   | .llvm .mlir__poison => do
     op.verifyPlainOpCounts ctx opIn 0 1


### PR DESCRIPTION
Parse dense<0>:tensor<4xi8> as UnregisteredAttrBody for now. 
This fixes #779.