### PR TITLE
 feat: add `i32` and `ptr` round trip casting

### DIFF
--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -108,6 +108,71 @@
         // CHECK-NEXT:   "test.test"([[ARG]], [[ARG]]) : (i64, i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
+
+  ^10():
+    "func.func"()  <{function_type = (i32) -> ()}> ({
+      ^1(%0 : i32):
+        // i32 -> reg -> i32 
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !riscv.reg
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
+        "test.test"(%2) : (i32) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i32):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (i32) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+  ^11():
+    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+      ^1(%0 : !riscv.reg):
+        // reg -> i32 -> reg : NOT IMPLEMENT YET SO SHOULD NOT BE FOLDED AWAY.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i32
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> !riscv.reg
+        "test.test"(%2) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
+        // CHECK-NEXT:   %[[C1:.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:   %[[C2:.*]] = "builtin.unrealized_conversion_cast"(%[[C1]]) : (i32) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%[[C2]]) : (!riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+  ^12():
+    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+      ^1(%0 : !llvm.ptr):
+        // ptr -> reg -> ptr (64-bit)
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!llvm.ptr) -> !riscv.reg
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> !llvm.ptr
+        "test.test"(%2) : (!llvm.ptr) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !llvm.ptr):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (!llvm.ptr) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+  ^13():
+    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+      ^1(%0 : !riscv.reg):
+        // reg -> ptr -> reg (64-bit)
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> !llvm.ptr
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (!llvm.ptr) -> !riscv.reg
+        "test.test"(%2) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (!riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+  ^14():
+    "func.func"()  <{function_type = (i32) -> ()}> ({
+      ^1(%0 : i32):
+        // i32 -> reg -> i32  (reg is also used elsewhere)
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !riscv.reg
+        %2 = "test.test"(%1) : (!riscv.reg) -> (!riscv.reg)
+        %3 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
+        "test.test"(%2, %3) : (!riscv.reg, i32) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i32):
+        // CHECK-NEXT:   %{{.*}} = "builtin.unrealized_conversion_cast"([[ARG]]) : (i32) -> !riscv.reg
+        // CHECK-NEXT:   %{{.*}} = "test.test"(%{{.*}}) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%{{.*}}, [[ARG]]) : (!riscv.reg, i32) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
     
     
 

--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -124,7 +124,7 @@
   ^11():
     "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
       ^1(%0 : !riscv.reg):
-        // reg -> i32 -> reg : NOT IMPLEMENT YET SO SHOULD NOT BE FOLDED AWAY.
+        // reg -> i32 -> reg : should not be folded away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i32
         %2 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> !riscv.reg
         "test.test"(%2) : (!riscv.reg) -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/chacha20.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/chacha20.mlir
@@ -863,28 +863,20 @@
 // CHECK-NEXT:         %[[v3398:[0-9]+]] = "riscv.li"() <{"value" = 13 : i64}> : () -> !riscv.reg
 // CHECK-NEXT:         %[[v3394:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3396:[0-9]+]] = "riscv.sh2add"(%[[v3462]], %[[v3394]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3397:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3396]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3391:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3397]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3392:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3461]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3391]], %[[v3392]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3396]], %[[v3392]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3387:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3389:[0-9]+]] = "riscv.sh2add"(%[[v3458]], %[[v3387]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3390:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3389]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3384:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3390]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3385:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3457]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3384]], %[[v3385]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3389]], %[[v3385]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3380:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3382:[0-9]+]] = "riscv.sh2add"(%[[v3454]], %[[v3380]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3383:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3382]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3377:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3383]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3378:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3453]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3377]], %[[v3378]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3382]], %[[v3378]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3373:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3375:[0-9]+]] = "riscv.sh2add"(%[[v3450]], %[[v3373]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3376:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3375]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3370:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3376]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3371:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3449]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3370]], %[[v3371]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3375]], %[[v3371]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"(%[[v3462]]) [^[[bb49:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:       ^[[bb49]](%[[varg49_0:[a-zA-Z0-9_]+]] : !riscv.reg):
 // CHECK-NEXT:         %[[v3368:[0-9]+]] = "riscv.slt"(%[[varg49_0]], %[[v3446]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -895,18 +887,13 @@
 // CHECK-NEXT:         %[[v3364:[0-9]+]] = "riscv.mul"(%[[varg49_0]], %[[v3438]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3358:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_0]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3360:[0-9]+]] = "riscv.add"(%[[v3358]], %[[v3364]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3361:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3360]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3355:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3361]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3356:[0-9]+]] = "riscv.lb"(%[[v3355]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3356:[0-9]+]] = "riscv.lb"(%[[v3360]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3357:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3356]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3352:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3357]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3353:[0-9]+]] = "riscv.zextb"(%[[v3352]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3354:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3353]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3348:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3361]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3350:[0-9]+]] = "riscv.add"(%[[v3348]], %[[v3458]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3351:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3350]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3345:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3351]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3346:[0-9]+]] = "riscv.lb"(%[[v3345]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3350:[0-9]+]] = "riscv.add"(%[[v3360]], %[[v3458]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3346:[0-9]+]] = "riscv.lb"(%[[v3350]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3347:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3346]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3342:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3347]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3343:[0-9]+]] = "riscv.zextb"(%[[v3342]]) : (!riscv.reg) -> !riscv.reg
@@ -919,11 +906,8 @@
 // CHECK-NEXT:         %[[v3335:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3341]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3336:[0-9]+]] = "riscv.or"(%[[v3335]], %[[v3334]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3337:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3336]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3330:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3361]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3332:[0-9]+]] = "riscv.add"(%[[v3330]], %[[v3454]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3333:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3332]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3327:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3333]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3328:[0-9]+]] = "riscv.lb"(%[[v3327]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3332:[0-9]+]] = "riscv.add"(%[[v3360]], %[[v3454]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3328:[0-9]+]] = "riscv.lb"(%[[v3332]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3329:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3328]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3324:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3329]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3325:[0-9]+]] = "riscv.zextb"(%[[v3324]]) : (!riscv.reg) -> !riscv.reg
@@ -936,11 +920,8 @@
 // CHECK-NEXT:         %[[v3317:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3323]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3318:[0-9]+]] = "riscv.or"(%[[v3317]], %[[v3316]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3319:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3318]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3312:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3361]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3314:[0-9]+]] = "riscv.add"(%[[v3312]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3315:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3314]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3309:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3315]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3310:[0-9]+]] = "riscv.lb"(%[[v3309]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3314:[0-9]+]] = "riscv.add"(%[[v3360]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3310:[0-9]+]] = "riscv.lb"(%[[v3314]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3311:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3310]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3306:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3311]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3307:[0-9]+]] = "riscv.zextb"(%[[v3306]]) : (!riscv.reg) -> !riscv.reg
@@ -956,10 +937,8 @@
 // CHECK-NEXT:         %[[v3296:[0-9]+]] = "riscv.add"(%[[varg49_0]], %[[v3438]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3290:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3292:[0-9]+]] = "riscv.sh2add"(%[[v3296]], %[[v3290]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3293:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3292]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3287:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3293]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3288:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3301]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3287]], %[[v3288]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3292]], %[[v3288]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"() [^[[bb77:[0-9]+]]] : () -> ()
 // CHECK-NEXT:       ^[[bb77]]():
 // CHECK-NEXT:         %[[v3285:[0-9]+]] = "riscv.add"(%[[v3458]], %[[varg49_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -967,10 +946,8 @@
 // CHECK-NEXT:       ^[[bb53]]():
 // CHECK-NEXT:         %[[v3279:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3281:[0-9]+]] = "riscv.sh2add"(%[[v3444]], %[[v3279]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3282:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3281]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3276:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3282]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3277:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_1]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3276]], %[[v3277]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3281]], %[[v3277]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"(%[[v3462]]) [^[[bb83:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:       ^[[bb83]](%[[varg83_0:[a-zA-Z0-9_]+]] : !riscv.reg):
 // CHECK-NEXT:         %[[v3274:[0-9]+]] = "riscv.slt"(%[[varg83_0]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -981,18 +958,13 @@
 // CHECK-NEXT:         %[[v3270:[0-9]+]] = "riscv.mul"(%[[varg83_0]], %[[v3438]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3264:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_2]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3266:[0-9]+]] = "riscv.add"(%[[v3264]], %[[v3270]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3267:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3266]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3261:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3267]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3262:[0-9]+]] = "riscv.lb"(%[[v3261]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3262:[0-9]+]] = "riscv.lb"(%[[v3266]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3263:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3262]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3258:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3263]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3259:[0-9]+]] = "riscv.zextb"(%[[v3258]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3260:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3259]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3254:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3267]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3256:[0-9]+]] = "riscv.add"(%[[v3254]], %[[v3458]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3257:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3256]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3251:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3257]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3252:[0-9]+]] = "riscv.lb"(%[[v3251]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3256:[0-9]+]] = "riscv.add"(%[[v3266]], %[[v3458]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3252:[0-9]+]] = "riscv.lb"(%[[v3256]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3253:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3252]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3248:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3253]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3249:[0-9]+]] = "riscv.zextb"(%[[v3248]]) : (!riscv.reg) -> !riscv.reg
@@ -1005,11 +977,8 @@
 // CHECK-NEXT:         %[[v3241:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3247]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3242:[0-9]+]] = "riscv.or"(%[[v3241]], %[[v3240]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3243:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3242]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3236:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3267]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3238:[0-9]+]] = "riscv.add"(%[[v3236]], %[[v3454]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3239:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3238]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3233:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3239]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3234:[0-9]+]] = "riscv.lb"(%[[v3233]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3238:[0-9]+]] = "riscv.add"(%[[v3266]], %[[v3454]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3234:[0-9]+]] = "riscv.lb"(%[[v3238]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3235:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3234]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3230:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3235]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3231:[0-9]+]] = "riscv.zextb"(%[[v3230]]) : (!riscv.reg) -> !riscv.reg
@@ -1022,11 +991,8 @@
 // CHECK-NEXT:         %[[v3223:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3229]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3224:[0-9]+]] = "riscv.or"(%[[v3223]], %[[v3222]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3225:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3224]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3218:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3267]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3220:[0-9]+]] = "riscv.add"(%[[v3218]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3221:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3220]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3215:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3221]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3216:[0-9]+]] = "riscv.lb"(%[[v3215]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3220:[0-9]+]] = "riscv.add"(%[[v3266]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3216:[0-9]+]] = "riscv.lb"(%[[v3220]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3217:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3216]]) : (!riscv.reg) -> i8
 // CHECK-NEXT:         %[[v3212:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3217]]) : (i8) -> !riscv.reg
 // CHECK-NEXT:         %[[v3213:[0-9]+]] = "riscv.zextb"(%[[v3212]]) : (!riscv.reg) -> !riscv.reg
@@ -1042,10 +1008,8 @@
 // CHECK-NEXT:         %[[v3202:[0-9]+]] = "riscv.add"(%[[varg83_0]], %[[v3398]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3196:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3198:[0-9]+]] = "riscv.sh2add"(%[[v3202]], %[[v3196]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3199:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3198]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3193:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3199]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3194:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3207]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3193]], %[[v3194]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3198]], %[[v3194]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"() [^[[bb111:[0-9]+]]] : () -> ()
 // CHECK-NEXT:       ^[[bb111]]():
 // CHECK-NEXT:         %[[v3191:[0-9]+]] = "riscv.add"(%[[v3458]], %[[varg83_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -1060,16 +1024,12 @@
 // CHECK-NEXT:       ^[[bb118]]():
 // CHECK-NEXT:         %[[v3181:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3183:[0-9]+]] = "riscv.sh2add"(%[[varg115_0]], %[[v3181]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3184:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3183]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3178:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3184]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3179:[0-9]+]] = "riscv.lw"(%[[v3178]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3179:[0-9]+]] = "riscv.lw"(%[[v3183]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3180:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3179]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3174:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3176:[0-9]+]] = "riscv.sh2add"(%[[varg115_0]], %[[v3174]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3177:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3176]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3171:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3177]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3172:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3180]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3171]], %[[v3172]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3176]], %[[v3172]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"() [^[[bb125:[0-9]+]]] : () -> ()
 // CHECK-NEXT:       ^[[bb125]]():
 // CHECK-NEXT:         %[[v3169:[0-9]+]] = "riscv.add"(%[[v3458]], %[[varg115_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -1086,51 +1046,39 @@
 // CHECK-NEXT:         %[[v3161:[0-9]+]] = "riscv.sextw"(%[[v3160]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3156:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3158:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v3156]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3159:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3158]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3153:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3159]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3154:[0-9]+]] = "riscv.lw"(%[[v3153]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3154:[0-9]+]] = "riscv.lw"(%[[v3158]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3155:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3154]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3150:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3429]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3151:[0-9]+]] = "riscv.sextw"(%[[v3150]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3146:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3148:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v3146]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3149:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3148]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3143:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3149]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3144:[0-9]+]] = "riscv.lw"(%[[v3143]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3144:[0-9]+]] = "riscv.lw"(%[[v3148]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3145:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3144]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3139:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3145]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3140:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3155]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3141:[0-9]+]] = "riscv.addw"(%[[v3140]], %[[v3139]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3142:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3141]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3136:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3149]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3137:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3142]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3136]], %[[v3137]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3148]], %[[v3137]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3132:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3134:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v3132]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3135:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3134]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3129:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3135]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3130:[0-9]+]] = "riscv.lw"(%[[v3129]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3130:[0-9]+]] = "riscv.lw"(%[[v3134]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3131:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3130]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3126:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3127:[0-9]+]] = "riscv.sextw"(%[[v3126]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3122:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3124:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v3122]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3125:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3124]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3119:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3125]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3120:[0-9]+]] = "riscv.lw"(%[[v3119]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3120:[0-9]+]] = "riscv.lw"(%[[v3124]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3121:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3120]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3115:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3121]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3116:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3131]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3117:[0-9]+]] = "riscv.xor"(%[[v3116]], %[[v3115]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3118:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3117]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3112:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3125]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3113:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3118]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3112]], %[[v3113]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3124]], %[[v3113]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3108:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3110:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v3108]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3111:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3110]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3105:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3111]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3106:[0-9]+]] = "riscv.lw"(%[[v3105]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3106:[0-9]+]] = "riscv.lw"(%[[v3110]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3107:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3106]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3101:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3107]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3102:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -1150,55 +1098,41 @@
 // CHECK-NEXT:         %[[v3092:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3091]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3085:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3087:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v3085]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3088:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3087]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3082:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3088]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3083:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3092]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3082]], %[[v3083]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3087]], %[[v3083]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3078:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3080:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v3078]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3081:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3080]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3075:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3081]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3076:[0-9]+]] = "riscv.lw"(%[[v3075]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3076:[0-9]+]] = "riscv.lw"(%[[v3080]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3077:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3076]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3072:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3073:[0-9]+]] = "riscv.sextw"(%[[v3072]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3068:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3070:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v3068]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3071:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3070]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3065:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3071]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3066:[0-9]+]] = "riscv.lw"(%[[v3065]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3066:[0-9]+]] = "riscv.lw"(%[[v3070]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3067:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3066]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3061:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3067]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3062:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3077]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3063:[0-9]+]] = "riscv.addw"(%[[v3062]], %[[v3061]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3064:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3063]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3058:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3071]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3059:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3064]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3058]], %[[v3059]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3070]], %[[v3059]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3054:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3056:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v3054]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3057:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3056]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3051:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3057]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3052:[0-9]+]] = "riscv.lw"(%[[v3051]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3052:[0-9]+]] = "riscv.lw"(%[[v3056]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3053:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3052]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3047:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3049:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v3047]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3050:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3049]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3044:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3050]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3045:[0-9]+]] = "riscv.lw"(%[[v3044]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3045:[0-9]+]] = "riscv.lw"(%[[v3049]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3046:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3045]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3040:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3046]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3041:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3053]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3042:[0-9]+]] = "riscv.xor"(%[[v3041]], %[[v3040]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3043:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3042]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v3037:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3050]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3038:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3043]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3037]], %[[v3038]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3049]], %[[v3038]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3033:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3035:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v3033]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3036:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3035]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3030:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3036]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3031:[0-9]+]] = "riscv.lw"(%[[v3030]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3031:[0-9]+]] = "riscv.lw"(%[[v3035]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3032:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3031]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3026:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3032]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v3027:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -1218,53 +1152,39 @@
 // CHECK-NEXT:         %[[v3017:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3016]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v3010:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3012:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v3010]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3013:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3012]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3007:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3013]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3008:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3017]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v3007]], %[[v3008]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v3012]], %[[v3008]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v3003:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v3005:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v3003]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v3006:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3005]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v3000:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3006]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v3001:[0-9]+]] = "riscv.lw"(%[[v3000]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v3001:[0-9]+]] = "riscv.lw"(%[[v3005]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v3002:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3001]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2996:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2998:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v2996]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2999:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2998]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2993:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2999]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2994:[0-9]+]] = "riscv.lw"(%[[v2993]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2994:[0-9]+]] = "riscv.lw"(%[[v2998]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2995:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2994]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2989:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2995]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2990:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3002]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2991:[0-9]+]] = "riscv.addw"(%[[v2990]], %[[v2989]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2992:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2991]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2986:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2999]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2987:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2992]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2986]], %[[v2987]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2998]], %[[v2987]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2982:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2984:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v2982]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2985:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2984]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2979:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2985]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2980:[0-9]+]] = "riscv.lw"(%[[v2979]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2980:[0-9]+]] = "riscv.lw"(%[[v2984]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2981:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2980]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2975:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2977:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v2975]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2978:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2977]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2972:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2978]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2973:[0-9]+]] = "riscv.lw"(%[[v2972]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2973:[0-9]+]] = "riscv.lw"(%[[v2977]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2974:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2973]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2968:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2974]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2969:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2981]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2970:[0-9]+]] = "riscv.xor"(%[[v2969]], %[[v2968]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2971:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2970]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2965:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2978]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2966:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2971]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2965]], %[[v2966]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2977]], %[[v2966]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2961:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2963:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v2961]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2964:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2963]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2958:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2964]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2959:[0-9]+]] = "riscv.lw"(%[[v2958]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2959:[0-9]+]] = "riscv.lw"(%[[v2963]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2960:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2959]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2954:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2960]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2955:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -1284,53 +1204,39 @@
 // CHECK-NEXT:         %[[v2945:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2944]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2938:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2940:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v2938]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2941:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2940]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2935:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2941]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2936:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2945]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2935]], %[[v2936]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2940]], %[[v2936]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2931:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2933:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v2931]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2934:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2933]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2928:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2934]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2929:[0-9]+]] = "riscv.lw"(%[[v2928]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2929:[0-9]+]] = "riscv.lw"(%[[v2933]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2930:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2929]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2924:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2926:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v2924]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2927:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2926]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2921:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2927]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2922:[0-9]+]] = "riscv.lw"(%[[v2921]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2922:[0-9]+]] = "riscv.lw"(%[[v2926]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2923:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2922]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2917:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2923]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2918:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2930]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2919:[0-9]+]] = "riscv.addw"(%[[v2918]], %[[v2917]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2920:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2919]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2914:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2927]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2915:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2920]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2914]], %[[v2915]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2926]], %[[v2915]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2910:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2912:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v2910]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2913:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2912]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2907:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2913]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2908:[0-9]+]] = "riscv.lw"(%[[v2907]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2908:[0-9]+]] = "riscv.lw"(%[[v2912]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2909:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2908]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2903:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2905:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v2903]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2906:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2905]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2900:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2906]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2901:[0-9]+]] = "riscv.lw"(%[[v2900]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2901:[0-9]+]] = "riscv.lw"(%[[v2905]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2902:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2901]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2896:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2902]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2897:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2909]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2898:[0-9]+]] = "riscv.xor"(%[[v2897]], %[[v2896]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2899:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2898]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2893:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2906]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2894:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2899]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2893]], %[[v2894]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2905]], %[[v2894]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2889:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2891:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v2889]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2892:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2891]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2886:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2892]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2887:[0-9]+]] = "riscv.lw"(%[[v2886]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2887:[0-9]+]] = "riscv.lw"(%[[v2891]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2888:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2887]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2882:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2888]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2883:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -1350,59 +1256,45 @@
 // CHECK-NEXT:         %[[v2873:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2872]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2866:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2868:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v2866]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2869:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2868]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2863:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2869]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2864:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2873]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2863]], %[[v2864]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2868]], %[[v2864]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2860:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3421]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2861:[0-9]+]] = "riscv.sextw"(%[[v2860]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2856:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2858:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2856]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2859:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2858]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2853:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2859]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2854:[0-9]+]] = "riscv.lw"(%[[v2853]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2854:[0-9]+]] = "riscv.lw"(%[[v2858]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2855:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2854]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2850:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3419]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2851:[0-9]+]] = "riscv.sextw"(%[[v2850]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2846:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2848:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v2846]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2849:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2848]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2843:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2849]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2844:[0-9]+]] = "riscv.lw"(%[[v2843]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2844:[0-9]+]] = "riscv.lw"(%[[v2848]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2845:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2844]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2839:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2845]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2840:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2855]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2841:[0-9]+]] = "riscv.addw"(%[[v2840]], %[[v2839]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2842:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2841]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2836:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2849]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2837:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2842]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2836]], %[[v2837]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2848]], %[[v2837]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2832:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2834:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v2832]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2835:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2834]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2829:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2835]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2830:[0-9]+]] = "riscv.lw"(%[[v2829]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2830:[0-9]+]] = "riscv.lw"(%[[v2834]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2831:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2830]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2826:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3417]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2827:[0-9]+]] = "riscv.sextw"(%[[v2826]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2822:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2824:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2822]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2825:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2824]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2819:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2825]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2820:[0-9]+]] = "riscv.lw"(%[[v2819]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2820:[0-9]+]] = "riscv.lw"(%[[v2824]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2821:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2820]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2815:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2821]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2816:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2831]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2817:[0-9]+]] = "riscv.xor"(%[[v2816]], %[[v2815]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2818:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2817]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2812:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2825]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2813:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2818]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2812]], %[[v2813]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2824]], %[[v2813]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2808:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2810:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2808]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2811:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2810]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2805:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2811]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2806:[0-9]+]] = "riscv.lw"(%[[v2805]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2806:[0-9]+]] = "riscv.lw"(%[[v2810]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2807:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2806]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2801:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2807]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2802:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -1418,55 +1310,41 @@
 // CHECK-NEXT:         %[[v2796:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2795]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2789:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2791:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2789]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2792:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2791]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2786:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2792]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2787:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2796]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2786]], %[[v2787]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2791]], %[[v2787]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2782:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2784:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2782]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2785:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2784]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2779:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2785]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2780:[0-9]+]] = "riscv.lw"(%[[v2779]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2780:[0-9]+]] = "riscv.lw"(%[[v2784]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2781:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2780]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2776:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3415]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2777:[0-9]+]] = "riscv.sextw"(%[[v2776]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2772:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2774:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v2772]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2775:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2774]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2769:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2775]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2770:[0-9]+]] = "riscv.lw"(%[[v2769]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2770:[0-9]+]] = "riscv.lw"(%[[v2774]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2771:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2770]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2765:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2771]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2766:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2781]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2767:[0-9]+]] = "riscv.addw"(%[[v2766]], %[[v2765]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2768:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2767]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2762:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2775]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2763:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2768]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2762]], %[[v2763]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2774]], %[[v2763]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2758:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2760:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v2758]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2761:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2760]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2755:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2761]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2756:[0-9]+]] = "riscv.lw"(%[[v2755]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2756:[0-9]+]] = "riscv.lw"(%[[v2760]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2757:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2756]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2751:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2753:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2751]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2754:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2753]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2748:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2754]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2749:[0-9]+]] = "riscv.lw"(%[[v2748]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2749:[0-9]+]] = "riscv.lw"(%[[v2753]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2750:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2749]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2744:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2750]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2745:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2757]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2746:[0-9]+]] = "riscv.xor"(%[[v2745]], %[[v2744]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2747:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2746]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2741:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2754]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2742:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2747]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2741]], %[[v2742]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2753]], %[[v2742]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2737:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2739:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2737]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2740:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2739]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2734:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2740]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2735:[0-9]+]] = "riscv.lw"(%[[v2734]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2735:[0-9]+]] = "riscv.lw"(%[[v2739]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2736:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2735]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2730:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2736]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2731:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -1482,53 +1360,39 @@
 // CHECK-NEXT:         %[[v2725:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2724]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2718:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2720:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2718]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2721:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2720]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2715:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2721]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2716:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2725]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2715]], %[[v2716]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2720]], %[[v2716]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2711:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2713:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2711]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2714:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2713]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2708:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2714]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2709:[0-9]+]] = "riscv.lw"(%[[v2708]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2709:[0-9]+]] = "riscv.lw"(%[[v2713]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2710:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2709]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2704:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2706:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v2704]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2707:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2706]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2701:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2707]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2702:[0-9]+]] = "riscv.lw"(%[[v2701]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2702:[0-9]+]] = "riscv.lw"(%[[v2706]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2703:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2702]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2697:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2703]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2698:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2710]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2699:[0-9]+]] = "riscv.addw"(%[[v2698]], %[[v2697]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2700:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2699]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2694:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2707]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2695:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2700]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2694]], %[[v2695]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2706]], %[[v2695]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2690:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2692:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v2690]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2693:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2692]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2687:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2693]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2688:[0-9]+]] = "riscv.lw"(%[[v2687]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2688:[0-9]+]] = "riscv.lw"(%[[v2692]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2689:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2688]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2683:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2685:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2683]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2686:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2685]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2680:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2686]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2681:[0-9]+]] = "riscv.lw"(%[[v2680]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2681:[0-9]+]] = "riscv.lw"(%[[v2685]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2682:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2681]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2676:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2682]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2677:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2689]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2678:[0-9]+]] = "riscv.xor"(%[[v2677]], %[[v2676]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2679:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2678]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2673:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2686]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2674:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2679]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2673]], %[[v2674]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2685]], %[[v2674]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2669:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2671:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2669]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2672:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2671]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2666:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2672]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2667:[0-9]+]] = "riscv.lw"(%[[v2666]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2667:[0-9]+]] = "riscv.lw"(%[[v2671]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2668:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2667]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2662:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2668]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2663:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -1544,53 +1408,39 @@
 // CHECK-NEXT:         %[[v2657:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2656]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2650:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2652:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2650]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2653:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2652]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2647:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2653]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2648:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2657]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2647]], %[[v2648]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2652]], %[[v2648]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2643:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2645:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v2643]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2646:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2645]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2640:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2646]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2641:[0-9]+]] = "riscv.lw"(%[[v2640]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2641:[0-9]+]] = "riscv.lw"(%[[v2645]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2642:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2641]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2636:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2638:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v2636]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2639:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2638]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2633:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2639]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2634:[0-9]+]] = "riscv.lw"(%[[v2633]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2634:[0-9]+]] = "riscv.lw"(%[[v2638]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2635:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2634]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2629:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2635]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2630:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2642]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2631:[0-9]+]] = "riscv.addw"(%[[v2630]], %[[v2629]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2632:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2631]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2626:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2639]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2627:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2632]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2626]], %[[v2627]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2638]], %[[v2627]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2622:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2624:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v2622]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2625:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2624]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2619:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2625]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2620:[0-9]+]] = "riscv.lw"(%[[v2619]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2620:[0-9]+]] = "riscv.lw"(%[[v2624]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2621:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2620]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2615:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2617:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2615]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2618:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2617]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2612:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2618]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2613:[0-9]+]] = "riscv.lw"(%[[v2612]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2613:[0-9]+]] = "riscv.lw"(%[[v2617]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2614:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2613]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2608:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2614]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2609:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2621]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2610:[0-9]+]] = "riscv.xor"(%[[v2609]], %[[v2608]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2611:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2610]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2605:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2618]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2606:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2611]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2605]], %[[v2606]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2617]], %[[v2606]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2601:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2603:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2601]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2604:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2603]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2598:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2604]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2599:[0-9]+]] = "riscv.lw"(%[[v2598]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2599:[0-9]+]] = "riscv.lw"(%[[v2603]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2600:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2599]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2594:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2600]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2595:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -1606,59 +1456,45 @@
 // CHECK-NEXT:         %[[v2589:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2588]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2582:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2584:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2582]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2585:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2584]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2579:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2585]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2580:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2589]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2579]], %[[v2580]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2584]], %[[v2580]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2576:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3413]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2577:[0-9]+]] = "riscv.sextw"(%[[v2576]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2572:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2574:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2572]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2575:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2574]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2569:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2575]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2570:[0-9]+]] = "riscv.lw"(%[[v2569]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2570:[0-9]+]] = "riscv.lw"(%[[v2574]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2571:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2570]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2566:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3411]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2567:[0-9]+]] = "riscv.sextw"(%[[v2566]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2562:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2564:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v2562]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2565:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2564]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2559:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2565]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2560:[0-9]+]] = "riscv.lw"(%[[v2559]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2560:[0-9]+]] = "riscv.lw"(%[[v2564]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2561:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2560]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2555:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2561]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2556:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2571]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2557:[0-9]+]] = "riscv.addw"(%[[v2556]], %[[v2555]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2558:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2557]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2552:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2565]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2553:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2558]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2552]], %[[v2553]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2564]], %[[v2553]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2548:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2550:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v2548]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2551:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2550]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2545:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2551]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2546:[0-9]+]] = "riscv.lw"(%[[v2545]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2546:[0-9]+]] = "riscv.lw"(%[[v2550]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2547:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2546]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2542:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3409]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2543:[0-9]+]] = "riscv.sextw"(%[[v2542]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2538:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2540:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2538]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2541:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2540]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2535:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2541]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2536:[0-9]+]] = "riscv.lw"(%[[v2535]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2536:[0-9]+]] = "riscv.lw"(%[[v2540]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2537:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2536]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2531:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2537]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2532:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2547]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2533:[0-9]+]] = "riscv.xor"(%[[v2532]], %[[v2531]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2534:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2533]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2528:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2541]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2529:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2534]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2528]], %[[v2529]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2540]], %[[v2529]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2524:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2526:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2524]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2527:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2526]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2521:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2527]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2522:[0-9]+]] = "riscv.lw"(%[[v2521]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2522:[0-9]+]] = "riscv.lw"(%[[v2526]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2523:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2522]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2517:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2523]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2518:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -1674,55 +1510,41 @@
 // CHECK-NEXT:         %[[v2512:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2511]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2505:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2507:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2505]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2508:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2507]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2502:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2508]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2503:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2512]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2502]], %[[v2503]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2507]], %[[v2503]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2498:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2500:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2498]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2501:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2500]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2495:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2501]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2496:[0-9]+]] = "riscv.lw"(%[[v2495]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2496:[0-9]+]] = "riscv.lw"(%[[v2500]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2497:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2496]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2492:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3407]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2493:[0-9]+]] = "riscv.sextw"(%[[v2492]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2488:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2490:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v2488]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2491:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2490]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2485:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2491]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2486:[0-9]+]] = "riscv.lw"(%[[v2485]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2486:[0-9]+]] = "riscv.lw"(%[[v2490]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2487:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2486]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2481:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2487]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2482:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2497]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2483:[0-9]+]] = "riscv.addw"(%[[v2482]], %[[v2481]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2484:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2483]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2478:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2491]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2479:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2484]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2478]], %[[v2479]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2490]], %[[v2479]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2474:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2476:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v2474]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2477:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2476]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2471:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2477]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2472:[0-9]+]] = "riscv.lw"(%[[v2471]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2472:[0-9]+]] = "riscv.lw"(%[[v2476]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2473:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2472]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2467:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2469:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2467]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2470:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2469]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2464:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2470]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2465:[0-9]+]] = "riscv.lw"(%[[v2464]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2465:[0-9]+]] = "riscv.lw"(%[[v2469]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2466:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2465]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2460:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2466]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2461:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2473]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2462:[0-9]+]] = "riscv.xor"(%[[v2461]], %[[v2460]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2463:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2462]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2457:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2470]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2458:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2463]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2457]], %[[v2458]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2469]], %[[v2458]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2453:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2455:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2453]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2456:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2455]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2450:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2456]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2451:[0-9]+]] = "riscv.lw"(%[[v2450]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2451:[0-9]+]] = "riscv.lw"(%[[v2455]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2452:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2451]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2446:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2452]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2447:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -1738,53 +1560,39 @@
 // CHECK-NEXT:         %[[v2441:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2440]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2434:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2436:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2434]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2437:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2436]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2431:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2437]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2432:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2441]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2431]], %[[v2432]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2436]], %[[v2432]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2427:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2429:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2427]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2430:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2429]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2424:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2430]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2425:[0-9]+]] = "riscv.lw"(%[[v2424]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2425:[0-9]+]] = "riscv.lw"(%[[v2429]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2426:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2425]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2420:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2422:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v2420]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2423:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2422]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2417:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2423]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2418:[0-9]+]] = "riscv.lw"(%[[v2417]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2418:[0-9]+]] = "riscv.lw"(%[[v2422]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2419:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2418]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2413:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2419]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2414:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2426]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2415:[0-9]+]] = "riscv.addw"(%[[v2414]], %[[v2413]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2416:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2415]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2410:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2423]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2411:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2416]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2410]], %[[v2411]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2422]], %[[v2411]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2406:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2408:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v2406]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2409:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2408]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2403:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2409]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2404:[0-9]+]] = "riscv.lw"(%[[v2403]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2404:[0-9]+]] = "riscv.lw"(%[[v2408]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2405:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2404]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2399:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2401:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2399]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2402:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2401]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2396:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2402]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2397:[0-9]+]] = "riscv.lw"(%[[v2396]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2397:[0-9]+]] = "riscv.lw"(%[[v2401]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2398:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2397]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2392:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2398]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2393:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2405]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2394:[0-9]+]] = "riscv.xor"(%[[v2393]], %[[v2392]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2395:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2394]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2389:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2402]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2390:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2395]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2389]], %[[v2390]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2401]], %[[v2390]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2385:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2387:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2385]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2388:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2387]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2382:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2388]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2383:[0-9]+]] = "riscv.lw"(%[[v2382]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2383:[0-9]+]] = "riscv.lw"(%[[v2387]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2384:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2383]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2378:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2384]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2379:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -1800,53 +1608,39 @@
 // CHECK-NEXT:         %[[v2373:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2372]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2366:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2368:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2366]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2369:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2368]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2363:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2369]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2364:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2373]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2363]], %[[v2364]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2368]], %[[v2364]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2359:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2361:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v2359]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2362:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2361]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2356:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2362]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2357:[0-9]+]] = "riscv.lw"(%[[v2356]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2357:[0-9]+]] = "riscv.lw"(%[[v2361]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2358:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2357]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2352:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2354:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v2352]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2355:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2354]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2349:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2355]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2350:[0-9]+]] = "riscv.lw"(%[[v2349]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2350:[0-9]+]] = "riscv.lw"(%[[v2354]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2351:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2350]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2345:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2351]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2346:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2358]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2347:[0-9]+]] = "riscv.addw"(%[[v2346]], %[[v2345]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2348:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2347]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2342:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2355]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2343:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2348]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2342]], %[[v2343]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2354]], %[[v2343]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2338:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2340:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v2338]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2341:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2340]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2335:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2341]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2336:[0-9]+]] = "riscv.lw"(%[[v2335]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2336:[0-9]+]] = "riscv.lw"(%[[v2340]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2337:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2336]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2331:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2333:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2331]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2334:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2333]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2328:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2334]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2329:[0-9]+]] = "riscv.lw"(%[[v2328]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2329:[0-9]+]] = "riscv.lw"(%[[v2333]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2330:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2329]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2324:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2330]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2325:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2337]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2326:[0-9]+]] = "riscv.xor"(%[[v2325]], %[[v2324]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2327:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2326]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2321:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2334]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2322:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2327]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2321]], %[[v2322]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2333]], %[[v2322]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2317:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2319:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2317]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2320:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2319]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2314:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2320]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2315:[0-9]+]] = "riscv.lw"(%[[v2314]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2315:[0-9]+]] = "riscv.lw"(%[[v2319]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2316:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2315]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2310:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2316]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2311:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -1862,59 +1656,45 @@
 // CHECK-NEXT:         %[[v2305:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2304]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2298:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2300:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v2298]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2301:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2300]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2295:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2301]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2296:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2305]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2295]], %[[v2296]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2300]], %[[v2296]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2292:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2293:[0-9]+]] = "riscv.sextw"(%[[v2292]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2288:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2290:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2288]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2291:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2290]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2285:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2291]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2286:[0-9]+]] = "riscv.lw"(%[[v2285]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2286:[0-9]+]] = "riscv.lw"(%[[v2290]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2287:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2286]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2282:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3405]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2283:[0-9]+]] = "riscv.sextw"(%[[v2282]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2278:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2280:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v2278]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2281:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2280]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2275:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2281]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2276:[0-9]+]] = "riscv.lw"(%[[v2275]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2276:[0-9]+]] = "riscv.lw"(%[[v2280]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2277:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2276]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2271:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2277]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2272:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2287]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2273:[0-9]+]] = "riscv.addw"(%[[v2272]], %[[v2271]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2274:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2273]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2268:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2281]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2269:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2274]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2268]], %[[v2269]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2280]], %[[v2269]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2264:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2266:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v2264]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2267:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2266]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2261:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2267]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2262:[0-9]+]] = "riscv.lw"(%[[v2261]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2262:[0-9]+]] = "riscv.lw"(%[[v2266]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2263:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2262]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2258:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3403]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2259:[0-9]+]] = "riscv.sextw"(%[[v2258]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2254:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2256:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2254]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2257:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2256]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2251:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2257]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2252:[0-9]+]] = "riscv.lw"(%[[v2251]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2252:[0-9]+]] = "riscv.lw"(%[[v2256]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2253:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2252]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2247:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2253]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2248:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2263]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2249:[0-9]+]] = "riscv.xor"(%[[v2248]], %[[v2247]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2250:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2249]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2244:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2257]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2245:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2250]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2244]], %[[v2245]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2256]], %[[v2245]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2240:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2242:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2240]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2243:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2242]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2237:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2243]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2238:[0-9]+]] = "riscv.lw"(%[[v2237]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2238:[0-9]+]] = "riscv.lw"(%[[v2242]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2239:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2238]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2233:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2239]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2234:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -1930,55 +1710,41 @@
 // CHECK-NEXT:         %[[v2228:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2227]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2221:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2223:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2221]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2224:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2223]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2218:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2224]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2219:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2228]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2218]], %[[v2219]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2223]], %[[v2219]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2214:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2216:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2214]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2217:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2216]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2211:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2217]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2212:[0-9]+]] = "riscv.lw"(%[[v2211]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2212:[0-9]+]] = "riscv.lw"(%[[v2216]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2213:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2212]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2208:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3401]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2209:[0-9]+]] = "riscv.sextw"(%[[v2208]]) : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2204:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2206:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v2204]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2207:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2206]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2201:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2207]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2202:[0-9]+]] = "riscv.lw"(%[[v2201]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2202:[0-9]+]] = "riscv.lw"(%[[v2206]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2203:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2202]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2197:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2203]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2198:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2213]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2199:[0-9]+]] = "riscv.addw"(%[[v2198]], %[[v2197]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2200:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2199]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2194:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2207]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2195:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2200]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2194]], %[[v2195]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2206]], %[[v2195]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2190:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2192:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v2190]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2193:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2192]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2187:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2193]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2188:[0-9]+]] = "riscv.lw"(%[[v2187]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2188:[0-9]+]] = "riscv.lw"(%[[v2192]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2189:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2188]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2183:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2185:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2183]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2186:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2185]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2180:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2186]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2181:[0-9]+]] = "riscv.lw"(%[[v2180]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2181:[0-9]+]] = "riscv.lw"(%[[v2185]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2182:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2181]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2176:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2182]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2177:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2189]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2178:[0-9]+]] = "riscv.xor"(%[[v2177]], %[[v2176]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2179:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2178]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2173:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2186]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2174:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2179]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2173]], %[[v2174]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2185]], %[[v2174]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2169:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2171:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2169]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2172:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2171]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2166:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2172]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2167:[0-9]+]] = "riscv.lw"(%[[v2166]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2167:[0-9]+]] = "riscv.lw"(%[[v2171]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2168:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2167]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2162:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2168]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2163:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -1994,53 +1760,39 @@
 // CHECK-NEXT:         %[[v2157:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2156]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2150:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2152:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2150]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2153:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2152]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2147:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2153]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2148:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2157]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2147]], %[[v2148]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2152]], %[[v2148]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2143:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2145:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2143]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2146:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2145]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2140:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2146]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2141:[0-9]+]] = "riscv.lw"(%[[v2140]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2141:[0-9]+]] = "riscv.lw"(%[[v2145]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2142:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2141]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2136:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2138:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v2136]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2139:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2138]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2133:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2139]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2134:[0-9]+]] = "riscv.lw"(%[[v2133]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2134:[0-9]+]] = "riscv.lw"(%[[v2138]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2135:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2134]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2129:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2135]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2130:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2142]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2131:[0-9]+]] = "riscv.addw"(%[[v2130]], %[[v2129]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2132:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2131]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2126:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2139]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2127:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2132]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2126]], %[[v2127]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2138]], %[[v2127]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2122:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2124:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v2122]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2125:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2124]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2119:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2125]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2120:[0-9]+]] = "riscv.lw"(%[[v2119]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2120:[0-9]+]] = "riscv.lw"(%[[v2124]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2121:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2120]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2115:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2117:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2115]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2118:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2117]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2112:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2118]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2113:[0-9]+]] = "riscv.lw"(%[[v2112]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2113:[0-9]+]] = "riscv.lw"(%[[v2117]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2114:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2113]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2108:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2114]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2109:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2121]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2110:[0-9]+]] = "riscv.xor"(%[[v2109]], %[[v2108]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2111:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2110]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2105:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2118]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2106:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2111]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2105]], %[[v2106]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2117]], %[[v2106]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2101:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2103:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2101]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2104:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2103]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2098:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2104]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2099:[0-9]+]] = "riscv.lw"(%[[v2098]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2099:[0-9]+]] = "riscv.lw"(%[[v2103]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2100:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2099]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2094:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2100]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2095:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -2056,53 +1808,39 @@
 // CHECK-NEXT:         %[[v2089:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2088]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2082:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2084:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2082]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2085:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2084]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2079:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2085]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2080:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2089]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2079]], %[[v2080]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2084]], %[[v2080]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2075:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2077:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v2075]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2078:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2077]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2072:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2078]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2073:[0-9]+]] = "riscv.lw"(%[[v2072]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2073:[0-9]+]] = "riscv.lw"(%[[v2077]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2074:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2073]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2068:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2070:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v2068]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2071:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2070]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2065:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2071]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2066:[0-9]+]] = "riscv.lw"(%[[v2065]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2066:[0-9]+]] = "riscv.lw"(%[[v2070]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2067:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2066]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2061:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2067]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2062:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2074]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2063:[0-9]+]] = "riscv.addw"(%[[v2062]], %[[v2061]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2064:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2063]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2058:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2071]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2059:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2064]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2058]], %[[v2059]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2070]], %[[v2059]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2054:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2056:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v2054]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2057:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2056]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2051:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2057]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2052:[0-9]+]] = "riscv.lw"(%[[v2051]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2052:[0-9]+]] = "riscv.lw"(%[[v2056]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2053:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2052]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2047:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2049:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2047]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2050:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2049]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2044:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2050]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2045:[0-9]+]] = "riscv.lw"(%[[v2044]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2045:[0-9]+]] = "riscv.lw"(%[[v2049]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2046:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2045]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2040:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2046]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2041:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2053]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2042:[0-9]+]] = "riscv.xor"(%[[v2041]], %[[v2040]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2043:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2042]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v2037:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2050]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2038:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2043]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2037]], %[[v2038]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2049]], %[[v2038]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2033:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2035:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2033]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2036:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2035]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2030:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2036]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2031:[0-9]+]] = "riscv.lw"(%[[v2030]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2031:[0-9]+]] = "riscv.lw"(%[[v2035]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2032:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2031]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2026:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2032]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v2027:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -2118,53 +1856,39 @@
 // CHECK-NEXT:         %[[v2021:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2020]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2014:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2016:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v2014]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2017:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2016]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2011:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2017]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2012:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2021]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v2011]], %[[v2012]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2016]], %[[v2012]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v2007:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2009:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v2007]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2010:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2009]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v2004:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2010]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v2005:[0-9]+]] = "riscv.lw"(%[[v2004]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v2005:[0-9]+]] = "riscv.lw"(%[[v2009]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v2006:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2005]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v2000:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v2002:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v2000]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v2003:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2002]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1997:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2003]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1998:[0-9]+]] = "riscv.lw"(%[[v1997]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1998:[0-9]+]] = "riscv.lw"(%[[v2002]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1999:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1998]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1993:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1999]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1994:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2006]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1995:[0-9]+]] = "riscv.addw"(%[[v1994]], %[[v1993]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1996:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1995]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1990:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v2003]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1991:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1996]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1990]], %[[v1991]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v2002]], %[[v1991]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1986:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1988:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v1986]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1989:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1988]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1983:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1989]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1984:[0-9]+]] = "riscv.lw"(%[[v1983]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1984:[0-9]+]] = "riscv.lw"(%[[v1988]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1985:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1984]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1979:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1981:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1979]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1982:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1981]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1976:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1982]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1977:[0-9]+]] = "riscv.lw"(%[[v1976]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1977:[0-9]+]] = "riscv.lw"(%[[v1981]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1978:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1977]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1972:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1978]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1973:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1985]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1974:[0-9]+]] = "riscv.xor"(%[[v1973]], %[[v1972]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1975:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1974]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1969:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1982]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1970:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1975]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1969]], %[[v1970]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1981]], %[[v1970]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1965:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1967:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1965]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1968:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1967]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1962:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1968]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1963:[0-9]+]] = "riscv.lw"(%[[v1962]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1963:[0-9]+]] = "riscv.lw"(%[[v1967]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1964:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1963]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1958:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1964]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1959:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -2180,53 +1904,39 @@
 // CHECK-NEXT:         %[[v1953:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1952]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1946:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1948:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1946]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1949:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1948]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1943:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1949]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1944:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1953]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1943]], %[[v1944]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1948]], %[[v1944]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1939:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1941:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1939]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1942:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1941]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1936:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1942]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1937:[0-9]+]] = "riscv.lw"(%[[v1936]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1937:[0-9]+]] = "riscv.lw"(%[[v1941]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1938:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1937]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1932:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1934:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v1932]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1935:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1934]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1929:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1935]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1930:[0-9]+]] = "riscv.lw"(%[[v1929]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1930:[0-9]+]] = "riscv.lw"(%[[v1934]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1931:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1930]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1925:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1931]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1926:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1938]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1927:[0-9]+]] = "riscv.addw"(%[[v1926]], %[[v1925]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1928:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1927]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1922:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1935]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1923:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1928]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1922]], %[[v1923]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1934]], %[[v1923]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1918:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1920:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v1918]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1921:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1920]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1915:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1921]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1916:[0-9]+]] = "riscv.lw"(%[[v1915]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1916:[0-9]+]] = "riscv.lw"(%[[v1920]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1917:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1916]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1911:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1913:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1911]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1914:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1913]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1908:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1914]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1909:[0-9]+]] = "riscv.lw"(%[[v1908]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1909:[0-9]+]] = "riscv.lw"(%[[v1913]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1910:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1909]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1904:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1910]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1905:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1917]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1906:[0-9]+]] = "riscv.xor"(%[[v1905]], %[[v1904]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1907:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1906]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1901:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1914]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1902:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1907]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1901]], %[[v1902]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1913]], %[[v1902]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1897:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1899:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1897]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1900:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1899]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1894:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1900]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1895:[0-9]+]] = "riscv.lw"(%[[v1894]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1895:[0-9]+]] = "riscv.lw"(%[[v1899]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1896:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1895]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1890:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1896]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1891:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -2242,53 +1952,39 @@
 // CHECK-NEXT:         %[[v1885:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1884]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1878:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1880:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1878]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1881:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1880]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1875:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1881]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1876:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1885]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1875]], %[[v1876]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1880]], %[[v1876]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1871:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1873:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1871]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1874:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1873]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1868:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1874]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1869:[0-9]+]] = "riscv.lw"(%[[v1868]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1869:[0-9]+]] = "riscv.lw"(%[[v1873]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1870:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1869]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1864:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1866:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v1864]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1867:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1866]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1861:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1867]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1862:[0-9]+]] = "riscv.lw"(%[[v1861]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1862:[0-9]+]] = "riscv.lw"(%[[v1866]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1863:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1862]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1857:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1863]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1858:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1870]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1859:[0-9]+]] = "riscv.addw"(%[[v1858]], %[[v1857]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1860:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1859]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1854:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1867]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1855:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1860]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1854]], %[[v1855]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1866]], %[[v1855]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1850:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1852:[0-9]+]] = "riscv.sh2add"(%[[v3151]], %[[v1850]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1853:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1852]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1847:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1853]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1848:[0-9]+]] = "riscv.lw"(%[[v1847]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1848:[0-9]+]] = "riscv.lw"(%[[v1852]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1849:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1848]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1843:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1845:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1843]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1846:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1845]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1840:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1846]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1841:[0-9]+]] = "riscv.lw"(%[[v1840]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1841:[0-9]+]] = "riscv.lw"(%[[v1845]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1842:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1841]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1836:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1842]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1837:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1849]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1838:[0-9]+]] = "riscv.xor"(%[[v1837]], %[[v1836]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1839:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1838]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1833:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1846]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1834:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1839]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1833]], %[[v1834]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1845]], %[[v1834]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1829:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1831:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1829]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1832:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1831]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1826:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1832]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1827:[0-9]+]] = "riscv.lw"(%[[v1826]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1827:[0-9]+]] = "riscv.lw"(%[[v1831]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1828:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1827]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1822:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1828]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1823:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -2304,53 +2000,39 @@
 // CHECK-NEXT:         %[[v1817:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1816]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1810:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1812:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1810]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1813:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1812]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1807:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1813]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1808:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1817]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1807]], %[[v1808]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1812]], %[[v1808]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1803:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1805:[0-9]+]] = "riscv.sh2add"(%[[v2259]], %[[v1803]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1806:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1805]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1800:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1806]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1801:[0-9]+]] = "riscv.lw"(%[[v1800]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1801:[0-9]+]] = "riscv.lw"(%[[v1805]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1802:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1801]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1796:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1798:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v1796]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1799:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1798]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1793:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1799]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1794:[0-9]+]] = "riscv.lw"(%[[v1793]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1794:[0-9]+]] = "riscv.lw"(%[[v1798]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1795:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1794]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1789:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1795]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1790:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1802]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1791:[0-9]+]] = "riscv.addw"(%[[v1790]], %[[v1789]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1792:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1791]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1786:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1799]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1787:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1792]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1786]], %[[v1787]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1798]], %[[v1787]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1782:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1784:[0-9]+]] = "riscv.sh2add"(%[[v2493]], %[[v1782]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1785:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1784]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1779:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1785]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1780:[0-9]+]] = "riscv.lw"(%[[v1779]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1780:[0-9]+]] = "riscv.lw"(%[[v1784]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1781:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1780]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1775:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1777:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1775]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1778:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1777]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1772:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1778]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1773:[0-9]+]] = "riscv.lw"(%[[v1772]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1773:[0-9]+]] = "riscv.lw"(%[[v1777]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1774:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1773]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1768:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1774]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1769:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1781]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1770:[0-9]+]] = "riscv.xor"(%[[v1769]], %[[v1768]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1771:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1770]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1765:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1778]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1766:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1771]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1765]], %[[v1766]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1777]], %[[v1766]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1761:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1763:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1761]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1764:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1763]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1758:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1764]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1759:[0-9]+]] = "riscv.lw"(%[[v1758]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1759:[0-9]+]] = "riscv.lw"(%[[v1763]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1760:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1759]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1754:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1760]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1755:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -2366,53 +2048,39 @@
 // CHECK-NEXT:         %[[v1749:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1748]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1742:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1744:[0-9]+]] = "riscv.sh2add"(%[[v2861]], %[[v1742]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1745:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1744]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1739:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1745]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1740:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1749]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1739]], %[[v1740]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1744]], %[[v1740]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1735:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1737:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1735]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1738:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1737]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1732:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1738]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1733:[0-9]+]] = "riscv.lw"(%[[v1732]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1733:[0-9]+]] = "riscv.lw"(%[[v1737]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1734:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1733]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1728:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1730:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v1728]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1731:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1730]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1725:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1731]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1726:[0-9]+]] = "riscv.lw"(%[[v1725]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1726:[0-9]+]] = "riscv.lw"(%[[v1730]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1727:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1726]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1721:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1727]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1722:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1734]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1723:[0-9]+]] = "riscv.addw"(%[[v1722]], %[[v1721]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1724:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1723]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1718:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1731]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1719:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1724]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1718]], %[[v1719]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1730]], %[[v1719]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1714:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1716:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v1714]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1717:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1716]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1711:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1717]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1712:[0-9]+]] = "riscv.lw"(%[[v1711]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1712:[0-9]+]] = "riscv.lw"(%[[v1716]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1713:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1712]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1707:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1709:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1707]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1710:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1709]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1704:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1710]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1705:[0-9]+]] = "riscv.lw"(%[[v1704]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1705:[0-9]+]] = "riscv.lw"(%[[v1709]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1706:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1705]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1700:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1706]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1701:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1713]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1702:[0-9]+]] = "riscv.xor"(%[[v1701]], %[[v1700]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1703:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1702]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1697:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1710]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1698:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1703]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1697]], %[[v1698]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1709]], %[[v1698]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1693:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1695:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1693]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1696:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1695]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1690:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1696]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1691:[0-9]+]] = "riscv.lw"(%[[v1690]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1691:[0-9]+]] = "riscv.lw"(%[[v1695]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1692:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1691]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1686:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1692]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1687:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -2428,53 +2096,39 @@
 // CHECK-NEXT:         %[[v1681:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1680]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1674:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1676:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1674]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1677:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1676]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1671:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1677]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1672:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1681]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1671]], %[[v1672]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1676]], %[[v1672]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1667:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1669:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1667]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1670:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1669]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1664:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1670]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1665:[0-9]+]] = "riscv.lw"(%[[v1664]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1665:[0-9]+]] = "riscv.lw"(%[[v1669]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1666:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1665]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1660:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1662:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v1660]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1663:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1662]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1657:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1663]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1658:[0-9]+]] = "riscv.lw"(%[[v1657]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1658:[0-9]+]] = "riscv.lw"(%[[v1662]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1659:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1658]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1653:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1659]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1654:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1666]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1655:[0-9]+]] = "riscv.addw"(%[[v1654]], %[[v1653]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1656:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1655]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1650:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1663]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1651:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1656]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1650]], %[[v1651]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1662]], %[[v1651]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1646:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1648:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v1646]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1649:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1648]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1643:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1649]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1644:[0-9]+]] = "riscv.lw"(%[[v1643]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1644:[0-9]+]] = "riscv.lw"(%[[v1648]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1645:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1644]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1639:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1641:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1639]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1642:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1641]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1636:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1642]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1637:[0-9]+]] = "riscv.lw"(%[[v1636]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1637:[0-9]+]] = "riscv.lw"(%[[v1641]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1638:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1637]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1632:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1638]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1633:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1645]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1634:[0-9]+]] = "riscv.xor"(%[[v1633]], %[[v1632]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1635:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1634]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1629:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1642]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1630:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1635]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1629]], %[[v1630]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1641]], %[[v1630]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1625:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1627:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1625]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1628:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1627]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1622:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1628]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1623:[0-9]+]] = "riscv.lw"(%[[v1622]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1623:[0-9]+]] = "riscv.lw"(%[[v1627]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1624:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1623]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1618:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1624]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1619:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -2490,53 +2144,39 @@
 // CHECK-NEXT:         %[[v1613:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1612]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1606:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1608:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1606]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1609:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1608]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1603:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1609]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1604:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1613]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1603]], %[[v1604]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1608]], %[[v1604]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1599:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1601:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1599]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1602:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1601]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1596:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1602]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1597:[0-9]+]] = "riscv.lw"(%[[v1596]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1597:[0-9]+]] = "riscv.lw"(%[[v1601]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1598:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1597]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1592:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1594:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v1592]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1595:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1594]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1589:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1595]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1590:[0-9]+]] = "riscv.lw"(%[[v1589]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1590:[0-9]+]] = "riscv.lw"(%[[v1594]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1591:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1590]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1585:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1591]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1586:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1598]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1587:[0-9]+]] = "riscv.addw"(%[[v1586]], %[[v1585]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1588:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1587]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1582:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1595]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1583:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1588]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1582]], %[[v1583]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1594]], %[[v1583]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1578:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1580:[0-9]+]] = "riscv.sh2add"(%[[v2851]], %[[v1578]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1581:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1580]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1575:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1581]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1576:[0-9]+]] = "riscv.lw"(%[[v1575]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1576:[0-9]+]] = "riscv.lw"(%[[v1580]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1577:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1576]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1571:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1573:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1571]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1574:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1573]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1568:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1574]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1569:[0-9]+]] = "riscv.lw"(%[[v1568]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1569:[0-9]+]] = "riscv.lw"(%[[v1573]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1570:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1569]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1564:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1570]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1565:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1577]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1566:[0-9]+]] = "riscv.xor"(%[[v1565]], %[[v1564]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1567:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1566]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1561:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1574]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1562:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1567]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1561]], %[[v1562]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1573]], %[[v1562]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1557:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1559:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1557]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1560:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1559]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1554:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1560]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1555:[0-9]+]] = "riscv.lw"(%[[v1554]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1555:[0-9]+]] = "riscv.lw"(%[[v1559]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1556:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1555]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1550:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1556]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1551:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -2552,53 +2192,39 @@
 // CHECK-NEXT:         %[[v1545:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1544]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1538:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1540:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1538]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1541:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1540]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1535:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1541]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1536:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1545]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1535]], %[[v1536]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1540]], %[[v1536]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1531:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1533:[0-9]+]] = "riscv.sh2add"(%[[v3127]], %[[v1531]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1534:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1533]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1528:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1534]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1529:[0-9]+]] = "riscv.lw"(%[[v1528]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1529:[0-9]+]] = "riscv.lw"(%[[v1533]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1530:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1529]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1524:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1526:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v1524]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1527:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1526]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1521:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1527]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1522:[0-9]+]] = "riscv.lw"(%[[v1521]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1522:[0-9]+]] = "riscv.lw"(%[[v1526]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1523:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1522]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1517:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1523]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1518:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1530]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1519:[0-9]+]] = "riscv.addw"(%[[v1518]], %[[v1517]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1520:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1519]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1514:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1527]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1515:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1520]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1514]], %[[v1515]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1526]], %[[v1515]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1510:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1512:[0-9]+]] = "riscv.sh2add"(%[[v2209]], %[[v1510]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1513:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1512]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1507:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1513]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1508:[0-9]+]] = "riscv.lw"(%[[v1507]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1508:[0-9]+]] = "riscv.lw"(%[[v1512]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1509:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1508]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1503:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1505:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1503]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1506:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1505]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1500:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1506]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1501:[0-9]+]] = "riscv.lw"(%[[v1500]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1501:[0-9]+]] = "riscv.lw"(%[[v1505]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1502:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1501]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1496:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1502]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1497:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1509]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1498:[0-9]+]] = "riscv.xor"(%[[v1497]], %[[v1496]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1499:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1498]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1493:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1506]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1494:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1499]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1493]], %[[v1494]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1505]], %[[v1494]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1489:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1491:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1489]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1492:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1491]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1486:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1492]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1487:[0-9]+]] = "riscv.lw"(%[[v1486]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1487:[0-9]+]] = "riscv.lw"(%[[v1491]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1488:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1487]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1482:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1488]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1483:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -2614,53 +2240,39 @@
 // CHECK-NEXT:         %[[v1477:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1476]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1470:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1472:[0-9]+]] = "riscv.sh2add"(%[[v2577]], %[[v1470]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1473:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1472]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1467:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1473]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1468:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1477]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1467]], %[[v1468]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1472]], %[[v1468]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1463:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1465:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1463]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1466:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1465]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1460:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1466]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1461:[0-9]+]] = "riscv.lw"(%[[v1460]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1461:[0-9]+]] = "riscv.lw"(%[[v1465]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1462:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1461]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1456:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1458:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v1456]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1459:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1458]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1453:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1459]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1454:[0-9]+]] = "riscv.lw"(%[[v1453]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1454:[0-9]+]] = "riscv.lw"(%[[v1458]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1455:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1454]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1449:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1455]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1450:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1462]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1451:[0-9]+]] = "riscv.addw"(%[[v1450]], %[[v1449]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1452:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1451]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1446:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1459]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1447:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1452]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1446]], %[[v1447]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1458]], %[[v1447]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1442:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1444:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v1442]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1445:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1444]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1439:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1445]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1440:[0-9]+]] = "riscv.lw"(%[[v1439]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1440:[0-9]+]] = "riscv.lw"(%[[v1444]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1441:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1440]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1435:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1437:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1435]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1438:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1437]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1432:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1438]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1433:[0-9]+]] = "riscv.lw"(%[[v1432]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1433:[0-9]+]] = "riscv.lw"(%[[v1437]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1434:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1433]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1428:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1434]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1429:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1441]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1430:[0-9]+]] = "riscv.xor"(%[[v1429]], %[[v1428]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1431:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1430]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1425:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1438]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1426:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1431]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1425]], %[[v1426]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1437]], %[[v1426]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1421:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1423:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1421]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1424:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1423]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1418:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1424]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1419:[0-9]+]] = "riscv.lw"(%[[v1418]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1419:[0-9]+]] = "riscv.lw"(%[[v1423]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1420:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1419]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1414:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1420]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1415:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -2676,53 +2288,39 @@
 // CHECK-NEXT:         %[[v1409:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1408]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1402:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1404:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1402]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1405:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1404]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1399:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1405]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1400:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1409]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1399]], %[[v1400]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1404]], %[[v1400]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1395:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1397:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1395]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1398:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1397]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1392:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1398]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1393:[0-9]+]] = "riscv.lw"(%[[v1392]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1393:[0-9]+]] = "riscv.lw"(%[[v1397]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1394:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1393]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1388:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1390:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v1388]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1391:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1390]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1385:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1391]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1386:[0-9]+]] = "riscv.lw"(%[[v1385]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1386:[0-9]+]] = "riscv.lw"(%[[v1390]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1387:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1386]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1381:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1387]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1382:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1394]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1383:[0-9]+]] = "riscv.addw"(%[[v1382]], %[[v1381]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1384:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1383]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1378:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1391]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1379:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1384]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1378]], %[[v1379]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1390]], %[[v1379]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1374:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1376:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v1374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1377:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1376]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1371:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1377]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1372:[0-9]+]] = "riscv.lw"(%[[v1371]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1372:[0-9]+]] = "riscv.lw"(%[[v1376]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1373:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1372]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1367:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1369:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1367]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1370:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1369]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1364:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1370]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1365:[0-9]+]] = "riscv.lw"(%[[v1364]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1365:[0-9]+]] = "riscv.lw"(%[[v1369]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1366:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1365]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1360:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1366]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1361:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1373]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1362:[0-9]+]] = "riscv.xor"(%[[v1361]], %[[v1360]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1363:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1362]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1357:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1370]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1358:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1363]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1357]], %[[v1358]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1369]], %[[v1358]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1353:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1355:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1353]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1356:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1355]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1350:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1356]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1351:[0-9]+]] = "riscv.lw"(%[[v1350]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1351:[0-9]+]] = "riscv.lw"(%[[v1355]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1352:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1351]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1346:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1352]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1347:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -2738,53 +2336,39 @@
 // CHECK-NEXT:         %[[v1341:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1340]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1334:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1336:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1334]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1337:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1336]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1331:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1337]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1332:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1341]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1331]], %[[v1332]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1336]], %[[v1332]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1327:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1329:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1327]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1330:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1329]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1324:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1330]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1325:[0-9]+]] = "riscv.lw"(%[[v1324]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1325:[0-9]+]] = "riscv.lw"(%[[v1329]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1326:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1325]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1320:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1322:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v1320]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1323:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1322]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1317:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1323]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1318:[0-9]+]] = "riscv.lw"(%[[v1317]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1318:[0-9]+]] = "riscv.lw"(%[[v1322]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1319:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1318]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1313:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1319]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1314:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1326]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1315:[0-9]+]] = "riscv.addw"(%[[v1314]], %[[v1313]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1316:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1315]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1310:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1323]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1311:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1316]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1310]], %[[v1311]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1322]], %[[v1311]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1306:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1308:[0-9]+]] = "riscv.sh2add"(%[[v2567]], %[[v1306]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1309:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1308]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1303:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1309]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1304:[0-9]+]] = "riscv.lw"(%[[v1303]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1304:[0-9]+]] = "riscv.lw"(%[[v1308]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1305:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1304]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1299:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1301:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1299]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1302:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1301]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1296:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1302]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1297:[0-9]+]] = "riscv.lw"(%[[v1296]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1297:[0-9]+]] = "riscv.lw"(%[[v1301]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1298:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1297]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1292:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1298]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1293:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1305]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1294:[0-9]+]] = "riscv.xor"(%[[v1293]], %[[v1292]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1295:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1294]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1289:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1302]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1290:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1295]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1289]], %[[v1290]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1301]], %[[v1290]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1285:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1287:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1285]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1288:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1287]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1282:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1288]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1283:[0-9]+]] = "riscv.lw"(%[[v1282]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1283:[0-9]+]] = "riscv.lw"(%[[v1287]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1284:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1283]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1278:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1284]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1279:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -2800,53 +2384,39 @@
 // CHECK-NEXT:         %[[v1273:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1272]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1266:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1268:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1266]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1269:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1268]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1263:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1269]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1264:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1273]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1263]], %[[v1264]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1268]], %[[v1264]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1259:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1261:[0-9]+]] = "riscv.sh2add"(%[[v2827]], %[[v1259]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1262:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1261]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1256:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1262]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1257:[0-9]+]] = "riscv.lw"(%[[v1256]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1257:[0-9]+]] = "riscv.lw"(%[[v1261]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1258:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1257]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1252:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1254:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v1252]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1255:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1254]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1249:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1255]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1250:[0-9]+]] = "riscv.lw"(%[[v1249]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1250:[0-9]+]] = "riscv.lw"(%[[v1254]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1251:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1250]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1245:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1251]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1246:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1258]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1247:[0-9]+]] = "riscv.addw"(%[[v1246]], %[[v1245]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1248:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1247]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1242:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1255]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1243:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1248]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1242]], %[[v1243]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1254]], %[[v1243]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1238:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1240:[0-9]+]] = "riscv.sh2add"(%[[v3073]], %[[v1238]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1241:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1240]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1235:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1241]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1236:[0-9]+]] = "riscv.lw"(%[[v1235]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1236:[0-9]+]] = "riscv.lw"(%[[v1240]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1237:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1236]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1231:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1233:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1231]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1234:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1233]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1228:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1234]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1229:[0-9]+]] = "riscv.lw"(%[[v1228]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1229:[0-9]+]] = "riscv.lw"(%[[v1233]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1230:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1229]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1224:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1230]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1225:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1237]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1226:[0-9]+]] = "riscv.xor"(%[[v1225]], %[[v1224]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1227:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1226]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1221:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1234]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1222:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1227]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1221]], %[[v1222]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1233]], %[[v1222]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1217:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1219:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1217]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1220:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1219]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1214:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1220]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1215:[0-9]+]] = "riscv.lw"(%[[v1214]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1215:[0-9]+]] = "riscv.lw"(%[[v1219]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1216:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1215]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1210:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1216]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1211:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -2862,53 +2432,39 @@
 // CHECK-NEXT:         %[[v1205:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1204]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1198:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1200:[0-9]+]] = "riscv.sh2add"(%[[v2293]], %[[v1198]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1201:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1200]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1195:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1201]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1196:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1205]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1195]], %[[v1196]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1200]], %[[v1196]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1191:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1193:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v1191]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1194:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1193]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1188:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1194]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1189:[0-9]+]] = "riscv.lw"(%[[v1188]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1189:[0-9]+]] = "riscv.lw"(%[[v1193]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1190:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1189]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1184:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1186:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v1184]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1187:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1186]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1181:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1187]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1182:[0-9]+]] = "riscv.lw"(%[[v1181]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1182:[0-9]+]] = "riscv.lw"(%[[v1186]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1183:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1182]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1177:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1183]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1178:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1190]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1179:[0-9]+]] = "riscv.addw"(%[[v1178]], %[[v1177]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1180:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1179]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1174:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1187]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1175:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1180]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1174]], %[[v1175]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1186]], %[[v1175]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1170:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1172:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v1170]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1173:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1172]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1167:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1173]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1168:[0-9]+]] = "riscv.lw"(%[[v1167]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1168:[0-9]+]] = "riscv.lw"(%[[v1172]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1169:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1168]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1163:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1165:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v1163]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1166:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1165]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1160:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1166]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1161:[0-9]+]] = "riscv.lw"(%[[v1160]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1161:[0-9]+]] = "riscv.lw"(%[[v1165]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1162:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1161]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1156:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1162]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1157:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1169]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1158:[0-9]+]] = "riscv.xor"(%[[v1157]], %[[v1156]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1159:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1158]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1153:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1166]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1154:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1159]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1153]], %[[v1154]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1165]], %[[v1154]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1149:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1151:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v1149]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1152:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1151]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1146:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1152]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1147:[0-9]+]] = "riscv.lw"(%[[v1146]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1147:[0-9]+]] = "riscv.lw"(%[[v1151]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1148:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1147]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1142:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1148]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1143:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
@@ -2924,53 +2480,39 @@
 // CHECK-NEXT:         %[[v1137:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1136]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1130:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1132:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v1130]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1133:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1132]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1127:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1133]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1128:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1137]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1127]], %[[v1128]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1132]], %[[v1128]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1123:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1125:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v1123]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1126:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1125]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1120:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1126]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1121:[0-9]+]] = "riscv.lw"(%[[v1120]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1121:[0-9]+]] = "riscv.lw"(%[[v1125]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1122:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1121]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1116:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1118:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v1116]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1119:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1118]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1113:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1119]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1114:[0-9]+]] = "riscv.lw"(%[[v1113]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1114:[0-9]+]] = "riscv.lw"(%[[v1118]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1115:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1114]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1109:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1115]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1110:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1122]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1111:[0-9]+]] = "riscv.addw"(%[[v1110]], %[[v1109]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1112:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1111]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1106:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1119]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1107:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1112]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1106]], %[[v1107]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1118]], %[[v1107]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1102:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1104:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v1102]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1105:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1104]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1099:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1105]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1100:[0-9]+]] = "riscv.lw"(%[[v1099]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1100:[0-9]+]] = "riscv.lw"(%[[v1104]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1101:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1100]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1095:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1097:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v1095]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1098:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1097]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1092:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1098]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1093:[0-9]+]] = "riscv.lw"(%[[v1092]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1093:[0-9]+]] = "riscv.lw"(%[[v1097]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1094:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1093]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1088:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1094]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1089:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1101]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1090:[0-9]+]] = "riscv.xor"(%[[v1089]], %[[v1088]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1091:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1090]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1085:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1098]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1086:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1091]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1085]], %[[v1086]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1097]], %[[v1086]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1081:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1083:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v1081]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1084:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1083]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1078:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1084]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1079:[0-9]+]] = "riscv.lw"(%[[v1078]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1079:[0-9]+]] = "riscv.lw"(%[[v1083]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1080:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1079]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1074:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1080]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1075:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3427]]) : (i32) -> !riscv.reg
@@ -2986,53 +2528,39 @@
 // CHECK-NEXT:         %[[v1069:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1068]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1062:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1064:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v1062]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1065:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1064]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1059:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1065]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1060:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1069]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1059]], %[[v1060]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1064]], %[[v1060]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1055:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1057:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v1055]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1058:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1057]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1052:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1058]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1053:[0-9]+]] = "riscv.lw"(%[[v1052]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1053:[0-9]+]] = "riscv.lw"(%[[v1057]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1054:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1053]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1048:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1050:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v1048]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1051:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1050]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1045:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1051]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1046:[0-9]+]] = "riscv.lw"(%[[v1045]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1046:[0-9]+]] = "riscv.lw"(%[[v1050]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1047:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1046]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1041:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1047]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1042:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1054]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1043:[0-9]+]] = "riscv.addw"(%[[v1042]], %[[v1041]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1044:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1043]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1038:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1051]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1039:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1044]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1038]], %[[v1039]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1050]], %[[v1039]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1034:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1036:[0-9]+]] = "riscv.sh2add"(%[[v2283]], %[[v1034]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1037:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1036]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1031:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1037]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1032:[0-9]+]] = "riscv.lw"(%[[v1031]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1032:[0-9]+]] = "riscv.lw"(%[[v1036]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1033:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1032]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1027:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1029:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v1027]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1030:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1029]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1024:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1030]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1025:[0-9]+]] = "riscv.lw"(%[[v1024]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1025:[0-9]+]] = "riscv.lw"(%[[v1029]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1026:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1025]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1020:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1026]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1021:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1033]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1022:[0-9]+]] = "riscv.xor"(%[[v1021]], %[[v1020]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1023:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1022]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v1017:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1030]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1018:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1023]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v1017]], %[[v1018]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v1029]], %[[v1018]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v1013:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v1015:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v1013]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v1016:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1015]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v1010:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1016]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v1011:[0-9]+]] = "riscv.lw"(%[[v1010]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v1011:[0-9]+]] = "riscv.lw"(%[[v1015]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v1012:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1011]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v1006:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1012]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v1007:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
@@ -3048,53 +2576,39 @@
 // CHECK-NEXT:         %[[v1001:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1000]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v994:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v996:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v994]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v997:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v996]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v991:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v997]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v992:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v1001]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v991]], %[[v992]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v996]], %[[v992]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v987:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v989:[0-9]+]] = "riscv.sh2add"(%[[v2543]], %[[v987]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v990:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v989]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v984:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v990]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v985:[0-9]+]] = "riscv.lw"(%[[v984]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v985:[0-9]+]] = "riscv.lw"(%[[v989]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v986:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v985]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v980:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v982:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v980]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v983:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v982]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v977:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v983]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v978:[0-9]+]] = "riscv.lw"(%[[v977]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v978:[0-9]+]] = "riscv.lw"(%[[v982]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v979:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v978]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v973:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v979]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v974:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v986]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v975:[0-9]+]] = "riscv.addw"(%[[v974]], %[[v973]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v976:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v975]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v970:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v983]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v971:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v976]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v970]], %[[v971]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v982]], %[[v971]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v966:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v968:[0-9]+]] = "riscv.sh2add"(%[[v2777]], %[[v966]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v969:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v968]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v963:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v969]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v964:[0-9]+]] = "riscv.lw"(%[[v963]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v964:[0-9]+]] = "riscv.lw"(%[[v968]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v965:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v964]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v959:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v961:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v959]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v962:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v961]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v956:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v962]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v957:[0-9]+]] = "riscv.lw"(%[[v956]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v957:[0-9]+]] = "riscv.lw"(%[[v961]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v958:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v957]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v952:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v958]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v953:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v965]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v954:[0-9]+]] = "riscv.xor"(%[[v953]], %[[v952]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v955:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v954]]) : (!riscv.reg) -> i32
-// CHECK-NEXT:         %[[v949:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v962]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v950:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v955]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v949]], %[[v950]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v961]], %[[v950]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v945:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v947:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v945]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v948:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v947]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v942:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v948]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v943:[0-9]+]] = "riscv.lw"(%[[v942]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v943:[0-9]+]] = "riscv.lw"(%[[v947]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v944:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v943]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v938:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v944]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v939:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3423]]) : (i32) -> !riscv.reg
@@ -3110,10 +2624,8 @@
 // CHECK-NEXT:         %[[v933:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v932]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v926:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v928:[0-9]+]] = "riscv.sh2add"(%[[v3161]], %[[v926]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v929:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v928]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v923:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v929]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v924:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v933]]) : (i32) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sw"(%[[v923]], %[[v924]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sw"(%[[v928]], %[[v924]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"() [^[[bb763:[0-9]+]]] : () -> ()
 // CHECK-NEXT:       ^[[bb763]]():
 // CHECK-NEXT:         %[[v921:[0-9]+]] = "riscv.add"(%[[v3458]], %[[varg129_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -3129,18 +2641,13 @@
 // CHECK-NEXT:         %[[v913:[0-9]+]] = "riscv.mul"(%[[varg767_0]], %[[v3438]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v907:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_3]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v909:[0-9]+]] = "riscv.add"(%[[v907]], %[[v913]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v910:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v909]]) : (!riscv.reg) -> !llvm.ptr
 // CHECK-NEXT:         %[[v903:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v905:[0-9]+]] = "riscv.sh2add"(%[[varg767_0]], %[[v903]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v906:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v905]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v900:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v906]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v901:[0-9]+]] = "riscv.lw"(%[[v900]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v901:[0-9]+]] = "riscv.lw"(%[[v905]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v902:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v901]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v896:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v898:[0-9]+]] = "riscv.sh2add"(%[[varg767_0]], %[[v896]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v899:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v898]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v893:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v899]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v894:[0-9]+]] = "riscv.lw"(%[[v893]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v894:[0-9]+]] = "riscv.lw"(%[[v898]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v895:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v894]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v889:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v902]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v890:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v895]]) : (i32) -> !riscv.reg
@@ -3148,45 +2655,35 @@
 // CHECK-NEXT:         %[[v892:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v891]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v887:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v892]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v888:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v887]]) : (!riscv.reg) -> i8
-// CHECK-NEXT:         %[[v884:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v910]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:         %[[v885:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v888]]) : (i8) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sb"(%[[v884]], %[[v885]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sb"(%[[v909]], %[[v885]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v880:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v892]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v881:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3437]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v882:[0-9]+]] = "riscv.srlw"(%[[v880]], %[[v881]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v883:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v882]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v878:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v883]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v879:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v878]]) : (!riscv.reg) -> i8
-// CHECK-NEXT:         %[[v874:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v910]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v876:[0-9]+]] = "riscv.add"(%[[v874]], %[[v3458]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v877:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v876]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v871:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v877]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v876:[0-9]+]] = "riscv.add"(%[[v909]], %[[v3458]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v872:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v879]]) : (i8) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sb"(%[[v871]], %[[v872]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sb"(%[[v876]], %[[v872]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v867:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v892]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v868:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3435]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v869:[0-9]+]] = "riscv.srlw"(%[[v867]], %[[v868]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v870:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v869]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v865:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v870]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v866:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v865]]) : (!riscv.reg) -> i8
-// CHECK-NEXT:         %[[v861:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v910]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v863:[0-9]+]] = "riscv.add"(%[[v861]], %[[v3454]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v864:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v863]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v858:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v864]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v863:[0-9]+]] = "riscv.add"(%[[v909]], %[[v3454]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v859:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v866]]) : (i8) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sb"(%[[v858]], %[[v859]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sb"(%[[v863]], %[[v859]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         %[[v854:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v892]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v855:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v3433]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v856:[0-9]+]] = "riscv.srlw"(%[[v854]], %[[v855]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v857:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v856]]) : (!riscv.reg) -> i32
 // CHECK-NEXT:         %[[v852:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v857]]) : (i32) -> !riscv.reg
 // CHECK-NEXT:         %[[v853:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v852]]) : (!riscv.reg) -> i8
-// CHECK-NEXT:         %[[v848:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v910]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:         %[[v850:[0-9]+]] = "riscv.add"(%[[v848]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:         %[[v851:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v850]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:         %[[v845:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v851]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v850:[0-9]+]] = "riscv.add"(%[[v909]], %[[v3450]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:         %[[v846:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v853]]) : (i8) -> !riscv.reg
-// CHECK-NEXT:         "riscv.sb"(%[[v845]], %[[v846]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv.sb"(%[[v850]], %[[v846]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:         "riscv_cf.branch"() [^[[bb794:[0-9]+]]] : () -> ()
 // CHECK-NEXT:       ^[[bb794]]():
 // CHECK-NEXT:         %[[v843:[0-9]+]] = "riscv.add"(%[[v3458]], %[[varg767_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
@@ -113,166 +113,157 @@
 }) {"dlti.dl_spec" = #dlti.dl_spec<!llvm.ptr<270> = dense<32> : vector<4xi64>, !llvm.ptr<271> = dense<32> : vector<4xi64>, !llvm.ptr<272> = dense<64> : vector<4xi64>, i64 = dense<64> : vector<2xi64>, i128 = dense<128> : vector<2xi64>, f80 = dense<128> : vector<2xi64>, !llvm.ptr = dense<64> : vector<4xi64>, i1 = dense<8> : vector<2xi64>, i8 = dense<8> : vector<2xi64>, i16 = dense<16> : vector<2xi64>, i32 = dense<32> : vector<2xi64>, f16 = dense<16> : vector<2xi64>, f64 = dense<64> : vector<2xi64>, f128 = dense<128> : vector<2xi64>, "dlti.endianness" = "little", "dlti.mangling_mode" = "e", "dlti.legal_int_widths" = array<i32: 8, 16, 32, 64>, "dlti.stack_alignment" = 128 : i64>, "llvm.ident" = "Ubuntu clang version 18.1.3 (1ubuntu1)", "llvm.module_asm" = [], "llvm.target_triple" = "x86_64-pc-linux-gnu"} : () -> ()
 
 
-// CHECK:       "builtin.module"() ({
-// CHECK-NEXT:    ^[[BB_ENTRY:[a-zA-Z0-9_]+]]():
-// CHECK-NEXT:      "llvm.module_flags"()
-// CHECK-NEXT:      "llvm.func"() <{"CConv" = #llvm.cconv<ccc>, always_inline, "arg_attrs" = [{llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}, {llvm.noundef}], dso_local, "frame_pointer" = #llvm.framePointerKind<all>, "function_type" = !llvm.func<void (!llvm.ptr, i64, i64, !llvm.ptr, i64, i64)>, "linkage" = #llvm.linkage<external>, no_unwind, "passthrough" = [["min-legal-vector-width", "0"], ["no-trapping-math", "true"], ["stack-protector-buffer-size", "8"], ["target-cpu", "x86-64"]], "sym_name" = "fastNTT", "target_cpu" = "x86-64", "target_features" = #llvm.target_features<["+cmov", "+cx8", "+fxsr", "+mmx", "+sse", "+sse2", "+x87"]>, "tune_cpu" = "generic", "unnamed_addr" = 0 : i64, "uwtable_kind" = #llvm.uwtableKind<async>, "visibility_" = 0 : i64}> ({
-// CHECK-NEXT:        ^[[BB_FUNC_ENTRY:[a-zA-Z0-9_]+]](%{{.*}}: !llvm.ptr, %{{.*}}: i64, %{{.*}}: i64, %{{.*}}: !llvm.ptr, %{{.*}}: i64, %{{.*}}: i64):
-// CHECK-NEXT:          %[[REG_C0:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_C2:[0-9]+]] = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_C1:[0-9]+]] = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST0:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_XOR0:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_C0_2:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SLTU0:[0-9]+]] = "riscv.sltu"(%[[REG_C0_2]], %[[REG_XOR0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST1:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU0]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST2:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST1]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST2]]) [^[[BB_12:[0-9]+]], ^[[BB_13:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_12]]():
-// CHECK-NEXT:          %[[REG_CAST3:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_CAST3]]) [^[[BB_15:[0-9]+]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_13]]():
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C2]]) [^[[BB_15]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_15]](%{{.*}}: !riscv.reg):
-// CHECK-NEXT:          %[[REG_CAST4:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_XOR1:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST4]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_C0_3:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SLTU1:[0-9]+]] = "riscv.sltu"(%[[REG_C0_3]], %[[REG_XOR1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST5:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU1]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST6:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST5]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST6]]) [^[[BB_19:[0-9]+]], ^[[BB_20:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_19]]():
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C1]]) [^[[BB_22:[0-9]+]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_20]]():
-// CHECK-NEXT:          %[[REG_CAST7:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV0:[0-9]+]] = "riscv.div"(%[[REG_CAST7]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV0]]) [^[[BB_22]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_22]](%{{.*}}: !riscv.reg):
-// CHECK-NEXT:          %[[REG_CAST8:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV1:[0-9]+]] = "riscv.div"(%[[REG_CAST8]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"({{.*}}, %[[REG_DIV1]], %[[REG_C0]], {{.*}}) [^[[BB_27:[0-9]+]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_27]]({{.*}}):
-// CHECK-NEXT:          %[[REG_CAST9:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]], %[[REG_CAST9]]) [^[[BB_29:[0-9]+]]] : (!riscv.reg, !riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_29]]({{.*}}):
-// CHECK-NEXT:          %[[REG_SLT0:[0-9]+]] = "riscv.slt"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST10:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT0]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST11:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST10]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST11]]) [^[[BB_32:[0-9]+]], ^[[BB_33:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_32]]():
-// CHECK-NEXT:          %[[REG_SRA0:[0-9]+]] = "riscv.sra"({{.*}}, %[[REG_C1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD0:[0-9]+]] = "riscv.add"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD0]], %[[REG_SRA0]]) [^[[BB_29]]] : (!riscv.reg, !riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_33]]():
-// CHECK-NEXT:          %[[REG_SLT1:[0-9]+]] = "riscv.slt"({{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST12:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT1]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST13:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST12]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST13]]) [^[[BB_39:[0-9]+]], ^[[BB_40:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_39]]():
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]]) [^[[BB_42:[0-9]+]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_42]](%[[ARG_42_0:[a-zA-Z0-9_]+]] : !riscv.reg):
-// CHECK-NEXT:          %[[REG_CAST14:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV2:[0-9]+]] = "riscv.div"(%[[REG_CAST14]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SLT2:[0-9]+]] = "riscv.slt"(%[[ARG_42_0]], %[[REG_DIV2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST15:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT2]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST16:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST15]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST16]]) [^[[BB_46:[0-9]+]], ^[[BB_47:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_46]]():
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]]) [^[[BB_49:[0-9]+]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_49]](%[[ARG_49_0:[a-zA-Z0-9_]+]] : !riscv.reg):
-// CHECK-NEXT:          %[[REG_DIV3:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SLT3:[0-9]+]] = "riscv.slt"(%[[ARG_49_0]], %[[REG_DIV3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST17:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT3]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST18:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST17]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST18]]) [^[[BB_53:[0-9]+]], ^[[BB_54:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_53]]():
-// CHECK-NEXT:          %[[REG_MUL0:[0-9]+]] = "riscv.mul"({{.*}}, %[[ARG_42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD1:[0-9]+]] = "riscv.add"(%[[ARG_49_0]], %[[REG_MUL0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST19:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SH3ADD0:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD1]], %[[REG_CAST19]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST20:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD0]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:          %[[REG_CAST21:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST20]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_LD0:[0-9]+]] = "riscv.ld"(%[[REG_CAST21]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV4:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD2:[0-9]+]] = "riscv.add"(%[[REG_DIV4]], %[[REG_ADD1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST22:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SH3ADD1:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD2]], %[[REG_CAST22]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST23:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD1]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:          %[[REG_CAST24:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST23]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_LD1:[0-9]+]] = "riscv.ld"(%[[REG_CAST24]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_MUL1:[0-9]+]] = "riscv.mul"(%[[ARG_49_0]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD3:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[REG_MUL1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_MUL2:[0-9]+]] = "riscv.mul"({{.*}}, %[[REG_ADD3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST25:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SH3ADD2:[0-9]+]] = "riscv.sh3add"(%[[REG_MUL2]], %[[REG_CAST25]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST26:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD2]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:          %[[REG_CAST27:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST26]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_LD2:[0-9]+]] = "riscv.ld"(%[[REG_CAST27]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_MUL3:[0-9]+]] = "riscv.mul"(%[[REG_LD1]], %[[REG_LD2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST28:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_REM0:[0-9]+]] = "riscv.rem"(%[[REG_MUL3]], %[[REG_CAST28]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD4:[0-9]+]] = "riscv.add"(%[[REG_REM0]], %[[REG_LD0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST29:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_REM1:[0-9]+]] = "riscv.rem"(%[[REG_ADD4]], %[[REG_CAST29]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SUB0:[0-9]+]] = "riscv.sub"(%[[REG_LD0]], %[[REG_REM0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST30:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD5:[0-9]+]] = "riscv.add"(%[[REG_CAST30]], %[[REG_SUB0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST31:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_REM2:[0-9]+]] = "riscv.rem"(%[[REG_ADD5]], %[[REG_CAST31]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST32:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SH3ADD3:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD1]], %[[REG_CAST32]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST33:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD3]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:          %[[REG_CAST34:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST33]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          "riscv.sd"(%[[REG_CAST34]], %[[REG_REM1]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
-// CHECK-NEXT:          %[[REG_CAST35:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SH3ADD4:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD2]], %[[REG_CAST35]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST36:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD4]]) : (!riscv.reg) -> !llvm.ptr
-// CHECK-NEXT:          %[[REG_CAST37:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST36]]) : (!llvm.ptr) -> !riscv.reg
-// CHECK-NEXT:          "riscv.sd"(%[[REG_CAST37]], %[[REG_REM2]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
-// CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_80:[0-9]+]]] : () -> ()
-// CHECK-NEXT:      ^[[BB_80]]():
-// CHECK-NEXT:          %[[REG_ADD6:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[ARG_49_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD6]]) [^[[BB_49]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_54]]():
-// CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_84:[0-9]+]]] : () -> ()
-// CHECK-NEXT:      ^[[BB_84]]():
-// CHECK-NEXT:          %[[REG_ADD7:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[ARG_42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD7]]) [^[[BB_42]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_47]]():
-// CHECK-NEXT:          %[[REG_DIV5:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST38:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_XOR2:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST38]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_C0_4:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SLTU2:[0-9]+]] = "riscv.sltu"(%[[REG_C0_4]], %[[REG_XOR2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST39:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU2]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST40:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST39]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST40]]) [^[[BB_90:[0-9]+]], ^[[BB_91:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_90]]():
-// CHECK-NEXT:          %[[REG_DIV6:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV6]]) [^[[BB_94:[0-9]+]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_91]]():
-// CHECK-NEXT:          %[[REG_ADD8:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD8]]) [^[[BB_94]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_94]](%[[ARG_94_0:[a-zA-Z0-9_]+]] : !riscv.reg):
-// CHECK-NEXT:          %[[REG_CAST41:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_XOR3:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST41]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_C0_5:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-// CHECK-NEXT:          %[[REG_SLTU3:[0-9]+]] = "riscv.sltu"(%[[REG_C0_5]], %[[REG_XOR3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_CAST42:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLTU3]]) : (!riscv.reg) -> i1
-// CHECK-NEXT:          %[[REG_CAST43:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST42]]) : (i1) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST43]]) [^[[BB_99:[0-9]+]], ^[[BB_100:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_99]]():
-// CHECK-NEXT:          %[[REG_ADD9:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD9]]) [^[[BB_103:[0-9]+]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_100]]():
-// CHECK-NEXT:          %[[REG_DIV7:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV7]]) [^[[BB_103]]] : (!riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_103]](%[[ARG_103_0:[a-zA-Z0-9_]+]] : !riscv.reg):
-// CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_107:[0-9]+]]] : () -> ()
-// CHECK-NEXT:      ^[[BB_107]]():
-// CHECK-NEXT:          %[[REG_ADD10:[0-9]+]] = "riscv.add"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          "riscv_cf.branch"(%[[ARG_103_0]], %[[REG_DIV5]], %[[REG_ADD10]], %[[ARG_94_0]]) [^[[BB_27]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
-// CHECK-NEXT:      ^[[BB_40]]():
-// CHECK-NEXT:          "llvm.return"() : () -> ()
-// CHECK-NEXT:    })
-// CHECK:         "llvm.target_triple" = "x86_64-pc-linux-gnu"
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^[[bb4:[0-9]+]]():
+// CHECK-NEXT:     "llvm.module_flags"() {{.*}} : () -> ()
+// CHECK-NEXT:     "llvm.func"() <{{{.*}}"sym_name" = "fastNTT"{{.*}}}> ({
+// CHECK-NEXT:       ^[[bb7:[0-9]+]](%[[varg7_0:[a-zA-Z0-9_]+]] : !llvm.ptr, %[[varg7_1:[a-zA-Z0-9_]+]] : i64, %[[varg7_2:[a-zA-Z0-9_]+]] : i64, %[[varg7_3:[a-zA-Z0-9_]+]] : !llvm.ptr, %[[varg7_4:[a-zA-Z0-9_]+]] : i64, %[[varg7_5:[a-zA-Z0-9_]+]] : i64):
+// CHECK-NEXT:         %[[v376:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v374:[0-9]+]] = "riscv.li"() <{"value" = 2 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v372:[0-9]+]] = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v366:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v368:[0-9]+]] = "riscv.xor"(%[[v376]], %[[v366]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v369:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v370:[0-9]+]] = "riscv.sltu"(%[[v369]], %[[v368]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v371:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v370]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v114:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v371]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v114]]) [^[[bb12:[0-9]+]], ^[[bb13:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb12]]():
+// CHECK-NEXT:         %[[v118:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_1]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v118]]) [^[[bb15:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb13]]():
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v374]]) [^[[bb15]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb15]](%[[varg15_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v360:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v362:[0-9]+]] = "riscv.xor"(%[[v376]], %[[v360]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v363:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v364:[0-9]+]] = "riscv.sltu"(%[[v363]], %[[v362]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v365:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v364]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v122:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v365]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v122]]) [^[[bb19:[0-9]+]], ^[[bb20:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb19]]():
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v372]]) [^[[bb22:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb20]]():
+// CHECK-NEXT:         %[[v356:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_5]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v358:[0-9]+]] = "riscv.div"(%[[v356]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v358]]) [^[[bb22]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb22]](%[[varg22_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v352:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_1]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v354:[0-9]+]] = "riscv.div"(%[[v352]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[varg22_0]], %[[v354]], %[[v376]], %[[varg15_0]]) [^[[bb27:[0-9]+]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb27]](%[[varg27_0:[a-zA-Z0-9_]+]] : !riscv.reg, %[[varg27_1:[a-zA-Z0-9_]+]] : !riscv.reg, %[[varg27_2:[a-zA-Z0-9_]+]] : !riscv.reg, %[[varg27_3:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v150:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_1]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v376]], %[[v150]]) [^[[bb29:[0-9]+]]] : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb29]](%[[varg29_0:[a-zA-Z0-9_]+]] : !riscv.reg, %[[varg29_1:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v350:[0-9]+]] = "riscv.slt"(%[[v372]], %[[varg29_1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v351:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v350]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v159:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v351]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v159]]) [^[[bb32:[0-9]+]], ^[[bb33:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb32]]():
+// CHECK-NEXT:         %[[v346:[0-9]+]] = "riscv.sra"(%[[varg29_1]], %[[v372]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v342:[0-9]+]] = "riscv.add"(%[[v372]], %[[varg29_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v342]], %[[v346]]) [^[[bb29]]] : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb33]]():
+// CHECK-NEXT:         %[[v338:[0-9]+]] = "riscv.slt"(%[[varg27_2]], %[[varg29_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v339:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v338]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v168:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v339]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v168]]) [^[[bb39:[0-9]+]], ^[[bb40:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb39]]():
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v376]]) [^[[bb42:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb42]](%[[varg42_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v332:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_1]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v334:[0-9]+]] = "riscv.div"(%[[v332]], %[[varg27_3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v330:[0-9]+]] = "riscv.slt"(%[[varg42_0]], %[[v334]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v331:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v330]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v176:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v331]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v176]]) [^[[bb46:[0-9]+]], ^[[bb47:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb46]]():
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v376]]) [^[[bb49:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb49]](%[[varg49_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v326:[0-9]+]] = "riscv.div"(%[[varg27_3]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v322:[0-9]+]] = "riscv.slt"(%[[varg49_0]], %[[v326]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v323:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v322]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v183:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v323]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v183]]) [^[[bb53:[0-9]+]], ^[[bb54:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb53]]():
+// CHECK-NEXT:         %[[v318:[0-9]+]] = "riscv.mul"(%[[varg27_3]], %[[varg42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v314:[0-9]+]] = "riscv.add"(%[[varg49_0]], %[[v318]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v308:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_0]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v310:[0-9]+]] = "riscv.sh3add"(%[[v314]], %[[v308]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v306:[0-9]+]] = "riscv.ld"(%[[v310]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v303:[0-9]+]] = "riscv.div"(%[[varg27_3]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v299:[0-9]+]] = "riscv.add"(%[[v303]], %[[v314]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v293:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_0]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v295:[0-9]+]] = "riscv.sh3add"(%[[v299]], %[[v293]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v291:[0-9]+]] = "riscv.ld"(%[[v295]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v288:[0-9]+]] = "riscv.mul"(%[[varg49_0]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v284:[0-9]+]] = "riscv.add"(%[[v372]], %[[v288]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v280:[0-9]+]] = "riscv.mul"(%[[varg27_1]], %[[v284]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v274:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_3]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v276:[0-9]+]] = "riscv.sh3add"(%[[v280]], %[[v274]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v272:[0-9]+]] = "riscv.ld"(%[[v276]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v269:[0-9]+]] = "riscv.mul"(%[[v291]], %[[v272]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v264:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_2]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v265:[0-9]+]] = "riscv.rem"(%[[v269]], %[[v264]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v261:[0-9]+]] = "riscv.add"(%[[v265]], %[[v306]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v256:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_2]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v257:[0-9]+]] = "riscv.rem"(%[[v261]], %[[v256]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v253:[0-9]+]] = "riscv.sub"(%[[v306]], %[[v265]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v248:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_2]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v249:[0-9]+]] = "riscv.add"(%[[v248]], %[[v253]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v244:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_2]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v245:[0-9]+]] = "riscv.rem"(%[[v249]], %[[v244]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v239:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_0]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v241:[0-9]+]] = "riscv.sh3add"(%[[v314]], %[[v239]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv.sd"(%[[v241]], %[[v257]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         %[[v232:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_0]]) : (!llvm.ptr) -> !riscv.reg
+// CHECK-NEXT:         %[[v234:[0-9]+]] = "riscv.sh3add"(%[[v299]], %[[v232]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv.sd"(%[[v234]], %[[v245]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:         "riscv_cf.branch"() [^[[bb80:[0-9]+]]] : () -> ()
+// CHECK-NEXT:       ^[[bb80]]():
+// CHECK-NEXT:         %[[v227:[0-9]+]] = "riscv.add"(%[[v372]], %[[varg49_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v227]]) [^[[bb49]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb54]]():
+// CHECK-NEXT:         "riscv_cf.branch"() [^[[bb84:[0-9]+]]] : () -> ()
+// CHECK-NEXT:       ^[[bb84]]():
+// CHECK-NEXT:         %[[v223:[0-9]+]] = "riscv.add"(%[[v372]], %[[varg42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v223]]) [^[[bb42]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb47]]():
+// CHECK-NEXT:         %[[v219:[0-9]+]] = "riscv.div"(%[[varg27_1]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v211:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v213:[0-9]+]] = "riscv.xor"(%[[v376]], %[[v211]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v214:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v215:[0-9]+]] = "riscv.sltu"(%[[v214]], %[[v213]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v216:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v215]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v130:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v216]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v130]]) [^[[bb90:[0-9]+]], ^[[bb91:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb90]]():
+// CHECK-NEXT:         %[[v209:[0-9]+]] = "riscv.div"(%[[varg27_3]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v209]]) [^[[bb94:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb91]]():
+// CHECK-NEXT:         %[[v205:[0-9]+]] = "riscv.add"(%[[varg27_3]], %[[varg27_3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v205]]) [^[[bb94]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb94]](%[[varg94_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         %[[v197:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[varg7_4]]) : (i64) -> !riscv.reg
+// CHECK-NEXT:         %[[v199:[0-9]+]] = "riscv.xor"(%[[v376]], %[[v197]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v200:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %[[v201:[0-9]+]] = "riscv.sltu"(%[[v200]], %[[v199]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         %[[v202:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v201]]) : (!riscv.reg) -> i1
+// CHECK-NEXT:         %[[v161:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[v202]]) : (i1) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.bnez"(%[[v161]]) [^[[bb99:[0-9]+]], ^[[bb100:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb99]]():
+// CHECK-NEXT:         %[[v195:[0-9]+]] = "riscv.add"(%[[varg27_0]], %[[varg27_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v195]]) [^[[bb103:[0-9]+]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb100]]():
+// CHECK-NEXT:         %[[v191:[0-9]+]] = "riscv.div"(%[[varg27_0]], %[[v374]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[v191]]) [^[[bb103]]] : (!riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb103]](%[[varg103_0:[a-zA-Z0-9_]+]] : !riscv.reg):
+// CHECK-NEXT:         "riscv_cf.branch"() [^[[bb107:[0-9]+]]] : () -> ()
+// CHECK-NEXT:       ^[[bb107]]():
+// CHECK-NEXT:         %[[v187:[0-9]+]] = "riscv.add"(%[[v372]], %[[varg27_2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:         "riscv_cf.branch"(%[[varg103_0]], %[[v219]], %[[v187]], %[[varg94_0]]) [^[[bb27]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
+// CHECK-NEXT:       ^[[bb40]]():
+// CHECK-NEXT:         "llvm.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) {{.*}} : () -> ()
+

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -15,8 +15,7 @@ def isRiscvRegToI64Cast (inputType interType : TypeAttr): Bool :=
   | _, _ => false
 
 /-!
-   Cast for the `i32 -> reg -> i32` direction: `toReg` zero-extends into the 64-bit register and
-   `toInt 32` takes the low 32 bits.
+    We reconcile casts in `builtin.unrealized_conversion_cast` operations for `!riscv.reg` and `i32` types, however only for the `i32 -> reg -> i32` direction.
 -/
 def isRiscvRegToI32Cast (inputType interType : TypeAttr): Bool :=
  match inputType.val, interType.val with
@@ -24,12 +23,13 @@ def isRiscvRegToI32Cast (inputType interType : TypeAttr): Bool :=
   | _, _ => false
 
 /-!
-  Same for `!llvm.ptr` and `!riscv.reg` (analogous to `isRiscvRegToI64Cast`).
+ We reconcile casts in `builtin.unrealized_conversion_cast` operations for `!llvm.ptr` and `!riscv.reg` types.
+ This cast assums that the `.llvmPointerType` is bit-wide.
 -/
 def isRiscvRegToPtrCast (inputType interType : TypeAttr): Bool :=
  match inputType.val, interType.val with
-  | .llvmPointerType _, .registerType _ => true
-  | .registerType _, .llvmPointerType _ => true
+  | .llvmPointerType _ , .registerType _ => true
+  | .registerType _, .llvmPointerType _  => true
   | _, _ => false
 
 /-!

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -25,7 +25,7 @@ def isRiscvRegToI32Cast (inputType interType : TypeAttr): Bool :=
   | _, _ => false
 
 /-!
-  Same for `!llvm.ptr` and `!riscv.reg` (analog to 'RiscvRegToI64Cast')
+  Same for `!llvm.ptr` and `!riscv.reg` (analogous to `isRiscvRegToI64Cast`).
 -/
 def isRiscvRegToPtrCast (inputType interType : TypeAttr): Bool :=
  match inputType.val, interType.val with

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -15,9 +15,8 @@ def isRiscvRegToI64Cast (inputType interType : TypeAttr): Bool :=
   | _, _ => false
 
 /-!
-  Same for `!riscv.reg` and `i32`, but only the `i32 -> reg -> i32` direction:
-  `toReg` zero-extends into the 64-bit register and `toInt 32` takes the low 32
-  bits.
+   Cast for the `i32 -> reg -> i32` direction: `toReg` zero-extends into the 64-bit register and
+   `toInt 32` takes the low 32 bits.
 -/
 def isRiscvRegToI32Cast (inputType interType : TypeAttr): Bool :=
  match inputType.val, interType.val with

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -15,6 +15,25 @@ def isRiscvRegToI64Cast (inputType interType : TypeAttr): Bool :=
   | _, _ => false
 
 /-!
+  Same for `!riscv.reg` and `i32`, but only the `i32 -> reg -> i32` direction:
+  `toReg` zero-extends into the 64-bit register and `toInt 32` takes the low 32
+  bits.
+-/
+def isRiscvRegToI32Cast (inputType interType : TypeAttr): Bool :=
+ match inputType.val, interType.val with
+  | .integerType x, .registerType _ => x.bitwidth = 32
+  | _, _ => false
+
+/-!
+  Same for `!llvm.ptr` and `!riscv.reg` (analog to 'RiscvRegToI64Cast')
+-/
+def isRiscvRegToPtrCast (inputType interType : TypeAttr): Bool :=
+ match inputType.val, interType.val with
+  | .llvmPointerType _, .registerType _ => true
+  | .registerType _, .llvmPointerType _ => true
+  | _, _ => false
+
+/-!
   We reconcile casts in `builtin.unrealized_conversion_cast` operations for `iX` and `iY` types,
   of the form:
   ```
@@ -72,7 +91,7 @@ def reconcileIdentityCast (rewriter : PatternRewriter OpCode) (op : OperationPtr
 
 def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern #[reconcilePairingCast isRiscvRegToI64Cast, reconcilePairingCast isPreservingIntegerTypeRoundTrip, reconcileIdentityCast]
+  let pattern := RewritePattern.GreedyRewritePattern #[reconcilePairingCast isRiscvRegToI64Cast, reconcilePairingCast isRiscvRegToI32Cast, reconcilePairingCast isRiscvRegToPtrCast, reconcilePairingCast isPreservingIntegerTypeRoundTrip, reconcileIdentityCast]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying cast reconciliation"
   | some ctx => pure ctx


### PR DESCRIPTION
This PR adds the checks that allow to fold conversion casts from 'i32' to 'reg' back to 'i32' as well as 'ptr' to 'reg' to 'ptr' (i64) and reverse 'reg' to 'ptr' to 'reg'.

Currently fails the fastest and chacham checks because their CHECK lines still have the explicit conversion cast not folded away.