### PR TITLE
feat(isel): isel patterns for `i1 -> i64`

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/sext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sext.mlir
@@ -1,13 +1,14 @@
-// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+// RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i8, i16, i32) -> ()}> ({
-    ^bb0(%a: i8, %b: i16, %c: i32, %d: i42):
+    "func.func"()  <{function_type = (i1, i16, i32) -> ()}> ({
+    ^bb0(%a: i1, %b: i16, %c: i32, %d: i42):
         %sexta = "llvm.sext"(%b) : (i16) -> i64
         %sextb = "llvm.sext"(%b) : (i16) -> i32
         %sextc = "llvm.sext"(%c) : (i32) -> i64
+        %sextd = "llvm.sext"(%a) : (i1) -> i64
         
-        // CHECK:           ^{{.*}}([[A:.*]] : i8, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
+        // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
         // CHECK-NEXT:      %[[E:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
         // CHECK-NEXT:      %[[F:.*]] = "riscv.sexth"(%[[E]]) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[G:.*]] = "builtin.unrealized_conversion_cast"(%[[F]]) : (!riscv.reg) -> i64
@@ -17,6 +18,10 @@
         // CHECK-NEXT:      %[[K:.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !riscv.reg
         // CHECK-NEXT:      %[[L:.*]] = "riscv.sextw"(%[[K]]) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[M:.*]] = "builtin.unrealized_conversion_cast"(%[[L]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
+        // CHECK-NEXT:      %[[O:.*]] = "riscv.slli"(%[[N]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[P:.*]] = "riscv.srai"(%[[O]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[Q:.*]] = "builtin.unrealized_conversion_cast"(%[[P]]) : (!riscv.reg) -> i64
         
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/zext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/zext.mlir
@@ -1,13 +1,14 @@
-// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+// RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i8, i16, i32) -> ()}> ({
-    ^bb0(%a: i8, %b: i16, %c: i32, %d: i42):
+    "func.func"()  <{function_type = (i1, i16, i32) -> ()}> ({
+    ^bb0(%a: i1, %b: i16, %c: i32, %d: i42):
         %sexta = "llvm.zext"(%b) : (i16) -> i64
         %sextb = "llvm.zext"(%b) : (i16) -> i32
         %sextc = "llvm.zext"(%c) : (i32) -> i64
+        %sextd = "llvm.zext"(%a) : (i1) -> i64
         
-        // CHECK:           ^{{.*}}([[A:.*]] : i8, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
+        // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42):
         // CHECK-NEXT:      %[[E:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
         // CHECK-NEXT:      %[[F:.*]] = "riscv.zexth"(%[[E]]) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[G:.*]] = "builtin.unrealized_conversion_cast"(%[[F]]) : (!riscv.reg) -> i64
@@ -17,6 +18,9 @@
         // CHECK-NEXT:      %[[K:.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i32) -> !riscv.reg
         // CHECK-NEXT:      %[[L:.*]] = "riscv.zextw"(%[[K]]) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[M:.*]] = "builtin.unrealized_conversion_cast"(%[[L]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
+        // CHECK-NEXT:      %[[O:.*]] = "riscv.andi"(%[[N]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[P:.*]] = "builtin.unrealized_conversion_cast"(%[[O]]) : (!riscv.reg) -> i64
         
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -448,6 +448,14 @@ theorem zext_refinement_32_64 {x : LLVM.Int 32} :
   veir_bv_decide
 
 /--
+  Prove the correctness of the `zext` lowering pattern `i1` -> `i64`
+-/
+theorem zext_refinement_1_64 {x : LLVM.Int 1} :
+    (Data.LLVM.Int.zext x 64 b h) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.andi 1#12 (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
   Prove the correctness of the `sext` lowering pattern `i8` -> `i16`
 -/
 theorem sext_refinement_8_16 {x : LLVM.Int 8} :
@@ -493,6 +501,14 @@ theorem sext_refinement_16_64 {x : LLVM.Int 16} :
 theorem sext_refinement_32_64 {x : LLVM.Int 32} :
     (Data.LLVM.Int.sext x 64 h) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sextw (LLVM.Int.toReg x)) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `sext` lowering pattern `i1` -> `i64`
+-/
+theorem sext_refinement_1_64 {x : LLVM.Int 1} :
+    (Data.LLVM.Int.sext x 64 h) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.srai 63#6 (Data.RISCV.slli 63#6 (LLVM.Int.toReg x))) 64) := by
   veir_bv_decide
 
 /--

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -339,6 +339,46 @@ def slliuw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
       #[] #[] immProps (some $ .before op) sorry (by simp) (by simp) sorry
   replaceWithReg rewriter op (newOp.getResult 0)
 
+set_option warn.sorry false in
+/-- llvm.zext x i1 to i64 -> and x 1 -/
+def zext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (operand, _) := matchZext op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
+  if opType.bitwidth ≠ 1 then return rewriter
+  /- First, cast the operand to registers -/
+  let (rewriter, opCastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
+  let (rewriter, andiOp) ← rewriter.createOp (.riscv .andi) #[RegisterType.mk] #[opCastOp.getResult 0]
+      #[] #[] imm (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[t] #[andiOp.getResult 0]
+      #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+
+set_option warn.sorry false in
+/-- llvm.sext x i1 to i64 -> srai (slli x 63) 1 -/
+def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (operand, _) := matchZext op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
+  if opType.bitwidth ≠ 1 then return rewriter
+  /- First, cast the operand to registers -/
+  let (rewriter, opCastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+      #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
+  let (rewriter, slliOp) ← rewriter.createOp (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
+      #[] #[] imm (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, sraiOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]
+      #[] #[] imm (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[t] #[sraiOp.getResult 0]
+      #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
+  rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
+
 /-! # Pass implementation -/
 
 def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
@@ -350,7 +390,7 @@ def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   let pattern := RewritePattern.GreedyRewritePattern #[andn, orn, xnor, orcb,
     bexti, bseti, bclri, binvi, slliuw,
     addi, ori, andi, xori, slli, srli, srai, slti,
-    addiw, slliw, srliw, sraiw, roriw, roliw]
+    addiw, slliw, srliw, sraiw, roriw, roliw, zext_1, sext_1]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying SDAG patterns"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -362,7 +362,7 @@ set_option warn.sorry false in
 /-- llvm.sext x i1 to i64 -> srai (slli x 63) 1 -/
 def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (operand, _) := matchZext op rewriter.ctx | return rewriter
+  let some (operand, _) := matchSext op rewriter.ctx | return rewriter
   let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
   if t.bitwidth ≠ 64 then return rewriter
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter


### PR DESCRIPTION
adding the sext/zext isel patterns `i1 -> i64`
see: https://godbolt.org/z/eGqqW6fsh, https://godbolt.org/z/KhePdTKj6
since these are a bit different than the existing ones I put them in the sdag set, but don't have a strong opinion here - @regehr do you have any thoughts?