### PR TITLE
feat: add `veir_bv_normalize` annotations to new Byte API

### DIFF
--- a/Veir/Data/LLVM/Byte/Basic.lean
+++ b/Veir/Data/LLVM/Byte/Basic.lean
@@ -23,6 +23,7 @@ deriving DecidableEq
 
 namespace Byte
 
+@[veir_bv_normalize]
 def cast {w₁ w₂ : Nat} (x : Byte w₁) (h : w₁ = w₂) : Byte w₂ :=
   ⟨x.val.cast h, x.poison.cast h, by simp [x.h]⟩
 
@@ -30,6 +31,7 @@ def cast {w₁ w₂ : Nat} (x : Byte w₁) (h : w₁ = w₂) : Byte w₂ :=
 theorem cast_self {w : Nat} (x : Byte w) (h : w = w) : cast x h = x := by
   simp [cast]
 
+@[veir_bv_normalize]
 def allPoison : Byte w :=
   ⟨0, BitVec.allOnes w, by simp⟩
 
@@ -51,20 +53,21 @@ def xor (x y : Byte w) : Byte w :=
 
 instance {w : Nat} : XorOp (Byte w) := ⟨xor⟩
 
+@[veir_bv_normalize]
 def trunc (x : Byte w) (w' : Nat) : Byte w' :=
   ⟨x.val.truncate w', x.poison.truncate w', by (
     simp [←BitVec.setWidth_and, x.h]
   )⟩
 
-def lshr (x : Byte w) (y : Int w) : Byte w := Id.run do
-  let .val y := y | allPoison
-
-  if y ≥ w then
-    return allPoison
-
-  ⟨x.val >>> y, x.poison >>> y, by (
-    simp [←BitVec.ushiftRight_and_distrib, x.h]
-  )⟩
+@[veir_bv_normalize]
+def lshr (x : Byte w) (y : Int w) : Byte w :=
+  if y.isPoison || y.getValueD ≥ w then
+    allPoison
+  else
+    let y := y.getValueD
+    ⟨x.val >>> y, x.poison >>> y, by (
+      simp [←BitVec.ushiftRight_and_distrib, x.h]
+    )⟩
 
 def toString_rec {w : Nat} (b : Byte w) : String :=
   if w = 0 then "" else
@@ -103,7 +106,7 @@ def fromUInt64 (x : UInt64) : Byte 64 :=
 /--
   i is refined by i' if for each bit, either i is poison, or the bits are the same and i' is not poison.
 -/
-@[simp, grind .]
+@[simp, grind ., veir_bv_normalize]
 def isRefinedBy {w : Nat} (i i' : Veir.Data.LLVM.Byte w) : Prop :=
   (i.poison ||| ((i.val ^^^ ~~~i'.val) &&& ~~~i'.poison)) = BitVec.allOnes w
 

--- a/Veir/Data/LLVM/Byte/Examples.lean
+++ b/Veir/Data/LLVM/Byte/Examples.lean
@@ -24,4 +24,16 @@ example (x : Byte 8) :
     (Byte.fromInt x.toInt) = x := by
   veir_bv_decide
 
+example (x y : Byte 8) : (x ||| y).trunc 4 = x.trunc 4 ||| y.trunc 4 := by
+  veir_bv_decide
+
+example (x : Byte 8) : x.lshr .poison = allPoison := by
+  veir_bv_decide
+
+example (x : Byte 8) : x.lshr (.val 0#8) = x := by
+  veir_bv_decide
+
+example (x : Byte 8) : x.lshr (.val 8#8) = allPoison := by
+  veir_bv_decide
+
 end Veir.Data.LLVM.Byte

--- a/Veir/Data/LLVM/Byte/Lemmas.lean
+++ b/Veir/Data/LLVM/Byte/Lemmas.lean
@@ -50,7 +50,7 @@ theorem and_comm {w : Nat} (x y : Byte w) :
   simp only [and_eq, BitVec.and_comm, BitVec.or_comm]
 
 theorem val_and {w : Nat} (x y : Byte w) :
-    (x&&& y).val = (x.val &&& y.val) &&& ~~~(x.poison ||| y.poison) := by
+    (x &&& y).val = (x.val &&& y.val) &&& ~~~(x.poison ||| y.poison) := by
   simp [and_eq]
 
 /- # or -/


### PR DESCRIPTION
This PR adds the appropriate annotations to make `Byte.cast`, `allPoison`, trunc` and `isRefinedBy` bitblastable (simply by unfolding the definitions).

I also refactored the definition of `lshr` so that it is immediately bitblastable, instead of having to write a separate unfolding lemma. This new definition is otherwise equivalent to the previous one.
