### PR TITLE
fix(parser): allow omitting `!llvm.` prefix for nested `!llvm.struct`

### DIFF
--- a/Test/LLVM/struct-type.mlir
+++ b/Test/LLVM/struct-type.mlir
@@ -1,0 +1,45 @@
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+//
+// Regression test for parsing LLVM struct types nested inside other LLVM types.
+//
+// The LLVM dialect has a convenience syntax where types can usually [0] drop
+// the `!llvm.` prefix if they're already nested inside another LLVM-dialect
+// type.
+//
+// The first case below is the array-of-identified-struct type from the original
+// bug report (originally seen on an `llvm.mlir.global`), plus literal, packed,
+// and deeply-nested variants.
+//
+// [0]: Not always, but in practice this is allowed wherever nested types are
+// allowed. See `parseLLVMType` for the exact details.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      // Identified struct nested in an array (original bug report).
+      "test.named"() <{ty = !llvm.array<23 x struct<"struct.et_info", (i8, i8, i8, i8, i8, i8, i8)>>}> : () -> ()
+
+      // Literal struct nested in an array.
+      "test.literal"() <{ty = !llvm.array<2 x struct<(i32, f32)>>}> : () -> ()
+
+      // Packed struct nested in an array.
+      "test.packed"() <{ty = !llvm.array<4 x struct<packed (i8, i32)>>}> : () -> ()
+
+      // Deeply nested: struct containing a bare array and a bare struct.
+      "test.nested"() <{ty = !llvm.array<2 x struct<(i32, array<3 x i8>, struct<(ptr)>)>>}> : () -> ()
+
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:       "builtin.module"() ({
+// CHECK-NEXT:    ^{{.*}}():
+// CHECK-NEXT:      "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
+// CHECK-NEXT:        ^{{.*}}():
+// CHECK-NEXT:          "test.named"() <{"ty" = !llvm.array<23 x !llvm.struct<"struct.et_info", (i8, i8, i8, i8, i8, i8, i8)>>}> : () -> ()
+// CHECK-NEXT:          "test.literal"() <{"ty" = !llvm.array<2 x !llvm.struct<(i32, f32)>>}> : () -> ()
+// CHECK-NEXT:          "test.packed"() <{"ty" = !llvm.array<4 x !llvm.struct<packed (i8, i32)>>}> : () -> ()
+// CHECK-NEXT:          "test.nested"() <{"ty" = !llvm.array<2 x !llvm.struct<(i32, array<3 x i8>, struct<(ptr)>)>>}> : () -> ()
+// CHECK-NEXT:          "func.return"() : () -> ()
+// CHECK-NEXT:      }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -232,6 +232,36 @@ macro "#assert " e:term : command =>
 /-! ## LLVM Byte type -/
 #assert expectSuccessType "!llvm.byte<64>" (LLVM.ByteType.mk 64)
 
+/-! ## LLVM Struct type (parsed opaquely; see `parseOptionalLLVMStructType`)
+
+  The struct type is handled by a dedicated parser that accepts both the
+  standalone `!llvm.struct<...>` form and the bare `struct<...>` form used when a
+  struct is nested inside another LLVM type (e.g. an array element). Both forms
+  are normalized to the full `!llvm.struct<...>` spelling, and neither requires
+  `allowUnregisteredDialect` (like `!llvm.array`). The struct name, fields, and
+  packed flag are *not* modeled structurally — they survive only as text. -/
+
+-- Standalone struct: both forms parse identically, with or without the flag.
+#assert expectSuccessType "!llvm.struct<(i32, f32)>"
+  ⟨UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true, by grind⟩ false
+#assert expectSuccessType "!llvm.struct<(i32, f32)>"
+  ⟨UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true, by grind⟩ true
+-- Literal struct nested in an array (original `!llvm.array<N x struct<...>>` bug).
+#assert expectSuccessType "!llvm.array<2 x struct<(i32, f32)>>"
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true : Attribute)) true
+#assert expectSuccessType "!llvm.array<2 x struct<(i32, f32)>>"
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true : Attribute)) false
+-- The bare nested form and the prefixed nested form are equivalent.
+#assert expectSuccessType "!llvm.array<2 x !llvm.struct<(i32, f32)>>"
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true : Attribute)) false
+-- Identified (named) struct: the name is preserved verbatim inside the text.
+#assert expectSuccessType "!llvm.array<23 x struct<\"struct.et_info\", (i8, i8)>>"
+  (LLVM.ArrayType.mk 23
+    (UnregisteredAttr.mk "!llvm.struct<\"struct.et_info\", (i8, i8)>" true : Attribute)) true
+-- Packed struct nested in an array.
+#assert expectSuccessType "!llvm.array<4 x struct<packed (i8, i32)>>"
+  (LLVM.ArrayType.mk 4 (UnregisteredAttr.mk "!llvm.struct<packed (i8, i32)>" true : Attribute)) true
+
 /-! ## LLVM Function type -/
 #assert expectSuccessType "!llvm.func<i32 (i32)>"
   ⟨.llvmFunctionType (FunctionType.mk

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -603,8 +603,66 @@ partial def parseOptionalFunctionType : AttrParserM (Option FunctionType) := do
     return some (FunctionType.mk inputs #[outputType] (isVarArg := false))
 
 /--
+  Parse an LLVM struct type, if present.
+  Its syntax is `!llvm.struct<...>`, or (exclusively) the shorter form
+  `struct<...>` if the corresponding argument is set.
+
+  LIMITATION: the struct is parsed *opaquely* as an `UnregisteredAttr` holding the
+  body as text. There is no structured representation: the struct name (for
+  identified structs like `struct<"name", (...)>`), the element list, and the
+  packed flag all live only as a substring of the stored text, so VeIR cannot
+  compare struct types semantically, resolve a recursive reference
+  (`struct<"node">`) against its definition, or inspect fields.
+
+  A proper fix would introduce a dedicated `LLVM.StructType` (mirroring the
+  existing `LLVM.ArrayType`): an inductive constructor carrying the literal vs.
+  identified distinction, the packed flag, and the element list, with the
+  identity/recursion handling that identified structs require. That is a larger
+  change and unnecessary until a pass needs to reason about struct layout or
+  identity; until then the opaque representation parses and roundtrips correctly,
+  which is all that is currently required.
+-/
+partial def parseOptionalLLVMStructType (short := false) : AttrParserM (Option TypeAttr) := do
+  if short then
+    let .true ← parseOptionalKeyword "struct".toByteArray | return none
+  else
+    let token ← peekToken
+    let .exclamationIdent := token.kind | return none
+    let input := (← getThe ParserState).input
+    let typeName := { token.slice with start := token.slice.start + 1 }.of input
+    if typeName ≠ "llvm.struct".toByteArray then return none
+    let _ ← consumeToken
+  -- Capture the `struct<...>` body opaquely and normalize to the full
+  -- `!llvm.struct<...>` spelling, so both forms produce identical output.
+  let startPos ← getPos
+  parsePunctuation "<"
+  let _ ← parseUnregisteredAttrBody
+  let endPos := (← peekToken).slice.stop
+  parsePunctuation ">"
+  let body := (Slice.mk startPos endPos).of (← getThe ParserState).input
+  return some ⟨UnregisteredAttr.mk ("!llvm.struct" ++ String.fromUTF8! body) true, by grind⟩
+
+/--
   Parse a type within an LLVM-dialect type body, accepting the LLVM "pretty-print"
-  sugar keywords `void` and `ptr` in addition to the regular MLIR type forms.
+  sugar keywords `void`, `ptr`, and the bare nested forms `array<...>` and
+  `struct<...>` in addition to the regular MLIR type forms.
+
+  The bare nested form exists because the LLVM dialect has a custom directive
+  `PrettyLLVMType`, which allows types from the LLVM dialect to be written
+  without the `!llvm.` prefix when they're already nested inside a LLVM-dialect
+  type. For example, `!llvm.array<2 x struct<...>>` is the same as
+  `!llvm.array<2 x !llvm.struct<...>>`.
+
+  In practice, this syntax (`PrettyLLVMType`) is used almost everywhere in the
+  LLVM dialect wherever a nested type is allowed. So we can always turn on the
+  shorthand whenever we know that we're parsing a LLVM-dialect type.
+
+  Upstream MLIR handles this convenience syntax by rolling their own parser and
+  printer. VeIR needs to do the same. We only handle the parser part for now
+  since always printing the full `!llvm.` prefix is still valid syntax.
+
+  Source: see `dispatchParse` and `LLVM::parsePrettyLLVMType` in
+  `mlir/lib/Dialect/LLVMIR/IR/LLVMTypeSyntax.cpp`.
 -/
 partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM TypeAttr := do
   if ← parseOptionalKeyword "void".toByteArray then
@@ -612,6 +670,8 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
   if ← parseOptionalKeyword "ptr".toByteArray then
     return (LLVM.PointerType.mk : TypeAttr)
   if let some type ← parseOptionalLLVMArrayType true then
+    return type
+  if let some type ← parseOptionalLLVMStructType true then
     return type
   parseType errorMsg
 
@@ -663,6 +723,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some llvmPointerType
   if let some llvmArrayType := ← parseOptionalLLVMArrayType then
     return some llvmArrayType
+  if let some llvmStructType ← parseOptionalLLVMStructType then
+    return some llvmStructType
   if let some llvmFunctionType ← parseOptionalLLVMFunctionType then
     return some llvmFunctionType
   if let some cudaTilePointerType := ← parseOptionalCudaTilePointerType then


### PR DESCRIPTION
LLVM dialect has a custom directive `PrettyLLVMType` that allows one to write types from the LLVM dialect without `!llvm.` prefix when it's already nested inside another LLVM-dialect type. For example, `!llvm.array<2 x struct<...>>` is the same as `!llvm.array<2 x !llvm.struct<...>>`.

This convenience syntax is only available for types wrapped inside the `PrettyLLVMType` custom directive. In practice, this convenience syntax is available wherever a nested type is allowed, so we can always turn it on when we know we're parsing inside a `!llvm.` type. We're already doing this for some LLVM-dialect types like `!llvm.array`; this PR just enables this convenience syntax for `!llvm.struct` as well.

Printing without `!llvm.` is not supported for now, always prints the full `!llvm.struct` regardless of nesting status, same behavior as `!llvm.aray`. 

Note that since this shorthand is valid for any LLVM-dialect type, our `parseLLVMType` is incomplete (only handles 4 out of the 10 LLVM-dialect types). This needs to be fixed in future PRs. Tracked in #952.