### PR TITLE
chore(formatting): drop double-newline

### DIFF
--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -453,4 +453,3 @@ namespace Rat
 def twoPow (k : Int) : Rat := 2 ^ k
 
 end Rat
-


### PR DESCRIPTION
vscode drops this line on any edit to this file, leading to an unrelated change. Just drop it separately.