### PR TITLE
fix(isel): polymorphism of `poison`

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/poison.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/poison.mlir
@@ -5,6 +5,12 @@
         %one = "llvm.mlir.poison"() : () -> i1
         // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i1
+        %two = "llvm.mlir.poison"() : () -> i32
+        // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i32
+        %three = "llvm.mlir.poison"() : () -> i64
+        // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -218,9 +218,9 @@ def matchGetelementptr (op : OperationPtr) (ctx : IRContext OpCode) :
   let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 2
   return (op[0]!, op[1]!, properties)
 
-def matchPoison (op : OperationPtr) (ctx : IRContext OpCode) : Option ValuePtr := do
-  let (op, _) ← matchOp op ctx (.llvm .mlir__poison) 0
-  return op[0]!
+def matchPoison (op : OperationPtr) (ctx : IRContext OpCode) : Option Unit := do
+  let (_, _) ← matchOp op ctx (.llvm .mlir__poison) 0
+  return ()
 
 def matchStore (op : OperationPtr) (ctx : IRContext OpCode) :
     Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do


### PR DESCRIPTION
Test lowering of poison constant with `i32` and `i64` type and fix the matching that yielded an index out of bound error whenever invoked.