### PR TITLE
feat(parser): support forward references to SSA values

### DIFF
--- a/Test/Parsing/forward-reference-invalid-result-index.mlir
+++ b/Test/Parsing/forward-reference-invalid-result-index.mlir
@@ -1,0 +1,16 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    %b = "test.test"(%a#1) : (i32) -> i1
+    %a = "test.test"() : () -> i32
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:forward-reference-invalid-result-index.mlir:6:5: error: definition of value %a provides 1 results, but result #1 was used
+// CHECK-NEXT:    %a = "test.test"() : () -> i32
+// CHECK-NEXT:    ^
+// CHECK-NEXT:forward-reference-invalid-result-index.mlir:5:22: note: value used here
+// CHECK-NEXT:    %b = "test.test"(%a#1) : (i32) -> i1
+// CHECK-NEXT:                     ^

--- a/Test/Parsing/forward-reference-missing-block.mlir
+++ b/Test/Parsing/forward-reference-missing-block.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+  ^entry:
+    "cf.br"() [^missing] : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:forward-reference-missing-block.mlir:6:16: error: block %missing was used but never defined
+// CHECK-NEXT:    "cf.br"() [^missing] : () -> ()
+// CHECK-NEXT:               ^

--- a/Test/Parsing/forward-reference-missing-value.mlir
+++ b/Test/Parsing/forward-reference-missing-value.mlir
@@ -1,0 +1,15 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+
+// A value that is used but never defined anywhere is reported once top-level parsing
+// finishes.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    "test.test"(%a) : (i32) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:forward-reference-missing-value.mlir:8:17: error: use of undefined value %a
+// CHECK-NEXT:    "test.test"(%a) : (i32) -> ()
+// CHECK-NEXT:                ^

--- a/Test/Parsing/forward-reference-nested.mlir
+++ b/Test/Parsing/forward-reference-nested.mlir
@@ -1,0 +1,33 @@
+// RUN: veir-opt %s --allow-unregistered-dialect | filecheck %s
+
+// A value name forward-referenced before its definition resolves to the FIRST textual
+// definition of that name, wherever it appears -- following MLIR's generic-form parser,
+// whose SSA name table is flat across regions. Here both uses of %a (the one in the function
+// body and the one inside the nested region) bind to the first definition, which is inside
+// the nested region; the later definition in the function body is an independent value.
+//
+// Whether this is legal under dominance / IsolatedFromAbove is a verifier concern that MLIR
+// checks after parsing. Implementation in VeIR TBD. For details see `ForwardValue` in 
+// `Veir.Parser.MlirParser`.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    "test.use"(%a) : (i32) -> ()
+    "test.wrapper"() ({
+    ^inner:
+      "test.use"(%a) : (i32) -> ()
+      %a = "test.def"() : () -> i32
+      "cf.br"() [^inner] : () -> ()
+    }) : () -> ()
+    %a = "test.def"() : () -> i32
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// Both uses bind to the first (nested) definition ...
+// CHECK:        "test.use"(%[[A:.*]]) : (i32) -> ()
+// CHECK:            "test.use"(%[[A]]) : (i32) -> ()
+// CHECK-NEXT:       %[[A]] = "test.def"() : () -> i32
+// ... and the later definition is an independent value.
+// CHECK:        %[[B:.*]] = "test.def"() : () -> i32
+// CHECK-NOT:    %[[A]] =

--- a/Test/Parsing/forward-reference-parent-scope.mlir
+++ b/Test/Parsing/forward-reference-parent-scope.mlir
@@ -1,0 +1,27 @@
+// RUN: veir-opt %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    "test.test"() ({
+    ^inner:
+      "test.test"(%a) : (i32) -> ()
+      "cf.br"() [^inner] : () -> ()
+    }) : () -> ()
+    %a = "test.test"() : () -> i32
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{{.*}}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         "test.test"() ({
+// CHECK-NEXT:           ^[[INNER:.*]]():
+// CHECK-NEXT:             "test.test"(%[[A:.*]]) : (i32) -> ()
+// CHECK-NEXT:             "cf.br"() [^[[INNER]]] : () -> ()
+// CHECK-NEXT:         }) : () -> ()
+// CHECK-NEXT:         %[[A]] = "test.test"() : () -> i32
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/Parsing/forward-reference.mlir
+++ b/Test/Parsing/forward-reference.mlir
@@ -1,0 +1,32 @@
+// RUN: veir-opt %s --allow-unregistered-dialect | filecheck %s
+
+// A value may be used in a block that appears, in file order, before the block
+// that defines it, as long as the definition dominates the use in the CFG. The
+// parser resolves such forward references rather than rejecting them.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+  ^bb0:
+    "cf.br"() [^bb2] : () -> ()
+  ^bb1:
+    "test.test"(%v) : (i32) -> ()
+    "func.return"() : () -> ()
+  ^bb2:
+    %v = "test.test"() : () -> i32
+    "cf.br"() [^bb1] : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "func.func"() <{{.*}}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         "cf.br"() [^[[DEF:.*]]] : () -> ()
+// CHECK-NEXT:       ^[[USE:.*]]():
+// CHECK-NEXT:         "test.test"(%[[V:.*]]) : (i32) -> ()
+// CHECK-NEXT:         "func.return"() : () -> ()
+// CHECK-NEXT:       ^[[DEF]]():
+// CHECK-NEXT:         %[[V]] = "test.test"() : () -> i32
+// CHECK-NEXT:         "cf.br"() [^[[USE]]] : () -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/DataFlowFramework/Helpers.lean
+++ b/UnitTest/DataFlowFramework/Helpers.lean
@@ -27,7 +27,7 @@ def parseTopLevelOp (s : String) : Except String (OperationPtr × MlirParserStat
     | throw "internal error: failed to create IR context"
   let parserState ← (ParserState.fromInput s.toByteArray).mapError toString
   let (op, mlirState, _) ←
-    ((parseOp none).run (MlirParserState.fromContext ctx) parserState).mapError toString
+    (Veir.Parser.parseTopLevelOp.run (MlirParserState.fromContext ctx) parserState).mapError toString
   pure (op, mlirState)
 
 /--

--- a/UnitTest/IR/Operation.lean
+++ b/UnitTest/IR/Operation.lean
@@ -11,7 +11,7 @@ private def parse (s : String) : OperationPtr × IRContext OpCode :=
     match ParserState.fromInput s.toByteArray with
     | .error _ => panic! "lex error"
     | .ok parser =>
-      match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+      match parseTopLevelOp.run (MlirParserState.fromContext ctx) parser with
       | .error _ => panic! "parse error"
       | .ok (op, state, _) => (op, state.ctx.raw)
 

--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -14,7 +14,7 @@ def testParseOp (s : String) : IO Unit :=
   | some (ctx, _) =>
     match ParserState.fromInput (s.toByteArray) with
     | .ok parser =>
-      match (parseOp none).run (MlirParserState.fromContext ctx) parser with
+      match parseTopLevelOp.run (MlirParserState.fromContext ctx) parser with
       | .ok (op, state, _) => Printer.printOperation state.ctx op
       | .error err => .error (toString err)
     | .error err => .error (toString err)
@@ -279,4 +279,114 @@ def testParseOp (s : String) : IO Unit :=
   %a = "test.test"() : () -> i32
 ^bb1:
   %a = "test.test"() : () -> i32
+}) : () -> ()"#
+
+/-!
+## Forward references to SSA values
+
+The parser accepts textual forward references to SSA values by creating a placeholder
+for the not-yet-defined value and resolving it once the definition is parsed. Dominance
+is not checked by the parser.
+-/
+
+/--
+  info: "builtin.module"() ({
+  ^4():
+    "test.test"() [^5] : () -> ()
+  ^5():
+    "test.test"(%10) : (i32) -> ()
+  ^9():
+    %10 = "test.test"() : () -> i32
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+^bb0:
+  "test.test"() [^bb1] : () -> ()
+^bb1:
+  "test.test"(%v) : (i32) -> ()
+^bb2:
+  %v = "test.test"() : () -> i32
+}) : () -> ()"#
+
+/--
+  info: "builtin.module"() ({
+  ^4():
+    %6 = "test.test"(%7) : (i32) -> i32
+    %7 = "test.test"() : () -> i32
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+  %b = "test.test"(%a) : (i32) -> i32
+  %a = "test.test"() : () -> i32
+}) : () -> ()"#
+
+/--
+  info: "builtin.module"() ({
+  ^4():
+    "test.test"() [^5] : () -> ()
+  ^5():
+    %8 = "test.test"(%10#1) : (i64) -> i32
+  ^9():
+    %10:2 = "test.test"() : () -> (i32, i64)
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+^bb0:
+  "test.test"() [^bb1] : () -> ()
+^bb1:
+  %b = "test.test"(%a#1) : (i64) -> i32
+^bb2:
+  %a:2 = "test.test"() : () -> (i32, i64)
+}) : () -> ()"#
+
+/--
+  error: definition of value %a#0 has type i64 but was used with type i32
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+  %b = "test.test"(%a) : (i32) -> i32
+  %a = "test.test"() : () -> i64
+}) : () -> ()"#
+
+/--
+  error: type mismatch for value %a: expected i64, got i32
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+  %b = "test.test"(%a) : (i32) -> i32
+  %c = "test.test"(%a) : (i64) -> i32
+  %a = "test.test"() : () -> i32
+}) : () -> ()"#
+
+-- A forward reference resolves to the first textual definition of the name, even one inside
+-- a nested region (MLIR's generic-form parser keeps a flat SSA name table). Legality under
+-- dominance / IsolatedFromAbove is deferred to future implementation (for details see
+-- `ForwardValue` in `Veir.Parser.MlirParser`).
+/--
+info: "builtin.module"() ({
+  ^4():
+    "test.test"(%9) : (i32) -> ()
+    "test.test"() ({
+      ^8():
+        %9 = "test.test"() : () -> i32
+    }) : () -> ()
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+  "test.test"(%a) : (i32) -> ()
+  "test.test"() ({
+    %a = "test.test"() : () -> i32
+  }) : () -> ()
+}) : () -> ()"#
+
+/--
+  error: use of undefined value %a
+-/
+#guard_msgs in
+#eval! testParseOp r#""builtin.module"() ({
+  "test.test"(%a) : (i32) -> ()
 }) : () -> ()"#

--- a/Veir/Parser/DecidableInBounds.lean
+++ b/Veir/Parser/DecidableInBounds.lean
@@ -66,6 +66,29 @@ def checkValueInBounds (value : ValuePtr) (ctx : IRContext OpInfo) :
   if h : value.InBounds ctx then pure ⟨h⟩
   else throwString s!"internal error: value is not in bounds"
 
+/-- Check that two values are distinct. -/
+def checkValuesNe (v₁ v₂ : ValuePtr) :
+    m (PLift (v₁ ≠ v₂)) :=
+  if h : v₁ ≠ v₂ then pure ⟨h⟩
+  else throwString s!"internal error: values are unexpectedly equal"
+
+/-- Check that an operation has no regions. -/
+def checkOpNoRegions (op : OperationPtr) (ctx : IRContext OpInfo) :
+    m (PLift (op.getNumRegions! ctx = 0)) :=
+  if h : op.getNumRegions! ctx = 0 then pure ⟨h⟩
+  else throwString s!"internal error: operation unexpectedly has regions"
+
+/--
+Check that an operation has no uses.
+
+Uses boolean negation `!` rather than `= false` to match the `opUses` parameter of
+`WfRewriter.eraseOp`.
+-/
+def checkOpNoUses (op : OperationPtr) (ctx : IRContext OpInfo) :
+    m (PLift (!op.hasUses! ctx)) :=
+  if h : !op.hasUses! ctx then pure ⟨h⟩
+  else throwString s!"internal error: operation unexpectedly has uses"
+
 /-- Check that a region is in bounds. -/
 def checkRegionInBounds (region : RegionPtr) (ctx : IRContext OpInfo) :
     m (PLift (region.InBounds ctx)) :=

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -35,6 +35,29 @@ def BlockEntry.block : BlockEntry → BlockPtr
   | .Defined block _ => block
   | .ForwardDeclared block _ => block
 
+/--
+  Bookkeeping for an SSA value referenced before it is defined (a "forward reference").
+
+  Following MLIR's generic-form parser, the name table is flat across all regions: a forward
+  reference is resolved by the first textual definition of the name, wherever it appears. Each
+  referenced result index holds a detached single-result placeholder operation standing in for
+  the value; when the definition is parsed, all uses of each placeholder are replaced by the
+  real value (via `Rewriter.replaceValue`) and the placeholder is erased.
+
+  Whether such a reference is actually legal (dominance, `IsolatedFromAbove`) is a verifier
+  concern that MLIR checks after parsing; we likewise leave it to a later verification pass and
+  only report values that are never defined anywhere.
+
+  This mirrors MLIR's approach that uses a throwaway operation result as the placeholder
+  (specifically `unrealized_conversion_cast`).
+-/
+structure ForwardValue where
+  /-- Placeholder operation per referenced result index, with that index's first-use location. -/
+  placeholders : Std.HashMap Nat (OperationPtr × Location)
+  /-- Location of the first use, used for error reporting if the value is never defined. -/
+  loc : Location
+  deriving Inhabited
+
 structure MlirParserState where
   /-- The current IR context. -/
   ctx : WfIRContext OpCode
@@ -46,6 +69,13 @@ structure MlirParserState where
     Each scope sees all values defined in parent scopes (those that appear earlier in the array).
   -/
   definitionsPerScope : Array (Std.HashSet ByteArray)
+  /--
+    Values referenced but not yet defined, keyed by name. Following MLIR's generic-form parser,
+    this table is flat: a definition resolves the forward reference regardless of which region
+    it appears in. Entries remaining when top-level parsing finishes are reported as uses of
+    undefined values.
+  -/
+  forwardValues : Std.HashMap ByteArray ForwardValue
   /--
     The blocks that have been encountered during parsing, along with whether
     they have been defined or only forward declared.
@@ -62,6 +92,7 @@ def MlirParserState.fromContext (ctx : WfIRContext OpCode)
     allowUnregisteredDialect
     values := Std.HashMap.emptyWithCapacity 128
     definitionsPerScope := #[Std.HashSet.emptyWithCapacity 2]
+    forwardValues := Std.HashMap.emptyWithCapacity 1
     blocks := Std.HashMap.emptyWithCapacity 1
   }
 
@@ -126,28 +157,6 @@ def inChildScope {α : Type} (m : MlirParserM α) : MlirParserM α := do
   return result
 
 /--
-  Register an array of parsed values with the given name in the current scope.
-  This is used to keep track of values that have been defined during parsing.
--/
-def registerValueDefs (name : ByteArray) (pos : Location) (values : Array ValuePtr) : MlirParserM Unit := do
-  if let some (_, existingPos) := (← get).values[name]? then
-    let error := ParserError.mk s!"value %{String.fromUTF8! name} has already been defined" pos []
-    let error := error.addNote existingPos "previously defined here"
-    throw error
-  modify fun s =>
-    { s with
-      values := s.values.insert name (values, pos)
-      definitionsPerScope := s.definitionsPerScope.modify (s.definitionsPerScope.size - 1) (·.insert name)
-    }
-
-/--
-  Register a single value with the given name in current scope.
-  This is used to keep track of values that have been defined during parsing.
--/
-def registerValueDef (name : ByteArray) (pos : Location) (value : ValuePtr) : MlirParserM Unit :=
-  registerValueDefs name pos #[value]
-
-/--
   Set the current IR context.
   This should be called whenever any modifications have been made to the context
   outside of the parser monad.
@@ -183,6 +192,100 @@ def modifyContextM' (f : WfIRContext OpCode → MlirParserM (α × WfIRContext O
 -/
 def modifyContextM (f : WfIRContext OpCode → MlirParserM (WfIRContext OpCode)) : MlirParserM Unit :=
   modifyContextM' (fun ctx => do pure ((), ← f ctx))
+
+/--
+  The operation code used for forward-reference placeholders.
+  We use a throwaway operation result (specifically a `builtin.unrealized_conversion_cast`)
+  to stand in for a value that is referenced before it is defined.
+-/
+def placeholderOpCode : OpCode := .builtin .unrealized_conversion_cast
+
+/--
+  Create a detached, single-result placeholder operation of the given type.
+  Its result is used to stand in for a value that has been referenced but not yet
+  defined. The operation is not inserted into any block; once the real definition is
+  parsed, `resolveForwardValue` replaces all uses of this result with the real value
+  and erases this operation.
+-/
+def createForwardRefPlaceholder (ty : TypeAttr) (loc : Location) : MlirParserM OperationPtr :=
+  modifyContextM' fun ctx => do
+    match WfRewriter.createOp ctx placeholderOpCode #[ty] #[] #[] #[]
+        (default : propertiesOf placeholderOpCode) none with
+    | none => throwAt loc "internal error: failed to create forward-reference placeholder"
+    | some (ctx', op) => pure (op, ctx')
+
+/--
+  Replace every use of a placeholder operation's single result with `target`, then erase
+  the (now unused, region-less) placeholder operation.
+-/
+def rewirePlaceholder (placeholderOp : OperationPtr) (target : ValuePtr) : MlirParserM Unit := do
+  let placeholderValue : ValuePtr := placeholderOp.getResult 0
+  modifyContextM fun ctx => do
+    let ⟨hOldIn⟩ ← checkValueInBounds placeholderValue ctx.raw
+    let ⟨hNewIn⟩ ← checkValueInBounds target ctx.raw
+    let ⟨hNe⟩ ← checkValuesNe placeholderValue target
+    pure (WfRewriter.replaceValue ctx placeholderValue target hNe hOldIn hNewIn)
+  modifyContextM fun ctx => do
+    let ⟨hOpIn⟩ ← checkOpInBounds placeholderOp ctx.raw
+    let ⟨hNoRegions⟩ ← checkOpNoRegions placeholderOp ctx.raw
+    let ⟨hNoUses⟩ ← checkOpNoUses placeholderOp ctx.raw
+    pure (WfRewriter.eraseOp ctx placeholderOp hNoRegions hNoUses hOpIn)
+
+/--
+  Modify the (scope-wide) forward-reference table.
+-/
+def modifyForwardValues
+    (f : Std.HashMap ByteArray ForwardValue → Std.HashMap ByteArray ForwardValue) : MlirParserM Unit :=
+  modify fun s => { s with forwardValues := f s.forwardValues }
+
+/--
+  Resolve a forward-referenced value now that its real definition has been parsed. For each
+  referenced result index, replace all uses of the placeholder result with the corresponding
+  real value and erase the placeholder operation.
+-/
+def resolveForwardValue (name : ByteArray) (pos : Location) (fwd : ForwardValue)
+    (values : Array ValuePtr) : MlirParserM Unit := do
+  for (index, (placeholderOp, useLoc)) in fwd.placeholders do
+    let some realValue := values[index]?
+      | throw (({ msg := s!"definition of value %{String.fromUTF8! name} provides {values.size} results, but result #{index} was used",
+                  pos := some pos } : ParserError).addNote useLoc "value used here")
+    /- The value has a single type, so the definition must match every use. -/
+    let placeholderValue : ValuePtr := placeholderOp.getResult 0
+    let ⟨ctx, _⟩ ← getContext
+    let usedType := placeholderValue.getType! ctx
+    let definedType := realValue.getType! ctx
+    if usedType ≠ definedType then
+      throw (({ msg := s!"definition of value %{String.fromUTF8! name}#{index} has type {definedType} but was used with type {usedType}",
+                pos := some pos } : ParserError).addNote useLoc "value used here")
+    rewirePlaceholder placeholderOp realValue
+  modifyForwardValues (·.erase name)
+
+/--
+  Register an array of parsed values with the given name in the current scope.
+  This is used to keep track of values that have been defined during parsing.
+  If the name was forward-referenced earlier, the placeholders created for it are resolved to
+  the newly-parsed values (following MLIR: the first definition of a name resolves it).
+-/
+def registerValueDefs (name : ByteArray) (pos : Location) (values : Array ValuePtr) : MlirParserM Unit := do
+  let st ← get
+  if let some fwd := st.forwardValues[name]? then
+    resolveForwardValue name pos fwd values
+  if let some (_, existingPos) := (← get).values[name]? then
+    let error := ParserError.mk s!"value %{String.fromUTF8! name} has already been defined" pos []
+    let error := error.addNote existingPos "previously defined here"
+    throw error
+  modify fun s =>
+    { s with
+      values := s.values.insert name (values, pos)
+      definitionsPerScope := s.definitionsPerScope.modify (s.definitionsPerScope.size - 1) (·.insert name)
+    }
+
+/--
+  Register a single value with the given name in current scope.
+  This is used to keep track of values that have been defined during parsing.
+-/
+def registerValueDef (name : ByteArray) (pos : Location) (value : ValuePtr) : MlirParserM Unit :=
+  registerValueDefs name pos #[value]
 
 /--
   Create a block at the given insert point and register its name in the parsing context.
@@ -348,12 +451,50 @@ def parseBlockOperands : MlirParserM (Array BlockPtr) := do
   return (← parseOptionalDelimitedList .square parseBlockOperand).getD #[]
 
 /--
+  Resolve a reference to a value that has not yet been defined by creating (or reusing)
+  a placeholder operation whose result stands in for the eventual definition.
+  The placeholder is recorded in the flat forward-reference table and resolved by the first
+  definition of the name, wherever it later appears (as in MLIR's generic-form parser).
+-/
+def resolveForwardOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) : MlirParserM ValuePtr := do
+  let idx := operand.indexD
+  match (← get).forwardValues[operand.name]? with
+  | some fwd =>
+    match fwd.placeholders[idx]? with
+    | some (placeholderOp, useLoc) =>
+      /- The same result index was referenced before: reuse its placeholder and
+         check the type is consistent with the previous use. -/
+      let placeholderValue : ValuePtr := placeholderOp.getResult 0
+      let ⟨ctx, _⟩ ← getContext
+      let parsedType := placeholderValue.getType! ctx
+      if parsedType ≠ expectedType then
+        throw (({ msg := s!"type mismatch for value {operand}: expected {expectedType}, got {parsedType}",
+                  pos := some operand.pos } : ParserError).addNote useLoc "value first used here")
+      return placeholderValue
+    | none =>
+      /- A new result index of an already forward-referenced value. -/
+      let placeholderOp ← createForwardRefPlaceholder expectedType operand.pos
+      modifyForwardValues (·.insert operand.name
+        { fwd with
+          placeholders := fwd.placeholders.insert idx (placeholderOp, operand.pos) })
+      return placeholderOp.getResult 0
+  | none =>
+    /- First reference of a not-yet-defined value. -/
+    let placeholderOp ← createForwardRefPlaceholder expectedType operand.pos
+    modifyForwardValues (·.insert operand.name
+      { placeholders := (Std.HashMap.emptyWithCapacity 1).insert idx (placeholderOp, operand.pos),
+        loc := operand.pos })
+    return placeholderOp.getResult 0
+
+/--
   Resolve an operand to an SSA value of the expected type.
-  Throw an error if the value is not defined or if the type does not match.
+  If the value has not yet been defined, a forward-reference placeholder is created;
+  it will be resolved when the definition is parsed, or reported as an error once
+  top-level parsing finishes if the value is never defined.
 -/
 def resolveOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) : MlirParserM ValuePtr := do
   let some (values, defPos) := (← getValues? operand.name)
-    | throwAt operand.pos s!"use of undefined value %{operand.nameString}"
+    | resolveForwardOperand operand expectedType
   let some value := values[operand.indexD]?
     | throw (({ msg := s!"invalid result index {operand.indexD} for %{operand.nameString}",
                 pos := some operand.pos } : ParserError).addNote defPos "value defined here")
@@ -557,13 +698,6 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   return op
 
 /--
-  Parse an operation.
--/
-partial def parseOp (ip : Option InsertPoint) : MlirParserM OperationPtr := do
-  let some op ← parseOptionalOp ip | throwAtCurrentPos "operation expected"
-  return op
-
-/--
   Parse a region.
 -/
 partial def parseRegion : MlirParserM RegionPtr := do
@@ -627,5 +761,23 @@ partial def parseOptionalBlock (ip : BlockInsertPoint) : MlirParserM (Option Blo
   return block
 
 end
+
+/--
+  Parse an operation.
+-/
+private def parseOp (ip : Option InsertPoint) : MlirParserM OperationPtr := do
+  let some op ← parseOptionalOp ip | throwAtCurrentPos "operation expected"
+  return op
+
+/-- Check that all SSA values forward referenced while parsing were eventually defined. -/
+def checkNoUnresolvedForwardValues : MlirParserM Unit := do
+  for (valueName, fwd) in (← get).forwardValues do
+    throwAt fwd.loc s!"use of undefined value %{String.fromUTF8! valueName}"
+
+/-- Parse a top-level operation and report any unresolved SSA forward references. -/
+partial def parseTopLevelOp : MlirParserM OperationPtr := do
+  let op ← parseOp none
+  checkNoUnresolvedForwardValues
+  return op
 
 end Veir.Parser

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -24,7 +24,7 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode Ã
   match ParserState.fromInput fileContent with
   | .ok parser =>
     let parserState := MlirParserState.fromContext ctx (allowUnregisteredDialect := true)
-    match (parseOp none).run parserState parser with
+    match parseTopLevelOp.run parserState parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error errMsg =>

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -112,7 +112,7 @@ def parseOperation (filename : Option String) (allowUnregisteredDialect : Bool :
   match ParserState.fromInput fileContent with
   | .ok parser =>
     let state := MlirParserState.fromContext ctx allowUnregisteredDialect
-    match (parseOp none).run state parser with
+    match parseTopLevelOp.run state parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error err =>

--- a/VeirToMIR.lean
+++ b/VeirToMIR.lean
@@ -19,7 +19,7 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode Ã
   match ParserState.fromInput fileContent with
   | .ok parser =>
     let parserState := MlirParserState.fromContext ctx (allowUnregisteredDialect := true)
-    match (parseOp none).run parserState parser with
+    match parseTopLevelOp.run parserState parser with
     | .ok (op, state, _) =>
       return (state.ctx, op)
     | .error errMsg =>


### PR DESCRIPTION
Implements MLIR parser support for SSA forward references.

The parser now:
- creates parser-local placeholders for SSA operands referenced before definition
- follows MLIR's approach by using temporary `builtin.unrealized_conversion_cast` operation results as placeholders, rather than adding a new SSA value kind
- resolves placeholders when the real SSA definition is parsed
- reports unresolved or type-incompatible forward references with source locations

Added coverage for three cases:
- valid SSA forward reference across blocks
- missing forward block reference in `[]` successor syntax
- parser unit coverage for forward SSA references, including multi-result references and error cases
