### PR TITLE
chore(isel): prove sdivPow2Exact/sdivwPow2Exact negative-divisor sorries

### DIFF
--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -442,6 +442,37 @@ theorem udiv_one_shl {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂) :
       rw [BitVec.toNat_twoPow_of_le hk, BitVec.toNat_ofNat, Nat.zero_mod])
     rw [htw, BitVec.udiv_zero, BitVec.ushiftRight_eq_zero hk]
 
+/-- The heterogeneous-width variant of `toInt_sshiftRight'`, which is only stated for a shift
+    amount of the same width as the shifted value. -/
+theorem toInt_sshiftRight'' {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂) :
+    (x.sshiftRight' k).toInt = x.toInt >>> k.toNat := by
+  rw [BitVec.sshiftRight_eq']
+  exact BitVec.toInt_sshiftRight
+
+/-- An exact `sdiv` by a power of two (i.e. one where the dividend has no fractional part to
+    round, witnessed by `x.smod (2^k) = 0`) agrees with the arithmetic shift `x.sshiftRight' k`.
+    `k` must leave room for a sign bit (`k.toNat + 1 < w`, i.e. `2^k` isn't `x`'s own `intMin`),
+    matching the range for which `sdivPow2Exact`/`sdivwPow2Exact` are selected. -/
+@[veir_bv_normalize_post]
+theorem sdiv_one_shl_of_smod_eq_zero {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂)
+    (hk : k.toNat + 1 < w₁) (h : x.smod ((1#w₁) <<< k) = 0#w₁) :
+    x.sdiv ((1#w₁) <<< k) = x.sshiftRight' k := by
+  have hy : ((1#w₁) <<< k).toInt = ((2 ^ k.toNat : Nat) : Int) := by
+    rw [BitVec.shiftLeft_eq', ← BitVec.twoPow_eq, BitVec.toInt_twoPow, if_neg (by omega),
+      if_neg (by omega)]
+    exact (Int.natCast_pow 2 k.toNat).symm
+  apply BitVec.eq_of_toInt_eq
+  have hsmod : x.toInt.fmod ((1#w₁) <<< k).toInt = 0 := by
+    rw [← BitVec.toInt_smod, h, BitVec.toInt_zero]
+  rw [hy] at hsmod
+  rw [BitVec.toInt_sdiv, toInt_sshiftRight'', hy]
+  have hnn : (0 : Int) ≤ ((2 ^ k.toNat : Nat) : Int) := Int.natCast_nonneg _
+  rw [Int.fmod_eq_emod_of_nonneg _ hnn] at hsmod
+  have hdvd : ((2 ^ k.toNat : Nat) : Int) ∣ x.toInt := Int.dvd_of_emod_eq_zero hsmod
+  rw [Int.tdiv_eq_ediv_of_dvd hdvd, ← Int.shiftRight_eq_div_pow]
+  have hcancel := BitVec.toInt_bmod_cancel (x.sshiftRight' k)
+  rwa [toInt_sshiftRight''] at hcancel
+
 @[veir_bv_normalize]
 theorem setWidth_ofInt_32_64 (v : Int) :
     BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -472,6 +472,46 @@ theorem sdiv_one_shl_of_smod_eq_zero {w₁ w₂ : Nat} (x : BitVec w₁) (k : Bi
   have hcancel := BitVec.toInt_bmod_cancel (x.sshiftRight' k)
   rwa [toInt_sshiftRight''] at hcancel
 
+/-- The `toInt` of a negated power of two. Unlike `toInt_twoPow`, this needs no case split on
+    whether `2^k` is itself `intMin`: negating `intMin` wraps back to `intMin` (`neg_intMin`),
+    whose `toInt` is `-2^(w-1)`, i.e. exactly `-2^k` at that boundary too. -/
+theorem toInt_neg_one_shl {w₁ w₂ : Nat} (k : BitVec w₂) (hk : k.toNat < w₁) :
+    (-((1#w₁) <<< k)).toInt = -((2 ^ k.toNat : Nat) : Int) := by
+  have hle : 2 ^ k.toNat ≤ 2 ^ (w₁ - 1) := Nat.pow_le_pow_right (by omega) (by omega)
+  have hlt : 2 ^ k.toNat < 2 ^ w₁ := Nat.pow_lt_pow_right (by omega) hk
+  have h2 : 2 ^ (w₁ - 1) * 2 = 2 ^ w₁ := by
+    rw [← Nat.pow_succ]
+    congr 1
+    omega
+  have hy : ((1#w₁) <<< k).toNat = 2 ^ k.toNat := by
+    rw [BitVec.shiftLeft_eq', ← BitVec.twoPow_eq, BitVec.toNat_twoPow_of_lt hk]
+  obtain ⟨q, hq⟩ := Nat.le.dest (Nat.le_of_lt hlt)
+  have hsubval : 2 ^ w₁ - 2 ^ k.toNat = q := by omega
+  have hneg : (-((1#w₁) <<< k)).toNat = q := by
+    rw [BitVec.toNat_neg, hy, Nat.mod_eq_of_lt (Nat.sub_lt (Nat.two_pow_pos w₁) (Nat.two_pow_pos k.toNat)),
+      hsubval]
+  have hcond : ¬ (2 * (-((1#w₁) <<< k)).toNat < 2 ^ w₁) := by rw [hneg]; omega
+  rw [BitVec.toInt_eq_toNat_cond, if_neg hcond, hneg]
+  omega
+
+/-- Negative-divisor analogue of `sdiv_one_shl_of_smod_eq_zero`: an exact `sdiv` by `-2^k` agrees
+    with the negated arithmetic shift. No bound relating `k` to `w` is needed beyond `k < w`
+    (unlike the positive-divisor version): `-2^(w-1)` is itself a valid divisor, since negating
+    it wraps back to itself. -/
+@[veir_bv_normalize_post]
+theorem sdiv_neg_one_shl_of_smod_eq_zero {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂)
+    (hk : k.toNat < w₁) (h : x.smod (-((1#w₁) <<< k)) = 0#w₁) :
+    x.sdiv (-((1#w₁) <<< k)) = -(x.sshiftRight' k) := by
+  apply BitVec.eq_of_toInt_eq
+  have hsmod : x.toInt.fmod (-((2 ^ k.toNat : Nat) : Int)) = 0 := by
+    have hcong := congrArg BitVec.toInt h
+    rwa [BitVec.toInt_smod, toInt_neg_one_shl k hk, BitVec.toInt_zero] at hcong
+  have hdvd : ((2 ^ k.toNat : Nat) : Int) ∣ x.toInt :=
+    Int.neg_dvd.mp (Int.dvd_of_fmod_eq_zero hsmod)
+  rw [BitVec.toInt_sdiv, toInt_neg_one_shl k hk, Int.tdiv_neg,
+    Int.tdiv_eq_ediv_of_dvd hdvd, ← Int.shiftRight_eq_div_pow,
+    BitVec.toInt_neg, toInt_sshiftRight'']
+
 @[veir_bv_normalize]
 theorem setWidth_ofInt_32_64 (v : Int) :
     BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -446,8 +446,7 @@ theorem udiv_one_shl {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂) :
     amount of the same width as the shifted value. -/
 theorem toInt_sshiftRight'' {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂) :
     (x.sshiftRight' k).toInt = x.toInt >>> k.toNat := by
-  rw [BitVec.sshiftRight_eq']
-  exact BitVec.toInt_sshiftRight
+  simp
 
 /-- An exact `sdiv` by a power of two (i.e. one where the dividend has no fractional part to
     round, witnessed by `x.smod (2^k) = 0`) agrees with the arithmetic shift `x.sshiftRight' k`.

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -14,11 +14,23 @@ Preprocessing happens in two stages because rewrites are generally
 easier to state with the dependently-typed `Int.getValue`, but `bv_decide` works
 better with the non-dependent `Int.getValueD`. Thus, `veir_bv_normalize_post`
 contains `Int.getValue_eq_getValueD`, which rewrites the former into the latter.
+
+Exception: conditional rewrites whose side condition only becomes available *after*
+unfolding poison-checks into a chain of hypotheses (e.g. `isPoison_sdiv`) must go in
+`veir_bv_normalize_post` instead, since only its `simp` call runs with `+contextual`
+(threading those hypotheses forward as it descends). Its `discharger := bv_omega` lets
+such a lemma's side condition draw on both the threaded hypotheses and any ambient
+local hypotheses (e.g. a range bound on a shift amount) that aren't part of that chain,
+since `bv_omega` scans the whole local context, not just the current subgoal. The
+first-phase `simp` is plain (no `+contextual`, no discharger), so such lemmas silently
+fail to fire there.
 -/
 @[expose] macro "veir_bv_normalize" : tactic =>
   `(tactic| ((
       simp -failIfUnchanged only [veir_bv_normalize] <;>
-      simp +contextual -failIfUnchanged only [veir_bv_normalize_post, reduceIte])))
+      simp +contextual -failIfUnchanged
+        (discharger := bv_omega)
+        only [veir_bv_normalize_post, reduceIte])))
 /-
 The lack of `only` is copied from the previous version of this tactic, and indeed
 some of the tests seem to rely on certain simp-lemmas from the default simp-set.
@@ -43,4 +55,4 @@ attribute [veir_bv_normalize] Bool.false_eq_true false_and or_self decide_false
 
 attribute [veir_bv_normalize_post] dite_eq_ite Bool.if_true_left Bool.decide_or
   Bool.decide_eq_true Bool.or_eq_false_iff decide_eq_false_iff_not
-  BitVec.not_le and_imp Bool.false_eq_true implies_true
+  BitVec.not_le and_imp Bool.false_eq_true implies_true Decidable.not_not

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -342,7 +342,6 @@ theorem sdivPow2Exact_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk : k < 
       (RISCV.Reg.toInt (Data.RISCV.srai k (LLVM.Int.toReg x)) 64) := by
   veir_bv_decide
 
-set_option warn.sorry false in
 /--
   `sdiv exact x, -2^k` -> `riscv.sub 0, (riscv.srai x, k)` (`sdivPow2Exact`, negative
   divisor). No upper bound on `k` is needed here: `-2^63` (`k = 63`) is itself a
@@ -351,7 +350,7 @@ set_option warn.sorry false in
 theorem sdivPow2Exact_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#64) <<< k))) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.neg (Data.RISCV.srai k (LLVM.Int.toReg x))) 64) := by
-  sorry -- bv_decide needs a non-default timeout (120s) to close this goal
+  veir_bv_decide
 
 set_option warn.sorry false in
 /--
@@ -1000,14 +999,13 @@ theorem sdivwPow2Exact_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk : k <
       (RISCV.Reg.toInt (Data.RISCV.sraiw k (LLVM.Int.toReg x)) 32) := by
   veir_bv_decide
 
-set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2Exact_neg_refinement` (`sdivwPow2Exact`, negative
     divisor): `-2^31` (`k = 31`) is itself a valid `i32` divisor, so no upper bound
     on `k` is needed. -/
 theorem sdivwPow2Exact_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.negw (Data.RISCV.sraiw k (LLVM.Int.toReg x))) 32) := by
-  sorry -- bv_decide times out with the default timeout on this goal
+  veir_bv_decide
 
 set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2_pos_refinement` (`sdivwPow2`, positive divisor). -/

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -331,7 +331,6 @@ theorem udivPow2_refinement {x : LLVM.Int 64} (k : BitVec 6) :
       (RISCV.Reg.toInt (Data.RISCV.srli k (LLVM.Int.toReg x)) 64) := by
   veir_bv_decide
 
-set_option warn.sorry false in
 /--
   `sdiv exact x, 2^k` -> `riscv.srai x, k` (`sdivPow2Exact`, positive divisor).
   Since `exact` makes the source poison whenever `x` isn't a multiple of `2^k`, this
@@ -341,7 +340,7 @@ set_option warn.sorry false in
 theorem sdivPow2Exact_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk : k < 63) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#64) <<< k)) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.srai k (LLVM.Int.toReg x)) 64) := by
-  sorry -- bv_decide needs a non-default timeout (120s) to close this goal
+  veir_bv_decide
 
 set_option warn.sorry false in
 /--
@@ -994,13 +993,12 @@ theorem udivwPow2_refinement {x : LLVM.Int 32} (k : BitVec 5) :
       (RISCV.Reg.toInt (Data.RISCV.srliw k (LLVM.Int.toReg x)) 32) := by
   veir_bv_decide
 
-set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2Exact_pos_refinement` (`sdivwPow2Exact`, positive
     divisor): a genuine positive `i32` divisor `2^k` needs `k < 31`. -/
 theorem sdivwPow2Exact_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk : k < 31) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) true) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sraiw k (LLVM.Int.toReg x)) 32) := by
-  sorry -- bv_decide times out with the default timeout on this goal
+  veir_bv_decide
 
 set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2Exact_neg_refinement` (`sdivwPow2Exact`, negative


### PR DESCRIPTION
## Summary
- Adds `BitVec.toInt_neg_one_shl` and `BitVec.sdiv_neg_one_shl_of_smod_eq_zero`, the negative-divisor analogues of the positive-divisor lemmas from #991: an exact `sdiv` by `-2^k` agrees with the negated arithmetic shift `-(x.sshiftRight' k)`.
- No case split is needed at the `intMin` boundary (`k = w-1`, e.g. `-2^63` for i64): `-2^k` is always already within the valid signed range for `k < w`, so `-2^(w-1)` (self-negating `intMin`) falls out of the same uniform proof.
- Closes the `sdivPow2Exact_neg_refinement` and `sdivwPow2Exact_neg_refinement` `sorry`s in `Veir/Passes/InstructionSelection/Proofs.lean`, both now single-line `veir_bv_decide` proofs.

Stacked on #991 (`tobias/division_sorries`).

## Test plan
- [x] `lake env lean Veir/ForLean.lean` — clean
- [x] `lake env lean Veir/Passes/InstructionSelection/Proofs.lean` — clean
- [x] Full `lake build Veir` — 134/134 jobs, zero warnings/errors