### PR TITLE
feat(llvm): support `lw/sw` and `lb/sb` for i8/i32 load/stores

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/load.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load.mlir
@@ -9,5 +9,25 @@
         // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
-    
+
+    // i32 load lowers to `riscv.lw`
+    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    ^bb0(%a: !llvm.ptr):
+        %val = "llvm.load"(%a) : (!llvm.ptr) -> i32
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "riscv.lw"({{.*}}) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!riscv.reg) -> i32
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // i8 load lowers to `riscv.lb`.
+    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    ^bb0(%a: !llvm.ptr):
+        %val = "llvm.load"(%a) : (!llvm.ptr) -> i8
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "riscv.lb"({{.*}}) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!riscv.reg) -> i8
+        "func.return"() : () -> ()
+    }) : () -> ()
+
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
@@ -3,8 +3,9 @@
 "builtin.module"() ({
     "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
     ^bb0(%a: !llvm.ptr):
-        %val = "llvm.load"(%a) : (!llvm.ptr) -> i32
-        // CHECK: {{.*}} = "llvm.load"({{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
+        // i16 loads are not supported (only i64/i32/i8), so this stays un-lowered.
+        %val = "llvm.load"(%a) : (!llvm.ptr) -> i16
+        // CHECK: {{.*}} = "llvm.load"({{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i16
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/store.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/store.mlir
@@ -9,4 +9,24 @@
         // CHECK-NEXT: "riscv.sd"({{.*}}, {{.*}}) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
+
+    // i32 store lowers to `riscv.sw`.
+    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    ^bb0(%a: !llvm.ptr, %b : i32):
+        "llvm.store"(%b, %a) : (i32, !llvm.ptr) -> ()
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (i32) -> !riscv.reg
+        // CHECK-NEXT: "riscv.sw"({{.*}}, {{.*}}) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // i8 store lowers to `riscv.sb`.
+    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    ^bb0(%a: !llvm.ptr, %b : i8):
+        "llvm.store"(%b, %a) : (i8, !llvm.ptr) -> ()
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: "riscv.sb"({{.*}}, {{.*}}) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -706,7 +706,7 @@ def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds
   /- cast value (i64/i32/i8) -> register -/
   let (rewriter, valcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[arg]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte) -/
+  /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte), with offset zero: operands are (addr, val), no results -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
   let (rewriter, sdOp) ←
     if type'.bitwidth = 8 then

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -664,44 +664,60 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
-/-- llvm.load -> riscv.ld -/
+/-- llvm.load -> riscv.ld (i64) / riscv.lw (i32) / riscv.lb (i8) -/
 def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (ptr, _) := matchLoad op rewriter.ctx | return rewriter
-  /- only support `i64` (the loaded value type) -/
+  /- support `i64`, `i32` and `i8` (the loaded value type) -/
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | return rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return rewriter
   /- cast ptr (!llvm.ptr) -> register -/
   let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- `riscv.ld` with offset zero -/
+  /- 64-bit `riscv.ld`, or its `lw` (i32) / `lb` (i8) variants -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, ldOp) ← rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
-      #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, ldOp) ←
+    if type'.bitwidth = 8 then
+      rewriter.createOp (.riscv .lb) #[RegisterType.mk] #[pcastOp.getResult 0]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    else if type'.bitwidth = 32 then
+      rewriter.createOp (.riscv .lw) #[RegisterType.mk] #[pcastOp.getResult 0]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    else
+      rewriter.createOp (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
   let (rewriter, castOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in
-/-- llvm.store -> riscv.sd -/
+/-- llvm.store -> riscv.sd (i64) / riscv.sw (i32) / riscv.sb (i8) -/
 def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (arg, ptr, _) := matchStore op rewriter.ctx | return rewriter
-  /- only support `i64` (the stored value type) -/
+  /- support `i64`, `i32` and `i8` (the stored value type) -/
   let type := arg.getType! rewriter.ctx.raw
   let .integerType type' := type.val | return rewriter
-  if type'.bitwidth ≠ 64 then return rewriter
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return rewriter
   /- cast ptr (!llvm.ptr) -> register -/
   let (rewriter, pcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- cast value (i64) -> register -/
+  /- cast value (i64/i32/i8) -> register -/
   let (rewriter, valcastOp) ← rewriter.createOp (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[arg]
       #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
-  /- `riscv.sd` with offset zero: operands are (addr, val), no results -/
+  /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte) -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, sdOp) ← rewriter.createOp (.riscv .sd) #[] #[pcastOp.getResult 0, valcastOp.getResult 0]
-      #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, sdOp) ←
+    if type'.bitwidth = 8 then
+      rewriter.createOp (.riscv .sb) #[] #[pcastOp.getResult 0, valcastOp.getResult 0]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    else if type'.bitwidth = 32 then
+      rewriter.createOp (.riscv .sw) #[] #[pcastOp.getResult 0, valcastOp.getResult 0]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    else
+      rewriter.createOp (.riscv .sd) #[] #[pcastOp.getResult 0, valcastOp.getResult 0]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
   rewriter.replaceOp op sdOp sorry sorry sorry sorry sorry
 
 set_option warn.sorry false in


### PR DESCRIPTION
This PR adds `lw/sw`(i32)  as well as `lb/sb` (i8)  lowerings.

 On proofs: These aren't fully proven yet but it is analogous to the rest of memory (i64). Proves and follow-up exec test as a  lightweight check will be added in the future + someone else working on the memory proofs.

Where these lowering come from: LLVM's RISC-V backend selects integer loads/stores by byte width — i8/i32/i64 → LB/LW/LD and SB/SW/SD (it only uses the zero-extending LBU/LWU when the loaded value is explicitly zero-extended). We mirror that with the plain signed loads and I think we should implement the LBU/LWU lowering as a rewrite in the future? Because it needs to also account for having a zero-extension after the load which can be pattern-matched.