### PR TITLE
feat: Replace reg -> iX -> reg casts with zero extension

### DIFF
--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -129,9 +129,8 @@
         %2 = "builtin.unrealized_conversion_cast"(%1) : (i32) -> !riscv.reg
         "test.test"(%2) : (!riscv.reg) -> ()
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   %[[C1:.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i32
-        // CHECK-NEXT:   %[[C2:.*]] = "builtin.unrealized_conversion_cast"(%[[C1]]) : (i32) -> !riscv.reg
-        // CHECK-NEXT:   "test.test"(%[[C2]]) : (!riscv.reg) -> ()
+        // CHECK-NEXT:   %[[C1:.*]] = "riscv.zextw"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%[[C1]]) : (!riscv.reg) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -174,6 +173,44 @@
         "func.return"() : () -> ()
     }) : () -> ()
     
+  ^15():
+    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+      ^1(%0 : !riscv.reg):
+        // reg -> i16 -> reg : should not be folded away.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i16
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i16) -> !riscv.reg
+        "test.test"(%2) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
+        // CHECK-NEXT:   %[[C1:.*]] = "riscv.zexth"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%[[C1]]) : (!riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
     
+  ^16():
+    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+      ^1(%0 : !riscv.reg):
+        // reg -> i8 -> reg : should not be folded away.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i8
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i8) -> !riscv.reg
+        "test.test"(%2) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
+        // CHECK-NEXT:   %[[C1:.*]] = "riscv.zextb"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%[[C1]]) : (!riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+  ^17():
+    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+      ^1(%0 : !riscv.reg):
+        // reg -> i14 -> reg : should not be folded away.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i14
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i14) -> !riscv.reg
+        "test.test"(%2) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
+        // CHECK-NEXT:   %[[C1:.*]] = "riscv.slli"([[ARG]]) <{"value" = 50 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   %[[C2:.*]] = "riscv.srli"(%[[C1]]) <{"value" = 50 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%[[C2]]) : (!riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
 
 }) : () -> ()

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -88,9 +88,54 @@ def reconcileIdentityCast (rewriter : PatternRewriter OpCode) (op : OperationPtr
   let rewriter := rewriter.replaceValue (op.getResult 0) input sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
 
+/- Reconciles round-trip casts of the form !riscv.reg->iX->!riscv.reg
+   using zext.b/w/h for 8/16/32-bit values, or slli+slri for other bitwidths. -/
+set_option warn.sorry false in
+def reconcileRegIntCast (rewriter : PatternRewriter OpCode)
+    (op : OperationPtr) (opInBounds : op.InBounds rewriter.ctx.raw) :
+    Option (PatternRewriter OpCode) := do
+  let some cast := matchCastOp op rewriter.ctx.raw | return rewriter
+  let input := op.getOperand! rewriter.ctx.raw 0
+  /- Note that reconciliation matches on the second casting operation, so the input type of this op would be the intermediate type -/
+  let interType := input.getType! rewriter.ctx.raw
+  let resultType := ((op.getResult 0).get! rewriter.ctx.raw).type
+  /- If the operand's parent is a cast operation -/
+  let .opResult op' := input | return rewriter
+  let some cast := matchCastOp op'.op rewriter.ctx.raw | return rewriter
+  let parentInput := (op'.op.getOperand! rewriter.ctx.raw 0)
+  /- And the result's type coincides with the parent operation operand's type -/
+  let inputType := parentInput.getType! rewriter.ctx.raw
+  if resultType ≠ inputType then return rewriter
+  /- And the reconciliation involves the right types -/
+  if inputType ≠ RegisterType.mk then return rewriter
+  let .integerType ⟨ interBw ⟩ := interType.val | rewriter
+  /- Replace the initial operation's output with a zero-extension of the parent's input -/
+  let (rewriter, newOp) ← match interBw with
+  | 8 =>
+      some $ rewriter.createOp! (.riscv .zextb) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+  | 16 =>
+      some $ rewriter.createOp! (.riscv .zexth) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+  | 32 =>
+      some $ rewriter.createOp! (.riscv .zextw) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+  | bw =>
+      /- for bitwidths with no dedicated instruction, shift left then right -/
+      if bw >= 64 then none else
+      let imm := IntegerAttr.mk (64-bw) (.mk 64)
+      let (rewriter, shlOp) := rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[parentInput] #[] #[] ⟨imm⟩ (some $ .before op)
+      some $ rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[shlOp.getResult 0] #[] #[] ⟨imm⟩ (some $ .before op)
+  let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
+  /- Erase the redundant cast operation -/
+  let rewriter ← rewriter.eraseOp op sorry sorry sorry
+  /- If unused and side-effect-free, erase the parent cast operation as well.
+    These need to be erased in this order, otherwise the parent operation will always be used. -/
+  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ op'.op.hasSideEffects rewriter.ctx.raw then
+    rewriter.eraseOp op'.op sorry sorry sorry
+  else
+    return rewriter
+
 def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern #[reconcilePairingCast isRiscvRegToI64Cast, reconcilePairingCast isRiscvRegToI32Cast, reconcilePairingCast isRiscvRegToPtrCast, reconcilePairingCast isPreservingIntegerTypeRoundTrip, reconcileIdentityCast]
+  let pattern := RewritePattern.GreedyRewritePattern #[reconcilePairingCast isRiscvRegToI64Cast, reconcilePairingCast isRiscvRegToI32Cast, reconcilePairingCast isRiscvRegToPtrCast, reconcilePairingCast isPreservingIntegerTypeRoundTrip, reconcileIdentityCast, reconcileRegIntCast]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying cast reconciliation"
   | some ctx => pure ctx


### PR DESCRIPTION
This is done using either dedicated zext instructions, or shift-left then shift-right.