### PR TITLE
feat: prove `ctlz`, `cttz`, and `ctpop` semantics preservation

### DIFF
--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
@@ -1,0 +1,97 @@
+import Veir.IR.WellFormed
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Dominance
+import Veir.Passes.Matching
+import Veir.Verifier
+import Veir.Passes.InstructionSelection.Common
+import Veir.Interpreter
+
+namespace Veir
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {rawCtx rawCtx' : IRContext OpInfo} {ctx ctx' : WfIRContext OpInfo}
+
+/-!
+  This file contains lemmas that are useful when proving that a local rewrite preserves
+  semantics with `PreservesSemantics`. Some of these lemmas should be moved to other files in the
+  future.
+-/
+
+/--
+Read a refined integer operand in a `PreservesSemantics` proof: a value `v` that is not one of the
+matched op's results maps to itself through `LocalRewritePattern.mapping`, so given its integer
+value in the source state, the value-refinement hypothesis and `DefinesDominating` for the target
+state yield its integer value in the target state, refined by the source one.
+-/
+theorem LocalRewritePattern.exists_refined_int_getVar?
+    {ctx : WfIRContext OpCode}
+    {ipIn : ip.InBounds ctx.raw}
+    {pattern : LocalRewritePattern OpCode}
+    {hpattern : pattern ctx op = some (newCtx, some (newOps, newValues))}
+    {hreturn : pattern.ReturnValuesInBounds} {hreturn₂ : pattern.ReturnValues}
+    {hreturn₃ : pattern.ReturnCtxChanges}
+    {state : InterpreterState ctx} {state' : InterpreterState newCtx}
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpattern hreturn hreturn₂ hreturn₃) (.at ip) (.at ip) ipIn ipIn')
+    (state'Dom : state'.DefinesDominating ip ipIn')
+    (vIn : v.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? v = some (RuntimeValue.int bw x))
+    (hDomCtx : v.dominatesIp ip ctx) (hDom' : v.dominatesIp ip newCtx)
+    (hNotRes : v ∉ op.getResults! ctx.raw) :
+    ∃ xt, state'.variables.getVar? v = some (RuntimeValue.int bw xt) ∧ x ⊒ xt := by
+  have ⟨tv, hTv⟩ := InterpreterState.DefinesDominating.exists_getVar_of_dominatesIp state'Dom
+      (hreturn₃.valuePtr_inBounds hpattern vIn) hDom'
+  have hRef : RuntimeValue.int bw x ⊒ tv := by
+    grind [LocalRewritePattern.mapping, valueRefinement v]
+  grind [RuntimeValue.int_of_isRefinedBy hRef]
+
+/-- `createEmptyOp` leaves a pre-existing operation's properties (at every op code) untouched: it only
+`set`s the fresh `newOp`'s record. The shipped `getProperties!_createEmptyOp` is code-specific. -/
+theorem OperationPtr.getProperties!_createEmptyOp_ne
+    (h : Rewriter.createEmptyOp rawCtx opType properties = some (rawCtx', newOp))
+    (hne : operation ≠ newOp) :
+    operation.getProperties! rawCtx' oc = operation.getProperties! rawCtx oc := by
+  simp only [Rewriter.createEmptyOp, OperationPtr.allocEmpty] at h
+  grind [OperationPtr.getProperties!, OperationPtr.set, OperationPtr.get!]
+
+/-- A `WfRewriter.createOp` leaves a pre-existing operation's properties (at every op code) untouched:
+only the fresh `newOp` gets properties, and the init steps touch only results/regions/operands. The
+code-specific `getProperties!_WfRewriter_createOp` covers only the created op's own type. -/
+theorem OperationPtr.getProperties!_WfRewriter_createOp_ne
+    (h : WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
+      none h₁ h₂ h₃ h₄ = some (ctx', newOp))
+    (hne : operation ≠ newOp) :
+    operation.getProperties! ctx'.raw oc = operation.getProperties! ctx.raw oc := by
+  simp only [WfRewriter.createOp] at h
+  grind [Rewriter.createOp, OperationPtr.getProperties!_createEmptyOp_ne,
+    OperationPtr.getProperties!_initOpRegions]
+
+/-- Reducing `WfRewriter.createOp!` at a `none` insertion point (the local-rewrite case): when all
+    the operand/block-operand/region in-bounds side conditions hold, it is just `createOp`. -/
+theorem WfRewriter.createOp!_none_eq {wfCtx : WfIRContext OpInfo} {opType : OpInfo}
+    {resultTypes operands blockOperands regions} {properties : HasOpInfo.propertiesOf opType}
+    (hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw)
+    (hblock : ∀ oper, oper ∈ blockOperands → oper.InBounds wfCtx.raw)
+    (hreg : ∀ reg, reg ∈ regions → reg.InBounds wfCtx.raw) :
+    WfRewriter.createOp! wfCtx opType resultTypes operands blockOperands regions properties none
+      = WfRewriter.createOp wfCtx opType resultTypes operands blockOperands regions properties none
+          hoper hblock hreg := by
+  simp only [WfRewriter.createOp!, dif_pos hoper, dif_pos hblock, dif_pos hreg]
+
+/-- Creating an operation at a `none` insertion point preserves dominance of a value at the program
+    point before any *other* operation `op'`: a freshly created (detached) operation `newOp ≠ op'`
+    cannot change whether `value` dominates `before op'`.
+
+    Axiomatised because `Veir.ValuePtr.dominatesIp` is opaque and the rewriter API currently exposes
+    no dominance-preservation lemma; this is the dominance analogue of the in-bounds preservation
+    lemmas for `WfRewriter.createOp`. -/
+axiom ValuePtr.dominatesIp_before_WfRewriter_createOp
+    {wfCtx wfCtx' : WfIRContext OpInfo} {opType : OpInfo}
+    {resultTypes operands blockOperands regions} {properties : HasOpInfo.propertiesOf opType}
+    {hoper hblock hreg hins} {newOp op' : OperationPtr} {value : ValuePtr}
+    (h : WfRewriter.createOp wfCtx opType resultTypes operands blockOperands regions properties none
+          hoper hblock hreg hins = some (wfCtx', newOp))
+    (hop' : op'.InBounds wfCtx.raw) (hne : op' ≠ newOp) :
+    value.dominatesIp (InsertPoint.before op') wfCtx'
+      ↔ value.dominatesIp (InsertPoint.before op') wfCtx

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
@@ -14,8 +14,7 @@ variable {rawCtx rawCtx' : IRContext OpInfo} {ctx ctx' : WfIRContext OpInfo}
 
 /-!
   This file contains lemmas that are useful when proving that a local rewrite preserves
-  semantics with `PreservesSemantics`. Some of these lemmas should be moved to other files in the
-  future.
+  semantics with `PreservesSemantics`.
 -/
 
 /--

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
@@ -1,0 +1,115 @@
+import Veir.IR.WellFormed
+import Veir.Rewriter.WfRewriter
+import Veir.Dominance
+import Veir.Passes.Matching
+import Veir.Verifier
+import Veir.Passes.InstructionSelection.Common
+import Veir.Interpreter
+
+/-!
+# Forward interpretation lemmas for instruction-selection rewrite proofs
+
+This file collects `interpretOp_forward` specializations tailored to the operations that show up in
+RISC-V instruction-selection lowerings. Each lemma fixes the shape of a specific op (cast-to-register,
+cast-back, and unary register-to-register `riscv` ops) and reduces its one-step interpretation to a
+concrete result binding, so the surrounding rewrite proofs can reason about semantics without
+unfolding the interpreter by hand.
+-/
+
+namespace Veir
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {rawCtx rawCtx' : IRContext OpInfo} {ctx ctx' : WfIRContext OpInfo}
+
+/-- Cast-to-register specialization of `interpretOp_forward`: `castOp` is a
+`builtin.unrealized_conversion_cast` with single operand `v` (holding an `i{bw}` value `x`) and a
+single `!riscv.reg` result. Interpreting it always succeeds, leaves memory untouched, binds the
+result to `.reg (LLVM.Int.toReg x)`, and leaves every non-result value unchanged. -/
+theorem interpretOp_castToReg_forward
+    {ctx : WfIRContext OpCode} {castOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : castOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {bw : Nat} {x : Data.LLVM.Int bw}
+    (hType : castOp.getOpType! ctx.raw = .builtin .unrealized_conversion_cast)
+    (hOperands : castOp.getOperands! ctx.raw = #[v])
+    (hResTypes : castOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.int bw x)) :
+    ∃ state', interpretOp castOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (castOp.getResult 0))
+        = some (.reg (LLVM.Int.toReg x)) ∧
+      (∀ v', v' ∉ castOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVar⟩ :=
+    interpretOp_forward (op := castOp) (state := state) (inBounds := inBounds)
+      (vals := #[.int bw x]) (results := #[.reg (LLVM.Int.toReg x)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [hResTypes, interpretOp', pure, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Cast-back specialization of `interpretOp_forward`, symmetric to
+`interpretOp_castToReg_forward`: `castOp` is a `builtin.unrealized_conversion_cast` with single
+operand `v` (holding a register value `r`) and a single `i{bw}` result. Interpreting it always
+succeeds, leaves memory untouched, binds the result to `.int bw (RISCV.Reg.toInt r bw)`, and
+leaves every non-result value unchanged. -/
+theorem interpretOp_castBack_forward
+    {ctx : WfIRContext OpCode} {castOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : castOp.InBounds ctx.raw} {v : ValuePtr} {intTy : IntegerType} {hIsTy}
+    {r : Data.RISCV.Reg}
+    (hType : castOp.getOpType! ctx.raw = .builtin .unrealized_conversion_cast)
+    (hOperands : castOp.getOperands! ctx.raw = #[v])
+    (hResTypes : castOp.getResultTypes! ctx.raw = #[⟨.integerType intTy, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp castOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (castOp.getResult 0))
+        = some (.int intTy.bitwidth (RISCV.Reg.toInt r intTy.bitwidth)) ∧
+      (∀ v', v' ∉ castOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVar⟩ :=
+    interpretOp_forward (op := castOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r])
+      (results := #[.int intTy.bitwidth (RISCV.Reg.toInt r intTy.bitwidth)])
+      (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [hResTypes, interpretOp', pure, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Unary register-to-register `riscv` op specialization of `interpretOp_forward`: `theOp` is any
+`riscv` op `rop` whose interpretation maps a single register operand `r` to `f r` (hypothesis
+`hSem`, discharged by `rfl` at each concrete opcode), with a single `!riscv.reg` result.
+Interpreting it always succeeds, leaves memory untouched, binds the result to `.reg (f r)`, and
+leaves every non-result value unchanged. This covers `riscv.clz`/`clzw`/`ctz`/`ctzw`/`cpop`/
+`cpopw` and any future unary Zbb op. -/
+theorem interpretOp_riscv_unaryReg_forward
+    {ctx : WfIRContext OpCode} {rop : Riscv} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r : Data.RISCV.Reg} {f : Data.RISCV.Reg → Data.RISCV.Reg}
+    (hSem : ∀ (props : HasDialectOpInfo.propertiesOf rop) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' rop props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (f r)], mem, none)))
+    (hType : theOp.getOpType! ctx.raw = .riscv rop)
+    (hOperands : theOp.getOperands! ctx.raw = #[v])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (f r)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r]) (results := #[.reg (f r)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', hSem, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonTactics.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonTactics.lean
@@ -1,0 +1,105 @@
+import Veir.IR.WellFormed
+import Veir.Rewriter.WfRewriter
+import Veir.Dominance
+import Veir.Passes.Matching
+import Veir.Verifier
+import Veir.Passes.InstructionSelection.Common
+import Veir.Interpreter
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+
+/-!
+# Common tactics for instruction-selection rewrite proofs
+
+These macros help drive `PreservesSemantics`-style proofs about local rewrites. A rewrite's pattern
+is typically a chain of `bind`s that split on guard conditions and create ops one at a time, so the
+tactics here "peel" that chain apart: they discharge the split conditions and introduce, for each
+created op, the updated context, the new op, and its creation hypothesis (rewritten into a plain
+`createOp` form). Several also transport a dominance hypothesis through each creation step so it stays
+usable in the resulting context.
+-/
+
+namespace Veir
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {rawCtx rawCtx' : IRContext OpInfo} {ctx ctx' : WfIRContext OpInfo}
+
+
+open Lean in
+/-- Split the `if`/`match` guarding `hpattern`, discharge the false branch with `grind`, and name the
+    resulting facts `hyps`, simplifying `hpattern` in the surviving branch. -/
+macro "peelSplittableCondition" "[" hyps:binderIdent* "]" hpattern:ident : tactic =>
+  `(tactic| (
+      split at $hpattern:ident; grind; rename_i $[$hyps]*
+      try simp at $hpattern:ident
+     ))
+
+open Lean in
+/-- Like `peelSplittableCondition`, but `grind` discharges the *other* branch (via `rotate_left`),
+    keeping the first branch of the split. -/
+macro "peelSplittableCondition'" "[" hyps:binderIdent* "]" hpattern:ident : tactic =>
+  `(tactic| (
+      split at $hpattern:ident; rotate_left; grind; rename_i $[$hyps]*
+      try simp at $hpattern:ident
+     ))
+
+open Lean in
+/-- Simplify `hpattern` to a three-way conjunction of equalities and substitute each one into the
+    goal, clearing `hpattern`. -/
+macro "cleanupHpattern" hpattern:ident : tactic =>
+  `(tactic| (
+      simp at $hpattern:ident; have ⟨ha, hb, hc⟩ := $hpattern:ident; clear $hpattern:ident
+      subst ha hb hc
+     ))
+
+open Lean in
+/-- Peel one op-creation step from `hpattern`, introducing the updated context `newCtx`, the created
+    op `newOp`, and the creation hypothesis `hNewCtx`, leaving the rest of the pattern in `hpattern`. -/
+macro "peelOpCreation" hpattern:ident newCtx:ident newOp:ident hNewCtx:ident : tactic =>
+  `(tactic| (
+      try simp only [Option.bind_eq_some_iff] at $hpattern:ident
+      have ⟨⟨$newCtx, $newOp⟩, $hNewCtx, pat'⟩ := $hpattern:ident
+      clear $hpattern:ident; have $hpattern:ident := pat'; clear pat'
+     ))
+
+open Lean in
+/-- Peel a `castToRegLocal` creation from `hpattern` (like `peelOpCreation`), unfold it to the plain
+    `createOp` form in `hCast`, and transport the dominance hypothesis `oldDom` into `newDom` over the
+    new context `newCtx`. -/
+macro "peelCastToRegLocal" hpattern:ident newCtx:ident newOp:ident hCast:ident
+    oldDom:ident newDom:ident : tactic =>
+  `(tactic| (
+      peelOpCreation $hpattern:ident $newCtx:ident $newOp:ident $hCast:ident
+      simp only [castToRegLocal] at $hCast:ident
+      rw [WfRewriter.createOp!_none_eq (by grind) (by simp) (by simp)] at $hCast:ident
+      have $newDom:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hCast:ident
+        (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom:ident
+     ))
+
+open Lean in
+/-- Like `peelOpCreation`, but also rewrites the peeled `createOp!` to the plain `createOp` form and
+    transports the dominance hypothesis `oldDom` into `newDom` over `newCtx`. Dischargers clear the
+    unpeeled `hpattern` so it stays available for later peels. -/
+macro "peelOpCreation!" hpattern:ident newCtx:ident newOp:ident hNewCtx:ident
+    oldDom:ident newDom:ident : tactic =>
+  `(tactic| (
+      peelOpCreation $hpattern:ident $newCtx:ident $newOp:ident $hNewCtx:ident
+      rw [WfRewriter.createOp!_none_eq (by clear $hpattern:ident; grind)
+        (by clear $hpattern:ident; simp) (by clear $hpattern:ident; simp)] at $hNewCtx:ident
+      have $newDom:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hNewCtx:ident
+        (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom:ident
+     ))
+
+open Lean in
+/-- Like `peelCastToRegLocal`, but peels a `replaceWithRegLocal` creation into `hCastBack`,
+    rewriting it to the plain `createOp` form and transporting the dominance hypothesis `oldDom`
+    into `newDom` over `newCtx`. -/
+macro "peelReplaceWithRegLocal" hpattern:ident newCtx:ident newOp:ident hCastBack:ident
+    oldDom:ident newDom:ident : tactic =>
+  `(tactic| (
+      peelOpCreation $hpattern:ident $newCtx:ident $newOp:ident $hCastBack:ident
+      simp only [replaceWithRegLocal] at $hCastBack:ident
+      rw [WfRewriter.createOp!_none_eq (by clear $hpattern:ident; grind)
+        (by clear $hpattern:ident; simp) (by clear $hpattern:ident; simp)] at $hCastBack:ident
+      have $newDom:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hCastBack:ident
+        (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom:ident
+     ))

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUnaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUnaryW.lean
@@ -1,0 +1,498 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+
+namespace Veir
+
+/-!
+## Generic correctness of `lowerUnaryWLocal`
+
+`lowerUnaryWLocal match? op64 op32` lowers a single-operand LLVM integer op to
+`unrealized_conversion_cast` (to a register) → `riscv` op (`op64`, or its `W` variant `op32` for
+`i32`) → `unrealized_conversion_cast` (back to the integer type). Its `PreservesSemantics` proof
+is shared: instantiating it for a concrete lowering (`ctlz_local`, `cttz_local`, `ctpop_local`)
+only requires the matcher facts, the interpreter computation facts (all `rfl`), and the two
+data-level refinement lemmas.
+-/
+
+/-- Interpreting a matched single-operand LLVM op (of opcode `srcOp`, interpreted by `srcFn` per
+    `hSemSrc`) whose operand has integer type `intType` reads that operand's `i{bw}` value `x` and
+    stores `srcFn x props` in the result variable, leaving memory and control flow untouched. The
+    operand's value `x` is derived internally (from the successful interpretation and the
+    operand's type), so it is exposed as an existential output rather than required as an input. -/
+theorem matchUnaryOp_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCode}
+    {op : OperationPtr} {operand : ValuePtr} {props : propertiesOf (.llvm srcOp)} {intType}
+    {srcFn : ∀ {bw : Nat}, Data.LLVM.Int bw → propertiesOf (.llvm srcOp) → Data.LLVM.Int bw}
+    {state : InterpreterState ctx} {newState cf} (opInBounds : op.InBounds ctx.raw)
+    (hOpType : op.getOpType! ctx.raw = .llvm srcOp)
+    (hNumResults : op.getNumResults! ctx.raw = 1)
+    (hOperands : op.getOperands! ctx.raw = #[operand])
+    (hProps : props = op.getProperties! ctx.raw (.llvm srcOp))
+    (hSemSrc : ∀ (bw : Nat) (x : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x] blockOperands mem
+          = some (.ok (#[.int bw (srcFn x props)], mem, none)))
+    (hinterp : interpretOp op state opInBounds = some (newState, cf))
+    (hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType intType) :
+    ∃ x, state.variables.getVar? operand = some (RuntimeValue.int intType.bitwidth x) ∧
+      state.memory = newState.memory ∧
+      newState.variables.getVar? (op.getResult 0) =
+        some (RuntimeValue.int intType.bitwidth (srcFn x props)) ∧
+      cf = none := by
+  have hNumOperands : op.getNumOperands! ctx.raw = 1 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by
+    rw [hOperands]; rfl
+  simp only [liftM, monadLift, MonadLift.monadLift] at hinterp
+  -- Derive the operand's `i{bw}` value from the successful interpretation and its integer type.
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize : 0 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨val, hval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize
+  have hgetVar : state.variables.getVar? operand = some val := by
+    rw [hOperandEq, show (op.getOperands! ctx.raw)[0]! = (op.getOperands! ctx.raw)[0] from by grind]
+    exact hval
+  have hconf := VariableState.getVar?_conforms hgetVar
+  rw [show operand.getType! ctx.raw = ⟨.integerType intType, hOperandType ▸ (operand.getType! ctx.raw).2⟩
+        from Subtype.ext hOperandType] at hconf
+  obtain ⟨x, rfl⟩ := RuntimeValue.Conforms.integerType hconf
+  refine ⟨x, hgetVar, ?_⟩
+  -- With the value in hand, unfold the interpretation of the matched op.
+  have hOperand0 : op.getOperand! ctx.raw 0 = operand := by
+    rw [hOperandEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues op = some #[RuntimeValue.int intType.bitwidth x] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    obtain rfl : i = 0 := by omega
+    simpa [hOperand0] using hgetVar
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [← hProps, interpretOp'] at hInterp'
+  rw [hSemSrc] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ : resValues = #[RuntimeValue.int intType.bitwidth (srcFn x props)] ∧
+      mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  refine ⟨rfl, ?_, rfl⟩
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
+set_option maxHeartbeats 1000000 in
+/-- Shared correctness proof for every `lowerUnaryWLocal` lowering: the round trip
+    `int → reg → op64/op32 → int` refines `srcFn`.
+
+    Per-lowering inputs: the matcher's syntactic facts (`hMatchImplies`), the verifier facts
+    (`hVerified`), the interpreter computation facts for the source op and the two riscv ops
+    (`hSemSrc`/`hSemR64`/`hSemR32`, all discharged by `rfl` at concrete opcodes), and the two
+    data-level refinement lemmas (`hRefine64`/`hRefine32`). -/
+theorem lowerUnaryWLocal_preservesSemantics {srcOp : Llvm}
+    {match? : OperationPtr → IRContext OpCode → Option (ValuePtr × propertiesOf (.llvm srcOp))}
+    {op64 op32 : Riscv}
+    {props64 : propertiesOf (.riscv op64)} {props32 : propertiesOf (.riscv op32)}
+    {f64 f32 : Data.RISCV.Reg → Data.RISCV.Reg}
+    {srcFn : ∀ {bw : Nat}, Data.LLVM.Int bw → propertiesOf (.llvm srcOp) → Data.LLVM.Int bw}
+    (hMatchImplies : ∀ {op : OperationPtr} {ctx : IRContext OpCode} {operand props},
+        match? op ctx = some (operand, props) →
+        op.getOpType! ctx = .llvm srcOp ∧
+        op.getNumResults! ctx = 1 ∧
+        op.getOperands! ctx = #[operand] ∧
+        props = op.getProperties! ctx (.llvm srcOp))
+    (hVerified : ∀ {ctx : WfIRContext OpCode} {op : OperationPtr}
+        {opInBounds : op.InBounds ctx.raw},
+        op.Verified ctx opInBounds → op.getOpType! ctx.raw = .llvm srcOp →
+        op.IsVerifiedIntegerUnop ctx)
+    (hSemSrc : ∀ (bw : Nat) (x : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x] blockOperands mem
+          = some (.ok (#[.int bw (srcFn x props)], mem, none)))
+    (hSemR64 : ∀ (r : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op64)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' op64 props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (f64 r)], mem, none)))
+    (hSemR32 : ∀ (r : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op32)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' op32 props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (f32 r)], mem, none)))
+    (hRefine64 : ∀ (x xt : Data.LLVM.Int 64) (props : propertiesOf (.llvm srcOp)), x ⊒ xt →
+        srcFn x props ⊒ RISCV.Reg.toInt (f64 (LLVM.Int.toReg xt)) 64)
+    (hRefine32 : ∀ (x xt : Data.LLVM.Int 32) (props : propertiesOf (.llvm srcOp)), x ⊒ xt →
+        srcFn x props ⊒ RISCV.Reg.toInt (f32 (LLVM.Int.toReg xt)) 32)
+    {h : LocalRewritePattern.ReturnOps (lowerUnaryWLocal match? op64 op32 props64 props32)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (lowerUnaryWLocal match? op64 op32 props64 props32)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds
+      (lowerUnaryWLocal match? op64 op32 props64 props32)}
+    {h₄ : LocalRewritePattern.ReturnValues (lowerUnaryWLocal match? op64 op32 props64 props32)} :
+    LocalRewritePattern.PreservesSemantics
+      (lowerUnaryWLocal match? op64 op32 props64 props32) h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, lowerUnaryWLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (match? op ctx.raw).isSome := by
+    cases hM : match? op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨operand, props⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := hMatchImplies hMatch
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by
+    rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, hResOperType, intType, isT, hResType⟩ :=
+    hVerified opVerif hOpType
+  -- The operand type is the integer type `intType`; resolve the type-destructuring match.
+  have hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [show operand.getType! ctx.raw = ⟨.integerType intType, isT⟩ from by grind]
+  rw [hOperandType] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand's value and its `srcFn`.
+  obtain ⟨xVal, hxVal, hMem, hRes, hCf⟩ :=
+    matchUnaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands hProps hSemSrc
+      hinterp hOperandType
+  subst hCf
+  -- The matched operand dominates the rewrite point in the source context.
+  have hDomCtx : operand.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition [hBw] hpattern
+  -- Source value: `op`'s single result is `srcFn` of its operand.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `operand` is not one of `op`'s results.
+  have vNotOp : ¬ operand ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the first `castToRegLocal` creation (a `builtin.unrealized_conversion_cast`),
+  -- transporting the operand's dominance fact `hDomCtx` into `ctx₁` as `hDom₁`.
+  peelCastToRegLocal hpattern ctx₁ castOp hCast hDomCtx hDom₁
+  have hBwCases : intType.bitwidth = 64 ∨ intType.bitwidth = 32 := by omega
+  rcases hBwCases with hbw | hbw
+  · -- 64-bit case: lowered to `op64`
+    rw [if_neg (show ¬intType.bitwidth = 32 by omega)] at hpattern
+    simp only [] at hpattern
+    -- Peel the `op64` creation and the `replaceWithRegLocal` cast-back, converting each
+    -- from the `createOp!`/helper form to plain `createOp` (`hCast` was already converted by
+    -- `peelCastToRegLocal`).
+    peelOpCreation! hpattern ctx₂ retOp hRet hDom₁ hDom₂
+    peelReplaceWithRegLocal hpattern ctx₃ castBackOp hCastBack hDom₂ hDom₃
+    cleanupHpattern hpattern
+    -- Read the refined value `xt` of `operand` in the target state `state'`.
+    obtain ⟨xt, hOpVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+        hDomCtx hDom₃ vNotOp
+    -- Normalise the bitwidth to the literal `64`.
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    -- Structural facts about the three created ops.
+    have hCastType : castOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by grind
+    have hRetType : retOp.getOpType! ctx₃.raw = .riscv op64 := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hCastOperands : castOp.getOperands! ctx₃.raw = #[operand] := by grind
+    have hRetOperands : retOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (castOp.getResult 0)] := by
+      grind
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+    -- The cast-back op's result type is `i64`.
+    have hCBType : ((op.getResult 0).get! ctx₂.raw).type
+        = (⟨Attribute.integerType { bitwidth := 64 }, isT⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₂.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hRet
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastResTypes : castOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castOp)]
+    have hRetResTypes : retOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.integerType { bitwidth := 64 }, isT⟩] := by grind
+    -- Interpretation tail: execute `interpretOpList [castOp, retOp, castBackOp]` in `state'`:
+    -- one cast-forward lemma per cast, one `interpretOp_riscv_unaryReg_forward` for the middle op.
+    -- `castOp` reads `operand = .int 64 xt` and casts it to `.reg (toReg xt)`.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        hCastType hCastOperands hCastResTypes hOpVal'
+    -- `retOp` (`op64`) maps `.reg r` to `.reg (f64 r)`.
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := s₁) (inBounds := by grind)
+        (f := f64) (hSemR64 _) hRetType hRetOperands hRetResTypes hRes₁
+    -- `castBackOp` casts `.reg (f64 (toReg xt))` back to `.int 64 (toInt (f64 (toReg xt)) 64)`.
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+      interpretOp_castBack_forward (state := s₂) (inBounds := by grind)
+        hCastBackType hCastBackOperands hCastBackResTypes hRes₂
+    refine ⟨s₃, ?_, by grind, ?_⟩
+    · -- The list interpretation is the chain of the three op interpretations.
+      simp [interpretOpList_cons, hI₁, hI₂, hI₃, liftM, monadLift, MonadLift.monadLift, Interp]
+    · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt (f64 (LLVM.Int.toReg xt)) 64)],
+        ?_, ?_⟩
+      · simp [hRes₃, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using hRefine64 xVal xt props hxtRef⟩
+  · -- 32-bit case: lowered to `op32`
+    rw [if_pos hbw] at hpattern
+    simp only [] at hpattern
+    -- Peel the `op32` creation and the `replaceWithRegLocal` cast-back, converting each
+    -- from the `createOp!`/helper form to plain `createOp` (`hCast` was already converted by
+    -- `peelCastToRegLocal`).
+    peelOpCreation! hpattern ctx₂ retOp hRet hDom₁ hDom₂
+    peelReplaceWithRegLocal hpattern ctx₃ castBackOp hCastBack hDom₂ hDom₃
+    cleanupHpattern hpattern
+    -- Read the refined value `xt` of `operand` in the target state `state'`.
+    obtain ⟨xt, hOpVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+        hDomCtx hDom₃ vNotOp
+    -- Normalise the bitwidth to the literal `32`.
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    -- Structural facts about the three created ops.
+    have hRetType : retOp.getOpType! ctx₃.raw = .riscv op32 := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hCastOperands : castOp.getOperands! ctx₃.raw = #[operand] := by grind
+    have hRetOperands : retOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (castOp.getResult 0)] := by
+      grind
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+    -- The cast-back op's result type is `i32`.
+    have hCBType : ((op.getResult 0).get! ctx₂.raw).type
+        = (⟨Attribute.integerType { bitwidth := 32 }, isT⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₂.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hRet
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hCast
+            (value := ValuePtr.opResult (op.getResult 0))]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastResTypes : castOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castOp)]
+    have hRetResTypes : retOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.integerType { bitwidth := 32 }, isT⟩] := by grind
+    -- Interpretation tail: execute `interpretOpList [castOp, retOp, castBackOp]` in `state'`:
+    -- one cast-forward lemma per cast, one `interpretOp_riscv_unaryReg_forward` for the middle op.
+    -- `castOp` reads `operand = .int 32 xt` and casts it to `.reg (toReg xt)`.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        (by grind) hCastOperands hCastResTypes hOpVal'
+    -- `retOp` (`op32`) maps `.reg r` to `.reg (f32 r)`.
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := s₁) (inBounds := by grind)
+        (f := f32) (hSemR32 _) hRetType hRetOperands hRetResTypes hRes₁
+    -- `castBackOp` casts `.reg (f32 (toReg xt))` back to `.int 32 (toInt (f32 (toReg xt)) 32)`.
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+      interpretOp_castBack_forward (state := s₂) (inBounds := by grind)
+        (by grind) hCastBackOperands hCastBackResTypes hRes₂
+    refine ⟨s₃, ?_, by grind, ?_⟩
+    · -- The list interpretation is the chain of the three op interpretations.
+      simp [interpretOpList_cons, hI₁, hI₂, hI₃, liftM, monadLift, MonadLift.monadLift, Interp]
+    · refine ⟨#[RuntimeValue.int 32 (RISCV.Reg.toInt (f32 (LLVM.Int.toReg xt)) 32)],
+        ?_, ?_⟩
+      · simp [hRes₃, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using hRefine32 xVal xt props hxtRef⟩
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
+/-!
+## RISC-V lowering of `llvm.intr.ctlz`
+
+`llvm.intr.ctlz` on a 64- or 32-bit integer is lowered to
+`unrealized_conversion_cast` (to a register) → `riscv.clz`/`riscv.clzw` →
+`unrealized_conversion_cast` (back to the integer type). This is the actual
+`Veir.ctlz_local` pattern from `Veir.Passes.InstructionSelection.RISCV64`.
+
+The structural part of the proof is shared with the other unary lowerings
+(`lowerUnaryWLocal_preservesSemantics`); only the two data-level refinement
+lemmas below are `ctlz`-specific.
+-/
+
+/-- Correctness of the `riscv.clz` lowering of a 64-bit `llvm.intr.ctlz`: the round trip
+    `int → reg → clz → int` refines `ctlz`. (`xt` is the possibly-more-defined target-side value
+    of the operand.) -/
+theorem ctlz_isRefinedBy_toInt_clz {x xt : Data.LLVM.Int 64} (pf : Bool) (h : x ⊒ xt) :
+    Data.LLVM.Int.ctlz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.clz (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_ctlz] at hnp; grind
+  have hvd : x.getValueD = xt.getValueD := by
+    rw [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq, dif_pos hxnp, dif_pos (hp hxnp)]
+    exact hv hxnp (hp hxnp)
+  rw [Data.LLVM.Int.getValue_ctlz _ hnp, toInt_getValue]
+  simp only [Data.RISCV.clz, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
+    dif_neg (show ¬xt.isPoison = true by simp [hp hxnp])]
+  rw [hvd]
+  bv_decide
+
+/-- Correctness of the `riscv.clzw` lowering of a 32-bit `llvm.intr.ctlz`. -/
+theorem ctlz_isRefinedBy_toInt_clzw {x xt : Data.LLVM.Int 32} (pf : Bool) (h : x ⊒ xt) :
+    Data.LLVM.Int.ctlz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.clzw (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.clzw]
+  veir_bv_decide
+
+theorem ctlz_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics ctlz_local h h₂ h₃ h₄ :=
+  lowerUnaryWLocal_preservesSemantics
+    (srcOp := .intr__ctlz)
+    (srcFn := fun x props => Data.LLVM.Int.ctlz x props.is_zero_poison)
+    (f64 := Data.RISCV.clz) (f32 := Data.RISCV.clzw)
+    matchCtlz_implies
+    OperationPtr.Verified.llvm_intr__ctlz
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ props h => ctlz_isRefinedBy_toInt_clz props.is_zero_poison h)
+    (fun _ _ props h => ctlz_isRefinedBy_toInt_clzw props.is_zero_poison h)
+
+/-!
+## RISC-V lowering of `llvm.intr.ctpop`
+
+`llvm.intr.ctpop` on a 64- or 32-bit integer is lowered to
+`unrealized_conversion_cast` (to a register) → `riscv.cpop`/`riscv.cpopw` →
+`unrealized_conversion_cast` (back to the integer type). The structural part of the proof is
+shared with the other unary lowerings (`lowerUnaryWLocal_preservesSemantics`); only the two
+data-level refinement lemmas below are `ctpop`-specific.
+-/
+
+/-- Correctness of the `riscv.cpop` lowering of a 64-bit `llvm.intr.ctpop`: the round trip
+    `int → reg → cpop → int` refines `ctpop`. (`xt` is the possibly-more-defined target-side
+    value of the operand.) -/
+theorem ctpop_isRefinedBy_toInt_cpop {x xt : Data.LLVM.Int 64} (h : x ⊒ xt) :
+    Data.LLVM.Int.ctpop x ⊒ RISCV.Reg.toInt (Data.RISCV.cpop (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_ctpop] at hnp; exact hnp
+  have hvd : x.getValueD = xt.getValueD := by
+    rw [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq, dif_pos hxnp, dif_pos (hp hxnp)]
+    exact hv hxnp (hp hxnp)
+  rw [Data.LLVM.Int.getValue_ctpop _ hnp, toInt_getValue]
+  simp only [Data.RISCV.cpop, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
+    dif_neg (show ¬xt.isPoison = true by simp [hp hxnp])]
+  rw [hvd]
+  bv_decide
+
+/-- Correctness of the `riscv.cpopw` lowering of a 32-bit `llvm.intr.ctpop`. -/
+theorem ctpop_isRefinedBy_toInt_cpopw {x xt : Data.LLVM.Int 32} (h : x ⊒ xt) :
+    Data.LLVM.Int.ctpop x ⊒ RISCV.Reg.toInt (Data.RISCV.cpopw (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.cpopw]
+  veir_bv_decide
+
+theorem ctpop_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics ctpop_local h h₂ h₃ h₄ :=
+  lowerUnaryWLocal_preservesSemantics
+    (srcOp := .intr__ctpop)
+    (srcFn := fun x _ => Data.LLVM.Int.ctpop x)
+    (f64 := Data.RISCV.cpop) (f32 := Data.RISCV.cpopw)
+    matchCtpop_implies
+    OperationPtr.Verified.llvm_intr__ctpop
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ _ h => ctpop_isRefinedBy_toInt_cpop h)
+    (fun _ _ _ h => ctpop_isRefinedBy_toInt_cpopw h)
+
+/-!
+## RISC-V lowering of `llvm.intr.cttz`
+
+`llvm.intr.cttz` on a 64- or 32-bit integer is lowered to
+`unrealized_conversion_cast` (to a register) → `riscv.ctz`/`riscv.ctzw` →
+`unrealized_conversion_cast` (back to the integer type). The structural part of the proof is
+shared with the other unary lowerings (`lowerUnaryWLocal_preservesSemantics`); only the two
+data-level refinement lemmas below are `cttz`-specific.
+-/
+
+/-- Correctness of the `riscv.ctz` lowering of a 64-bit `llvm.intr.cttz`: the round trip
+    `int → reg → ctz → int` refines `cttz`. (`xt` is the possibly-more-defined target-side value
+    of the operand.) -/
+theorem cttz_isRefinedBy_toInt_ctz {x xt : Data.LLVM.Int 64} (pf : Bool) (h : x ⊒ xt) :
+    Data.LLVM.Int.cttz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.ctz (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_cttz] at hnp; grind
+  have hvd : x.getValueD = xt.getValueD := by
+    rw [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq, dif_pos hxnp, dif_pos (hp hxnp)]
+    exact hv hxnp (hp hxnp)
+  rw [Data.LLVM.Int.getValue_cttz _ hnp, toInt_getValue]
+  simp only [Data.RISCV.ctz, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
+    dif_neg (show ¬xt.isPoison = true by simp [hp hxnp])]
+  rw [hvd]
+  bv_decide
+
+/-- Correctness of the `riscv.ctzw` lowering of a 32-bit `llvm.intr.cttz`. -/
+theorem cttz_isRefinedBy_toInt_ctzw {x xt : Data.LLVM.Int 32} (pf : Bool) (h : x ⊒ xt) :
+    Data.LLVM.Int.cttz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.ctzw (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.ctzw]
+  veir_bv_decide
+
+theorem cttz_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics cttz_local h h₂ h₃ h₄ :=
+  lowerUnaryWLocal_preservesSemantics
+    (srcOp := .intr__cttz)
+    (srcFn := fun x props => Data.LLVM.Int.cttz x props.is_zero_poison)
+    (f64 := Data.RISCV.ctz) (f32 := Data.RISCV.ctzw)
+    matchCttz_implies
+    OperationPtr.Verified.llvm_intr__cttz
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ props h => cttz_isRefinedBy_toInt_ctz props.is_zero_poison h)
+    (fun _ _ props h => cttz_isRefinedBy_toInt_ctzw props.is_zero_poison h)
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -1,0 +1,266 @@
+# Proving `PreservesSemantics` for RISC-V lowerings
+
+This document describes the proof strategy used for the `lowerUnaryWLocal` lowerings
+(`ctlz_local`, `cttz_local`, `ctpop_local` in `Veir/Passes/InstructionSelection/RISCV64.lean`)
+and how to extend it to the other `*_local` lowerings (`add_local`, `and_local`, `bswap_local`, …).
+
+## What we prove
+
+For each lowering `foo_local : LocalRewritePattern OpCode` we prove
+
+```lean
+theorem foo_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics foo_local h h₂ h₃ h₄
+```
+
+`PreservesSemantics` (`Veir/PatternRewriter/Semantics.lean`) is a one-step forward simulation:
+
+- **Given**: the pattern fired (`hpattern : foo_local ctx op = some (newCtx, some (newOps, newValues))`),
+  the matched `op` interpreted successfully in a source state (`interpretOp op state = some (newState, cf)`),
+  and a target state `state'` on `newCtx` that refines `state` at `InsertPoint.before op`
+  (plus `Dom`/`Verified`/`DefinesDominating` side conditions).
+- **Show**: `interpretOpList newOps.toList state'` succeeds with the *same* control flow `cf`,
+  the *same* memory, and the values in `newValues` refine the matched op's result values
+  (`sourceValues ⊒ targetValues`).
+
+## Architecture: one proof per lowering *shape*, not per lowering
+
+Lowerings sharing a shape are written as instances of a combinator in `RISCV64.lean`, and the
+structural proof is done **once per combinator**. Currently:
+
+- `lowerUnaryWLocal match? op64 op32 props64 props32` — match a single-operand LLVM integer op
+  on `i64`/`i32`, then emit `castToRegLocal` → `op64` (or its `W` variant `op32` for `i32`) →
+  `replaceWithRegLocal`. Its shared correctness proof is
+  `lowerUnaryWLocal_preservesSemantics` (`RewriteProofs/LowerUnaryW.lean`).
+
+The generic theorem is parameterized over everything opcode-specific:
+
+```lean
+theorem lowerUnaryWLocal_preservesSemantics
+    (hMatchImplies : …)   -- syntactic facts from a successful match?     (Layer 2)
+    (hVerified    : …)   -- Verified op ⇒ IsVerifiedIntegerUnop           (Layer 1)
+    (hSemSrc      : …)   -- Llvm.interpretOp' srcOp … = srcFn             (rfl)
+    (hSemR64      : …)   -- Riscv.interpretOp' op64 … = f64               (rfl)
+    (hSemR32      : …)   -- Riscv.interpretOp' op32 … = f32               (rfl)
+    (hRefine64    : …)   -- srcFn x props ⊒ toInt (f64 (toReg xt)) 64     (Layer 0)
+    (hRefine32    : …)   -- srcFn x props ⊒ toInt (f32 (toReg xt)) 32     (Layer 0)
+    : LocalRewritePattern.PreservesSemantics (lowerUnaryWLocal match? op64 op32 props64 props32) …
+```
+
+so instantiating it for a concrete lowering is a single term. The three `hSem*` interpreter
+computation facts are discharged by `rfl` at concrete opcodes. Example (`ctlz`):
+
+```lean
+theorem ctlz_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics ctlz_local h h₂ h₃ h₄ :=
+  lowerUnaryWLocal_preservesSemantics
+    (srcOp := .intr__ctlz)
+    (srcFn := fun x props => Data.LLVM.Int.ctlz x props.is_zero_poison)
+    (f64 := Data.RISCV.clz) (f32 := Data.RISCV.clzw)
+    (fun hMatch => matchCtlz_implies hMatch)
+    (fun opVerif hOpType => OperationPtr.Verified.llvm_intr__ctlz opVerif hOpType)
+    (fun _ _ _ _ _ _ => rfl) (fun _ _ _ _ _ => rfl) (fun _ _ _ _ _ => rfl)
+    (fun _ _ props h => ctlz_isRefinedBy_toInt_clz props.is_zero_poison h)
+    (fun _ _ props h => ctlz_isRefinedBy_toInt_clzw props.is_zero_poison h)
+```
+
+The instantiations live in `namespace Example` at the bottom of `LowerUnaryW.lean`.
+
+## The per-lowering layers
+
+### Layer 0 — Pure data refinement lemmas (per lowering, the only real new work)
+
+The mathematical core, stated purely on `Data.LLVM.Int` / `Data.RISCV.Reg` with no IR at all,
+one per (bitwidth, RISC-V opcode) branch:
+
+```lean
+theorem ctlz_isRefinedBy_toInt_clz {x xt : Data.LLVM.Int 64} (pf : Bool) (h : x ⊒ xt) :
+    Data.LLVM.Int.ctlz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.clz (LLVM.Int.toReg xt)) 64
+```
+
+i.e. *"round-tripping the (possibly more defined) operand through registers and running the
+RISC-V instruction refines the LLVM operation"*.
+
+Proof recipe: unfold refinement with `Data.LLVM.Int.isRefinedBy_iff`, split the
+poison/value obligations, reduce the value equality to a bitvector goal, close with
+`bv_decide` / `veir_bv_decide`. Poison bookkeeping (`isPoison_ctlz`, `getValueD_eq`, …) usually
+falls to `grind`. For binops the statement takes two refined operands
+(`h₁ : x ⊒ xt`, `h₂ : y ⊒ yt`).
+
+These lemmas live next to the instantiation (`Example` namespace of `LowerUnaryW.lean`); if they
+grow they can move to `Veir/Data/…/Lemmas.lean`.
+
+### Layer 1 — Verifier facts (per LLVM opcode, mostly shared)
+
+A `Verified.*` lemma in `Veir/Verifier.lean` extracting the structural facts the verifier
+guarantees for the matched opcode:
+
+```lean
+theorem OperationPtr.Verified.llvm_intr__ctlz … : op.IsVerifiedIntegerUnop ctx
+```
+
+`IsVerifiedIntegerUnop` / `IsVerifiedIntegerBinop` bundle: operand/result/successor/region
+counts, result type = operand type, and that type is an integer type. The heavy lifting is done
+once per *shape* (`verifyIntegerUnop_eq_ok` + `verifyIntegerUnop_ok_of_Verified`); the
+per-opcode lemma is then a three-liner that just points the dispatcher at the concrete opcode.
+These exist for the unops and binops proven or planned so far. Ops with a different verifier
+shape (e.g. `icmp`, `select`, `load`/`store`) need their own `IsVerified*` bundle, built the
+same way.
+
+### Layer 2 — Matcher facts (per LLVM opcode, mostly exist already)
+
+`matchFoo_implies` in `Veir/Passes/Matching/Lemmas.lean`: what a successful `matchFoo` says
+syntactically — op type, number of results, `getOperands! = #[operand…]`, and the properties
+equation. These exist for most matchers already; if one is missing, copy an existing one
+(the proof is `simp only [matchFoo, bind, Option.bind, pure]` + `grind`).
+
+## The shared machinery (already written, reused by every combinator proof)
+
+### Source-interpretation unfolding
+
+`matchUnaryOp_interpretOp_unfold` (`LowerUnaryW.lean`) is generic over the source opcode: given
+the matcher's syntactic facts, the `hSemSrc` computation fact, and a successful
+`interpretOp op state`, it produces
+
+- the operand's runtime value **as an existential** (`∃ x, state.variables.getVar? operand = some (.int bw x)`),
+- memory unchanged,
+- the result variable bound to `srcFn x props`,
+- `cf = none`.
+
+The operand value is *derived* inside the lemma — from `interpretOp_some_iff`, the matcher's
+`getOperands!` fact, and `VariableState.getVar?_conforms` + the operand's integer type
+(`RuntimeValue.Conforms.integerType` turns "conforms to `i{bw}`" into "`= .int bw x`") — so
+callers don't have to supply it. A binop combinator will need a binop analogue exposing two
+existentials, using two `Array.exists_mapM_option_eq_some_iff` reads (indices 0 and 1).
+
+### Forward lemmas for the emitted ops
+
+`CommonForwardInterpret.lean` holds *forward symbolic-execution* lemmas, thin specializations of
+the generic `interpretOp_forward` (`Veir/Interpreter/Lemmas.lean`):
+
+- `interpretOp_castToReg_forward` — `unrealized_conversion_cast`, `.int bw x` ↦ `.reg (toReg x)`;
+- `interpretOp_castBack_forward` — the reverse cast, `.reg r` ↦ `.int bw (toInt r bw)`;
+- `interpretOp_riscv_unaryReg_forward` — **generic over the RISC-V opcode**: any unary
+  reg-to-reg op whose `Riscv.interpretOp'` maps `.reg r` to `.reg (f r)` (hypothesis `hSem`,
+  discharged by `rfl` at each concrete opcode). Covers `clz`/`clzw`/`ctz`/`ctzw`/`cpop`/`cpopw`
+  and any future unary Zbb op with **no new lemma needed**.
+
+Each lemma's conclusion gives the successful one-step interpretation, memory unchanged, the
+result binding, and a **frame clause** (all non-result variables unchanged). The frame clause
+is what lets facts about earlier values survive to later ops in the chain — essential for
+binops (see below). New emitted-op *shapes* (binary reg ops, ops with immediates) need one new
+specialization each — ~20 lines of boilerplate: instantiate `interpretOp_forward` with explicit
+`vals := #[…]`, `results := #[…]`, `mem' := state.memory`, and discharge the three obligations
+with the same `simp` scripts as the existing ones. Binop variants take two operand hypotheses
+and `vals := #[.reg r₁, .reg r₂]`.
+
+### Peel tactics
+
+`CommonTactics.lean` provides macros that mirror the monadic structure of the pattern in
+`hpattern`:
+
+- `peelSplittableCondition` / `peelSplittableCondition'` — split an `if`/`match` guard,
+  discharge the impossible branch with `grind`;
+- `peelOpCreation` / `peelOpCreation!` — peel one op-creation bind, introducing the updated
+  context, the new op, and the creation hypothesis (the `!` form also rewrites `createOp!` to
+  plain `createOp` and transports a dominance hypothesis into the new context);
+- `peelCastToRegLocal` / `peelReplaceWithRegLocal` — same, specialized to the two cast helpers;
+- `cleanupHpattern` — substitute the final `newOps`/`newValues`/`newCtx` equalities.
+
+The matcher itself is peeled inline in the generic proof (case on `match? op ctx.raw`, the
+`none` branch contradicts `hpattern`), since the matcher is now a *parameter* rather than a
+concrete function.
+
+### Base lemmas
+
+`CommonBaseLemmas.lean` holds the glue: `LocalRewritePattern.exists_refined_int_getVar?`
+(read a refined integer operand in the target state), `WfRewriter.createOp!_none_eq`
+(reduce `createOp!` at a `none` insertion point to `createOp`), `getProperties!` preservation
+lemmas, and the axiom `ValuePtr.dominatesIp_before_WfRewriter_createOp` (dominance is preserved
+when creating a detached op — axiomatised because `dominatesIp` is opaque).
+
+## Checklist: proving a new lowering
+
+**If it fits `lowerUnaryWLocal`** (single integer operand, one unary reg-to-reg RISC-V op per
+bitwidth): define it as a `lowerUnaryWLocal` instance in `RISCV64.lean`, then in the `Example`
+namespace of `LowerUnaryW.lean`:
+
+1. **Layer 0**: `foo_isRefinedBy_toInt_<riscvop>` — one per bitwidth branch.
+2. **Layer 1**: check `OperationPtr.Verified.llvm_foo` exists in `Verifier.lean`; add the
+   three-liner if missing.
+3. **Layer 2**: check `matchFoo_implies` exists in `Matching/Lemmas.lean`; add if missing.
+4. Instantiate `lowerUnaryWLocal_preservesSemantics` (the three `hSem*` arguments are `rfl`).
+5. **Axiom check**: `#guard_msgs in #print axioms foo_local_preservesSemantics` to pin the
+   axiom footprint.
+
+**If it needs a new shape** (binop, longer chain, extra guards): first factor the lowering
+through a new combinator in `RISCV64.lean`, then prove that combinator's
+`PreservesSemantics` once, generic over the opcode-specific parameters, following
+`lowerUnaryWLocal_preservesSemantics` as the template. Its proof body is a linear script:
+peel the matcher and guards, unfold the source interpretation, peel the op creations (one
+`peel*` per created op, in program order), read the refined operand(s) with
+`exists_refined_int_getVar?`, establish the structural facts about the created ops (`grind`,
+seeded with `*_WfRewriter_createOp` transport lemmas where needed), symbolically execute the
+emitted chain with the forward lemmas, and assemble the simulation triple. Then instantiate
+per lowering as above.
+
+## Adapting to other lowering shapes
+
+- **Binops** (`add_local`, `and_local`, `mul_local`, …): two `castToRegLocal` peels, two
+  `exists_refined_int_getVar?` reads, two "operand is not a result of `op`" facts, a binop
+  analogue of `matchUnaryOp_interpretOp_unfold`, and a binop reg-to-reg forward lemma.
+  Crucially, when executing the chain, the value of the *first* cast's result must survive the
+  *second* cast's interpretation: keep the **frame clause** of the forward lemma (bind it as
+  `hFrame` instead of discarding with `-`) and rewrite the earlier result binding through it
+  before feeding the RISC-V op's forward lemma.
+- **Longer chains** (`bswap_local` 32-bit emits `cast, rev8, srli, castBack`): one extra
+  `peelOpCreation!` and one extra forward-lemma application per op; ops with an immediate
+  (`srli`) need their forward lemma to take the properties (`RISCVImmediateProperties`) into
+  account when unfolding `Riscv.interpretOp'`.
+- **Nested branching** (`bswap_local` branches *after* creating `rev8Op`): the `rcases` on the
+  bitwidth happens at the point where `hpattern` branches; peel the shared prefix first, split,
+  then peel each branch's suffix.
+- **Guards other than bitwidth** (e.g. constant-operand checks in `fshrConst_local`): each
+  `if c then return (ctx, none)` / `let some … := … | return (ctx, none)` in the pattern is one
+  `peelSplittableCondition` / matcher-style peel; the surviving hypothesis feeds the data lemma.
+
+## Gotchas
+
+- **`RewriteProofs` is not in the lake build graph**: nothing under `Veir/` imports these files,
+  so `lake build` alone does not check them. Build them explicitly, e.g.
+  `lake build Veir.Passes.InstructionSelection.RewriteProofs.LowerUnaryW`.
+- **`interpretOp_forward` needs explicit `vals`/`results`/`mem'`** — unification won't infer
+  them from the goal.
+- **`clear hpattern` inside dischargers**: the `peel*` macros clear `hpattern` in their
+  `by grind`/`by simp` side goals so its proof term isn't captured, which would block later
+  peels. Keep this if you write new peel macros.
+- **`grind` seeding for transport chains**: facts about ops created two contexts ago
+  (`retOp`'s result types viewed in `ctx₃`) need the `*_WfRewriter_createOp` transport lemmas
+  passed explicitly to `grind [...]`, instantiated at the right creation hypothesis.
+- **Bitwidth literals**: destructure `intType` (`obtain ⟨bw⟩ := intType`) and `subst` the
+  branch hypothesis before applying the Layer-0 lemmas, which are stated at literal `64`/`32`.
+- **`maxHeartbeats`**: the combinator theorem needs `set_option maxHeartbeats 1000000` (many
+  `grind` calls over a large context).
+- **Expected axioms**: `#print axioms` will list the dominance axioms
+  (`OperationPtr.dominates*`, `ValuePtr.dominatesIp*`,
+  `IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates`,
+  `ValuePtr.dominatesIp_before_WfRewriter_createOp`),
+  `OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants`, `floatEqOfToBitsEq`,
+  and a `…bv_decide.ax_…` native axiom per `bv_decide`/`veir_bv_decide` use (including
+  `MemoryState.llvmLoad._native.bv_decide.ax_8` pulled in by the interpreter) — that's the
+  accepted baseline, pin it with `#guard_msgs`.
+
+## File map
+
+| File | Contents | Growth per new lowering |
+|---|---|---|
+| `RewriteProofs/LowerUnaryW.lean` | `matchUnaryOp_interpretOp_unfold`, `lowerUnaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations (`Example` namespace) | two data lemmas + one instantiation (unary); new file per new *shape* |
+| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary reg-to-reg riscv op) | one lemma per new emitted-op *shape* |
+| `RewriteProofs/CommonTactics.lean` | `peel*` macros, `cleanupHpattern` | rarely |
+| `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `createOp!` reduction, properties/dominance transport | rarely |
+| `RewriteProofs/CommonMatchLemmas.lean` | ctlz-specific unfold/peel lemmas — currently unused (superseded by the generic `matchUnaryOp_interpretOp_unfold`); candidate for deletion | — |
+| `Veir/Passes/InstructionSelection/RISCV64.lean` | the lowering combinators (`lowerUnaryWLocal`) and their instances | one `def` (or a new combinator) |
+| `Veir/Verifier.lean` | `IsVerified*` bundles + `Verified.llvm_*` extractors (Layer 1) | one 3-line lemma (unop/binop) |
+| `Veir/Passes/Matching/Lemmas.lean` | `match*_implies` (Layer 2) | usually nothing |
+| `Veir/Interpreter/Lemmas.lean` | generic `interpretOp_forward`, `interpretOpList_cons` | nothing |
+| `Veir/PatternRewriter/Semantics.lean` | `PreservesSemantics` | nothing |


### PR DESCRIPTION
This PR introduce the first proof of local semantics preservation for rewrites.
It contains the following files:
* `CommonBaseLemmas.lean` : Lemmas that are useful to prove correctness, but don't yet have a place in the rest of the codebase
* `CommonForwardInterpret.lean` : A set of lemmas that proves that `interpretOp` is successful on given opcodes. This is very useful to simplify the semantic preservation proofs
* `CommonTactics.lean` : A few tactics that make processing a rewrite pattern easier. They "peel" the pattern by reasonning about each matching or rewriting instruction one by one
* `LowerUnaryW.lean` : A proof of semantics preservation for `ctlz`, `cttz`, and `ctpop`. This is written as one single lemma (`lowerUnaryWLocal_preservesSemantics`) that is instantiated with the 3 different operations.
* `ProofStrategy.md` : An LLM generated document that explains how to do a similar proof for other lowerings.