### PR TITLE
feat(riscv): optimize divisions by powers of 2

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
@@ -1,10 +1,5 @@
 // RUN: veir-opt %s -p=isel-sdag-riscv64 | filecheck %s
 
-// `udiv`/`sdiv` by a constant power of two select directly to shifts, mirroring
-// LLVM's `BuildLogBase2` (`udiv`), `BuildExactSDIV` (`sdiv exact`), and the
-// generic `sra`/`srl`/`add` sequence built by `visitSDIVLike` (`sdiv`, no `exact`).
-// See the `## Division by a constant power of two` section of RISCV64Sdag.lean.
-
 "builtin.module"() ({
     // llvm.udiv x, 8 -> riscv.srli x, 3
     "func.func"() <{function_type = (i64) -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
@@ -1,0 +1,137 @@
+// RUN: veir-opt %s -p=isel-sdag-riscv64 | filecheck %s
+
+// `udiv`/`sdiv` by a constant power of two select directly to shifts, mirroring
+// LLVM's `BuildLogBase2` (`udiv`), `BuildExactSDIV` (`sdiv exact`), and the
+// generic `sra`/`srl`/`add` sequence built by `visitSDIVLike` (`sdiv`, no `exact`).
+// See the `## Division by a constant power of two` section of RISCV64Sdag.lean.
+
+"builtin.module"() ({
+    // llvm.udiv x, 8 -> riscv.srli x, 3
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+        %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // llvm.udiv x, 8 (i32) -> riscv.srliw x, 3
+    "func.func"() <{function_type = (i32) -> i32}> ({
+    ^bb(%a: i32):
+        %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
+        %r = "llvm.udiv"(%a, %c) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "riscv.srliw"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i32) -> ()
+    }) : () -> ()
+
+    // udiv by 2^63: its bit pattern (0x8000...0) is decoded as the negative decimal
+    // -9223372036854775808, but is still a valid *unsigned* power-of-two divisor.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = -9223372036854775808 : i64}> : () -> i64
+        %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // Regression: 0xC000000000000000 (decimal -4611686018427387904) has *two* bits
+    // set, so it is not a power of two -- even though its magnitude as a signed
+    // `Int` (2^62) would incorrectly look like one under a naive sign/magnitude
+    // check that didn't first reduce it mod 2^64. Must stay unselected.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = -4611686018427387904 : i64}> : () -> i64
+        %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK: %{{.*}} = "llvm.udiv"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // Not a power of two: left unselected here (the generic isel-riscv64 pass
+    // picks it up as a plain `riscv.divu`).
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 6 : i64}> : () -> i64
+        %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK: %{{.*}} = "llvm.udiv"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // llvm.sdiv exact x, 8 -> riscv.srai x, 3 (no negation needed)
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) <{exact}> : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // llvm.sdiv exact x, -8 -> riscv.srai x, 3, then negate via `sub 0, _`.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = -8 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) <{exact}> : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // i32 exact variant.
+    "func.func"() <{function_type = (i32) -> i32}> ({
+    ^bb(%a: i32):
+        %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
+        %r = "llvm.sdiv"(%a, %c) <{exact}> : (i32, i32) -> i32
+        // CHECK: %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i32) -> ()
+    }) : () -> ()
+
+    // General (non-exact) llvm.sdiv x, 8 -> the biased 4-instruction sequence.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 61 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // General llvm.sdiv x, -8 -> the biased sequence plus a final negation.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = -8 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 61 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // i32 general variant.
+    "func.func"() <{function_type = (i32) -> i32}> ({
+    ^bb(%a: i32):
+        %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
+        %r = "llvm.sdiv"(%a, %c) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 31 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srliw"(%{{.*}}) <{"value" = 29 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.addw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i32) -> ()
+    }) : () -> ()
+
+    // Not a power of two: left unselected here (the generic isel-riscv64 pass
+    // picks it up as a plain `riscv.div`).
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 6 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK: %{{.*}} = "llvm.sdiv"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
@@ -119,14 +119,4 @@
         // CHECK-NEXT: %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
         "func.return"(%r) : (i32) -> ()
     }) : () -> ()
-
-    // Not a power of two: left unselected here (the generic isel-riscv64 pass
-    // picks it up as a plain `riscv.div`).
-    "func.func"() <{function_type = (i64) -> i64}> ({
-    ^bb(%a: i64):
-        %c = "llvm.mlir.constant"() <{value = 6 : i64}> : () -> i64
-        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
-        // CHECK: %{{.*}} = "llvm.sdiv"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
-        "func.return"(%r) : (i64) -> ()
-    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s -p=isel-br-riscv64,isel-riscv64,reconcile-cast | filecheck %s
+// RUN: veir-opt %s -p=isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,reconcile-cast,riscv-combine,dce | filecheck %s
 
 "builtin.module"() ({
   ^4():
@@ -145,11 +145,17 @@
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C1]]) [^[[BB_22:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_20]]():
 // CHECK-NEXT:          %[[REG_CAST7:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV0:[0-9]+]] = "riscv.div"(%[[REG_CAST7]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV0_SRA:[0-9]+]] = "riscv.srai"(%[[REG_CAST7]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV0_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV0_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV0_ADD:[0-9]+]] = "riscv.add"(%[[REG_CAST7]], %[[REG_DIV0_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV0:[0-9]+]] = "riscv.srai"(%[[REG_DIV0_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV0]]) [^[[BB_22]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_22]](%{{.*}}: !riscv.reg):
 // CHECK-NEXT:          %[[REG_CAST8:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV1:[0-9]+]] = "riscv.div"(%[[REG_CAST8]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV1_SRA:[0-9]+]] = "riscv.srai"(%[[REG_CAST8]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV1_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV1_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV1_ADD:[0-9]+]] = "riscv.add"(%[[REG_CAST8]], %[[REG_DIV1_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV1:[0-9]+]] = "riscv.srai"(%[[REG_DIV1_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"({{.*}}, %[[REG_DIV1]], %[[REG_C0]], {{.*}}) [^[[BB_27:[0-9]+]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_27]]({{.*}}):
 // CHECK-NEXT:          %[[REG_CAST9:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -160,8 +166,8 @@
 // CHECK-NEXT:          %[[REG_CAST11:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST10]]) : (i1) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST11]]) [^[[BB_32:[0-9]+]], ^[[BB_33:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_32]]():
-// CHECK-NEXT:          %[[REG_SRA0:[0-9]+]] = "riscv.sra"({{.*}}, %[[REG_C1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD0:[0-9]+]] = "riscv.add"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_SRA0:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD0:[0-9]+]] = "riscv.addi"({{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD0]], %[[REG_SRA0]]) [^[[BB_29]]] : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_33]]():
 // CHECK-NEXT:          %[[REG_SLT1:[0-9]+]] = "riscv.slt"({{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -180,7 +186,10 @@
 // CHECK-NEXT:      ^[[BB_46]]():
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]]) [^[[BB_49:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_49]](%[[ARG_49_0:[a-zA-Z0-9_]+]] : !riscv.reg):
-// CHECK-NEXT:          %[[REG_DIV3:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV3_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV3_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV3_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV3_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV3_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV3:[0-9]+]] = "riscv.srai"(%[[REG_DIV3_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_SLT3:[0-9]+]] = "riscv.slt"(%[[ARG_49_0]], %[[REG_DIV3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_CAST17:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SLT3]]) : (!riscv.reg) -> i1
 // CHECK-NEXT:          %[[REG_CAST18:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST17]]) : (i1) -> !riscv.reg
@@ -193,7 +202,10 @@
 // CHECK-NEXT:          %[[REG_CAST20:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD0]]) : (!riscv.reg) -> !llvm.ptr
 // CHECK-NEXT:          %[[REG_CAST21:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST20]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_LD0:[0-9]+]] = "riscv.ld"(%[[REG_CAST21]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV4:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV4_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV4_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV4_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV4_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV4_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV4:[0-9]+]] = "riscv.srai"(%[[REG_DIV4_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_ADD2:[0-9]+]] = "riscv.add"(%[[REG_DIV4]], %[[REG_ADD1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_CAST22:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_SH3ADD1:[0-9]+]] = "riscv.sh3add"(%[[REG_ADD2]], %[[REG_CAST22]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -201,7 +213,7 @@
 // CHECK-NEXT:          %[[REG_CAST24:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST23]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_LD1:[0-9]+]] = "riscv.ld"(%[[REG_CAST24]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_MUL1:[0-9]+]] = "riscv.mul"(%[[ARG_49_0]], %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_ADD3:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[REG_MUL1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD3:[0-9]+]] = "riscv.addi"(%[[REG_MUL1]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_MUL2:[0-9]+]] = "riscv.mul"({{.*}}, %[[REG_ADD3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_CAST25:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_SH3ADD2:[0-9]+]] = "riscv.sh3add"(%[[REG_MUL2]], %[[REG_CAST25]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -231,15 +243,18 @@
 // CHECK-NEXT:          "riscv.sd"(%[[REG_CAST37]], %[[REG_REM2]]) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_80:[0-9]+]]] : () -> ()
 // CHECK-NEXT:      ^[[BB_80]]():
-// CHECK-NEXT:          %[[REG_ADD6:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[ARG_49_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD6:[0-9]+]] = "riscv.addi"(%[[ARG_49_0]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD6]]) [^[[BB_49]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_54]]():
 // CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_84:[0-9]+]]] : () -> ()
 // CHECK-NEXT:      ^[[BB_84]]():
-// CHECK-NEXT:          %[[REG_ADD7:[0-9]+]] = "riscv.add"(%[[REG_C1]], %[[ARG_42_0]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD7:[0-9]+]] = "riscv.addi"(%[[ARG_42_0]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD7]]) [^[[BB_42]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_47]]():
-// CHECK-NEXT:          %[[REG_DIV5:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV5_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV5_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV5_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV5_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV5_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV5:[0-9]+]] = "riscv.srai"(%[[REG_DIV5_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_CAST38:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_XOR2:[0-9]+]] = "riscv.xor"(%[[REG_C0]], %[[REG_CAST38]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_C0_4:[0-9]+]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
@@ -248,7 +263,10 @@
 // CHECK-NEXT:          %[[REG_CAST40:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST39]]) : (i1) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST40]]) [^[[BB_90:[0-9]+]], ^[[BB_91:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_90]]():
-// CHECK-NEXT:          %[[REG_DIV6:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV6_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV6_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV6_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV6_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV6_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV6:[0-9]+]] = "riscv.srai"(%[[REG_DIV6_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV6]]) [^[[BB_94:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_91]]():
 // CHECK-NEXT:          %[[REG_ADD8:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -265,12 +283,15 @@
 // CHECK-NEXT:          %[[REG_ADD9:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD9]]) [^[[BB_103:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_100]]():
-// CHECK-NEXT:          %[[REG_DIV7:[0-9]+]] = "riscv.div"({{.*}}, %[[REG_C2]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV7_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV7_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV7_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV7_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV7_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV7:[0-9]+]] = "riscv.srai"(%[[REG_DIV7_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV7]]) [^[[BB_103]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_103]](%[[ARG_103_0:[a-zA-Z0-9_]+]] : !riscv.reg):
 // CHECK-NEXT:          "riscv_cf.branch"() [^[[BB_107:[0-9]+]]] : () -> ()
 // CHECK-NEXT:      ^[[BB_107]]():
-// CHECK-NEXT:          %[[REG_ADD10:[0-9]+]] = "riscv.add"(%[[REG_C1]], {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_ADD10:[0-9]+]] = "riscv.addi"({{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[ARG_103_0]], %[[REG_DIV5]], %[[REG_ADD10]], %[[ARG_94_0]]) [^[[BB_27]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_40]]():
 // CHECK-NEXT:          "llvm.return"() : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fastntt.mlir
@@ -145,15 +145,13 @@
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C1]]) [^[[BB_22:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_20]]():
 // CHECK-NEXT:          %[[REG_CAST7:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV0_SRA:[0-9]+]] = "riscv.srai"(%[[REG_CAST7]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV0_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV0_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV0_SRL:[0-9]+]] = "riscv.srli"(%[[REG_CAST7]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV0_ADD:[0-9]+]] = "riscv.add"(%[[REG_CAST7]], %[[REG_DIV0_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV0:[0-9]+]] = "riscv.srai"(%[[REG_DIV0_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV0]]) [^[[BB_22]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_22]](%{{.*}}: !riscv.reg):
 // CHECK-NEXT:          %[[REG_CAST8:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV1_SRA:[0-9]+]] = "riscv.srai"(%[[REG_CAST8]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV1_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV1_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV1_SRL:[0-9]+]] = "riscv.srli"(%[[REG_CAST8]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV1_ADD:[0-9]+]] = "riscv.add"(%[[REG_CAST8]], %[[REG_DIV1_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV1:[0-9]+]] = "riscv.srai"(%[[REG_DIV1_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"({{.*}}, %[[REG_DIV1]], %[[REG_C0]], {{.*}}) [^[[BB_27:[0-9]+]]] : (!riscv.reg, !riscv.reg, !riscv.reg, !riscv.reg) -> ()
@@ -186,8 +184,7 @@
 // CHECK-NEXT:      ^[[BB_46]]():
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_C0]]) [^[[BB_49:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_49]](%[[ARG_49_0:[a-zA-Z0-9_]+]] : !riscv.reg):
-// CHECK-NEXT:          %[[REG_DIV3_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV3_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV3_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV3_SRL:[0-9]+]] = "riscv.srli"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV3_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV3_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV3:[0-9]+]] = "riscv.srai"(%[[REG_DIV3_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_SLT3:[0-9]+]] = "riscv.slt"(%[[ARG_49_0]], %[[REG_DIV3]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -202,8 +199,7 @@
 // CHECK-NEXT:          %[[REG_CAST20:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_SH3ADD0]]) : (!riscv.reg) -> !llvm.ptr
 // CHECK-NEXT:          %[[REG_CAST21:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST20]]) : (!llvm.ptr) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_LD0:[0-9]+]] = "riscv.ld"(%[[REG_CAST21]]) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV4_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV4_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV4_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV4_SRL:[0-9]+]] = "riscv.srli"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV4_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV4_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV4:[0-9]+]] = "riscv.srai"(%[[REG_DIV4_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_ADD2:[0-9]+]] = "riscv.add"(%[[REG_DIV4]], %[[REG_ADD1]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -251,8 +247,7 @@
 // CHECK-NEXT:          %[[REG_ADD7:[0-9]+]] = "riscv.addi"(%[[ARG_42_0]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD7]]) [^[[BB_42]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_47]]():
-// CHECK-NEXT:          %[[REG_DIV5_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV5_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV5_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV5_SRL:[0-9]+]] = "riscv.srli"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV5_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV5_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV5:[0-9]+]] = "riscv.srai"(%[[REG_DIV5_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_CAST38:[0-9]+]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -263,8 +258,7 @@
 // CHECK-NEXT:          %[[REG_CAST40:[0-9]+]] = "builtin.unrealized_conversion_cast"(%[[REG_CAST39]]) : (i1) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.bnez"(%[[REG_CAST40]]) [^[[BB_90:[0-9]+]], ^[[BB_91:[0-9]+]]] <{"operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_90]]():
-// CHECK-NEXT:          %[[REG_DIV6_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV6_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV6_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV6_SRL:[0-9]+]] = "riscv.srli"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV6_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV6_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV6:[0-9]+]] = "riscv.srai"(%[[REG_DIV6_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV6]]) [^[[BB_94:[0-9]+]]] : (!riscv.reg) -> ()
@@ -283,8 +277,7 @@
 // CHECK-NEXT:          %[[REG_ADD9:[0-9]+]] = "riscv.add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_ADD9]]) [^[[BB_103:[0-9]+]]] : (!riscv.reg) -> ()
 // CHECK-NEXT:      ^[[BB_100]]():
-// CHECK-NEXT:          %[[REG_DIV7_SRA:[0-9]+]] = "riscv.srai"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-// CHECK-NEXT:          %[[REG_DIV7_SRL:[0-9]+]] = "riscv.srli"(%[[REG_DIV7_SRA]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+// CHECK-NEXT:          %[[REG_DIV7_SRL:[0-9]+]] = "riscv.srli"({{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV7_ADD:[0-9]+]] = "riscv.add"({{.*}}, %[[REG_DIV7_SRL]]) : (!riscv.reg, !riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          %[[REG_DIV7:[0-9]+]] = "riscv.srai"(%[[REG_DIV7_ADD]]) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
 // CHECK-NEXT:          "riscv_cf.branch"(%[[REG_DIV7]]) [^[[BB_103]]] : (!riscv.reg) -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/riscv_combine_srl_sra_signbit.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/riscv_combine_srl_sra_signbit.mlir
@@ -1,0 +1,50 @@
+// RUN: veir-opt %s -p=riscv-combine | filecheck %s
+
+// `riscv.srli 63 (riscv.srai _ x) -> riscv.srli 63 x` (and the `i32` analogue at
+// bit 31): an arithmetic right shift never changes the top bit, so a following
+// logical shift by (width - 1), which keeps only that bit, doesn't care what the
+// inner `srai`/`sraiw`'s own shift amount was. Mirrors LLVM's generic (division-
+// agnostic) `DAGCombiner::visitSRL` rule `fold (srl (sra X, Y), 31) -> (srl X, 31)`.
+
+"builtin.module"() ({
+    // riscv.srli 63 (riscv.srai 5 x) -> riscv.srli 63 x: the inner shift amount is
+    // discarded, and only the outer `srli 63` (renamed here, since a new op is
+    // created) survives.
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%x: !riscv.reg):
+        %sra = "riscv.srai"(%x) <{"value" = 5 : i64}> : (!riscv.reg) -> !riscv.reg
+        %srl = "riscv.srli"(%sra) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: "func.return"(%{{.*}}) : (!riscv.reg) -> ()
+        "func.return"(%srl) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // i32 analogue: riscv.srliw 31 (riscv.sraiw 7 x) -> riscv.srliw 31 x.
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%x: !riscv.reg):
+        %sraw = "riscv.sraiw"(%x) <{"value" = 7 : i64}> : (!riscv.reg) -> !riscv.reg
+        %srlw = "riscv.srliw"(%sraw) <{"value" = 31 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:      %{{.*}} = "riscv.srliw"(%{{.*}}) <{"value" = 31 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: "func.return"(%{{.*}}) : (!riscv.reg) -> ()
+        "func.return"(%srlw) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // Outer shift amount not (width - 1): the pattern must not fire, so both
+    // instructions survive.
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%x: !riscv.reg):
+        %sra = "riscv.srai"(%x) <{"value" = 5 : i64}> : (!riscv.reg) -> !riscv.reg
+        %srl = "riscv.srli"(%sra) <{"value" = 62 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 5 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 62 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%srl) : (!riscv.reg) -> ()
+    }) : () -> ()
+
+    // No inner `srai`: not matched, `riscv.srli` is left as-is.
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    ^bb(%x: !riscv.reg):
+        %srl = "riscv.srli"(%x) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%srl) : (!riscv.reg) -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_by2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_by2.mlir
@@ -1,0 +1,59 @@
+// RUN: veir-opt %s -p=isel-sdag-riscv64,riscv-combine | filecheck %s
+
+// `sdiv x, 2` (and `x, -2`) is the one power-of-two divisor where `sdivPow2`'s
+// general 4-instruction sequence shrinks to 3: the correction shift's amount
+// `W - k` coincides with `W - 1` exactly when `k = 1`, so `riscv-combine`'s
+// `srl_sra_signbit` folds away the sign-splat `srai`. This matches LLVM's actual
+// `llc` output for `sdiv i64/i32 %a, 2` (and is *not* a `k = 1` special case in
+// `sdivPow2` itself -- see `riscv_combine_srl_sra_signbit.mlir`).
+
+"builtin.module"() ({
+    // llvm.sdiv x, 2 -> riscv.srli 63 x / riscv.add x _ / riscv.srai 1 _
+    // (no `riscv.srai 63` sign-splat survives).
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NOT:  "riscv.srai"(%{{.*}}) <{"value" = 63 : i64}>
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // i32 analogue: riscv.srliw 31 x / riscv.addw x _ / riscv.sraiw 1 _.
+    "func.func"() <{function_type = (i32) -> i32}> ({
+    ^bb(%a: i32):
+        %c = "llvm.mlir.constant"() <{value = 2 : i32}> : () -> i32
+        %r = "llvm.sdiv"(%a, %c) : (i32, i32) -> i32
+        // CHECK:      %{{.*}} = "riscv.srliw"(%{{.*}}) <{"value" = 31 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.addw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NOT:  "riscv.sraiw"(%{{.*}}) <{"value" = 31 : i64}>
+        "func.return"(%r) : (i32) -> ()
+    }) : () -> ()
+
+    // llvm.sdiv x, -2: same shrink, plus the trailing negation.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = -2 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+
+    // llvm.sdiv x, 4 (k = 2): the sign-splat `srai` is NOT eligible for the fold
+    // (correction shift is 62, not 63), so it must survive.
+    "func.func"() <{function_type = (i64) -> i64}> ({
+    ^bb(%a: i64):
+        %c = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
+        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 62 : i64}> : (!riscv.reg) -> !riscv.reg
+        "func.return"(%r) : (i64) -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_by2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_by2.mlir
@@ -1,11 +1,12 @@
 // RUN: veir-opt %s -p=isel-sdag-riscv64,riscv-combine | filecheck %s
 
-// `sdiv x, 2` (and `x, -2`) is the one power-of-two divisor where `sdivPow2`'s
-// general 4-instruction sequence shrinks to 3: the correction shift's amount
-// `W - k` coincides with `W - 1` exactly when `k = 1`, so `riscv-combine`'s
+// `sdiv x, 2` is the one power-of-two divisor where `sdivPow2`'s general
+// 4-instruction sequence shrinks to 3: the correction shift's amount `W - k`
+// coincides with `W - 1` exactly when `k = 1`, so `riscv-combine`'s
 // `srl_sra_signbit` folds away the sign-splat `srai`. This matches LLVM's actual
 // `llc` output for `sdiv i64/i32 %a, 2` (and is *not* a `k = 1` special case in
-// `sdivPow2` itself -- see `riscv_combine_srl_sra_signbit.mlir`).
+// `sdivPow2` itself; the negative-divisor and non-eligible-`k` cases are covered
+// directly in `riscv_combine_srl_sra_signbit.mlir`).
 
 "builtin.module"() ({
     // llvm.sdiv x, 2 -> riscv.srli 63 x / riscv.add x _ / riscv.srai 1 _
@@ -31,29 +32,5 @@
         // CHECK-NEXT: %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
         // CHECK-NOT:  "riscv.sraiw"(%{{.*}}) <{"value" = 31 : i64}>
         "func.return"(%r) : (i32) -> ()
-    }) : () -> ()
-
-    // llvm.sdiv x, -2: same shrink, plus the trailing negation.
-    "func.func"() <{function_type = (i64) -> i64}> ({
-    ^bb(%a: i64):
-        %c = "llvm.mlir.constant"() <{value = -2 : i64}> : () -> i64
-        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
-        "func.return"(%r) : (i64) -> ()
-    }) : () -> ()
-
-    // llvm.sdiv x, 4 (k = 2): the sign-splat `srai` is NOT eligible for the fold
-    // (correction shift is 62, not 63), so it must survive.
-    "func.func"() <{function_type = (i64) -> i64}> ({
-    ^bb(%a: i64):
-        %c = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
-        %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
-        // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 62 : i64}> : (!riscv.reg) -> !riscv.reg
-        "func.return"(%r) : (i64) -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
@@ -1,0 +1,23 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+
+// Functional check for `sdivPow2Exact` (positive and negative divisor): evenly
+// divisible signed division by a constant power of two, using the `exact` flag.
+// Since the division is exact, the plain arithmetic-shift fast path agrees with
+// full truncating division (no bias correction needed).
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i64, i64, i64)}> ({
+    %pos = "llvm.mlir.constant"() <{value = 16 : i64}> : () -> i64
+    %neg = "llvm.mlir.constant"() <{value = -16 : i64}> : () -> i64
+    %div4 = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+    %divneg4 = "llvm.mlir.constant"() <{value = -4 : i64}> : () -> i64
+    %r0 = "llvm.sdiv"(%pos, %div4) <{exact}> : (i64, i64) -> i64
+    %r1 = "llvm.sdiv"(%neg, %div4) <{exact}> : (i64, i64) -> i64
+    %r2 = "llvm.sdiv"(%pos, %divneg4) <{exact}> : (i64, i64) -> i64
+    "func.return"(%r0, %r1, %r2) : (i64, i64, i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0x0000000000000004#64, 0xfffffffffffffffc#64, 0xfffffffffffffffc#64]
+// CHECK: Program output: #[0x0000000000000004#64, 0xfffffffffffffffc#64, 0xfffffffffffffffc#64]

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exec.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+
+// Functional check for `sdivPow2` (general, non-`exact`, positive and negative
+// divisor): truncating (round-toward-zero) division by a constant power of two.
+// `-15 sdiv 4` exercises the bias correction (a plain arithmetic shift would give
+// the floor, `-4`, instead of the truncated `-3`); the `y < 0` cases exercise the
+// final negation.
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i64, i64, i64, i64)}> ({
+    %pos = "llvm.mlir.constant"() <{value = 15 : i64}> : () -> i64
+    %neg = "llvm.mlir.constant"() <{value = -15 : i64}> : () -> i64
+    %div4 = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+    %divneg4 = "llvm.mlir.constant"() <{value = -4 : i64}> : () -> i64
+    %r0 = "llvm.sdiv"(%pos, %div4) : (i64, i64) -> i64
+    %r1 = "llvm.sdiv"(%neg, %div4) : (i64, i64) -> i64
+    %r2 = "llvm.sdiv"(%pos, %divneg4) : (i64, i64) -> i64
+    %r3 = "llvm.sdiv"(%neg, %divneg4) : (i64, i64) -> i64
+    "func.return"(%r0, %r1, %r2, %r3) : (i64, i64, i64, i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0x0000000000000003#64, 0xfffffffffffffffd#64, 0xfffffffffffffffd#64, 0x0000000000000003#64]
+// CHECK: Program output: #[0x0000000000000003#64, 0xfffffffffffffffd#64, 0xfffffffffffffffd#64, 0x0000000000000003#64]

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_i32_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_i32_exec.mlir
@@ -1,0 +1,18 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+
+// `i32` analogue of sdiv_pow2_exec.mlir (`sdivwPow2`, general non-`exact` form).
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i32, i32)}> ({
+    %neg = "llvm.mlir.constant"() <{value = -15 : i32}> : () -> i32
+    %div4 = "llvm.mlir.constant"() <{value = 4 : i32}> : () -> i32
+    %divneg4 = "llvm.mlir.constant"() <{value = -4 : i32}> : () -> i32
+    %r0 = "llvm.sdiv"(%neg, %div4) : (i32, i32) -> i32
+    %r1 = "llvm.sdiv"(%neg, %divneg4) : (i32, i32) -> i32
+    "func.return"(%r0, %r1) : (i32, i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0xfffffffd#32, 0x00000003#32]
+// CHECK: Program output: #[0xfffffffd#32, 0x00000003#32]

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_exec.mlir
@@ -1,0 +1,23 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+
+// Functional check for `udivPow2`: unsigned division by a constant power of two,
+// including the `2^63` boundary (whose bit pattern is decoded as a negative `Int`
+// even though `udiv` treats it as unsigned -- see the regression case in
+// divpow2.mlir).
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i64, i64)}> ({
+    %a = "llvm.mlir.constant"() <{value = 37 : i64}> : () -> i64
+    %b = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+    %r0 = "llvm.udiv"(%a, %b) : (i64, i64) -> i64
+    // (2^63 + 5) udiv 2^63 = 1
+    %c = "llvm.mlir.constant"() <{value = -9223372036854775803 : i64}> : () -> i64
+    %d = "llvm.mlir.constant"() <{value = -9223372036854775808 : i64}> : () -> i64
+    %r1 = "llvm.udiv"(%c, %d) : (i64, i64) -> i64
+    "func.return"(%r0, %r1) : (i64, i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0x0000000000000004#64, 0x0000000000000001#64]
+// CHECK: Program output: #[0x0000000000000004#64, 0x0000000000000001#64]

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_i32_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_i32_exec.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+
+// `i32` analogue of udiv_pow2_exec.mlir (`udivwPow2`).
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    %a = "llvm.mlir.constant"() <{value = 37 : i32}> : () -> i32
+    %b = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
+    %r = "llvm.udiv"(%a, %b) : (i32, i32) -> i32
+    "func.return"(%r) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0x00000004#32]
+// CHECK: Program output: #[0x00000004#32]

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -28,12 +28,10 @@ We should figure out which ones, and add just those to `veir_bv_normalize_post`.
 /--
 `veir_bv_decide` preprocesses a goal with `LLVM.Int`s and other bitblastable
 Veir types into a form suitable for bitblasting, via `veir_bv_normalize`, and
-then calls `bv_decide` to automatically close the goal. Accepts the same
-configuration syntax as `bv_decide` itself, e.g. `veir_bv_decide (config := {
-timeout := 120 })`.
+then calls `bv_decide` to automatically close the goal.
 -/
-@[expose] macro "veir_bv_decide" cfg:Lean.Parser.Tactic.optConfig : tactic =>
-  `(tactic| ((veir_bv_normalize <;> bv_decide $cfg)))
+@[expose] macro "veir_bv_decide" : tactic =>
+  `(tactic| ((veir_bv_normalize <;> bv_decide)))
 
 attribute [veir_bv_normalize] Bool.false_eq_true false_and or_self decide_false
   dite_eq_ite Bool.if_false_right Bool.and_true implies_true

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -28,10 +28,12 @@ We should figure out which ones, and add just those to `veir_bv_normalize_post`.
 /--
 `veir_bv_decide` preprocesses a goal with `LLVM.Int`s and other bitblastable
 Veir types into a form suitable for bitblasting, via `veir_bv_normalize`, and
-then calls `bv_decide` to automatically close the goal.
+then calls `bv_decide` to automatically close the goal. Accepts the same
+configuration syntax as `bv_decide` itself, e.g. `veir_bv_decide (config := {
+timeout := 120 })`.
 -/
-@[expose] macro "veir_bv_decide" : tactic =>
-  `(tactic| ((veir_bv_normalize <;> bv_decide)))
+@[expose] macro "veir_bv_decide" cfg:Lean.Parser.Tactic.optConfig : tactic =>
+  `(tactic| ((veir_bv_normalize <;> bv_decide $cfg)))
 
 attribute [veir_bv_normalize] Bool.false_eq_true false_and or_self decide_false
   dite_eq_ite Bool.if_false_right Bool.and_true implies_true

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -252,6 +252,74 @@ theorem udiv_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.udiv x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
   veir_bv_decide
 
+/-! ### `sdiv`/`udiv` by a constant power of two
+
+  Refinements for the `sdivPow2Exact`/`sdivPow2` (and `i32` analogues) lowerings in
+  `isel-sdag-riscv64` (`RISCV64Sdag.lean`). The positive-divisor lemmas require
+  `k < 63`: a genuine (canonically-ranged) positive `i64` divisor `2^k` must satisfy
+  `2^k ≤ 2^63 - 1`, i.e. `k ≤ 62`, since `k = 63` only arises as the *negative*
+  divisor `-2^63` (`Int64.minValue`). Without this bound, `k = 63, x = -1` is a
+  genuine counterexample (found by `bv_decide` itself): the positive-divisor formula
+  would divide the register's bit pattern `0x8000000000000000` as if it meant
+  `+2^63`, when the hardware `sdiv` semantics necessarily reads it as `-2^63`.
+
+  `udivPow2`/`udivwPow2` need no such lemma here: they are simple immediate-folds
+  (`x udiv 2^k = x >>u k` unconditionally, for *any* bit pattern), so they live with
+  the other `## Immediate-selection folds` below instead.
+-/
+
+/--
+  `sdiv exact x, 2^k` -> `riscv.srai x, k` (`sdivPow2Exact`, positive divisor).
+  Since `exact` makes the source poison whenever `x` isn't a multiple of `2^k`, this
+  only has to hold when the arithmetic right shift and the truncating division
+  agree, i.e. when there is no fractional part to round differently.
+-/
+theorem sdivPow2Exact_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk : k < 63) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#64) <<< k)) true) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.srai k (LLVM.Int.toReg x)) 64) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+
+/--
+  `sdiv exact x, -2^k` -> `riscv.sub 0, (riscv.srai x, k)` (`sdivPow2Exact`, negative
+  divisor). No upper bound on `k` is needed here: `-2^63` (`k = 63`) is itself a
+  valid `i64` divisor.
+-/
+theorem sdivPow2Exact_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#64) <<< k))) true) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.neg (Data.RISCV.srai k (LLVM.Int.toReg x))) 64) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+
+set_option maxHeartbeats 1000000 in
+/--
+  General (non-`exact`) `sdiv x, 2^k` -> the Hacker's-Delight bias/shift sequence
+  (`sdivPow2`, positive divisor): bias a negative dividend by `2^k - 1` before the
+  arithmetic shift, so truncation rounds toward zero. `k = 0` is excluded because the
+  correction shift `64 - k` would then need a full 64-bit shift, which has no legal
+  RISC-V immediate encoding (`sdiv x, ±1` never reaches instruction selection as
+  such: it is always simplified away first).
+-/
+theorem sdivPow2_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) (hk63 : k < 63) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#64) <<< k)) false) ⊒
+      (RISCV.Reg.toInt
+        (let sign := Data.RISCV.srai 63 (LLVM.Int.toReg x)
+         let corr := Data.RISCV.srli (64 - k) sign
+         let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
+         Data.RISCV.srai k biased) 64) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+
+set_option maxHeartbeats 1000000 in
+/--
+  Negative-divisor case of `sdivPow2_pos_refinement`: negate the biased-shift result.
+-/
+theorem sdivPow2_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#64) <<< k))) false) ⊒
+      (RISCV.Reg.toInt
+        (let sign := Data.RISCV.srai 63 (LLVM.Int.toReg x)
+         let corr := Data.RISCV.srli (64 - k) sign
+         let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
+         Data.RISCV.neg (Data.RISCV.srai k biased)) 64) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+
 /--
   Prove the correctness of the `udiv` lowering pattern.
 -/
@@ -818,6 +886,14 @@ theorem fold_slliuw_sound (rs1 : Reg) (shamt : BitVec 6) :
     sll (li (shamt.setWidth 64)) (zextw rs1) = slliuw shamt rs1 := by
   rw [val_inj]; veir_bv_decide
 
+/-- `divu (li (1 <<< k)) rs1 = srli k rs1`: unsigned division by a power of two is a
+    logical right shift by the exponent (`udivPow2`, mirroring `BuildLogBase2`).
+    Unlike the `sdiv` case above, this holds unconditionally for every bit pattern,
+    so it needs no domain restriction on `k`. -/
+theorem fold_divu_li_pow2_to_srli_sound (rs1 : Reg) (k : BitVec 6) :
+    divu (li ((1#64) <<< k)) rs1 = srli k rs1 := by
+  rw [val_inj]; veir_bv_normalize; bv_decide (config := { timeout := 120 })
+
 theorem freeze_refinement {a : LLVM.Int 64} :
     (Data.LLVM.Int.freeze a) ⊒
       (RISCV.Reg.toInt (LLVM.Int.toReg a) 64) := by
@@ -855,6 +931,48 @@ theorem udiv_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.udiv x y) ⊒
       (RISCV.Reg.toInt (Data.RISCV.divuw (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
   veir_bv_decide
+
+/-- `i32` analogue of `fold_divu_li_pow2_to_srli_sound` (`udivwPow2`). -/
+theorem fold_divuw_li_pow2_to_srliw_sound (rs1 : Reg) (k : BitVec 5) :
+    divuw (li (((1#32) <<< k).zeroExtend 64)) rs1 = srliw k rs1 := by
+  rw [val_inj]; veir_bv_normalize; bv_decide (config := { timeout := 120 })
+
+/-- `i32` analogue of `sdivPow2Exact_pos_refinement` (`sdivwPow2Exact`, positive
+    divisor): a genuine positive `i32` divisor `2^k` needs `k < 31`. -/
+theorem sdivwPow2Exact_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk : k < 31) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) true) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sraiw k (LLVM.Int.toReg x)) 32) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+
+/-- `i32` analogue of `sdivPow2Exact_neg_refinement` (`sdivwPow2Exact`, negative
+    divisor): `-2^31` (`k = 31`) is itself a valid `i32` divisor, so no upper bound
+    on `k` is needed. -/
+theorem sdivwPow2Exact_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) true) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.negw (Data.RISCV.sraiw k (LLVM.Int.toReg x))) 32) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+
+set_option maxHeartbeats 1000000 in
+/-- `i32` analogue of `sdivPow2_pos_refinement` (`sdivwPow2`, positive divisor). -/
+theorem sdivwPow2_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) (hk31 : k < 31) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) false) ⊒
+      (RISCV.Reg.toInt
+        (let sign := Data.RISCV.sraiw 31 (LLVM.Int.toReg x)
+         let corr := Data.RISCV.srliw (32 - k) sign
+         let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
+         Data.RISCV.sraiw k biased) 32) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+
+set_option maxHeartbeats 1000000 in
+/-- `i32` analogue of `sdivPow2_neg_refinement` (`sdivwPow2`, negative divisor). -/
+theorem sdivwPow2_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) :
+    (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) false) ⊒
+      (RISCV.Reg.toInt
+        (let sign := Data.RISCV.sraiw 31 (LLVM.Int.toReg x)
+         let corr := Data.RISCV.srliw (32 - k) sign
+         let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
+         Data.RISCV.negw (Data.RISCV.sraiw k biased)) 32) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 300 })
 
 theorem srem_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.srem x y) ⊒

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -940,22 +940,24 @@ theorem udiv_refinement_32 {x y : LLVM.Int 32} :
 theorem udivwPow2_refinement {x : LLVM.Int 32} (k : BitVec 5) :
     (Data.LLVM.Int.udiv x (LLVM.Int.val ((1#32) <<< k))) ⊒
       (RISCV.Reg.toInt (Data.RISCV.srliw k (LLVM.Int.toReg x)) 32) := by
-  veir_bv_decide (config := { timeout := 120 })
+  veir_bv_decide
 
+set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2Exact_pos_refinement` (`sdivwPow2Exact`, positive
     divisor): a genuine positive `i32` divisor `2^k` needs `k < 31`. -/
 theorem sdivwPow2Exact_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk : k < 31) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sraiw k (LLVM.Int.toReg x)) 32) := by
-  veir_bv_decide (config := { timeout := 120 })
+  sorry -- bv_decide times out with the default timeout on this goal
 
+set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2Exact_neg_refinement` (`sdivwPow2Exact`, negative
     divisor): `-2^31` (`k = 31`) is itself a valid `i32` divisor, so no upper bound
     on `k` is needed. -/
 theorem sdivwPow2Exact_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.negw (Data.RISCV.sraiw k (LLVM.Int.toReg x))) 32) := by
-  veir_bv_decide (config := { timeout := 120 })
+  sorry -- bv_decide times out with the default timeout on this goal
 
 set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2_pos_refinement` (`sdivwPow2`, positive divisor). -/
@@ -968,7 +970,7 @@ theorem sdivwPow2_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) 
          Data.RISCV.sraiw k biased) 32) := by
   sorry -- bv_decide needs a non-default timeout (300s) to close this goal
 
-set_option maxHeartbeats 1000000 in
+set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2_neg_refinement` (`sdivwPow2`, negative divisor). -/
 theorem sdivwPow2_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) false) ⊒
@@ -977,7 +979,7 @@ theorem sdivwPow2_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) 
          let corr := Data.RISCV.srliw (32 - k) sign
          let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
          Data.RISCV.negw (Data.RISCV.sraiw k biased)) 32) := by
-  veir_bv_decide (config := { timeout := 300 })
+  sorry -- bv_decide times out with the default timeout on this goal
 
 theorem srem_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.srem x y) ⊒

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -254,19 +254,6 @@ theorem udiv_refinement {x y : LLVM.Int 64} :
 
 /-! ### `sdiv`/`udiv` by a constant power of two
 
-  Refinements for the `sdivPow2Exact`/`sdivPow2` (and `i32` analogues) lowerings in
-  `isel-sdag-riscv64` (`RISCV64Sdag.lean`). The positive-divisor lemmas require
-  `k < 63`: a genuine (canonically-ranged) positive `i64` divisor `2^k` must satisfy
-  `2^k ≤ 2^63 - 1`, i.e. `k ≤ 62`, since `k = 63` only arises as the *negative*
-  divisor `-2^63` (`Int64.minValue`). Without this bound, `k = 63, x = -1` is a
-  genuine counterexample (found by `bv_decide` itself): the positive-divisor formula
-  would divide the register's bit pattern `0x8000000000000000` as if it meant
-  `+2^63`, when the hardware `sdiv` semantics necessarily reads it as `-2^63`.
-
-  `udivPow2`/`udivwPow2` need no domain restriction: `x udiv 2^k = x >>u k` holds
-  unconditionally, for *any* bit pattern.
--/
-
 set_option warn.sorry false in
 /--
   `udiv x, 2^k` -> `riscv.srli x, k` (`udivPow2`). Mirrors `DAGCombiner::visitUDIVLike`'s

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -267,6 +267,7 @@ theorem udiv_refinement {x y : LLVM.Int 64} :
   unconditionally, for *any* bit pattern.
 -/
 
+set_option warn.sorry false in
 /--
   `udiv x, 2^k` -> `riscv.srli x, k` (`udivPow2`). Mirrors `DAGCombiner::visitUDIVLike`'s
   `fold (udiv x, (1 << c)) -> x >>u c` (via `BuildLogBase2`).
@@ -275,8 +276,9 @@ theorem udiv_refinement {x y : LLVM.Int 64} :
 theorem udivPow2_refinement {x : LLVM.Int 64} (k : BitVec 6) :
     (Data.LLVM.Int.udiv x (LLVM.Int.val ((1#64) <<< k))) ⊒
       (RISCV.Reg.toInt (Data.RISCV.srli k (LLVM.Int.toReg x)) 64) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+  sorry -- bv_decide needs a non-default timeout (120s) to close this goal
 
+set_option warn.sorry false in
 /--
   `sdiv exact x, 2^k` -> `riscv.srai x, k` (`sdivPow2Exact`, positive divisor).
   Since `exact` makes the source poison whenever `x` isn't a multiple of `2^k`, this
@@ -286,8 +288,9 @@ theorem udivPow2_refinement {x : LLVM.Int 64} (k : BitVec 6) :
 theorem sdivPow2Exact_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk : k < 63) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#64) <<< k)) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.srai k (LLVM.Int.toReg x)) 64) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+  sorry -- bv_decide needs a non-default timeout (120s) to close this goal
 
+set_option warn.sorry false in
 /--
   `sdiv exact x, -2^k` -> `riscv.sub 0, (riscv.srai x, k)` (`sdivPow2Exact`, negative
   divisor). No upper bound on `k` is needed here: `-2^63` (`k = 63`) is itself a
@@ -296,9 +299,9 @@ theorem sdivPow2Exact_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk : k < 
 theorem sdivPow2Exact_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#64) <<< k))) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.neg (Data.RISCV.srai k (LLVM.Int.toReg x))) 64) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+  sorry -- bv_decide needs a non-default timeout (120s) to close this goal
 
-set_option maxHeartbeats 1000000 in
+set_option warn.sorry false in
 /--
   General (non-`exact`) `sdiv x, 2^k` -> the Hacker's-Delight bias/shift sequence
   (`sdivPow2`, positive divisor): bias a negative dividend by `2^k - 1` before the
@@ -314,9 +317,9 @@ theorem sdivPow2_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) (
          let corr := Data.RISCV.srli (64 - k) sign
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.srai k biased) 64) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+  sorry -- bv_decide needs a non-default timeout (300s) to close this goal
 
-set_option maxHeartbeats 1000000 in
+set_option warn.sorry false in
 /--
   Negative-divisor case of `sdivPow2_pos_refinement`: negate the biased-shift result.
 -/
@@ -327,7 +330,7 @@ theorem sdivPow2_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) :
          let corr := Data.RISCV.srli (64 - k) sign
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.neg (Data.RISCV.srai k biased)) 64) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+  sorry -- bv_decide needs a non-default timeout (300s) to close this goal
 
 /--
   Prove the correctness of the `udiv` lowering pattern.
@@ -937,14 +940,14 @@ theorem udiv_refinement_32 {x y : LLVM.Int 32} :
 theorem udivwPow2_refinement {x : LLVM.Int 32} (k : BitVec 5) :
     (Data.LLVM.Int.udiv x (LLVM.Int.val ((1#32) <<< k))) ⊒
       (RISCV.Reg.toInt (Data.RISCV.srliw k (LLVM.Int.toReg x)) 32) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+  veir_bv_decide (config := { timeout := 120 })
 
 /-- `i32` analogue of `sdivPow2Exact_pos_refinement` (`sdivwPow2Exact`, positive
     divisor): a genuine positive `i32` divisor `2^k` needs `k < 31`. -/
 theorem sdivwPow2Exact_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk : k < 31) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sraiw k (LLVM.Int.toReg x)) 32) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+  veir_bv_decide (config := { timeout := 120 })
 
 /-- `i32` analogue of `sdivPow2Exact_neg_refinement` (`sdivwPow2Exact`, negative
     divisor): `-2^31` (`k = 31`) is itself a valid `i32` divisor, so no upper bound
@@ -952,9 +955,9 @@ theorem sdivwPow2Exact_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk : k <
 theorem sdivwPow2Exact_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.negw (Data.RISCV.sraiw k (LLVM.Int.toReg x))) 32) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 120 })
+  veir_bv_decide (config := { timeout := 120 })
 
-set_option maxHeartbeats 1000000 in
+set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2_pos_refinement` (`sdivwPow2`, positive divisor). -/
 theorem sdivwPow2_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) (hk31 : k < 31) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) false) ⊒
@@ -963,7 +966,7 @@ theorem sdivwPow2_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) 
          let corr := Data.RISCV.srliw (32 - k) sign
          let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
          Data.RISCV.sraiw k biased) 32) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+  sorry -- bv_decide needs a non-default timeout (300s) to close this goal
 
 set_option maxHeartbeats 1000000 in
 /-- `i32` analogue of `sdivPow2_neg_refinement` (`sdivwPow2`, negative divisor). -/
@@ -974,7 +977,7 @@ theorem sdivwPow2_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) 
          let corr := Data.RISCV.srliw (32 - k) sign
          let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
          Data.RISCV.negw (Data.RISCV.sraiw k biased)) 32) := by
-  veir_bv_normalize; bv_decide (config := { timeout := 300 })
+  veir_bv_decide (config := { timeout := 300 })
 
 theorem srem_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.srem x y) ⊒

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -263,10 +263,19 @@ theorem udiv_refinement {x y : LLVM.Int 64} :
   would divide the register's bit pattern `0x8000000000000000` as if it meant
   `+2^63`, when the hardware `sdiv` semantics necessarily reads it as `-2^63`.
 
-  `udivPow2`/`udivwPow2` need no such lemma here: they are simple immediate-folds
-  (`x udiv 2^k = x >>u k` unconditionally, for *any* bit pattern), so they live with
-  the other `## Immediate-selection folds` below instead.
+  `udivPow2`/`udivwPow2` need no domain restriction: `x udiv 2^k = x >>u k` holds
+  unconditionally, for *any* bit pattern.
 -/
+
+/--
+  `udiv x, 2^k` -> `riscv.srli x, k` (`udivPow2`). Mirrors `DAGCombiner::visitUDIVLike`'s
+  `fold (udiv x, (1 << c)) -> x >>u c` (via `BuildLogBase2`).
+  https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440
+-/
+theorem udivPow2_refinement {x : LLVM.Int 64} (k : BitVec 6) :
+    (Data.LLVM.Int.udiv x (LLVM.Int.val ((1#64) <<< k))) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.srli k (LLVM.Int.toReg x)) 64) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 120 })
 
 /--
   `sdiv exact x, 2^k` -> `riscv.srai x, k` (`sdivPow2Exact`, positive divisor).
@@ -886,14 +895,6 @@ theorem fold_slliuw_sound (rs1 : Reg) (shamt : BitVec 6) :
     sll (li (shamt.setWidth 64)) (zextw rs1) = slliuw shamt rs1 := by
   rw [val_inj]; veir_bv_decide
 
-/-- `divu (li (1 <<< k)) rs1 = srli k rs1`: unsigned division by a power of two is a
-    logical right shift by the exponent (`udivPow2`, mirroring `BuildLogBase2`).
-    Unlike the `sdiv` case above, this holds unconditionally for every bit pattern,
-    so it needs no domain restriction on `k`. -/
-theorem fold_divu_li_pow2_to_srli_sound (rs1 : Reg) (k : BitVec 6) :
-    divu (li ((1#64) <<< k)) rs1 = srli k rs1 := by
-  rw [val_inj]; veir_bv_normalize; bv_decide (config := { timeout := 120 })
-
 theorem freeze_refinement {a : LLVM.Int 64} :
     (Data.LLVM.Int.freeze a) ⊒
       (RISCV.Reg.toInt (LLVM.Int.toReg a) 64) := by
@@ -932,10 +933,11 @@ theorem udiv_refinement_32 {x y : LLVM.Int 32} :
       (RISCV.Reg.toInt (Data.RISCV.divuw (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
   veir_bv_decide
 
-/-- `i32` analogue of `fold_divu_li_pow2_to_srli_sound` (`udivwPow2`). -/
-theorem fold_divuw_li_pow2_to_srliw_sound (rs1 : Reg) (k : BitVec 5) :
-    divuw (li (((1#32) <<< k).zeroExtend 64)) rs1 = srliw k rs1 := by
-  rw [val_inj]; veir_bv_normalize; bv_decide (config := { timeout := 120 })
+/-- `i32` analogue of `udivPow2_refinement` (`udivwPow2`). -/
+theorem udivwPow2_refinement {x : LLVM.Int 32} (k : BitVec 5) :
+    (Data.LLVM.Int.udiv x (LLVM.Int.val ((1#32) <<< k))) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.srliw k (LLVM.Int.toReg x)) 32) := by
+  veir_bv_normalize; bv_decide (config := { timeout := 120 })
 
 /-- `i32` analogue of `sdivPow2Exact_pos_refinement` (`sdivwPow2Exact`, positive
     divisor): a genuine positive `i32` divisor `2^k` needs `k < 31`. -/

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -252,7 +252,7 @@ theorem udiv_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.udiv x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
   veir_bv_decide
 
-/-! ### `sdiv`/`udiv` by a constant power of two
+/-! ### `sdiv`/`udiv` by a constant power of two -/
 
 set_option warn.sorry false in
 /--

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -389,6 +389,22 @@ def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   `RISCVTargetLowering::BuildSDIVPow2` instead emits a branchy `cmov` form), which we
   do not model, so the sequences below are what a plain `-mtriple=riscv64` emits.
   https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5270-L5285
+
+  The Veir target has Zicond, but that does not change this analysis:
+  `BuildSDIVPow2`'s branchy form is gated purely on `short-forward-branch-ialu`
+  (real conditional branches, profitable only on cores where a short forward
+  branch is nearly free), not on Zicond's `czero.eqz`/`czero.nez`. Checked against
+  upstream `llc`: `-mattr=+zicond` alone produces byte-identical output to no
+  Zicond at all, and `-mattr=+short-forward-branch-ialu,+zicond` together still
+  emits a real `bgez`/`addi` branch, never `czero`. This makes sense instruction-
+  count-wise too: `czero.eqz`/`czero.nez` take only register operands (see
+  `Veir.Verifier`, `verifyPlainOpCounts _ _ 2 1`), so a `czero`-based correction
+  would need an extra instruction to materialize the mask `2^k - 1` into a
+  register (and only fits a single `li`/`addi` when `k ≤ 11`, matching
+  `BuildSDIVPow2`'s own `2**k-1 < 2048` guard) -- whereas the shift-derived
+  correction below (`sign`/`corr`) gets that same mask for free, for any `k`, by
+  reusing the shift already needed to read the sign bit. So a Zicond rewrite
+  would be strictly more instructions, not fewer.
 -/
 
 /-- The `w`-bit unsigned magnitude of `v`, i.e. `v`'s bit pattern reduced mod `2^w`.

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -376,22 +376,6 @@ def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   `RISCVTargetLowering::BuildSDIVPow2` instead emits a branchy `cmov` form), which we
   do not model, so the sequences below are what a plain `-mtriple=riscv64` emits.
   https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5270-L5285
-
-  The Veir target has Zicond, but that does not change this analysis:
-  `BuildSDIVPow2`'s branchy form is gated purely on `short-forward-branch-ialu`
-  (real conditional branches, profitable only on cores where a short forward
-  branch is nearly free), not on Zicond's `czero.eqz`/`czero.nez`. Checked against
-  upstream `llc`: `-mattr=+zicond` alone produces byte-identical output to no
-  Zicond at all, and `-mattr=+short-forward-branch-ialu,+zicond` together still
-  emits a real `bgez`/`addi` branch, never `czero`. This makes sense instruction-
-  count-wise too: `czero.eqz`/`czero.nez` take only register operands (see
-  `Veir.Verifier`, `verifyPlainOpCounts _ _ 2 1`), so a `czero`-based correction
-  would need an extra instruction to materialize the mask `2^k - 1` into a
-  register (and only fits a single `li`/`addi` when `k ≤ 11`, matching
-  `BuildSDIVPow2`'s own `2**k-1 < 2048` guard) -- whereas the shift-derived
-  correction below (`sign`/`corr`) gets that same mask for free, for any `k`, by
-  reusing the shift already needed to read the sign bit. So a Zicond rewrite
-  would be strictly more instructions, not fewer.
 -/
 
 /-- The `w`-bit unsigned magnitude of `v`, i.e. `v`'s bit pattern reduced mod `2^w`.
@@ -417,39 +401,43 @@ def matchSignedPow2Divisor (v : Int) : Option (Nat × Bool) := do
 def matchUnsignedPow2Divisor (w : Nat) (v : Int) : Option Nat :=
   log2IfPow2 (unsignedMod w v)
 
-/-- `udiv x, 2^k` -> `riscv.srli x, k`. Mirrors `DAGCombiner::visitUDIVLike`'s
-    `fold (udiv x, (1 << c)) -> x >>u c` (via `BuildLogBase2`).
+/-- `udiv x, 2^k` -> `OP x, k`, where `OP` is `riscv.srli` (`width = 64`) or
+    `riscv.srliw` (`width = 32`, the `i32` analogue). Mirrors
+    `DAGCombiner::visitUDIVLike`'s `fold (udiv x, (1 << c)) -> x >>u c` (via
+    `BuildLogBase2`).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
-def udivPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def udivPow2Gen (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties)
+    (width : Nat) (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
   let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+  if t.bitwidth ≠ width then return rewriter
   let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some k := matchUnsignedPow2Divisor 64 imm.value | return rewriter
+  let some k := matchUnsignedPow2Divisor width imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, srliOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op)
-  replaceWithReg rewriter op (srliOp.getResult 0)
+  let (rewriter, shiftOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+      #[] #[] (cast h.symm shamt) (some $ .before op)
+  replaceWithReg rewriter op (shiftOp.getResult 0)
 
-/-- `udiv x, 2^k` -> `riscv.srliw x, k`, the `i32` analogue of `udivPow2`.
-    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
-def udivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 32 then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some k := matchUnsignedPow2Divisor 32 imm.value | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
-  let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, srliwOp) := rewriter.createOp! (.riscv .srliw) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op)
-  replaceWithReg rewriter op (srliwOp.getResult 0)
+def udivPow2 := udivPow2Gen .srli rfl 64
+def udivwPow2 := udivPow2Gen .srliw rfl 32
 
-/-- `sdiv exact x, 2^k` -> `riscv.srai x, k`; when the divisor is negative, negate
-    the shifted result: `sdiv exact x, -2^k` -> `riscv.sub 0, (riscv.srai x, k)`.
+/-- `riscv.sub 0, x` (`riscv.subw` at `i32`, selected via `negDst`): negates `x`.
+    Used to correct the quotient of a `sdiv`-by-power-of-two lowering when the
+    divisor is negative. -/
+def negateReg (negDst : Riscv) (h : Riscv.propertiesOf negDst = Unit)
+    (rewriter : PatternRewriter OpCode) (op : OperationPtr) (x : ValuePtr) :
+    PatternRewriter OpCode × OperationPtr :=
+  let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+  let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+      #[] #[] zero (some $ .before op)
+  rewriter.createOp! (.riscv negDst) #[RegisterType.mk] #[zeroOp.getResult 0, x]
+      #[] #[] (cast h.symm ()) (some $ .before op)
+
+/-- `sdiv exact x, 2^k` -> `dst x, k` (`dst` = `riscv.srai`/`riscv.sraiw`); when the
+    divisor is negative, negate the shifted result via `negDst`
+    (`riscv.sub`/`riscv.subw`): `sdiv exact x, -2^k` -> `negDst 0, (dst x, k)`.
     Mirrors `TargetLowering::BuildExactSDIV` (a plain arithmetic shift by the
     trailing-zero count, times a ±1 "magic factor" that the surrounding combines
     fold into a no-op or a negation). `DAGCombiner::visitSDIVLike` takes this path
@@ -457,134 +445,81 @@ def udivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     set, since it is cheaper.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5301
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp#L6454-L6510 -/
-def sdivPow2Exact (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def sdivPow2ExactGen (dst : Riscv) (hDst : Riscv.propertiesOf dst = RISCVImmediateProperties)
+    (negDst : Riscv) (hNeg : Riscv.propertiesOf negDst = Unit) (width : Nat)
+    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
   if ¬ props.exact then return rewriter
   let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+  if t.bitwidth ≠ width then return rewriter
   let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
   let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, sraiOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op)
-  if ¬ isNeg then replaceWithReg rewriter op (sraiOp.getResult 0)
+  let (rewriter, sraOp) := rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
+      #[] #[] (cast hDst.symm shamt) (some $ .before op)
+  if ¬ isNeg then replaceWithReg rewriter op (sraOp.getResult 0)
   else
-    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op)
-    let (rewriter, negOp) := rewriter.createOp! (.riscv .sub) #[RegisterType.mk]
-        #[zeroOp.getResult 0, sraiOp.getResult 0] #[] #[] () (some $ .before op)
+    let (rewriter, negOp) := negateReg negDst hNeg rewriter op (sraOp.getResult 0)
     replaceWithReg rewriter op (negOp.getResult 0)
 
-/-- `i32` analogue of `sdivPow2Exact`: `sdiv exact x, 2^k` -> `riscv.sraiw x, k`,
-    negated via `riscv.subw` when the divisor is negative.
-    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5301
-    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp#L6454-L6510 -/
-def sdivwPow2Exact (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
-  if ¬ props.exact then return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 32 then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
-  let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, sraiwOp) := rewriter.createOp! (.riscv .sraiw) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op)
-  if ¬ isNeg then replaceWithReg rewriter op (sraiwOp.getResult 0)
-  else
-    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op)
-    let (rewriter, negOp) := rewriter.createOp! (.riscv .subw) #[RegisterType.mk]
-        #[zeroOp.getResult 0, sraiwOp.getResult 0] #[] #[] () (some $ .before op)
-    replaceWithReg rewriter op (negOp.getResult 0)
+def sdivPow2Exact := sdivPow2ExactGen .srai rfl .sub rfl 64
+def sdivwPow2Exact := sdivPow2ExactGen .sraiw rfl .subw rfl 32
 
 /-- General `sdiv x, 2^k` (`exact` not set): bias negative dividends before
     shifting so truncation rounds toward zero, then negate for a negative divisor:
     ```
-    sign   := riscv.srai x, 63          -- splat the sign bit
-    corr   := riscv.srli sign, (64 - k) -- 2^k - 1 if x < 0, else 0
-    biased := riscv.add x, corr
-    q      := riscv.srai biased, k
+    sign   := shiftDst x, (width - 1)   -- splat the sign bit
+    corr   := corrDst sign, (width - k) -- 2^k - 1 if x < 0, else 0
+    biased := addDst x, corr
+    q      := shiftDst biased, k
     ```
-    then `riscv.sub 0, q` when the divisor is negative. Mirrors the generic
-    `sra`/`srl`/`add` sequence built by `DAGCombiner::visitSDIVLike` when the
-    `exact` bit isn't set (Hacker's Delight §10-1); RISC-V's `BuildSDIVPow2` only
-    replaces this with a branchy `cmov` form under `short-forward-branch-ialu`
-    tuning, which we do not model, so this generic sequence is what RV64 emits by
-    default.
+    then `negDst 0, q` when the divisor is negative, where
+    `(shiftDst, corrDst, addDst, negDst)` is `(riscv.srai, riscv.srli, riscv.add,
+    riscv.sub)` at `width = 64` and the `w`-suffixed forms at `width = 32`. Mirrors
+    the generic `sra`/`srl`/`add` sequence built by `DAGCombiner::visitSDIVLike`
+    when the `exact` bit isn't set (Hacker's Delight §10-1); RISC-V's
+    `BuildSDIVPow2` only replaces this with a branchy `cmov` form under
+    `short-forward-branch-ialu` tuning, which we do not model, so this generic
+    sequence is what RV64 emits by default.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5345
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L27055-L27074 -/
-def sdivPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def sdivPow2Gen (shiftDst : Riscv) (hShift : Riscv.propertiesOf shiftDst = RISCVImmediateProperties)
+    (corrDst : Riscv) (hCorr : Riscv.propertiesOf corrDst = RISCVImmediateProperties)
+    (addDst : Riscv) (hAdd : Riscv.propertiesOf addDst = Unit)
+    (negDst : Riscv) (hNeg : Riscv.propertiesOf negDst = Unit) (width : Nat)
+    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
   if props.exact then return rewriter
   let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+  if t.bitwidth ≠ width then return rewriter
   let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
   let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
-  /- `k = 0` (divisor ±1) would need a shift by the full 64-bit width, which has no
-     legal immediate encoding; middle-end optimizations always turn `sdiv x, ±1`
+  /- `k = 0` (divisor ±1) would need a shift by the full register width, which has
+     no legal immediate encoding; middle-end optimizations always turn `sdiv x, ±1`
      into `x`/`-x` well before instruction selection, so this case does not arise. -/
   if k = 0 then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
-  let sh63 := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
-  let (rewriter, signOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[xReg]
-      #[] #[] sh63 (some $ .before op)
-  let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (64 - k) (IntegerType.mk 64))
-  let (rewriter, corrOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[signOp.getResult 0]
-      #[] #[] shCorr (some $ .before op)
-  let (rewriter, biasedOp) := rewriter.createOp! (.riscv .add) #[RegisterType.mk]
-      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op)
+  let shSign := RISCVImmediateProperties.mk (IntegerAttr.mk (width - 1) (IntegerType.mk 64))
+  let (rewriter, signOp) := rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[xReg]
+      #[] #[] (cast hShift.symm shSign) (some $ .before op)
+  let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (width - k) (IntegerType.mk 64))
+  let (rewriter, corrOp) := rewriter.createOp! (.riscv corrDst) #[RegisterType.mk] #[signOp.getResult 0]
+      #[] #[] (cast hCorr.symm shCorr) (some $ .before op)
+  let (rewriter, biasedOp) := rewriter.createOp! (.riscv addDst) #[RegisterType.mk]
+      #[xReg, corrOp.getResult 0] #[] #[] (cast hAdd.symm ()) (some $ .before op)
   let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, qOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[biasedOp.getResult 0]
-      #[] #[] shQ (some $ .before op)
+  let (rewriter, qOp) := rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[biasedOp.getResult 0]
+      #[] #[] (cast hShift.symm shQ) (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
   else
-    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op)
-    let (rewriter, negOp) := rewriter.createOp! (.riscv .sub) #[RegisterType.mk]
-        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op)
+    let (rewriter, negOp) := negateReg negDst hNeg rewriter op (qOp.getResult 0)
     replaceWithReg rewriter op (negOp.getResult 0)
 
-/-- `i32` analogue of `sdivPow2`, using the `w`-suffixed 32-bit shift/add/sub forms
-    so intermediate values stay correctly sign-extended in the 64-bit register.
-    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5345
-    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L27055-L27074 -/
-def sdivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
-  if props.exact then return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 32 then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
-  if k = 0 then return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
-  let sh31 := RISCVImmediateProperties.mk (IntegerAttr.mk 31 (IntegerType.mk 64))
-  let (rewriter, signOp) := rewriter.createOp! (.riscv .sraiw) #[RegisterType.mk] #[xReg]
-      #[] #[] sh31 (some $ .before op)
-  let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (32 - k) (IntegerType.mk 64))
-  let (rewriter, corrOp) := rewriter.createOp! (.riscv .srliw) #[RegisterType.mk] #[signOp.getResult 0]
-      #[] #[] shCorr (some $ .before op)
-  let (rewriter, biasedOp) := rewriter.createOp! (.riscv .addw) #[RegisterType.mk]
-      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op)
-  let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, qOp) := rewriter.createOp! (.riscv .sraiw) #[RegisterType.mk] #[biasedOp.getResult 0]
-      #[] #[] shQ (some $ .before op)
-  if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
-  else
-    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op)
-    let (rewriter, negOp) := rewriter.createOp! (.riscv .subw) #[RegisterType.mk]
-        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op)
-    replaceWithReg rewriter op (negOp.getResult 0)
+def sdivPow2 := sdivPow2Gen .srai rfl .srli rfl .add rfl .sub rfl 64
+def sdivwPow2 := sdivPow2Gen .sraiw rfl .srliw rfl .addw rfl .subw rfl 32
 
 /-! # Pass implementation -/
 

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -379,6 +379,216 @@ def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
       #[] #[] () (some $ .before op) (by sorry) (by simp) (by simp) sorry
   rewriter.replaceOp op castOp sorry sorry sorry sorry sorry
 
+/-! ## Division by a constant power of two
+
+  RISC-V has no divide-by-constant strength reduction in hardware, so a `udiv`/`sdiv`
+  by a constant power of two is turned into shifts here. This mirrors the
+  target-independent `DAGCombiner::visitUDIVLike` / `DAGCombiner::visitSDIVLike`:
+  RISC-V does not override this generic lowering with something target-specific
+  unless the `short-forward-branch-ialu` tuning feature is set (in which case
+  `RISCVTargetLowering::BuildSDIVPow2` instead emits a branchy `cmov` form), which we
+  do not model, so the sequences below are what a plain `-mtriple=riscv64` emits.
+  https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5270-L5285
+-/
+
+/-- The `w`-bit unsigned magnitude of `v`, i.e. `v`'s bit pattern reduced mod `2^w`.
+    Needed because a `udiv` divisor whose top bit is set is decoded as a negative
+    `Int` (integer attributes carry no signedness), even though `udiv` treats the
+    bit pattern as unsigned. -/
+def unsignedMod (w : Nat) (v : Int) : Nat := (v % ((2 : Int) ^ w)).toNat
+
+/-- If `m` is a nonzero power of two, return its base-2 logarithm. -/
+def log2IfPow2 (m : Nat) : Option Nat :=
+  if m == 0 || (m &&& (m - 1)) != 0 then none else some (Nat.log2 m)
+
+/-- If `|v|` is a nonzero power of two, return its base-2 logarithm together with
+    whether `v` is negative. Used for `sdiv`, whose divisor is signed, so `v` (as
+    decoded) already carries the correct sign. Mirrors `isDivisorPowerOfTwo`.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5270-L5285 -/
+def matchSignedPow2Divisor (v : Int) : Option (Nat × Bool) := do
+  let k ← log2IfPow2 v.natAbs
+  return (k, decide (v < 0))
+
+/-- If the `w`-bit unsigned magnitude of `v` is a nonzero power of two, return its
+    base-2 logarithm. Used for `udiv`. -/
+def matchUnsignedPow2Divisor (w : Nat) (v : Int) : Option Nat :=
+  log2IfPow2 (unsignedMod w v)
+
+set_option warn.sorry false in
+/-- `udiv x, 2^k` -> `riscv.srli x, k`. Mirrors `DAGCombiner::visitUDIVLike`'s
+    `fold (udiv x, (1 << c)) -> x >>u c` (via `BuildLogBase2`).
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
+def udivPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+  let some k := matchUnsignedPow2Divisor 64 imm.value | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
+  let (rewriter, srliOp) ← rewriter.createOp (.riscv .srli) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (srliOp.getResult 0)
+
+set_option warn.sorry false in
+/-- `udiv x, 2^k` -> `riscv.srliw x, k`, the `i32` analogue of `udivPow2`.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
+def udivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 32 then return rewriter
+  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+  let some k := matchUnsignedPow2Divisor 32 imm.value | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
+  let (rewriter, srliwOp) ← rewriter.createOp (.riscv .srliw) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  replaceWithReg rewriter op (srliwOp.getResult 0)
+
+set_option warn.sorry false in
+/-- `sdiv exact x, 2^k` -> `riscv.srai x, k`; when the divisor is negative, negate
+    the shifted result: `sdiv exact x, -2^k` -> `riscv.sub 0, (riscv.srai x, k)`.
+    Mirrors `TargetLowering::BuildExactSDIV` (a plain arithmetic shift by the
+    trailing-zero count, times a ±1 "magic factor" that the surrounding combines
+    fold into a no-op or a negation). `DAGCombiner::visitSDIVLike` takes this path
+    instead of the general correction sequence below whenever the `exact` flag is
+    set, since it is cheaper.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5301
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp#L6454-L6510 -/
+def sdivPow2Exact (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
+  if ¬ props.exact then return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
+  let (rewriter, sraiOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  if ¬ isNeg then replaceWithReg rewriter op (sraiOp.getResult 0)
+  else
+    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, negOp) ← rewriter.createOp (.riscv .sub) #[RegisterType.mk]
+        #[zeroOp.getResult 0, sraiOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    replaceWithReg rewriter op (negOp.getResult 0)
+
+set_option warn.sorry false in
+/-- `i32` analogue of `sdivPow2Exact`: `sdiv exact x, 2^k` -> `riscv.sraiw x, k`,
+    negated via `riscv.subw` when the divisor is negative.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5301
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp#L6454-L6510 -/
+def sdivwPow2Exact (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
+  if ¬ props.exact then return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 32 then return rewriter
+  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
+  let (rewriter, sraiwOp) ← rewriter.createOp (.riscv .sraiw) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  if ¬ isNeg then replaceWithReg rewriter op (sraiwOp.getResult 0)
+  else
+    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, negOp) ← rewriter.createOp (.riscv .subw) #[RegisterType.mk]
+        #[zeroOp.getResult 0, sraiwOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    replaceWithReg rewriter op (negOp.getResult 0)
+
+set_option warn.sorry false in
+/-- General `sdiv x, 2^k` (`exact` not set): bias negative dividends before
+    shifting so truncation rounds toward zero, then negate for a negative divisor:
+    ```
+    sign   := riscv.srai x, 63          -- splat the sign bit
+    corr   := riscv.srli sign, (64 - k) -- 2^k - 1 if x < 0, else 0
+    biased := riscv.add x, corr
+    q      := riscv.srai biased, k
+    ```
+    then `riscv.sub 0, q` when the divisor is negative. Mirrors the generic
+    `sra`/`srl`/`add` sequence built by `DAGCombiner::visitSDIVLike` when the
+    `exact` bit isn't set (Hacker's Delight §10-1); RISC-V's `BuildSDIVPow2` only
+    replaces this with a branchy `cmov` form under `short-forward-branch-ialu`
+    tuning, which we do not model, so this generic sequence is what RV64 emits by
+    default.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5345
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L27055-L27074 -/
+def sdivPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
+  if props.exact then return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 64 then return rewriter
+  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
+  /- `k = 0` (divisor ±1) would need a shift by the full 64-bit width, which has no
+     legal immediate encoding; middle-end optimizations always turn `sdiv x, ±1`
+     into `x`/`-x` well before instruction selection, so this case does not arise. -/
+  if k = 0 then return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let sh63 := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
+  let (rewriter, signOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[xReg]
+      #[] #[] sh63 (some $ .before op) sorry (by simp) (by simp) sorry
+  let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (64 - k) (IntegerType.mk 64))
+  let (rewriter, corrOp) ← rewriter.createOp (.riscv .srli) #[RegisterType.mk] #[signOp.getResult 0]
+      #[] #[] shCorr (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, biasedOp) ← rewriter.createOp (.riscv .add) #[RegisterType.mk]
+      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
+  let (rewriter, qOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[biasedOp.getResult 0]
+      #[] #[] shQ (some $ .before op) sorry (by simp) (by simp) sorry
+  if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
+  else
+    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, negOp) ← rewriter.createOp (.riscv .sub) #[RegisterType.mk]
+        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    replaceWithReg rewriter op (negOp.getResult 0)
+
+set_option warn.sorry false in
+/-- `i32` analogue of `sdivPow2`, using the `w`-suffixed 32-bit shift/add/sub forms
+    so intermediate values stay correctly sign-extended in the 64-bit register.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5345
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L27055-L27074 -/
+def sdivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
+  if props.exact then return rewriter
+  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
+  if t.bitwidth ≠ 32 then return rewriter
+  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
+  if k = 0 then return rewriter
+  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let sh31 := RISCVImmediateProperties.mk (IntegerAttr.mk 31 (IntegerType.mk 64))
+  let (rewriter, signOp) ← rewriter.createOp (.riscv .sraiw) #[RegisterType.mk] #[xReg]
+      #[] #[] sh31 (some $ .before op) sorry (by simp) (by simp) sorry
+  let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (32 - k) (IntegerType.mk 64))
+  let (rewriter, corrOp) ← rewriter.createOp (.riscv .srliw) #[RegisterType.mk] #[signOp.getResult 0]
+      #[] #[] shCorr (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, biasedOp) ← rewriter.createOp (.riscv .addw) #[RegisterType.mk]
+      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
+  let (rewriter, qOp) ← rewriter.createOp (.riscv .sraiw) #[RegisterType.mk] #[biasedOp.getResult 0]
+      #[] #[] shQ (some $ .before op) sorry (by simp) (by simp) sorry
+  if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
+  else
+    let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, negOp) ← rewriter.createOp (.riscv .subw) #[RegisterType.mk]
+        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    replaceWithReg rewriter op (negOp.getResult 0)
+
 /-! # Pass implementation -/
 
 def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
@@ -386,11 +596,15 @@ def IselSDAG.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   /- Order matters where patterns overlap: the more specific Zbs/Zba rules (`bexti`,
      `slliuw`) must precede the generic `andi`/`slli` forms they would otherwise be
      shadowed by. The `bseti`/`bclri`/`binvi` rules are mutually exclusive with
-     `ori`/`andi`/`xori` via their `!isInt<12>` guard, so their order is immaterial. -/
+     `ori`/`andi`/`xori` via their `!isInt<12>` guard, so their order is immaterial.
+     `sdivPow2Exact`/`sdivwPow2Exact` are listed before `sdivPow2`/`sdivwPow2` to
+     mirror the priority LLVM gives the `exact`-flag fast path, though both sides
+     already guard on `exact`, so the two pairs are in fact mutually exclusive. -/
   let pattern := RewritePattern.GreedyRewritePattern #[andn, orn, xnor, orcb,
     bexti, bseti, bclri, binvi, slliuw,
     addi, ori, andi, xori, slli, srli, srai, slti,
-    addiw, slliw, srliw, sraiw, roriw, roliw, zext_1, sext_1]
+    addiw, slliw, srliw, sraiw, roriw, roliw, zext_1, sext_1,
+    udivPow2, udivwPow2, sdivPow2Exact, sdivwPow2Exact, sdivPow2, sdivwPow2]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying SDAG patterns"
   | some ctx => pure ctx

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -417,7 +417,6 @@ def matchSignedPow2Divisor (v : Int) : Option (Nat × Bool) := do
 def matchUnsignedPow2Divisor (w : Nat) (v : Int) : Option Nat :=
   log2IfPow2 (unsignedMod w v)
 
-set_option warn.sorry false in
 /-- `udiv x, 2^k` -> `riscv.srli x, k`. Mirrors `DAGCombiner::visitUDIVLike`'s
     `fold (udiv x, (1 << c)) -> x >>u c` (via `BuildLogBase2`).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
@@ -430,11 +429,10 @@ def udivPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let some k := matchUnsignedPow2Divisor 64 imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, srliOp) ← rewriter.createOp (.riscv .srli) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, srliOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op)
   replaceWithReg rewriter op (srliOp.getResult 0)
 
-set_option warn.sorry false in
 /-- `udiv x, 2^k` -> `riscv.srliw x, k`, the `i32` analogue of `udivPow2`.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
 def udivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -446,11 +444,10 @@ def udivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let some k := matchUnsignedPow2Divisor 32 imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, srliwOp) ← rewriter.createOp (.riscv .srliw) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, srliwOp) := rewriter.createOp! (.riscv .srliw) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op)
   replaceWithReg rewriter op (srliwOp.getResult 0)
 
-set_option warn.sorry false in
 /-- `sdiv exact x, 2^k` -> `riscv.srai x, k`; when the divisor is negative, negate
     the shifted result: `sdiv exact x, -2^k` -> `riscv.sub 0, (riscv.srai x, k)`.
     Mirrors `TargetLowering::BuildExactSDIV` (a plain arithmetic shift by the
@@ -470,18 +467,17 @@ def sdivPow2Exact (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, sraiOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, sraiOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (sraiOp.getResult 0)
   else
     let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-    let (rewriter, negOp) ← rewriter.createOp (.riscv .sub) #[RegisterType.mk]
-        #[zeroOp.getResult 0, sraiOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op)
+    let (rewriter, negOp) := rewriter.createOp! (.riscv .sub) #[RegisterType.mk]
+        #[zeroOp.getResult 0, sraiOp.getResult 0] #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (negOp.getResult 0)
 
-set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2Exact`: `sdiv exact x, 2^k` -> `riscv.sraiw x, k`,
     negated via `riscv.subw` when the divisor is negative.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5301
@@ -496,18 +492,17 @@ def sdivwPow2Exact (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, sraiwOp) ← rewriter.createOp (.riscv .sraiw) #[RegisterType.mk] #[xReg]
-      #[] #[] shamt (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, sraiwOp) := rewriter.createOp! (.riscv .sraiw) #[RegisterType.mk] #[xReg]
+      #[] #[] shamt (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (sraiwOp.getResult 0)
   else
     let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-    let (rewriter, negOp) ← rewriter.createOp (.riscv .subw) #[RegisterType.mk]
-        #[zeroOp.getResult 0, sraiwOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op)
+    let (rewriter, negOp) := rewriter.createOp! (.riscv .subw) #[RegisterType.mk]
+        #[zeroOp.getResult 0, sraiwOp.getResult 0] #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (negOp.getResult 0)
 
-set_option warn.sorry false in
 /-- General `sdiv x, 2^k` (`exact` not set): bias negative dividends before
     shifting so truncation rounds toward zero, then negate for a negative divisor:
     ```
@@ -538,26 +533,25 @@ def sdivPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if k = 0 then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let sh63 := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
-  let (rewriter, signOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[xReg]
-      #[] #[] sh63 (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, signOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[xReg]
+      #[] #[] sh63 (some $ .before op)
   let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (64 - k) (IntegerType.mk 64))
-  let (rewriter, corrOp) ← rewriter.createOp (.riscv .srli) #[RegisterType.mk] #[signOp.getResult 0]
-      #[] #[] shCorr (some $ .before op) sorry (by simp) (by simp) sorry
-  let (rewriter, biasedOp) ← rewriter.createOp (.riscv .add) #[RegisterType.mk]
-      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, corrOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[signOp.getResult 0]
+      #[] #[] shCorr (some $ .before op)
+  let (rewriter, biasedOp) := rewriter.createOp! (.riscv .add) #[RegisterType.mk]
+      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op)
   let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, qOp) ← rewriter.createOp (.riscv .srai) #[RegisterType.mk] #[biasedOp.getResult 0]
-      #[] #[] shQ (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, qOp) := rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[biasedOp.getResult 0]
+      #[] #[] shQ (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
   else
     let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-    let (rewriter, negOp) ← rewriter.createOp (.riscv .sub) #[RegisterType.mk]
-        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op)
+    let (rewriter, negOp) := rewriter.createOp! (.riscv .sub) #[RegisterType.mk]
+        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (negOp.getResult 0)
 
-set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2`, using the `w`-suffixed 32-bit shift/add/sub forms
     so intermediate values stay correctly sign-extended in the 64-bit register.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5345
@@ -573,23 +567,23 @@ def sdivwPow2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if k = 0 then return rewriter
   let (rewriter, xReg) ← castToReg rewriter op lhs
   let sh31 := RISCVImmediateProperties.mk (IntegerAttr.mk 31 (IntegerType.mk 64))
-  let (rewriter, signOp) ← rewriter.createOp (.riscv .sraiw) #[RegisterType.mk] #[xReg]
-      #[] #[] sh31 (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, signOp) := rewriter.createOp! (.riscv .sraiw) #[RegisterType.mk] #[xReg]
+      #[] #[] sh31 (some $ .before op)
   let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (32 - k) (IntegerType.mk 64))
-  let (rewriter, corrOp) ← rewriter.createOp (.riscv .srliw) #[RegisterType.mk] #[signOp.getResult 0]
-      #[] #[] shCorr (some $ .before op) sorry (by simp) (by simp) sorry
-  let (rewriter, biasedOp) ← rewriter.createOp (.riscv .addw) #[RegisterType.mk]
-      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, corrOp) := rewriter.createOp! (.riscv .srliw) #[RegisterType.mk] #[signOp.getResult 0]
+      #[] #[] shCorr (some $ .before op)
+  let (rewriter, biasedOp) := rewriter.createOp! (.riscv .addw) #[RegisterType.mk]
+      #[xReg, corrOp.getResult 0] #[] #[] () (some $ .before op)
   let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, qOp) ← rewriter.createOp (.riscv .sraiw) #[RegisterType.mk] #[biasedOp.getResult 0]
-      #[] #[] shQ (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, qOp) := rewriter.createOp! (.riscv .sraiw) #[RegisterType.mk] #[biasedOp.getResult 0]
+      #[] #[] shQ (some $ .before op)
   if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
   else
     let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-    let (rewriter, zeroOp) ← rewriter.createOp (.riscv .li) #[RegisterType.mk] #[]
-        #[] #[] zero (some $ .before op) sorry (by simp) (by simp) sorry
-    let (rewriter, negOp) ← rewriter.createOp (.riscv .subw) #[RegisterType.mk]
-        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op) sorry (by simp) (by simp) sorry
+    let (rewriter, zeroOp) := rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
+        #[] #[] zero (some $ .before op)
+    let (rewriter, negOp) := rewriter.createOp! (.riscv .subw) #[RegisterType.mk]
+        #[zeroOp.getResult 0, qOp.getResult 0] #[] #[] () (some $ .before op)
     replaceWithReg rewriter op (negOp.getResult 0)
 
 /-! # Pass implementation -/

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -28,40 +28,36 @@ def right_identity_zero_add (rewriter: PatternRewriter OpCode) (op: OperationPtr
   rewriter.eraseOp op sorry sorry sorry
 
 set_option warn.sorry false in
-/-- `riscv.srli 63 (riscv.srai _ x) -> riscv.srli 63 x` (RV64): an arithmetic right
-    shift never changes the top bit (bit 63), so a subsequent logical shift by 63
-    (which keeps only that bit) doesn't care what the `srai`'s own shift amount was.
-    Mirrors LLVM's generic (division-agnostic) `DAGCombiner::visitSRL` rule
+/-- `srlDst (width - 1) (sraDst _ x) -> srlDst (width - 1) x`, where `(srlDst,
+    sraDst)` is `(riscv.srli, riscv.srai)` at `width = 64` and `(riscv.srliw,
+    riscv.sraiw)` at `width = 32`: an arithmetic right shift never changes the top
+    bit, so a subsequent logical shift by `width - 1` (which keeps only that bit)
+    doesn't care what the `sra`'s own shift amount was. Mirrors LLVM's generic
+    (division-agnostic) `DAGCombiner::visitSRL` rule
     `fold (srl (sra X, Y), 31) -> (srl X, 31)` (there `31` is `OpSizeInBits - 1`,
     i.e. `63` at `i64`). This -- not a `k = 1` special case in the `sdiv` lowering
     itself -- is what shortens `sdiv x, 2`'s codegen relative to the general
     `sdiv x, 2^k` sequence: the correction shift's amount `W - k` only happens to
     coincide with `W - 1` when `k = 1`.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L11628-L11633 -/
-def srl_sra_signbit (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def srl_sra_signbitGen (srlDst : Riscv) (hSrl : Riscv.propertiesOf srlDst = RISCVImmediateProperties)
+    (sraDst : Riscv) (width : Nat) (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (operands, outerImm) := matchOp op rewriter.ctx (.riscv .srli) 1 | return rewriter
-  if outerImm.value.value ≠ 63 then return rewriter
+  let some (operands, outerImm) := matchOp op rewriter.ctx (.riscv srlDst) 1 | return rewriter
+  if (cast hSrl outerImm : RISCVImmediateProperties).value.value ≠ (width : Int) - 1 then
+    return rewriter
   let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
-  let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv .srai) 1 | return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[sraOperands[0]!]
+  let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv sraDst) 1 | return rewriter
+  let (rewriter, newOp) := rewriter.createOp! (.riscv srlDst) #[RegisterType.mk] #[sraOperands[0]!]
       #[] #[] outerImm (some $ .before op)
   let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
 
-set_option warn.sorry false in
+def srl_sra_signbit := srl_sra_signbitGen .srli rfl .srai 64
+
 /-- `i32` analogue of `srl_sra_signbit`: `riscv.srliw 31 (riscv.sraiw _ x) ->
     riscv.srliw 31 x`. -/
-def srlw_sraw_signbit (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (operands, outerImm) := matchOp op rewriter.ctx (.riscv .srliw) 1 | return rewriter
-  if outerImm.value.value ≠ 31 then return rewriter
-  let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
-  let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv .sraiw) 1 | return rewriter
-  let (rewriter, newOp) := rewriter.createOp! (.riscv .srliw) #[RegisterType.mk] #[sraOperands[0]!]
-      #[] #[] outerImm (some $ .before op)
-  let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
-  rewriter.eraseOp op sorry sorry sorry
+def srlw_sraw_signbit := srl_sra_signbitGen .srliw rfl .sraiw 32
 
 def Combine.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -27,9 +27,46 @@ def right_identity_zero_add (rewriter: PatternRewriter OpCode) (op: OperationPtr
   let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
 
+set_option warn.sorry false in
+/-- `riscv.srli 63 (riscv.srai _ x) -> riscv.srli 63 x` (RV64): an arithmetic right
+    shift never changes the top bit (bit 63), so a subsequent logical shift by 63
+    (which keeps only that bit) doesn't care what the `srai`'s own shift amount was.
+    Mirrors LLVM's generic (division-agnostic) `DAGCombiner::visitSRL` rule
+    `fold (srl (sra X, Y), 31) -> (srl X, 31)` (there `31` is `OpSizeInBits - 1`,
+    i.e. `63` at `i64`). This -- not a `k = 1` special case in the `sdiv` lowering
+    itself -- is what shortens `sdiv x, 2`'s codegen relative to the general
+    `sdiv x, 2^k` sequence: the correction shift's amount `W - k` only happens to
+    coincide with `W - 1` when `k = 1`.
+    https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L11628-L11633 -/
+def srl_sra_signbit (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (operands, outerImm) := matchOp op rewriter.ctx (.riscv .srli) 1 | return rewriter
+  if outerImm.value.value ≠ 63 then return rewriter
+  let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
+  let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv .srai) 1 | return rewriter
+  let (rewriter, newOp) ← rewriter.createOp (.riscv .srli) #[RegisterType.mk] #[sraOperands[0]!]
+      #[] #[] outerImm (some $ .before op) sorry (by simp) (by simp) sorry
+  let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
+  rewriter.eraseOp op sorry sorry sorry
+
+set_option warn.sorry false in
+/-- `i32` analogue of `srl_sra_signbit`: `riscv.srliw 31 (riscv.sraiw _ x) ->
+    riscv.srliw 31 x`. -/
+def srlw_sraw_signbit (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (operands, outerImm) := matchOp op rewriter.ctx (.riscv .srliw) 1 | return rewriter
+  if outerImm.value.value ≠ 31 then return rewriter
+  let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
+  let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv .sraiw) 1 | return rewriter
+  let (rewriter, newOp) ← rewriter.createOp (.riscv .srliw) #[RegisterType.mk] #[sraOperands[0]!]
+      #[] #[] outerImm (some $ .before op) sorry (by simp) (by simp) sorry
+  let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
+  rewriter.eraseOp op sorry sorry sorry
+
 def Combine.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let patterns : Array (RewritePattern OpCode) := #[right_identity_zero_add]
+  let patterns : Array (RewritePattern OpCode) :=
+    #[right_identity_zero_add, srl_sra_signbit, srlw_sraw_signbit]
   let pattern := RewritePattern.GreedyRewritePattern patterns
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -44,8 +44,8 @@ def srl_sra_signbit (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if outerImm.value.value ≠ 63 then return rewriter
   let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
   let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv .srai) 1 | return rewriter
-  let (rewriter, newOp) ← rewriter.createOp (.riscv .srli) #[RegisterType.mk] #[sraOperands[0]!]
-      #[] #[] outerImm (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, newOp) := rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[sraOperands[0]!]
+      #[] #[] outerImm (some $ .before op)
   let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
 
@@ -58,8 +58,8 @@ def srlw_sraw_signbit (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   if outerImm.value.value ≠ 31 then return rewriter
   let some sraOp := getDefiningOp operands[0]! rewriter.ctx | return rewriter
   let some (sraOperands, _) := matchOp sraOp rewriter.ctx (.riscv .sraiw) 1 | return rewriter
-  let (rewriter, newOp) ← rewriter.createOp (.riscv .srliw) #[RegisterType.mk] #[sraOperands[0]!]
-      #[] #[] outerImm (some $ .before op) sorry (by simp) (by simp) sorry
+  let (rewriter, newOp) := rewriter.createOp! (.riscv .srliw) #[RegisterType.mk] #[sraOperands[0]!]
+      #[] #[] outerImm (some $ .before op)
   let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
 

--- a/Veir/Passes/RISCVCombines/Proofs.lean
+++ b/Veir/Passes/RISCVCombines/Proofs.lean
@@ -1,5 +1,10 @@
 import Veir.Data.RISCV.Reg.Basic
 import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Data.LLVM.Int.Basic
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.LLVM.Int.Bitblast
+import Veir.Data.Casting
+import Veir.Data.Refinement
 
 import Veir.Meta.BVDecide
 
@@ -14,6 +19,32 @@ namespace Veir.Data.RISCV
 -/
 theorem right_identity_zero_add:
     (RISCV.add lhs (Data.RISCV.li (BitVec.ofInt 64 0))) = lhs := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `srl_sra_signbit` combine, phrased at the LLVM
+  level (the combine itself fires on already-selected `riscv.srai`/`riscv.srli`,
+  but the fact it relies on is a generic, division-agnostic property of `ashr`
+  followed by `lshr`): an arithmetic right shift by any amount `shamt` -- even an
+  out-of-range one, where `ashr` itself is poison and the refinement holds
+  trivially -- never changes the top bit, so a subsequent logical shift by 63
+  (which keeps only that bit) gives the same result as skipping the `ashr`
+  entirely. Mirrors LLVM's generic `DAGCombiner::visitSRL` rule
+  `fold (srl (sra X, Y), 31) -> (srl X, 31)`.
+  https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L11628-L11633
+-/
+theorem srl_sra_signbit_refinement {x shamt : LLVM.Int 64} :
+    (Data.LLVM.Int.lshr (Data.LLVM.Int.ashr x shamt) (LLVM.Int.constant 64 63)) ⊒
+      (Data.LLVM.Int.lshr x (LLVM.Int.constant 64 63)) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the `srlw_sraw_signbit` combine (the `i32` analogue of
+  `srl_sra_signbit_refinement`, at bit 31).
+-/
+theorem srlw_sraw_signbit_refinement {x shamt : LLVM.Int 32} :
+    (Data.LLVM.Int.lshr (Data.LLVM.Int.ashr x shamt) (LLVM.Int.constant 32 31)) ⊒
+      (Data.LLVM.Int.lshr x (LLVM.Int.constant 32 31)) := by
   veir_bv_decide
 
 end Veir.Data.RISCV

--- a/Veir/Passes/RISCVCombines/Proofs.lean
+++ b/Veir/Passes/RISCVCombines/Proofs.lean
@@ -1,10 +1,5 @@
 import Veir.Data.RISCV.Reg.Basic
 import Veir.Data.RISCV.Reg.Lemmas
-import Veir.Data.LLVM.Int.Basic
-import Veir.Data.LLVM.Int.Lemmas
-import Veir.Data.LLVM.Int.Bitblast
-import Veir.Data.Casting
-import Veir.Data.Refinement
 
 import Veir.Meta.BVDecide
 
@@ -22,29 +17,26 @@ theorem right_identity_zero_add:
   veir_bv_decide
 
 /--
-  Prove the correctness of the `srl_sra_signbit` combine, phrased at the LLVM
-  level (the combine itself fires on already-selected `riscv.srai`/`riscv.srli`,
-  but the fact it relies on is a generic, division-agnostic property of `ashr`
-  followed by `lshr`): an arithmetic right shift by any amount `shamt` -- even an
-  out-of-range one, where `ashr` itself is poison and the refinement holds
-  trivially -- never changes the top bit, so a subsequent logical shift by 63
-  (which keeps only that bit) gives the same result as skipping the `ashr`
-  entirely. Mirrors LLVM's generic `DAGCombiner::visitSRL` rule
-  `fold (srl (sra X, Y), 31) -> (srl X, 31)`.
+  Prove the correctness of the `srl_sra_signbit` combine, phrased directly on the
+  already-selected RISC-V register ops the combine rewrites: `riscv.srli 63
+  (riscv.srai shamt x) = riscv.srli 63 x`. An arithmetic right shift by any amount
+  `shamt` never changes the top bit, so a subsequent logical shift by 63 (which
+  keeps only that bit) gives the same result as skipping the `srai` entirely. The
+  RISC-V ops are total, so this is an exact equality. Mirrors LLVM's generic
+  `DAGCombiner::visitSRL` rule `fold (srl (sra X, Y), 31) -> (srl X, 31)`.
   https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L11628-L11633
 -/
-theorem srl_sra_signbit_refinement {x shamt : LLVM.Int 64} :
-    (Data.LLVM.Int.lshr (Data.LLVM.Int.ashr x shamt) (LLVM.Int.constant 64 63)) ⊒
-      (Data.LLVM.Int.lshr x (LLVM.Int.constant 64 63)) := by
+theorem srl_sra_signbit {x : Reg} {shamt : BitVec 6} :
+    RISCV.srli 63 (RISCV.srai shamt x) = RISCV.srli 63 x := by
   veir_bv_decide
 
 /--
   Prove the correctness of the `srlw_sraw_signbit` combine (the `i32` analogue of
-  `srl_sra_signbit_refinement`, at bit 31).
+  `srl_sra_signbit`, at bit 31): `riscv.srliw 31 (riscv.sraiw shamt x) =
+  riscv.srliw 31 x`.
 -/
-theorem srlw_sraw_signbit_refinement {x shamt : LLVM.Int 32} :
-    (Data.LLVM.Int.lshr (Data.LLVM.Int.ashr x shamt) (LLVM.Int.constant 32 31)) ⊒
-      (Data.LLVM.Int.lshr x (LLVM.Int.constant 32 31)) := by
+theorem srlw_sraw_signbit {x : Reg} {shamt : BitVec 5} :
+    RISCV.srliw 31 (RISCV.sraiw shamt x) = RISCV.srliw 31 x := by
   veir_bv_decide
 
 end Veir.Data.RISCV


### PR DESCRIPTION
LLVM backends have sophisticated lowerings to avoid expensive division instructions.

this PR gives us the trivial lowering from udiv by power-of-2 to a shift, and then also the less trivial lowering for sdiv by power-of-2. there are also some specific rewrites for the `exact` variants.

everything is a pretty straightforward port from the LLVM backend. our output matches LLVM's for all cases I looked at.

I also ported a nice little optimization that removes one instruction from the sdiv-by-2 case.

these fire multiple times in fastntt!

I've sorried out several slow proofs, division is hard for bitvector solvers
