### PR TITLE
chore (mod_arith): add mod_arith cast reconciliation

### DIFF
--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -241,4 +241,15 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "f18"}> ({
+      ^1(%0 : i32):
+        // Conversion cast to/from dissimilar types
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !mod_arith.int<7 : i32>
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (!mod_arith.int<7 : i32>) -> i32
+        "test.test"(%2) : (i32) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i32):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (i32) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
 }) : () -> ()

--- a/Test/Passes/ModArithToArith/chain.mlir
+++ b/Test/Passes/ModArithToArith/chain.mlir
@@ -1,0 +1,33 @@
+// RUN: veir-opt %s -p="mod-arith-to-arith,reconcile-cast" | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>, sym_name = "main"}> ({
+    ^bb0(%0 : !mod_arith.int<7 : i32>, %1 : !mod_arith.int<7 : i32>):
+      %a = "mod_arith.add"(%0, %1) : (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>
+      %b = "mod_arith.mul"(%a, %a) : (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>
+      "func.return"(%b) : (!mod_arith.int<7 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      ^{{.*}}([[ARG0:%.*]] : !mod_arith.int<7 : i32>, [[ARG1:%.*]] : !mod_arith.int<7 : i32>):
+// input casts are kept
+// CHECK-NEXT:   [[C0:%.*]] = "builtin.unrealized_conversion_cast"([[ARG0]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E0:%.*]] = "arith.extui"([[C0]]) : (i32) -> i33
+// CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG1]]) : (!mod_arith.int<7 : i32>) -> i32
+// CHECK-NEXT:   [[E1:%.*]] = "arith.extui"([[C1]]) : (i32) -> i33
+
+// "middle" casts are reconciled away
+// CHECK-NEXT:   [[QADD:%.*]] = "arith.constant"() <{"value" = 7 : i33}> : () -> i33
+// CHECK-NEXT:   [[SUM:%.*]] = "arith.addi"([[E0]], [[E1]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[SUMR:%.*]] = "arith.remui"([[SUM]], [[QADD]]) : (i33, i33) -> i33
+// CHECK-NEXT:   [[ADD:%.*]] = "arith.trunci"([[SUMR]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i33) -> i32
+// CHECK-NEXT:   [[M0:%.*]] = "arith.extui"([[ADD]]) : (i32) -> i64
+// CHECK-NEXT:   [[M1:%.*]] = "arith.extui"([[ADD]]) : (i32) -> i64
+// CHECK-NEXT:   [[QMUL:%.*]] = "arith.constant"() <{"value" = 7 : i64}> : () -> i64
+// CHECK-NEXT:   [[PROD:%.*]] = "arith.muli"([[M0]], [[M1]]) : (i64, i64) -> i64
+// CHECK-NEXT:   [[PRODR:%.*]] = "arith.remui"([[PROD]], [[QMUL]]) : (i64, i64) -> i64
+
+// output casts are kept
+// CHECK-NEXT:   [[MUL:%.*]] = "arith.trunci"([[PRODR]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i64) -> i32
+// CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[MUL]]) : (i32) -> !mod_arith.int<7 : i32>
+// CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i32>) -> ()

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -29,6 +29,15 @@ def isRiscvRegToPtrCast (inputType interType : TypeAttr): Bool :=
   | .registerType _, .llvmPointerType _  => true
   | _, _ => false
 
+
+/- We reconcile cast from `!mod_arith.int< q: iN> to iM (and back) for any M -/
+def isPreservingModArithToIntCast (inputType interType : TypeAttr) : Bool :=
+  match inputType.val, interType.val with
+  | .modArithType _, .integerType _ => True
+  | .integerType _, .modArithType _ => True
+  | _, _ => false
+
+
 /-- Reconciles round-trip casts of the form X->Y->X if allowed for these types by `legal X Y`.
 
   The parent cast is left in place: it is now dead, and DCE (run at the end of the pass) removes
@@ -104,6 +113,7 @@ def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : o
   let pattern := RewritePattern.GreedyRewritePattern #[
     .fromLocalRewrite (reconcilePairingCastLocal isRegToI64RoundTrip),
     .fromLocalRewrite (reconcilePairingCastLocal isRiscvRegToPtrCast),
+    .fromLocalRewrite (reconcilePairingCastLocal isPreservingModArithToIntCast),
     .fromLocalRewrite reconcileRegIntCastLocal]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying cast reconciliation"


### PR DESCRIPTION
Enables `builtin.unrealized_conversion_cast` reconciliation between `!mod_arith.int` and IntegerType.