### PR TITLE
feat(ir): add OperationPtr.getRegions

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -3,6 +3,7 @@ import UnitTest.ParserError
 import UnitTest.Parser
 import UnitTest.AttrParser
 import UnitTest.MlirParser
+import UnitTest.IR.Operation
 import UnitTest.FP
 import UnitTest.Bitblasting.Bitblasting
 import UnitTest.DataFlowFramework.Dominance

--- a/UnitTest/IR/Operation.lean
+++ b/UnitTest/IR/Operation.lean
@@ -1,0 +1,34 @@
+import Veir.IR.Basic
+import Veir.Parser.MlirParser
+
+open Veir
+open Veir.Parser
+
+private def parse (s : String) : OperationPtr × IRContext OpCode :=
+  match WfIRContext.create OpCode with
+  | none => panic! "failed to create IR context"
+  | some (ctx, _) =>
+    match ParserState.fromInput s.toByteArray with
+    | .error _ => panic! "lex error"
+    | .ok parser =>
+      match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+      | .error _ => panic! "parse error"
+      | .ok (op, state, _) => (op, state.ctx.raw)
+
+private def noRegions := parse r#""arith.muli"() : () -> ()"#
+#guard noRegions.1.getNumRegions! noRegions.2 == 0
+
+private def oneRegion := parse r#""arith.addi"() ({
+  "arith.muli"() : () -> ()
+}) : () -> ()"#
+#guard oneRegion.1.getNumRegions! oneRegion.2 == 1
+
+private def twoRegions := parse r#""arith.addi"() ({
+  "arith.muli"() : () -> ()
+}, {
+  "arith.muli"() : () -> ()
+}) : () -> ()"#
+#guard twoRegions.1.getNumRegions! twoRegions.2 == 2
+#guard (twoRegions.1.getRegions! twoRegions.2).size == twoRegions.1.getNumRegions! twoRegions.2
+#guard (twoRegions.1.getRegions! twoRegions.2)[0]! == twoRegions.1.getRegion! twoRegions.2 0
+#guard (twoRegions.1.getRegions! twoRegions.2)[1]! == twoRegions.1.getRegion! twoRegions.2 1

--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -181,7 +181,7 @@ partial def initializeRecursively
     (irCtx : IRContext OpCode) : DataFlowContext := Id.run do
   let mut dfCtx := dfCtx
 
-  for region in (op.get! irCtx).regions do
+  for region in op.getRegions! irCtx do
     dfCtx := initializeRegion region dfCtx irCtx
 
     let mut currentBlock := (region.get! irCtx).firstBlock

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -801,6 +801,51 @@ theorem getRegion!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
     op.getRegion! ctx = op.getRegion! ctx' := by
   grind [get!, getRegion!]
 
+def getRegions (op : OperationPtr) (ctx : IRContext OpInfo)
+  (inBounds : op.InBounds ctx := by grind) : Array RegionPtr :=
+  (op.get ctx inBounds).regions
+
+def getRegions! (op : OperationPtr) (ctx : IRContext OpInfo) : Array RegionPtr :=
+  (op.get! ctx).regions
+
+@[grind =_, eq_bang ←]
+theorem getRegions!_eq_getRegions {op : OperationPtr} (hin : op.InBounds ctx) :
+    op.getRegions! ctx = op.getRegions ctx (by grind) := by
+  grind [getRegions, getRegions!]
+
+theorem getRegions!.mem_iff_exists_index {op : OperationPtr} :
+    region ∈ op.getRegions! ctx ↔
+    ∃ index, index < op.getNumRegions! ctx ∧ op.getRegion! ctx index = region := by
+  simp only [getRegions!, getRegion!, getNumRegions!]
+  constructor
+  · rintro hregion
+    have ⟨i, hi, hregion⟩ := Array.getElem_of_mem hregion
+    exists i
+    grind
+  · grind
+
+theorem getRegions!.mem_getRegion! {op : OperationPtr} :
+    index < op.getNumRegions! ctx →
+    op.getRegion! ctx index ∈ op.getRegions! ctx := by
+  grind [getRegions!, getRegion!, getNumRegions!]
+
+@[simp, grind =]
+theorem getRegions!.size_eq_getNumRegions! {op : OperationPtr} :
+    (op.getRegions! ctx).size = op.getNumRegions! ctx := by
+  grind [getRegions!, getNumRegions!]
+
+@[simp, grind =]
+theorem getRegions!.getElem!_eq_getRegion! {op : OperationPtr} :
+    (op.getRegions! ctx)[index]! = op.getRegion! ctx index := by
+  simp only [getRegions!, getRegion!]
+
+@[simp, grind =]
+theorem getRegions!.getElem_eq_getRegion!
+    {op : OperationPtr} {h : index < (op.getRegions! ctx).size} :
+    (op.getRegions! ctx)[index]'h = op.getRegion! ctx index := by
+  simp only [getRegions!, getRegion!]
+  grind
+
 def set (ptr : OperationPtr) (ctx : IRContext OpInfo) (newOp : Operation OpInfo) : IRContext OpInfo :=
   {ctx with operations := ctx.operations.insert ptr newOp}
 

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -802,7 +802,7 @@ theorem getRegion!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
   grind [get!, getRegion!]
 
 def getRegions (op : OperationPtr) (ctx : IRContext OpInfo)
-  (inBounds : op.InBounds ctx := by grind) : Array RegionPtr :=
+    (inBounds : op.InBounds ctx := by grind) : Array RegionPtr :=
   (op.get ctx inBounds).regions
 
 def getRegions! (op : OperationPtr) (ctx : IRContext OpInfo) : Array RegionPtr :=


### PR DESCRIPTION
Closes: https://github.com/opencompl/veir/issues/664

Add regions (plural) accessors accessors mirroring `getOpResults`.

Start using them in `DominanceAnalysis` and add some `#guard` based unit tests.
