### PR TITLE
fix: make `createOp!` return an `Option` when allocation fails

### DIFF
--- a/Veir/Passes/Canonicalize.lean
+++ b/Veir/Passes/Canonicalize.lean
@@ -27,7 +27,7 @@ def commutativeConstantRHS (rewriter : PatternRewriter OpCode) (op : OperationPt
   if reordered == operands then return rewriter
   let resultTypes := op.getResultTypes! rewriter.ctx.raw
   let properties := op.getProperties! rewriter.ctx.raw opType
-  let (rewriter, newOp) := rewriter.createOp! opType resultTypes reordered
+  let (rewriter, newOp) ← rewriter.createOp! opType resultTypes reordered
     #[] #[] properties (some $ .before op)
   return rewriter.replaceOp! op newOp
 

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -112,17 +112,17 @@ def reconcileRegIntCast (rewriter : PatternRewriter OpCode)
   /- Replace the initial operation's output with a zero-extension of the parent's input -/
   let (rewriter, newOp) ← match interBw with
   | 8 =>
-      some $ rewriter.createOp! (.riscv .zextb) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+      rewriter.createOp! (.riscv .zextb) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
   | 16 =>
-      some $ rewriter.createOp! (.riscv .zexth) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+      rewriter.createOp! (.riscv .zexth) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
   | 32 =>
-      some $ rewriter.createOp! (.riscv .zextw) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+      rewriter.createOp! (.riscv .zextw) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
   | bw =>
       /- for bitwidths with no dedicated instruction, shift left then right -/
       if bw >= 64 then none else
       let imm := IntegerAttr.mk (64-bw) (.mk 64)
-      let (rewriter, shlOp) := rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[parentInput] #[] #[] ⟨imm⟩ (some $ .before op)
-      some $ rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[shlOp.getResult 0] #[] #[] ⟨imm⟩ (some $ .before op)
+      let (rewriter, shlOp) ← rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[parentInput] #[] #[] ⟨imm⟩ (some $ .before op)
+      rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[shlOp.getResult 0] #[] #[] ⟨imm⟩ (some $ .before op)
   let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
   /- Erase the redundant cast operation -/
   let rewriter ← rewriter.eraseOp op sorry sorry sorry

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -22,7 +22,7 @@ def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.
     | return rewriter
   if cst.value ≠ 2 then
     return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .add) #[lhs.getType! rewriter.ctx.raw] #[lhs, lhs]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .add) #[lhs.getType! rewriter.ctx.raw] #[lhs, lhs]
     #[] #[] properties (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -38,7 +38,7 @@ def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -91,7 +91,7 @@ def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -118,7 +118,7 @@ def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -169,7 +169,7 @@ def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op
   let .integerType type := (lhs.getType! rewriter.ctx.raw).val
     | return rewriter
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -200,7 +200,7 @@ def deMorganAndToOr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : o
     | return rewriter
   let resultType := a.getType! rewriter.ctx.raw
   let orProps : DisjointProperties := { disjoint := false }
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .or) #[resultType] #[a, b]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .or) #[resultType] #[a, b]
     #[] #[] orProps (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -219,7 +219,7 @@ def deMorganOrToAnd (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : o
   let some b := matchNot orR rewriter.ctx
     | return rewriter
   let resultType := a.getType! rewriter.ctx.raw
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .and) #[resultType] #[a, b]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .and) #[resultType] #[a, b]
     #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op newOp
 

--- a/Veir/Passes/InstructionSelection/Common.lean
+++ b/Veir/Passes/InstructionSelection/Common.lean
@@ -13,7 +13,7 @@ namespace Veir
 -/
 def castToReg (rewriter : PatternRewriter OpCode) (op : OperationPtr) (v : ValuePtr) :
     Option (PatternRewriter OpCode × ValuePtr) := do
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast)
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
       #[RegisterType.mk] #[v] #[] #[] () (some $ .before op)
   return (rewriter, castOp.getResult 0)
 
@@ -25,7 +25,7 @@ def castToReg (rewriter : PatternRewriter OpCode) (op : OperationPtr) (v : Value
 def replaceWithReg (rewriter : PatternRewriter OpCode) (op : OperationPtr) (reg : ValuePtr) :
     Option (PatternRewriter OpCode) := do
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast)
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
       #[type] #[reg] #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -28,7 +28,7 @@ def ctlz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
   if opType.bitwidth ≠ 64 ∧ opType.bitwidth ≠ 32 then return rewriter
   let (rewriter, opReg) ← castToReg rewriter op operand
-  let (rewriter, retOp) :=
+  let (rewriter, retOp) ←
     if opType.bitwidth = 32 then
       rewriter.createOp! (.riscv .clzw) #[RegisterType.mk] #[opReg]
           #[] #[] () (some $ .before op)
@@ -46,7 +46,7 @@ def cttz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
   if opType.bitwidth ≠ 64 ∧ opType.bitwidth ≠ 32 then return rewriter
   let (rewriter, opReg) ← castToReg rewriter op operand
-  let (rewriter, retOp) :=
+  let (rewriter, retOp) ←
     if opType.bitwidth = 32 then
       rewriter.createOp! (.riscv .ctzw) #[RegisterType.mk] #[opReg]
           #[] #[] () (some $ .before op)
@@ -64,7 +64,7 @@ def ctpop (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
   if opType.bitwidth ≠ 64 ∧ opType.bitwidth ≠ 32 then return rewriter
   let (rewriter, opReg) ← castToReg rewriter op operand
-  let (rewriter, retOp) :=
+  let (rewriter, retOp) ←
     if opType.bitwidth = 32 then
       rewriter.createOp! (.riscv .cpopw) #[RegisterType.mk] #[opReg]
           #[] #[] () (some $ .before op)
@@ -84,11 +84,11 @@ def bswap (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let (rewriter, opReg) ← castToReg rewriter op operand
   /- rev8 reverses all 8 bytes; for i32 the wanted bytes end up in the high 32 bits,
      so shift them down with srli 32. -/
-  let (rewriter, rev8Op) := rewriter.createOp! (.riscv .rev8) #[RegisterType.mk] #[opReg]
+  let (rewriter, rev8Op) ← rewriter.createOp! (.riscv .rev8) #[RegisterType.mk] #[opReg]
       #[] #[] () (some $ .before op)
   if opType.bitwidth = 32 then
     let sh32 := RISCVImmediateProperties.mk (IntegerAttr.mk 32 (IntegerType.mk 64))
-    let (rewriter, srliOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[rev8Op.getResult 0]
+    let (rewriter, srliOp) ← rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[rev8Op.getResult 0]
         #[] #[] sh32 (some $ .before op)
     replaceWithReg rewriter op (srliOp.getResult 0)
   else
@@ -102,18 +102,18 @@ def bitreverseStage (mask shamt : Int) (rewriter : PatternRewriter OpCode)
     (op : OperationPtr) (input : ValuePtr) :
     Option (PatternRewriter OpCode × ValuePtr) := do
   let maskAttr := RISCVImmediateProperties.mk (IntegerAttr.mk mask (IntegerType.mk 64))
-  let (rewriter, maskOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+  let (rewriter, maskOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] maskAttr (some $ .before op)
-  let (rewriter, lowOp) := rewriter.createOp! (.riscv .and) #[RegisterType.mk]
+  let (rewriter, lowOp) ← rewriter.createOp! (.riscv .and) #[RegisterType.mk]
       #[maskOp.getResult 0, input] #[] #[] () (some $ .before op)
   let shamtAttr := RISCVImmediateProperties.mk (IntegerAttr.mk shamt (IntegerType.mk 64))
-  let (rewriter, lowShiftOp) := rewriter.createOp! (.riscv .slli) #[RegisterType.mk]
+  let (rewriter, lowShiftOp) ← rewriter.createOp! (.riscv .slli) #[RegisterType.mk]
       #[lowOp.getResult 0] #[] #[] shamtAttr (some $ .before op)
-  let (rewriter, highShiftOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk]
+  let (rewriter, highShiftOp) ← rewriter.createOp! (.riscv .srli) #[RegisterType.mk]
       #[input] #[] #[] shamtAttr (some $ .before op)
-  let (rewriter, highOp) := rewriter.createOp! (.riscv .and) #[RegisterType.mk]
+  let (rewriter, highOp) ← rewriter.createOp! (.riscv .and) #[RegisterType.mk]
       #[maskOp.getResult 0, highShiftOp.getResult 0] #[] #[] () (some $ .before op)
-  let (rewriter, orOp) := rewriter.createOp! (.riscv .or) #[RegisterType.mk]
+  let (rewriter, orOp) ← rewriter.createOp! (.riscv .or) #[RegisterType.mk]
       #[lowShiftOp.getResult 0, highOp.getResult 0] #[] #[] () (some $ .before op)
   return (rewriter, orOp.getResult 0)
 
@@ -132,17 +132,17 @@ def bitreverse (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     let (rewriter, x1) ← bitreverseStage 0x55555555 1 rewriter op opReg
     let (rewriter, x2) ← bitreverseStage 0x33333333 2 rewriter op x1
     let (rewriter, x3) ← bitreverseStage 0x0f0f0f0f 4 rewriter op x2
-    let (rewriter, rev8Op) := rewriter.createOp! (.riscv .rev8) #[RegisterType.mk] #[x3]
+    let (rewriter, rev8Op) ← rewriter.createOp! (.riscv .rev8) #[RegisterType.mk] #[x3]
         #[] #[] () (some $ .before op)
     let sh32 := RISCVImmediateProperties.mk (IntegerAttr.mk 32 (IntegerType.mk 64))
-    let (rewriter, srliOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[rev8Op.getResult 0]
+    let (rewriter, srliOp) ← rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[rev8Op.getResult 0]
         #[] #[] sh32 (some $ .before op)
     replaceWithReg rewriter op (srliOp.getResult 0)
   else
     let (rewriter, x1) ← bitreverseStage 0x5555555555555555 1 rewriter op opReg
     let (rewriter, x2) ← bitreverseStage 0x3333333333333333 2 rewriter op x1
     let (rewriter, x3) ← bitreverseStage 0x0f0f0f0f0f0f0f0f 4 rewriter op x2
-    let (rewriter, retOp) := rewriter.createOp! (.riscv .rev8) #[RegisterType.mk] #[x3]
+    let (rewriter, retOp) ← rewriter.createOp! (.riscv .rev8) #[RegisterType.mk] #[x3]
         #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (retOp.getResult 0)
 
@@ -155,9 +155,9 @@ def constant (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBou
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] {value := const} (some $ .before op)
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type]
       #[newOp.getResult 0] #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -174,12 +174,12 @@ def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- 64-bit add, or its 32-bit `W` variant for i32 (keeps the result sign-extended) -/
-  let (rewriter, addOp) :=
+  let (rewriter, addOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .addw) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
         #[] #[] () (some $ .before op)
@@ -187,7 +187,7 @@ def add (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
       rewriter.createOp! (.riscv .add) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
         #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castAddOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[addOp.getResult 0]
+  let (rewriter, castAddOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[addOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castAddOp
 
@@ -204,15 +204,15 @@ def and (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- Actual `riscv.and` -/
-  let (rewriter, andOp) := rewriter.createOp! (.riscv .and) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
+  let (rewriter, andOp) ← rewriter.createOp! (.riscv .and) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
       #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castAddOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[andOp.getResult 0]
+  let (rewriter, castAddOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[andOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castAddOp
 
@@ -229,12 +229,12 @@ def ashr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- sraw for i32 (sign-extends result), sra for i64 -/
-  let (rewriter, sraOp) :=
+  let (rewriter, sraOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .sraw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
@@ -242,7 +242,7 @@ def ashr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       rewriter.createOp! (.riscv .sra) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castSraOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
+  let (rewriter, castSraOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castSraOp
 
@@ -267,17 +267,17 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType rtype := (rhs.getType! rewriter.ctx.raw).val | return rewriter
   if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return rewriter
   /- Casting is necessary regardless of the predicate. -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- For i32, sign-extend operands so both signed and unsigned comparisons work correctly.
      Zero-extended i32 negatives look positive in 64-bit signed arithmetic without this. -/
   let (rewriter, lCmpReg, rCmpReg) ←
     if ltype.bitwidth = 32 then do
-      let (rewriter, ls) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[lcastOp.getResult 0]
+      let (rewriter, ls) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[lcastOp.getResult 0]
           #[] #[] () (some $ .before op)
-      let (rewriter, rs) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[rcastOp.getResult 0]
+      let (rewriter, rs) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
       pure (rewriter, ls.getResult 0, rs.getResult 0)
     else
@@ -302,15 +302,15 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       | some cmpReg =>
         /- llvm.icmp eq a 0  -> riscv.sltiu a 1 (seqz) -/
         let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-        let (rewriter, retOp) := rewriter.createOp! (.riscv .sltiu) #[RegisterType.mk] #[cmpReg]
+        let (rewriter, retOp) ← rewriter.createOp! (.riscv .sltiu) #[RegisterType.mk] #[cmpReg]
           #[] #[] c1 (some $ .before op)
         pure (rewriter, retOp)
       | none =>
         /- llvm.icmp eq lhs rhs  -> riscv.sltiu (riscv.xor lhs rhs) 1 -/
-        let (rewriter, xorOp) := rewriter.createOp! (.riscv .xor) #[RegisterType.mk] #[rCmpReg, lCmpReg]
+        let (rewriter, xorOp) ← rewriter.createOp! (.riscv .xor) #[RegisterType.mk] #[rCmpReg, lCmpReg]
           #[] #[] () (some $ .before op)
         let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-        let (rewriter, retOp) := rewriter.createOp! (.riscv .sltiu) #[RegisterType.mk] #[xorOp.getResult 0]
+        let (rewriter, retOp) ← rewriter.createOp! (.riscv .sltiu) #[RegisterType.mk] #[xorOp.getResult 0]
           #[] #[] c1 (some $ .before op)
         pure (rewriter, retOp)
     | .ne =>
@@ -329,73 +329,73 @@ def icmp (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       match zeroCmpReg with
       | some cmpReg =>
         /- llvm.icmp ne a 0  -> riscv.sltu 0 a (snez) -/
-        let (rewriter, liOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        let (rewriter, liOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
           #[] #[] c0 (some $ .before op)
-        let (rewriter, retOp) := rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, cmpReg]
+        let (rewriter, retOp) ← rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, cmpReg]
           #[] #[] () (some $ .before op)
         pure (rewriter, retOp)
       | none =>
         /- llvm.icmp ne lhs rhs  -> riscv.sltu 0 (riscv.xor lhs rhs) -/
-        let (rewriter, xorOp) := rewriter.createOp! (.riscv .xor) #[RegisterType.mk] #[rCmpReg, lCmpReg]
+        let (rewriter, xorOp) ← rewriter.createOp! (.riscv .xor) #[RegisterType.mk] #[rCmpReg, lCmpReg]
           #[] #[] () (some $ .before op)
-        let (rewriter, liOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        let (rewriter, liOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
           #[] #[] c0 (some $ .before op)
-        let (rewriter, retOp) := rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, xorOp.getResult 0]
+        let (rewriter, retOp) ← rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, xorOp.getResult 0]
           #[] #[] () (some $ .before op)
         pure (rewriter, retOp)
     | .slt =>
       /- llvm.icmp slt lhs rhs -> riscv.slt lhs rhs  -/
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[lCmpReg, rCmpReg]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[lCmpReg, rCmpReg]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | .sle =>
       /- llvm.icmp sle lhs rhs -> riscv.xori (riscv_slt rhs lhs) 1 -/
-      let (rewriter, sltOp) := rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[rCmpReg, lCmpReg]
+      let (rewriter, sltOp) ← rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[rCmpReg, lCmpReg]
         #[] #[] () (some $ .before op)
       let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
         #[] #[] c1 (some $ .before op)
       pure (rewriter, retOp)
     | .sgt =>
       /- llvm.icmp sgt lhs rhs -> riscv.slt rhs lhs -/
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[rCmpReg, lCmpReg]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[rCmpReg, lCmpReg]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | .sge =>
       /- llvm.icmp sge lhs rhs -> riscv.xori (riscv_slt lhs rhs) 1 -/
-      let (rewriter, sltOp) := rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[lCmpReg, rCmpReg]
+      let (rewriter, sltOp) ← rewriter.createOp! (.riscv .slt) #[RegisterType.mk] #[lCmpReg, rCmpReg]
         #[] #[] () (some $ .before op)
       let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
         #[] #[] c1 (some $ .before op)
       pure (rewriter, retOp)
     | .ult =>
       /- llvm.icmp ult lhs rhs -> riscv.sltu lhs rhs -/
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[lCmpReg, rCmpReg]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[lCmpReg, rCmpReg]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | .ule =>
       /- llvm.icmp ule lhs rhs -> riscv.xori (riscv_sltu rhs lhs) 1 -/
-      let (rewriter, sltuOp) := rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[rCmpReg, lCmpReg]
+      let (rewriter, sltuOp) ← rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[rCmpReg, lCmpReg]
         #[] #[] () (some $ .before op)
       let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
         #[] #[] c1 (some $ .before op)
       pure (rewriter, retOp)
     | .ugt =>
       /- llvm.icmp ugt lhs rhs -> riscv.sltu rhs lhs -/
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[rCmpReg, lCmpReg]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[rCmpReg, lCmpReg]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | .uge =>
       /- llvm.icmp uge lhs rhs -> riscv.xori (riscv_sltu lhs rhs) 1 -/
-      let (rewriter, sltuOp) := rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[lCmpReg, rCmpReg]
+      let (rewriter, sltuOp) ← rewriter.createOp! (.riscv .sltu) #[RegisterType.mk] #[lCmpReg, rCmpReg]
         #[] #[] () (some $ .before op)
       let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
         #[] #[] c1 (some $ .before op)
       pure (rewriter, retOp)
-  let (rewriter, castEqOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
+  let (rewriter, castEqOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
         #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castEqOp
 
@@ -412,15 +412,15 @@ def or (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds re
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- Actual `riscv.or` -/
-  let (rewriter, orOp) := rewriter.createOp! (.riscv .or) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
+  let (rewriter, orOp) ← rewriter.createOp! (.riscv .or) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
       #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOrOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[orOp.getResult 0]
+  let (rewriter, castOrOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[orOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOrOp
 
@@ -437,15 +437,15 @@ def xor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- Actual `riscv.xor` -/
-  let (rewriter, xorOp) := rewriter.createOp! (.riscv .xor) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
+  let (rewriter, xorOp) ← rewriter.createOp! (.riscv .xor) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
       #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castXorOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[xorOp.getResult 0]
+  let (rewriter, castXorOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[xorOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castXorOp
 
@@ -462,12 +462,12 @@ def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- mulw for i32 (sign-extends result), mul for i64 -/
-  let (rewriter, mulOp) :=
+  let (rewriter, mulOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .mulw) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
           #[] #[] () (some $ .before op)
@@ -475,7 +475,7 @@ def mul (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
       rewriter.createOp! (.riscv .mul) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -492,12 +492,12 @@ def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- divw for i32, div for i64 -/
-  let (rewriter, divOp) :=
+  let (rewriter, divOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .divw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
@@ -505,7 +505,7 @@ def sdiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       rewriter.createOp! (.riscv .div) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[divOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[divOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -522,12 +522,12 @@ def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- divuw for i32, divu for i64 -/
-  let (rewriter, divuOp) :=
+  let (rewriter, divuOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .divuw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
@@ -535,7 +535,7 @@ def udiv (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       rewriter.createOp! (.riscv .divu) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[divuOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[divuOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -552,12 +552,12 @@ def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- remw for i32, rem for i64 -/
-  let (rewriter, remOp) :=
+  let (rewriter, remOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .remw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
@@ -565,7 +565,7 @@ def srem (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       rewriter.createOp! (.riscv .rem) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[remOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[remOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -582,12 +582,12 @@ def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- remuw for i32, remu for i64 -/
-  let (rewriter, remuOp) :=
+  let (rewriter, remuOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .remuw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
@@ -595,7 +595,7 @@ def urem (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       rewriter.createOp! (.riscv .remu) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[remuOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[remuOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -612,12 +612,12 @@ def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- 64-bit sub, or its 32-bit `W` variant for i32 -/
-  let (rewriter, subOp) :=
+  let (rewriter, subOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .subw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op)
@@ -625,7 +625,7 @@ def sub (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
       rewriter.createOp! (.riscv .sub) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[subOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[subOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -645,26 +645,26 @@ def sext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType retType := type.val | rewriter
   if retType.bitwidth ≤ opType.bitwidth then return rewriter
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op)
   let (rewriter, retOp) ← match opType.bitwidth with
     | 8 =>
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .sextb) #[RegisterType.mk] #[opCastOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .sextb) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | 16 =>
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .sexth) #[RegisterType.mk] #[opCastOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .sexth) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | 32 =>
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[opCastOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | _ =>
       /- unreachable case -/
       return rewriter
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -682,26 +682,26 @@ def zext (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType retType := type.val | rewriter
   if retType.bitwidth ≤ opType.bitwidth then return rewriter
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op)
   let (rewriter, retOp) ← match opType.bitwidth with
     | 8 =>
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .zextb) #[RegisterType.mk] #[opCastOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .zextb) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | 16 =>
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .zexth) #[RegisterType.mk] #[opCastOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .zexth) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | 32 =>
-      let (rewriter, retOp) := rewriter.createOp! (.riscv .zextw) #[RegisterType.mk] #[opCastOp.getResult 0]
+      let (rewriter, retOp) ← rewriter.createOp! (.riscv .zextw) #[RegisterType.mk] #[opCastOp.getResult 0]
         #[] #[] () (some $ .before op)
       pure (rewriter, retOp)
     | _ =>
       /- unreachable case -/
       return rewriter
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -717,10 +717,10 @@ def trunc (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds
   let .integerType retType := type.val | rewriter
   if opType.bitwidth ≤ retType.bitwidth then return rewriter
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op)
   /- Then, cast register to expected output width. -/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[opCastOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[opCastOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -737,12 +737,12 @@ def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- 64-bit shift-left, or its 32-bit `W` variant for i32 -/
-  let (rewriter, mulOp) :=
+  let (rewriter, mulOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .sllw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op)
@@ -750,7 +750,7 @@ def shl (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
       rewriter.createOp! (.riscv .sll) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -767,12 +767,12 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return rewriter
   /- First, cast the operands to registers -/
-  let (rewriter, lcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (rewriter, lcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () (some $ .before op)
-  let (rewriter, rcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (rewriter, rcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () (some $ .before op)
   /- 64-bit logical shift-right, or its 32-bit `W` variant for i32 -/
-  let (rewriter, mulOp) :=
+  let (rewriter, mulOp) ←
     if type'.bitwidth = 32 then
       rewriter.createOp! (.riscv .srlw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op)
@@ -780,7 +780,7 @@ def lshr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
       rewriter.createOp! (.riscv .srl) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
         #[] #[] () (some $ .before op)
   /- Cast back result for type consistency-/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -793,11 +793,11 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   let .integerType type' := type.val | return rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return rewriter
   /- cast ptr (!llvm.ptr) -> register -/
-  let (rewriter, pcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+  let (rewriter, pcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
       #[] #[] () (some $ .before op)
   /- 64-bit `riscv.ld`, or its `lw` (i32) / `lb` (i8) variants -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, ldOp) :=
+  let (rewriter, ldOp) ←
     if type'.bitwidth = 8 then
       rewriter.createOp! (.riscv .lb) #[RegisterType.mk] #[pcastOp.getResult 0]
         #[] #[] zero (some $ .before op)
@@ -807,7 +807,7 @@ def load (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
     else
       rewriter.createOp! (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
         #[] #[] zero (some $ .before op)
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -820,14 +820,14 @@ def store (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds
   let .integerType type' := type.val | return rewriter
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return rewriter
   /- cast ptr (!llvm.ptr) -> register -/
-  let (rewriter, pcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+  let (rewriter, pcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
       #[] #[] () (some $ .before op)
   /- cast value (i64/i32/i8) -> register -/
-  let (rewriter, valcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[arg]
+  let (rewriter, valcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[arg]
       #[] #[] () (some $ .before op)
   /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte), with offset zero: operands are (addr, val), no results -/
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, sdOp) :=
+  let (rewriter, sdOp) ←
     if type'.bitwidth = 8 then
       rewriter.createOp! (.riscv .sb) #[] #[pcastOp.getResult 0, valcastOp.getResult 0]
         #[] #[] zero (some $ .before op)
@@ -853,13 +853,13 @@ def getelementptr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.
   if itype.bitwidth ≠ 64 then return rewriter
   let some scale := Attribute.sizeOfType properties.elem_type.val | return rewriter
   let type := ((op.getResult 0).get! rewriter.ctx.raw).type
-  let (rewriter, pcastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+  let (rewriter, pcastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
       #[] #[] () (some $ .before op)
-  let (rewriter, icastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[idx]
+  let (rewriter, icastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[idx]
       #[] #[] () (some $ .before op)
   let pReg := pcastOp.getResult 0
   let iReg := icastOp.getResult 0
-  let (rewriter, retOp) := match scale with
+  let (rewriter, retOp) ← match scale with
     | 1 =>
       /- ptr + idx -/
       rewriter.createOp! (.riscv .add) #[RegisterType.mk] #[pReg, iReg]
@@ -880,21 +880,21 @@ def getelementptr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.
       if scale &&& (scale - 1) == 0 then
         /- scale is a power of two: ptr + (idx << log2 scale) -/
         let k := RISCVImmediateProperties.mk (IntegerAttr.mk (Nat.log2 scale) (IntegerType.mk 64))
-        let (rewriter, slliOp) := rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[iReg]
+        let (rewriter, slliOp) ← rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[iReg]
           #[] #[] k (some $ .before op)
         rewriter.createOp! (.riscv .add) #[RegisterType.mk] #[pReg, slliOp.getResult 0]
           #[] #[] () (some $ .before op)
       else
         /- arbitrary scale: ptr + idx * scale -/
         let s := RISCVImmediateProperties.mk (IntegerAttr.mk scale (IntegerType.mk 64))
-        let (rewriter, liOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        let (rewriter, liOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
           #[] #[] s (some $ .before op)
-        let (rewriter, mulOp) := rewriter.createOp! (.riscv .mul) #[RegisterType.mk] #[iReg, liOp.getResult 0]
+        let (rewriter, mulOp) ← rewriter.createOp! (.riscv .mul) #[RegisterType.mk] #[iReg, liOp.getResult 0]
           #[] #[] () (some $ .before op)
         rewriter.createOp! (.riscv .add) #[RegisterType.mk] #[pReg, mulOp.getResult 0]
           #[] #[] () (some $ .before op)
   /- Cast the resulting register back to `!llvm.ptr`. -/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -923,7 +923,7 @@ def selectCzeroeqz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let some _ := matchConstantZero fval rewriter.ctx | return rewriter
   let (rewriter, tReg) ← castToReg rewriter op tval
   let (rewriter, condReg) ← castToReg rewriter op cond
-  let (rewriter, czOp) := rewriter.createOp! (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
+  let (rewriter, czOp) ← rewriter.createOp! (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (czOp.getResult 0)
 
@@ -938,7 +938,7 @@ def selectCzeronez (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let some _ := matchConstantZero tval rewriter.ctx | return rewriter
   let (rewriter, fReg) ← castToReg rewriter op fval
   let (rewriter, condReg) ← castToReg rewriter op cond
-  let (rewriter, czOp) := rewriter.createOp! (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
+  let (rewriter, czOp) ← rewriter.createOp! (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (czOp.getResult 0)
 
@@ -954,11 +954,11 @@ def selectGeneral (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let (rewriter, tReg) ← castToReg rewriter op tval
   let (rewriter, fReg) ← castToReg rewriter op fval
   let (rewriter, condReg) ← castToReg rewriter op cond
-  let (rewriter, eqzOp) := rewriter.createOp! (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
+  let (rewriter, eqzOp) ← rewriter.createOp! (.riscv .czeroeqz) #[RegisterType.mk] #[tReg, condReg]
       #[] #[] () (some $ .before op)
-  let (rewriter, nezOp) := rewriter.createOp! (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
+  let (rewriter, nezOp) ← rewriter.createOp! (.riscv .czeronez) #[RegisterType.mk] #[fReg, condReg]
       #[] #[] () (some $ .before op)
-  let (rewriter, orOp) := rewriter.createOp! (.riscv .or) #[RegisterType.mk]
+  let (rewriter, orOp) ← rewriter.createOp! (.riscv .or) #[RegisterType.mk]
       #[eqzOp.getResult 0, nezOp.getResult 0]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (orOp.getResult 0)
@@ -982,16 +982,16 @@ def smax (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let (rewriter, rReg) ← castToReg rewriter op rhs
   /- For i32, sign-extend before max so negative values compare correctly. -/
   if t.bitwidth = 32 then
-    let (rewriter, ls) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[lReg]
+    let (rewriter, ls) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[lReg]
         #[] #[] () (some $ .before op)
-    let (rewriter, rs) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[rReg]
+    let (rewriter, rs) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[rReg]
         #[] #[] () (some $ .before op)
-    let (rewriter, maxOp) := rewriter.createOp! (.riscv .max) #[RegisterType.mk]
+    let (rewriter, maxOp) ← rewriter.createOp! (.riscv .max) #[RegisterType.mk]
         #[ls.getResult 0, rs.getResult 0]
         #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (maxOp.getResult 0)
   else
-    let (rewriter, maxOp) := rewriter.createOp! (.riscv .max) #[RegisterType.mk] #[lReg, rReg]
+    let (rewriter, maxOp) ← rewriter.createOp! (.riscv .max) #[RegisterType.mk] #[lReg, rReg]
         #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (maxOp.getResult 0)
 
@@ -1005,16 +1005,16 @@ def smin (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let (rewriter, rReg) ← castToReg rewriter op rhs
   /- For i32, sign-extend before min so negative values compare correctly. -/
   if t.bitwidth = 32 then
-    let (rewriter, ls) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[lReg]
+    let (rewriter, ls) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[lReg]
         #[] #[] () (some $ .before op)
-    let (rewriter, rs) := rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[rReg]
+    let (rewriter, rs) ← rewriter.createOp! (.riscv .sextw) #[RegisterType.mk] #[rReg]
         #[] #[] () (some $ .before op)
-    let (rewriter, minOp) := rewriter.createOp! (.riscv .min) #[RegisterType.mk]
+    let (rewriter, minOp) ← rewriter.createOp! (.riscv .min) #[RegisterType.mk]
         #[ls.getResult 0, rs.getResult 0]
         #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (minOp.getResult 0)
   else
-    let (rewriter, minOp) := rewriter.createOp! (.riscv .min) #[RegisterType.mk] #[lReg, rReg]
+    let (rewriter, minOp) ← rewriter.createOp! (.riscv .min) #[RegisterType.mk] #[lReg, rReg]
         #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (minOp.getResult 0)
 
@@ -1026,7 +1026,7 @@ def umax (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return rewriter
   let (rewriter, lReg) ← castToReg rewriter op lhs
   let (rewriter, rReg) ← castToReg rewriter op rhs
-  let (rewriter, maxuOp) := rewriter.createOp! (.riscv .maxu) #[RegisterType.mk] #[lReg, rReg]
+  let (rewriter, maxuOp) ← rewriter.createOp! (.riscv .maxu) #[RegisterType.mk] #[lReg, rReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (maxuOp.getResult 0)
 
@@ -1038,7 +1038,7 @@ def umin (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return rewriter
   let (rewriter, lReg) ← castToReg rewriter op lhs
   let (rewriter, rReg) ← castToReg rewriter op rhs
-  let (rewriter, minuOp) := rewriter.createOp! (.riscv .minu) #[RegisterType.mk] #[lReg, rReg]
+  let (rewriter, minuOp) ← rewriter.createOp! (.riscv .minu) #[RegisterType.mk] #[lReg, rReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (minuOp.getResult 0)
 
@@ -1052,7 +1052,7 @@ def fshl (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return rewriter
   let (rewriter, valReg) ← castToReg rewriter op a
   let (rewriter, amtReg) ← castToReg rewriter op amt
-  let (rewriter, rolOp) :=
+  let (rewriter, rolOp) ←
     if t.bitwidth = 32 then
       rewriter.createOp! (.riscv .rolw) #[RegisterType.mk] #[valReg, amtReg]
           #[] #[] () (some $ .before op)
@@ -1071,7 +1071,7 @@ def fshr (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return rewriter
   let (rewriter, valReg) ← castToReg rewriter op a
   let (rewriter, amtReg) ← castToReg rewriter op amt
-  let (rewriter, rorOp) :=
+  let (rewriter, rorOp) ←
     if t.bitwidth = 32 then
       rewriter.createOp! (.riscv .rorw) #[RegisterType.mk] #[valReg, amtReg]
           #[] #[] () (some $ .before op)
@@ -1093,14 +1093,14 @@ def fshrConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if t.bitwidth = 32 then
     let sh : Int := ((amtAttr.value % 32) + 32) % 32
     let imm := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-    let (rewriter, roriOp) := rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
+    let (rewriter, roriOp) ← rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
         #[] #[] imm (some $ .before op)
     replaceWithReg rewriter op (roriOp.getResult 0)
   else
     /- The funnel-shift amount is taken modulo the bit width. -/
     let sh : Int := ((amtAttr.value % 64) + 64) % 64
     let imm := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-    let (rewriter, roriOp) := rewriter.createOp! (.riscv .rori) #[RegisterType.mk] #[valReg]
+    let (rewriter, roriOp) ← rewriter.createOp! (.riscv .rori) #[RegisterType.mk] #[valReg]
         #[] #[] imm (some $ .before op)
     replaceWithReg rewriter op (roriOp.getResult 0)
 
@@ -1120,7 +1120,7 @@ def fshlConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     let sh : Int := ((amtAttr.value % 32) + 32) % 32
     let imm : Int := (32 - sh) % 32
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-    let (rewriter, roriOp) := rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
+    let (rewriter, roriOp) ← rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
         #[] #[] immProps (some $ .before op)
     replaceWithReg rewriter op (roriOp.getResult 0)
   else
@@ -1128,7 +1128,7 @@ def fshlConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     let sh : Int := ((amtAttr.value % 64) + 64) % 64
     let imm : Int := (64 - sh) % 64
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-    let (rewriter, roriOp) := rewriter.createOp! (.riscv .rori) #[RegisterType.mk] #[valReg]
+    let (rewriter, roriOp) ← rewriter.createOp! (.riscv .rori) #[RegisterType.mk] #[valReg]
         #[] #[] immProps (some $ .before op)
     replaceWithReg rewriter op (roriOp.getResult 0)
 
@@ -1138,7 +1138,7 @@ def poisonConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some _ := matchPoison op rewriter.ctx | return rewriter
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, liOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+  let (rewriter, liOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] imm (some $ .before op)
   replaceWithReg rewriter op (liOp.getResult 0)
 
@@ -1152,10 +1152,10 @@ def freeze (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBound
   let .integerType retType := type.val | rewriter
   if (opType.bitwidth ≠ 64 ∧ opType.bitwidth ≠ 32) ∨ (retType.bitwidth ≠ 64 ∧ retType.bitwidth ≠ 32) then return rewriter
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op)
   /- Then, cast register to expected output width. -/
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[opCastOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[type] #[opCastOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -35,7 +35,7 @@ def andn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
                | none => none) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let (rewriter, yReg) ← castToReg rewriter op y
-  let (rewriter, andnOp) := rewriter.createOp! (.riscv .andn) #[RegisterType.mk] #[xReg, yReg]
+  let (rewriter, andnOp) ← rewriter.createOp! (.riscv .andn) #[RegisterType.mk] #[xReg, yReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (andnOp.getResult 0)
 
@@ -55,7 +55,7 @@ def orn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds r
                | none => none) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let (rewriter, yReg) ← castToReg rewriter op y
-  let (rewriter, ornOp) := rewriter.createOp! (.riscv .orn) #[RegisterType.mk] #[xReg, yReg]
+  let (rewriter, ornOp) ← rewriter.createOp! (.riscv .orn) #[RegisterType.mk] #[xReg, yReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (ornOp.getResult 0)
 
@@ -75,7 +75,7 @@ def xnor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
                | none => none) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let (rewriter, yReg) ← castToReg rewriter op y
-  let (rewriter, xnorOp) := rewriter.createOp! (.riscv .xnor) #[RegisterType.mk] #[xReg, yReg]
+  let (rewriter, xnorOp) ← rewriter.createOp! (.riscv .xnor) #[RegisterType.mk] #[xReg, yReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (xnorOp.getResult 0)
 
@@ -120,7 +120,7 @@ def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   if !(isMask mo0 || isMask mo1) then return rewriter
   let (rewriter, mReg) ← castToReg rewriter op m
   /- actual `riscv.orcb` -/
-  let (rewriter, orcbOp) := rewriter.createOp! (.riscv .orcb) #[RegisterType.mk] #[mReg]
+  let (rewriter, orcbOp) ← rewriter.createOp! (.riscv .orcb) #[RegisterType.mk] #[mReg]
       #[] #[] () (some $ .before op)
   replaceWithReg rewriter op (orcbOp.getResult 0)
 
@@ -158,7 +158,7 @@ def selectBinopImm {α} (matchPair : OperationPtr → IRContext OpCode → Optio
   if imm.value < lo || imm.value > hi then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm.value (IntegerType.mk 64))
-  let (rewriter, newOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
       #[] #[] (cast h.symm immProps) (some $ .before op)
   replaceWithReg rewriter op (newOp.getResult 0)
 
@@ -233,11 +233,11 @@ def slti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     if immVal < -2048 || immVal > 2047 then return rewriter
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk immVal (IntegerType.mk 64))
     let (rewriter, xReg) ← castToReg rewriter op lhs
-    let (rewriter, cmpOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+    let (rewriter, cmpOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
         #[] #[] (cast h.symm immProps) (some $ .before op)
     if wrap then
       let one := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (rewriter, xorOp) := rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[cmpOp.getResult 0]
+      let (rewriter, xorOp) ← rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[cmpOp.getResult 0]
           #[] #[] one (some $ .before op)
       replaceWithReg rewriter op (xorOp.getResult 0)
     else
@@ -285,7 +285,7 @@ def selectSingleBit {α} (matchPair : OperationPtr → IRContext OpCode → Opti
   let some n := singleSetBit (if complement then ~~~ bv else bv) | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk n (IntegerType.mk 64))
-  let (rewriter, newOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
       #[] #[] (cast h.symm immProps) (some $ .before op)
   replaceWithReg rewriter op (newOp.getResult 0)
 
@@ -308,7 +308,7 @@ def bexti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if sh.value < 0 || sh.value > 63 then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .bexti) #[RegisterType.mk] #[xReg]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv .bexti) #[RegisterType.mk] #[xReg]
       #[] #[] immProps (some $ .before op)
   replaceWithReg rewriter op (newOp.getResult 0)
 
@@ -325,7 +325,7 @@ def roriw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let sh : Int := ((amtAttr.value % 32) + 32) % 32
   let (rewriter, valReg) ← castToReg rewriter op a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
       #[] #[] immProps (some $ .before op)
   replaceWithReg rewriter op (newOp.getResult 0)
 
@@ -344,7 +344,7 @@ def roliw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let imm : Int := (32 - sh) % 32
   let (rewriter, valReg) ← castToReg rewriter op a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
       #[] #[] immProps (some $ .before op)
   replaceWithReg rewriter op (newOp.getResult 0)
 
@@ -364,7 +364,7 @@ def slliuw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if srcT.bitwidth ≠ 32 then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op x
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .slliuw) #[RegisterType.mk] #[xReg]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv .slliuw) #[RegisterType.mk] #[xReg]
       #[] #[] immProps (some $ .before op)
   replaceWithReg rewriter op (newOp.getResult 0)
 
@@ -377,12 +377,12 @@ def zext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
   if opType.bitwidth ≠ 1 then return rewriter
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op)
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-  let (rewriter, andiOp) := rewriter.createOp! (.riscv .andi) #[RegisterType.mk] #[opCastOp.getResult 0]
+  let (rewriter, andiOp) ← rewriter.createOp! (.riscv .andi) #[RegisterType.mk] #[opCastOp.getResult 0]
       #[] #[] imm (some $ .before op)
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[t] #[andiOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[t] #[andiOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -395,14 +395,14 @@ def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
   if opType.bitwidth ≠ 1 then return rewriter
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () (some $ .before op)
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
-  let (rewriter, slliOp) := rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
+  let (rewriter, slliOp) ← rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
       #[] #[] imm (some $ .before op)
-  let (rewriter, sraiOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]
+  let (rewriter, sraiOp) ← rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]
       #[] #[] imm (some $ .before op)
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast) #[t] #[sraiOp.getResult 0]
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[t] #[sraiOp.getResult 0]
       #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
@@ -456,7 +456,7 @@ def udivPow2Gen (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProper
   let some k := matchUnsignedPow2Divisor width imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, shiftOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+  let (rewriter, shiftOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
       #[] #[] (cast h.symm shamt) (some $ .before op)
   replaceWithReg rewriter op (shiftOp.getResult 0)
 
@@ -468,9 +468,9 @@ def udivwPow2 := udivPow2Gen .srliw rfl 32
     divisor is negative. -/
 def negateReg (negDst : Riscv) (h : Riscv.propertiesOf negDst = Unit)
     (rewriter : PatternRewriter OpCode) (op : OperationPtr) (x : ValuePtr) :
-    PatternRewriter OpCode × OperationPtr :=
+    Option (PatternRewriter OpCode × OperationPtr) := do
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+  let (rewriter, zeroOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] zero (some $ .before op)
   rewriter.createOp! (.riscv negDst) #[RegisterType.mk] #[zeroOp.getResult 0, x]
       #[] #[] (cast h.symm ()) (some $ .before op)
@@ -497,11 +497,11 @@ def sdivPow2ExactGen (dst : Riscv) (hDst : Riscv.propertiesOf dst = RISCVImmedia
   let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, sraOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+  let (rewriter, sraOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
       #[] #[] (cast hDst.symm shamt) (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (sraOp.getResult 0)
   else
-    let (rewriter, negOp) := negateReg negDst hNeg rewriter op (sraOp.getResult 0)
+    let (rewriter, negOp) ← negateReg negDst hNeg rewriter op (sraOp.getResult 0)
     replaceWithReg rewriter op (negOp.getResult 0)
 
 def sdivPow2Exact := sdivPow2ExactGen .srai rfl .sub rfl 64
@@ -543,19 +543,19 @@ def sdivPow2Gen (shiftDst : Riscv) (hShift : Riscv.propertiesOf shiftDst = RISCV
   if k = 0 then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shSign := RISCVImmediateProperties.mk (IntegerAttr.mk (width - 1) (IntegerType.mk 64))
-  let (rewriter, signOp) := rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[xReg]
+  let (rewriter, signOp) ← rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[xReg]
       #[] #[] (cast hShift.symm shSign) (some $ .before op)
   let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (width - k) (IntegerType.mk 64))
-  let (rewriter, corrOp) := rewriter.createOp! (.riscv corrDst) #[RegisterType.mk] #[signOp.getResult 0]
+  let (rewriter, corrOp) ← rewriter.createOp! (.riscv corrDst) #[RegisterType.mk] #[signOp.getResult 0]
       #[] #[] (cast hCorr.symm shCorr) (some $ .before op)
-  let (rewriter, biasedOp) := rewriter.createOp! (.riscv addDst) #[RegisterType.mk]
+  let (rewriter, biasedOp) ← rewriter.createOp! (.riscv addDst) #[RegisterType.mk]
       #[xReg, corrOp.getResult 0] #[] #[] (cast hAdd.symm ()) (some $ .before op)
   let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, qOp) := rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[biasedOp.getResult 0]
+  let (rewriter, qOp) ← rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[biasedOp.getResult 0]
       #[] #[] (cast hShift.symm shQ) (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
   else
-    let (rewriter, negOp) := negateReg negDst hNeg rewriter op (qOp.getResult 0)
+    let (rewriter, negOp) ← negateReg negDst hNeg rewriter op (qOp.getResult 0)
     replaceWithReg rewriter op (negOp.getResult 0)
 
 def sdivPow2 := sdivPow2Gen .srai rfl .srli rfl .add rfl .sub rfl 64

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -23,14 +23,14 @@ def castToStorage (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ip : Inser
   let .modArithType mt := (v.getType! rewriter.ctx.raw).val
     | none
   let storageType : TypeAttr := mt.modulus.type
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast)
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
     #[storageType] #[v] #[] #[] () (some ip)
   return (rewriter, (castOp.getResult 0 : ValuePtr))
 
 /-- Emit `unrealized_conversion_cast x : iN → ty`, where `ty` is a `mod_arith` type. -/
 def castToModArith (rewriter : PatternRewriter OpCode) (x : ValuePtr) (ty : ModArithType)
     (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
-  let (rewriter, castOp) := rewriter.createOp! (.builtin .unrealized_conversion_cast)
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
     #[ty] #[x] #[] #[] () (some ip)
   return (rewriter, (castOp.getResult 0 : ValuePtr))
 
@@ -45,7 +45,7 @@ def unpackValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (intermediate
   let .integerType storageType := (stored.getType! rewriter.ctx.raw).val
     | none
   if intermediateType.bitwidth > storageType.bitwidth then
-    let (rewriter, ext) := rewriter.createOp! (.arith .extui)
+    let (rewriter, ext) ← rewriter.createOp! (.arith .extui)
       #[intermediateType] #[stored] #[] #[] { nneg := false } (some ip)
     return (rewriter, (ext.getResult 0 : ValuePtr))
   else
@@ -60,7 +60,7 @@ def packValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ty : ModArithT
     | none
   let storageType := ty.modulus.type
   if intermediateType.bitwidth > storageType.bitwidth then
-    let (rewriter, narrowed) := rewriter.createOp! (.arith .trunci)
+    let (rewriter, narrowed) ← rewriter.createOp! (.arith .trunci)
       #[storageType] #[v] #[] #[] { attr := { nsw := false, nuw := true } }
       (some ip)
     castToModArith rewriter (narrowed.getResult 0 : ValuePtr) ty ip
@@ -75,7 +75,7 @@ def emitArithConstant (rewriter : PatternRewriter OpCode) (c : Int) (width : Nat
     (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
   let ty : TypeAttr := IntegerType.mk width
   let props : ArithConstantProperties := { value := IntegerAttr.mk c (IntegerType.mk width) }
-  let (rewriter, c) := rewriter.createOp! (.arith .constant)
+  let (rewriter, c) ← rewriter.createOp! (.arith .constant)
     #[ty] #[] #[] #[] props (some ip)
   return (rewriter, (c.getResult 0 : ValuePtr))
 
@@ -84,7 +84,7 @@ def emitArithBinOp (rewriter : PatternRewriter OpCode) (arithOp : Arith)
     (props : propertiesOf (.arith arithOp)) (a b : ValuePtr) (ip : InsertPoint) :
     Option (PatternRewriter OpCode × ValuePtr) := do
   let ty := a.getType! rewriter.ctx.raw
-  let (rewriter, r) := rewriter.createOp! (.arith arithOp)
+  let (rewriter, r) ← rewriter.createOp! (.arith arithOp)
     #[ty] #[a, b] #[] #[] props (some ip)
   return (rewriter, (r.getResult 0 : ValuePtr))
 

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -48,7 +48,7 @@ def srl_sra_signbitGen (srlDst : Riscv) (hSrl : Riscv.propertiesOf srlDst = RISC
     return rewriter
   let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
   let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv sraDst) 1 | return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.riscv srlDst) #[RegisterType.mk] #[sraOperands[0]!]
+  let (rewriter, newOp) ← rewriter.createOp! (.riscv srlDst) #[RegisterType.mk] #[sraOperands[0]!]
       #[] #[] outerImm (some $ .before op)
   let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
@@ -77,7 +77,7 @@ def li_zero_to_x0 (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if cst.value.value ≠ 0 then return rewriter
   /- Nothing to do for a dead `li 0`; leave it for DCE and avoid creating a dead x0. -/
   if !op.hasUses! rewriter.ctx.raw then return rewriter
-  let (rewriter, x0Op) := rewriter.createOp! (.rv64 .get_register)
+  let (rewriter, x0Op) ← rewriter.createOp! (.rv64 .get_register)
     #[(RegisterType.mk (some 0) : TypeAttr)] #[] #[] #[] () (some $ .before op)
   let rewriter := rewriter.replaceValue (op.getResult 0) (x0Op.getResult 0) sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry

--- a/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
+++ b/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
@@ -13,9 +13,9 @@ def sub_minus_one (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if cst.value ≠ -1 then return rewriter
   let .integerType ctype := (op1.getType! rewriter.ctx.raw).val | return rewriter
   let cstOpProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) ctype))
-  let (rewriter, cstOp) := rewriter.createOp! (.llvm .mlir__constant) #[op1.getType! rewriter.ctx.raw] #[]
+  let (rewriter, cstOp) ← rewriter.createOp! (.llvm .mlir__constant) #[op1.getType! rewriter.ctx.raw] #[]
     #[] #[] cstOpProp (some $ .before op)
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .xor) #[op1.getType! rewriter.ctx.raw] #[op1, (cstOp.getResult 0)]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .xor) #[op1.getType! rewriter.ctx.raw] #[op1, (cstOp.getResult 0)]
     #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -113,7 +113,7 @@ def same_val_zero_0 (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if x != x1 then return rewriter
   let .integerType type := (x.getType! rewriter.ctx.raw).val | return rewriter
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) type))
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -123,7 +123,7 @@ def same_val_zero_1 (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if x != x1 then return rewriter
   let .integerType type := (x.getType! rewriter.ctx.raw).val | return rewriter
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) type))
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
     #[] #[] cstProp (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -143,9 +143,9 @@ def mul_by_neg_one (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if cst.value ≠ -1 then return rewriter
   let .integerType ctype := (x.getType! rewriter.ctx.raw).val | return rewriter
   let cstOpProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) ctype))
-  let (rewriter, cstOp) := rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
+  let (rewriter, cstOp) ← rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
     #[] #[] cstOpProp (some $ .before op)
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[x.getType! rewriter.ctx.raw] #[(cstOp.getResult 0), x]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[x.getType! rewriter.ctx.raw] #[(cstOp.getResult 0), x]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -159,7 +159,7 @@ def or_and_xor_to_or (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if y != y1 then return rewriter
   let some cst := matchConstantIntVal rhs rewriter.ctx | return rewriter
   if cst.value ≠ -1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .or) #[and.getType! rewriter.ctx.raw] #[x, y]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .or) #[and.getType! rewriter.ctx.raw] #[x, y]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -173,7 +173,7 @@ def and_xor_or_to_and (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   if y != y1 then return rewriter
   let some cst := matchConstantIntVal rhs rewriter.ctx | return rewriter
   if cst.value ≠ -1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .and) #[or.getType! rewriter.ctx.raw] #[x, y]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .and) #[or.getType! rewriter.ctx.raw] #[x, y]
     #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -205,7 +205,7 @@ def APlusBMinusCMinusB (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some defOp1 := getDefiningOp sub1 rewriter.ctx | return rewriter
   let some (B1, C, _props2) := matchSub defOp1 rewriter.ctx | return rewriter
   if B != B1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[add1.getType! rewriter.ctx.raw] #[A, C]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[add1.getType! rewriter.ctx.raw] #[A, C]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -217,7 +217,7 @@ def AMinusBMinusCMinusC (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some defOp1 := getDefiningOp sub1 rewriter.ctx | return rewriter
   let some (B, C1, _props2) := matchSub defOp1 rewriter.ctx | return rewriter
   if C != C1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[sub2.getType! rewriter.ctx.raw] #[A, B]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[sub2.getType! rewriter.ctx.raw] #[A, B]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -228,7 +228,7 @@ def ZeroMinusAPlusB (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some (lhs, A, _props1) := matchSub defOp rewriter.ctx | return rewriter
   let some cst := matchConstantIntVal lhs rewriter.ctx | return rewriter
   if cst.value ≠ 0 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[sub.getType! rewriter.ctx.raw] #[B, A]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[sub.getType! rewriter.ctx.raw] #[B, A]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -239,7 +239,7 @@ def APlusZeroMinusB (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some (lhs, B, _props1) := matchSub defOp rewriter.ctx | return rewriter
   let some cst := matchConstantIntVal lhs rewriter.ctx | return rewriter
   if cst.value ≠ 0 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[A.getType! rewriter.ctx.raw] #[A, B]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[A.getType! rewriter.ctx.raw] #[A, B]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -271,7 +271,7 @@ def AMinusBPlusCMinusA (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some defOp1 := getDefiningOp sub2 rewriter.ctx | return rewriter
   let some (C, A1, _props2) := matchSub defOp1 rewriter.ctx | return rewriter
   if A != A1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[sub1.getType! rewriter.ctx.raw] #[C, B]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[sub1.getType! rewriter.ctx.raw] #[C, B]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -283,7 +283,7 @@ def AMinusBPlusBMinusC (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some defOp1 := getDefiningOp sub2 rewriter.ctx | return rewriter
   let some (B1, C, _props2) := matchSub defOp1 rewriter.ctx | return rewriter
   if B != B1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[sub1.getType! rewriter.ctx.raw] #[A, C]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[sub1.getType! rewriter.ctx.raw] #[A, C]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -295,7 +295,7 @@ def APlusBMinusAplusC (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some defOp1 := getDefiningOp add1 rewriter.ctx | return rewriter
   let some (A1, C, _props2) := matchAdd defOp1 rewriter.ctx | return rewriter
   if A != A1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[A.getType! rewriter.ctx.raw] #[B, C]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[A.getType! rewriter.ctx.raw] #[B, C]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -307,7 +307,7 @@ def APlusBMinusCPlusA (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some defOp1 := getDefiningOp add1 rewriter.ctx | return rewriter
   let some (C, A1, _props2) := matchAdd defOp1 rewriter.ctx | return rewriter
   if A != A1 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .sub) #[A.getType! rewriter.ctx.raw] #[B, C]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .sub) #[A.getType! rewriter.ctx.raw] #[B, C]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 
@@ -318,7 +318,7 @@ def AMinusZeroMinusB (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let some (lhs, B, _props1) := matchSub defOp rewriter.ctx | return rewriter
   let some cst := matchConstantIntVal lhs rewriter.ctx | return rewriter
   if cst.value ≠ 0 then return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.llvm .add) #[A.getType! rewriter.ctx.raw] #[A, B]
+  let (rewriter, newOp) ← rewriter.createOp! (.llvm .add) #[A.getType! rewriter.ctx.raw] #[A, B]
     #[] #[] _props (some $ .before op)
   return rewriter.replaceOp! op newOp
 

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -179,8 +179,9 @@ not be created.
 def createOp! (rewriter: PatternRewriter OpInfo) (opType: OpInfo)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr)
     (blockOperands: Array BlockPtr) (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
-    (insertionPoint: Option InsertPoint) : (PatternRewriter OpInfo) × OperationPtr :=
-  let (newCtx, op) := WfRewriter.createOp! rewriter.ctx opType resultTypes operands blockOperands regions properties insertionPoint
+    (insertionPoint: Option InsertPoint) : Option ((PatternRewriter OpInfo) × OperationPtr) := do
+  let (newCtx, op) ← WfRewriter.createOp! rewriter.ctx opType resultTypes operands blockOperands
+    regions properties insertionPoint
   if insertionPoint.isNone then
     ({ rewriter with ctx := newCtx}, op)
   else

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -423,17 +423,14 @@ def WfRewriter.createOp! (wfCtx : WfIRContext OpInfo) (opType : OpInfo)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
     (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
     (insertionPoint : Option InsertPoint)
-    : WfIRContext OpInfo × OperationPtr :=
+    : Option (WfIRContext OpInfo × OperationPtr) :=
   if hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw then
     if hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds wfCtx.raw then
       if hregions : ∀ reg, reg ∈ regions → reg.InBounds wfCtx.raw then
         match insertionPoint with
         | none =>
-          if let some result := WfRewriter.createOp wfCtx opType resultTypes operands
-              blockOperands regions properties none hoper hblockOperands hregions then
-            result
-          else
-            panic! "WfRewriter.createOp! failed: could not create operation"
+          WfRewriter.createOp wfCtx opType resultTypes operands blockOperands regions
+            properties none hoper hblockOperands hregions
         | some ip =>
           if hins : ip.InBounds wfCtx.raw then
             if let some result := WfRewriter.createOp wfCtx opType resultTypes operands


### PR DESCRIPTION
`createOp!` was previously panicking whenever allocation failed. This meant that we couldn't really reason about `createOp!`, as we cannot reason whether an allocation would panic or not.