### PR TITLE
feat(riscv): Use `LocalRewritePattern` in SelectionDag lowerings

### DIFF
--- a/Veir/Passes/InstructionSelection/Common.lean
+++ b/Veir/Passes/InstructionSelection/Common.lean
@@ -29,4 +29,27 @@ def replaceWithReg (rewriter : PatternRewriter OpCode) (op : OperationPtr) (reg 
       #[type] #[reg] #[] #[] () (some $ .before op)
   return rewriter.replaceOp! op castOp
 
+/--
+  Local-rewrite variant of `castToReg`: create a detached
+  `unrealized_conversion_cast : (typeof v) -> !riscv.reg`, returning the updated
+  context and the register-typed cast operation. The caller is responsible for
+  inserting the returned operation.
+-/
+def castToRegLocal (ctx : WfIRContext OpCode) (v : ValuePtr) :
+    Option (WfIRContext OpCode × OperationPtr) :=
+  WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast)
+      #[RegisterType.mk] #[v] #[] #[] () none
+
+/--
+  Local-rewrite variant of `replaceWithReg`: create a detached
+  `unrealized_conversion_cast` from `reg` back to `op`'s result type, returning
+  the updated context and the cast operation. The caller is responsible for
+  inserting the returned operation and replacing `op`'s result with its result.
+-/
+def replaceWithRegLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (reg : ValuePtr) :
+    Option (WfIRContext OpCode × OperationPtr) :=
+  let type := ((op.getResult 0).get! ctx.raw).type
+  WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast)
+      #[type] #[reg] #[] #[] () none
+
 end Veir

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -22,107 +22,140 @@ def singleSetBit (x : BitVec 64) : Option Int :=
 /--
   `and x (not y)` -> `riscv.andn x y`. The `not` may appear on either operand.
 -/
-def andn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchAnd op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+def andn_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchAnd op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
   let some (x, y) :=
-    (match matchNot rhs rewriter.ctx with
+    (match matchNot rhs ctx with
      | some y => some (lhs, y)
-     | none => match matchNot lhs rewriter.ctx with
+     | none => match matchNot lhs ctx with
                | some y => some (rhs, y)
-               | none => none) | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op x
-  let (rewriter, yReg) ← castToReg rewriter op y
-  let (rewriter, andnOp) ← rewriter.createOp! (.riscv .andn) #[RegisterType.mk] #[xReg, yReg]
-      #[] #[] () (some $ .before op)
-  replaceWithReg rewriter op (andnOp.getResult 0)
+               | none => none) | return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx x
+  let (ctx, yCastOp) ← castToRegLocal ctx y
+  let (ctx, andnOp) ← WfRewriter.createOp! ctx (.riscv .andn) #[RegisterType.mk]
+      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] () none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (andnOp.getResult 0)
+  some (ctx, some (#[xCastOp, yCastOp, andnOp, castBackOp], #[castBackOp.getResult 0]))
+
+/--
+  `and x (not y)` -> `riscv.andn x y`. The `not` may appear on either operand.
+-/
+def andn (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite andn_local rewriter op opInBounds
 
 /--
   `or x (not y)` -> `riscv.orn x y`. The `not` may appear on either operand.
 -/
-def orn (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchOr op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+def orn_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchOr op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
   let some (x, y) :=
-    (match matchNot rhs rewriter.ctx with
+    (match matchNot rhs ctx with
      | some y => some (lhs, y)
-     | none => match matchNot lhs rewriter.ctx with
+     | none => match matchNot lhs ctx with
                | some y => some (rhs, y)
-               | none => none) | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op x
-  let (rewriter, yReg) ← castToReg rewriter op y
-  let (rewriter, ornOp) ← rewriter.createOp! (.riscv .orn) #[RegisterType.mk] #[xReg, yReg]
-      #[] #[] () (some $ .before op)
-  replaceWithReg rewriter op (ornOp.getResult 0)
+               | none => none) | return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx x
+  let (ctx, yCastOp) ← castToRegLocal ctx y
+  let (ctx, ornOp) ← WfRewriter.createOp! ctx (.riscv .orn) #[RegisterType.mk]
+      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] () none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (ornOp.getResult 0)
+  some (ctx, some (#[xCastOp, yCastOp, ornOp, castBackOp], #[castBackOp.getResult 0]))
+
+/--
+  `or x (not y)` -> `riscv.orn x y`. The `not` may appear on either operand.
+-/
+def orn (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite orn_local rewriter op opInBounds
 
 /--
   `xor x (not y)` -> `riscv.xnor x y`. The `not` may appear on either operand.
 -/
-def xnor (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchXor op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+def xnor_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchXor op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
   let some (x, y) :=
-    (match matchNot rhs rewriter.ctx with
+    (match matchNot rhs ctx with
      | some y => some (lhs, y)
-     | none => match matchNot lhs rewriter.ctx with
+     | none => match matchNot lhs ctx with
                | some y => some (rhs, y)
-               | none => none) | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op x
-  let (rewriter, yReg) ← castToReg rewriter op y
-  let (rewriter, xnorOp) ← rewriter.createOp! (.riscv .xnor) #[RegisterType.mk] #[xReg, yReg]
-      #[] #[] () (some $ .before op)
-  replaceWithReg rewriter op (xnorOp.getResult 0)
+               | none => none) | return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx x
+  let (ctx, yCastOp) ← castToRegLocal ctx y
+  let (ctx, xnorOp) ← WfRewriter.createOp! ctx (.riscv .xnor) #[RegisterType.mk]
+      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] () none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (xnorOp.getResult 0)
+  some (ctx, some (#[xCastOp, yCastOp, xnorOp, castBackOp], #[castBackOp.getResult 0]))
+
+/--
+  `xor x (not y)` -> `riscv.xnor x y`. The `not` may appear on either operand.
+-/
+def xnor (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite xnor_local rewriter op opInBounds
 
 /--
   `sub (shl M (8 - Y)) (lshr M Y)` -> `riscv.orcb M`,
   where `M = and Z (0x0101_0101_0101_0101 <<< Y)`
 -/
-def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (a, b, _) := matchSub op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
+def orcb_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (a, b, _) := matchSub op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
   /- left operand must be `shl M (8 - Y)` for some `0 ≤ Y < 8` -/
-  let some aOp := getDefiningOp a rewriter.ctx | return rewriter
-  let some (m, shamt, _) := matchShl aOp rewriter.ctx | return rewriter
-  let some shc := matchConstantIntVal shamt rewriter.ctx | return rewriter
-  if shc.value < 1 || 8 < shc.value then return rewriter
+  let some aOp := getDefiningOp a ctx | return (ctx, none)
+  let some (m, shamt, _) := matchShl aOp ctx | return (ctx, none)
+  let some shc := matchConstantIntVal shamt ctx | return (ctx, none)
+  if shc.value < 1 || 8 < shc.value then return (ctx, none)
   let y : Nat := (8 - shc.value).toNat
   /- right operand must be `M` itself (when `Y = 0`) or `lshr M Y` -/
   let rightMatches : Bool :=
     if y == 0 then
       decide (b = m)
     else
-      match getDefiningOp b rewriter.ctx with
+      match getDefiningOp b ctx with
       | none => false
       | some bOp =>
-        match matchLshr bOp rewriter.ctx with
+        match matchLshr bOp ctx with
         | none => false
         | some (m', yShamt, _) =>
-          match matchConstantIntVal yShamt rewriter.ctx with
+          match matchConstantIntVal yShamt ctx with
           | none => false
           | some yc => yc.value == (y : Int) && decide (m' = m)
-  if !rightMatches then return rewriter
+  if !rightMatches then return (ctx, none)
   /- soundness gate: `M = and Z (0x0101_0101_0101_0101 <<< Y)` -/
-  let some mOp := getDefiningOp m rewriter.ctx | return rewriter
-  let some (mo0, mo1, _) := matchAnd mOp rewriter.ctx | return rewriter
+  let some mOp := getDefiningOp m ctx | return (ctx, none)
+  let some (mo0, mo1, _) := matchAnd mOp ctx | return (ctx, none)
   let maskBV : BitVec 64 := BitVec.ofNat 64 0x0101010101010101 <<< y
   let isMask : ValuePtr → Bool := fun v =>
-    match matchConstantIntVal v rewriter.ctx with
+    match matchConstantIntVal v ctx with
     | some attr => BitVec.ofInt 64 attr.value == maskBV
     | none => false
-  if !(isMask mo0 || isMask mo1) then return rewriter
-  let (rewriter, mReg) ← castToReg rewriter op m
+  if !(isMask mo0 || isMask mo1) then return (ctx, none)
+  let (ctx, mCastOp) ← castToRegLocal ctx m
   /- actual `riscv.orcb` -/
-  let (rewriter, orcbOp) ← rewriter.createOp! (.riscv .orcb) #[RegisterType.mk] #[mReg]
-      #[] #[] () (some $ .before op)
-  replaceWithReg rewriter op (orcbOp.getResult 0)
+  let (ctx, orcbOp) ← WfRewriter.createOp! ctx (.riscv .orcb) #[RegisterType.mk] #[mCastOp.getResult 0]
+      #[] #[] () none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orcbOp.getResult 0)
+  some (ctx, some (#[mCastOp, orcbOp, castBackOp], #[castBackOp.getResult 0]))
+
+/--
+  `sub (shl M (8 - Y)) (lshr M Y)` -> `riscv.orcb M`,
+  where `M = and Z (0x0101_0101_0101_0101 <<< Y)`
+-/
+def orcb (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite orcb_local rewriter op opInBounds
 
 
 
@@ -147,41 +180,42 @@ def orcb (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds 
   immediate lies in `[lo, hi]`. Mirrors `PatGprImm<OpNode, Inst, ImmType>`. The
   matcher's trailing properties component (`α`) is ignored.
 -/
-def selectBinopImm {α} (matchPair : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × α))
+def selectBinopImmLocal {α} (matchPair : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × α))
     (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties) (width : Nat) (lo hi : Int)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchPair op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ width then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  if imm.value < lo || imm.value > hi then return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
+    (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchPair op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ width then return (ctx, none)
+  let some imm := matchConstantIntVal rhs ctx | return (ctx, none)
+  if imm.value < lo || imm.value > hi then return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm.value (IntegerType.mk 64))
-  let (rewriter, newOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
-      #[] #[] (cast h.symm immProps) (some $ .before op)
-  replaceWithReg rewriter op (newOp.getResult 0)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] (cast h.symm immProps) none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
 
 /-- imm12 binops on i64: `add/or/and/xor x (const ∈ [-2048, 2047])` -> `addi/ori/andi/xori`.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVInstrInfo.td#L1467-L1474 -/
-def addi := selectBinopImm matchAdd .addi rfl 64 (-2048) 2047
-def ori  := selectBinopImm matchOr  .ori  rfl 64 (-2048) 2047
-def andi := selectBinopImm matchAnd .andi rfl 64 (-2048) 2047
-def xori := selectBinopImm matchXor .xori rfl 64 (-2048) 2047
+def addi := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchAdd .addi rfl 64 (-2048) 2047)
+def ori  := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchOr  .ori  rfl 64 (-2048) 2047)
+def andi := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchAnd .andi rfl 64 (-2048) 2047)
+def xori := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchXor .xori rfl 64 (-2048) 2047)
 
 /-- uimm6 shifts on i64: `shl/lshr/ashr x (const ∈ [0, 63])` -> `slli/srli/srai`.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVInstrInfo.td#L1475-L1477 -/
-def slli := selectBinopImm matchShl  .slli rfl 64 0 63
-def srli := selectBinopImm matchLshr .srli rfl 64 0 63
-def srai := selectBinopImm matchAshr .srai rfl 64 0 63
+def slli := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchShl  .slli rfl 64 0 63)
+def srli := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchLshr .srli rfl 64 0 63)
+def srai := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchAshr .srai rfl 64 0 63)
 
 /-- Word `*w` immediate forms (best-effort: gated on an i32 result as a proxy for
     LLVM's `binop_allwusers`, which we lack the demanded-bits analysis to model).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVInstrInfo.td#L2249-L2254 -/
-def addiw := selectBinopImm matchAdd  .addiw rfl 32 (-2048) 2047
-def slliw := selectBinopImm matchShl  .slliw rfl 32 0 31
-def srliw := selectBinopImm matchLshr .srliw rfl 32 0 31
-def sraiw := selectBinopImm matchAshr .sraiw rfl 32 0 31
+def addiw := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchAdd  .addiw rfl 32 (-2048) 2047)
+def slliw := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchShl  .slliw rfl 32 0 31)
+def srliw := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchLshr .srliw rfl 32 0 31)
+def sraiw := RewritePattern.fromLocalRewrite (selectBinopImmLocal matchAshr .sraiw rfl 32 0 31)
 
 /--
   Immediate-form integer comparison selection (`PatGprSimm12` family). When the
@@ -218,38 +252,46 @@ def sraiw := selectBinopImm matchAshr .sraiw rfl 32 0 31
     `xor (setlt ...), 1`)
     https://github.com/llvm/llvm-project/blob/d9906882fc613471ab51e7185094efae893066de/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L326-L332
 -/
-def slti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, prop) := matchIcmp op rewriter.ctx | return rewriter
-  let .integerType lt := (lhs.getType! rewriter.ctx.raw).val | return rewriter
-  if lt.bitwidth ≠ 64 then return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx | return rewriter
+def slti_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, prop) := matchIcmp op ctx | return (ctx, none)
+  let .integerType lt := (lhs.getType! ctx.raw).val | return (ctx, none)
+  if lt.bitwidth ≠ 64 then return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx | return (ctx, none)
   let c := cst.value
   /- Emit `[xori _ 1] (<dst> x immVal)`, or bail (leaving `op` for the reg-reg
      lowering) when `immVal` does not fit a signed 12-bit field. `dst` is either
      `.slti` or `.sltiu`, both with `RISCVImmediateProperties` (hence `h`). -/
   let emit (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties)
-      (immVal : Int) (wrap : Bool) : Option (PatternRewriter OpCode) := do
-    if immVal < -2048 || immVal > 2047 then return rewriter
+      (immVal : Int) (wrap : Bool) :
+      Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+    if immVal < -2048 || immVal > 2047 then return (ctx, none)
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk immVal (IntegerType.mk 64))
-    let (rewriter, xReg) ← castToReg rewriter op lhs
-    let (rewriter, cmpOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
-        #[] #[] (cast h.symm immProps) (some $ .before op)
+    let (ctx, xCastOp) ← castToRegLocal ctx lhs
+    let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+        #[] #[] (cast h.symm immProps) none
     if wrap then
       let one := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (rewriter, xorOp) ← rewriter.createOp! (.riscv .xori) #[RegisterType.mk] #[cmpOp.getResult 0]
-          #[] #[] one (some $ .before op)
-      replaceWithReg rewriter op (xorOp.getResult 0)
+      let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[cmpOp.getResult 0]
+          #[] #[] one none
+      let (ctx, castBackOp) ← replaceWithRegLocal ctx op (xorOp.getResult 0)
+      some (ctx, some (#[xCastOp, cmpOp, xorOp, castBackOp], #[castBackOp.getResult 0]))
     else
-      replaceWithReg rewriter op (cmpOp.getResult 0)
+      let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
+      some (ctx, some (#[xCastOp, cmpOp, castBackOp], #[castBackOp.getResult 0]))
   match prop.predicate with
   | .slt => emit .slti  rfl c       false
   | .ult => emit .sltiu rfl c       false
   | .sge => emit .slti  rfl c       true
   | .uge => emit .sltiu rfl c       true
   | .sle => emit .slti  rfl (c + 1) false
-  | .ule => if c = -1 then return rewriter else emit .sltiu rfl (c + 1) false
-  | _    => return rewriter
+  | .ule => if c = -1 then return (ctx, none) else emit .sltiu rfl (c + 1) false
+  | _    => return (ctx, none)
+
+/-- Immediate-form integer comparison selection (`PatGprSimm12` family, see `slti_local`). -/
+def slti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite slti_local rewriter op opInBounds
 
 /-! ## Zbs single-bit immediate selection
 
@@ -271,140 +313,175 @@ def slti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   *complement* of the immediate is a single set bit). The emitted immediate is the
   bit index. Only fires when the immediate does not fit a signed 12-bit field.
 -/
-def selectSingleBit {α} (matchPair : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × α))
+def selectSingleBitLocal {α} (matchPair : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × α))
     (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties) (complement : Bool)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchPair op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
+    (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchPair op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
+  let some imm := matchConstantIntVal rhs ctx | return (ctx, none)
   /- ANDI/ORI/XORI handle the simm12 cases; only fire when the immediate doesn't fit. -/
-  if !(imm.value < -2048 || imm.value > 2047) then return rewriter
+  if !(imm.value < -2048 || imm.value > 2047) then return (ctx, none)
   let bv := BitVec.ofInt 64 imm.value
-  let some n := singleSetBit (if complement then ~~~ bv else bv) | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
+  let some n := singleSetBit (if complement then ~~~ bv else bv) | return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk n (IntegerType.mk 64))
-  let (rewriter, newOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
-      #[] #[] (cast h.symm immProps) (some $ .before op)
-  replaceWithReg rewriter op (newOp.getResult 0)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] (cast h.symm immProps) none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
 
-def bseti := selectSingleBit matchOr  .bseti rfl false
-def binvi := selectSingleBit matchXor .binvi rfl false
-def bclri := selectSingleBit matchAnd .bclri rfl true
+def bseti := RewritePattern.fromLocalRewrite (selectSingleBitLocal matchOr  .bseti rfl false)
+def binvi := RewritePattern.fromLocalRewrite (selectSingleBitLocal matchXor .binvi rfl false)
+def bclri := RewritePattern.fromLocalRewrite (selectSingleBitLocal matchAnd .bclri rfl true)
 
 /-- `and (lshr x n) 1` -> `riscv.bexti x n` (`PatGprImm`-style single-bit extract).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td#L536-L537 -/
-def bexti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchAnd op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let some one := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  if one.value ≠ 1 then return rewriter
-  let some shrOp := getDefiningOp lhs rewriter.ctx | return rewriter
-  let some (x, shamt, _) := matchLshr shrOp rewriter.ctx | return rewriter
-  let some sh := matchConstantIntVal shamt rewriter.ctx | return rewriter
-  if sh.value < 0 || sh.value > 63 then return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op x
+def bexti_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchAnd op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
+  let some one := matchConstantIntVal rhs ctx | return (ctx, none)
+  if one.value ≠ 1 then return (ctx, none)
+  let some shrOp := getDefiningOp lhs ctx | return (ctx, none)
+  let some (x, shamt, _) := matchLshr shrOp ctx | return (ctx, none)
+  let some sh := matchConstantIntVal shamt ctx | return (ctx, none)
+  if sh.value < 0 || sh.value > 63 then return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx x
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
-  let (rewriter, newOp) ← rewriter.createOp! (.riscv .bexti) #[RegisterType.mk] #[xReg]
-      #[] #[] immProps (some $ .before op)
-  replaceWithReg rewriter op (newOp.getResult 0)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .bexti) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] immProps none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `and (lshr x n) 1` -> `riscv.bexti x n` (see `bexti_local`). -/
+def bexti (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite bexti_local rewriter op opInBounds
 
 /-- `fshr x x (const)` on i32 is a constant word rotate-right -> `riscv.roriw`
     (i32 analogue of `fshrConst` -> `rori`; mirrors `PatGprImm<riscv_rorw, RORIW, uimm5>`).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td#L504 -/
-def roriw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (a, b, amt) := matchFshr op rewriter.ctx | return rewriter
-  if a ≠ b then return rewriter
-  let some amtAttr := matchConstantIntVal amt rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 32 then return rewriter
+def roriw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (a, b, amt) := matchFshr op ctx | return (ctx, none)
+  if a ≠ b then return (ctx, none)
+  let some amtAttr := matchConstantIntVal amt ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 32 then return (ctx, none)
   let sh : Int := ((amtAttr.value % 32) + 32) % 32
-  let (rewriter, valReg) ← castToReg rewriter op a
+  let (ctx, valCastOp) ← castToRegLocal ctx a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-  let (rewriter, newOp) ← rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
-      #[] #[] immProps (some $ .before op)
-  replaceWithReg rewriter op (newOp.getResult 0)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .roriw) #[RegisterType.mk] #[valCastOp.getResult 0]
+      #[] #[] immProps none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[valCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `fshr x x (const)` on i32 -> `riscv.roriw` (see `roriw_local`). -/
+def roriw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite roriw_local rewriter op opInBounds
 
 /-- `fshl x x (const)` on i32 is a constant word rotate-left. There is no `roliw`,
     so (like `fshlConst` at i64) it lowers to `riscv.roriw` with the negated immediate
     `(32 - amt) mod 32` (i32 analogue of `fshlConst`). -/
-def roliw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (a, b, amt) := matchFshl op rewriter.ctx | return rewriter
-  if a ≠ b then return rewriter
-  let some amtAttr := matchConstantIntVal amt rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 32 then return rewriter
+def roliw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (a, b, amt) := matchFshl op ctx | return (ctx, none)
+  if a ≠ b then return (ctx, none)
+  let some amtAttr := matchConstantIntVal amt ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 32 then return (ctx, none)
   /- rotate-left by `sh` == rotate-right by `32 - sh` (mod 32). -/
   let sh : Int := ((amtAttr.value % 32) + 32) % 32
   let imm : Int := (32 - sh) % 32
-  let (rewriter, valReg) ← castToReg rewriter op a
+  let (ctx, valCastOp) ← castToRegLocal ctx a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-  let (rewriter, newOp) ← rewriter.createOp! (.riscv .roriw) #[RegisterType.mk] #[valReg]
-      #[] #[] immProps (some $ .before op)
-  replaceWithReg rewriter op (newOp.getResult 0)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .roriw) #[RegisterType.mk] #[valCastOp.getResult 0]
+      #[] #[] immProps none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[valCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `fshl x x (const)` on i32 -> `riscv.roriw` with negated immediate (see `roliw_local`). -/
+def roliw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite roliw_local rewriter op opInBounds
 
 /-- `shl (zext i32->i64 x) (const ∈ [0,31])` -> `riscv.slliuw x shamt`
     (Zba: `(i64 (shl (and GPR, 0xFFFFFFFF), uimm5)) -> SLLI_UW`; our `zext` is the mask).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVInstrInfoZb.td#L821-L822 -/
-def slliuw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (base, shamt, _) := matchShl op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let some sh := matchConstantIntVal shamt rewriter.ctx | return rewriter
-  if sh.value < 0 || sh.value > 31 then return rewriter
-  let some baseOp := getDefiningOp base rewriter.ctx | return rewriter
-  let some (x, _) := matchZext baseOp rewriter.ctx | return rewriter
-  let .integerType srcT := (x.getType! rewriter.ctx.raw).val | return rewriter
-  if srcT.bitwidth ≠ 32 then return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op x
+def slliuw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (base, shamt, _) := matchShl op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
+  let some sh := matchConstantIntVal shamt ctx | return (ctx, none)
+  if sh.value < 0 || sh.value > 31 then return (ctx, none)
+  let some baseOp := getDefiningOp base ctx | return (ctx, none)
+  let some (x, _) := matchZext baseOp ctx | return (ctx, none)
+  let .integerType srcT := (x.getType! ctx.raw).val | return (ctx, none)
+  if srcT.bitwidth ≠ 32 then return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx x
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
-  let (rewriter, newOp) ← rewriter.createOp! (.riscv .slliuw) #[RegisterType.mk] #[xReg]
-      #[] #[] immProps (some $ .before op)
-  replaceWithReg rewriter op (newOp.getResult 0)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .slliuw) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] immProps none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `shl (zext i32->i64 x) (const ∈ [0,31])` -> `riscv.slliuw x shamt` (see `slliuw_local`). -/
+def slliuw (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite slliuw_local rewriter op opInBounds
+
+/-- llvm.zext x i1 to i64 -> and x 1 -/
+def zext_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (operand, _) := matchZext op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
+  let .integerType opType := (operand.getType! ctx.raw).val | return (ctx, none)
+  if opType.bitwidth ≠ 1 then return (ctx, none)
+  /- First, cast the operand to registers -/
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+      #[] #[] () none
+  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
+  let (ctx, andiOp) ← WfRewriter.createOp! ctx (.riscv .andi) #[RegisterType.mk] #[opCastOp.getResult 0]
+      #[] #[] imm none
+  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[t] #[andiOp.getResult 0]
+      #[] #[] () none
+  some (ctx, some (#[opCastOp, andiOp, castOp], #[castOp.getResult 0]))
 
 /-- llvm.zext x i1 to i64 -> and x 1 -/
 def zext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (operand, _) := matchZext op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
-  if opType.bitwidth ≠ 1 then return rewriter
-  /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
-      #[] #[] () (some $ .before op)
-  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-  let (rewriter, andiOp) ← rewriter.createOp! (.riscv .andi) #[RegisterType.mk] #[opCastOp.getResult 0]
-      #[] #[] imm (some $ .before op)
-  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[t] #[andiOp.getResult 0]
-      #[] #[] () (some $ .before op)
-  return rewriter.replaceOp! op castOp
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite zext_1_local rewriter op opInBounds
 
-/-- llvm.sext x i1 to i64 -> srai (slli x 63) 1 -/
-def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (operand, _) := matchSext op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ 64 then return rewriter
-  let .integerType opType := (operand.getType! rewriter.ctx.raw).val | return rewriter
-  if opType.bitwidth ≠ 1 then return rewriter
+/-- llvm.sext x i1 to i64 -> srai (slli x 63) 63 -/
+def sext_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (operand, _) := matchSext op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 then return (ctx, none)
+  let .integerType opType := (operand.getType! ctx.raw).val | return (ctx, none)
+  if opType.bitwidth ≠ 1 then return (ctx, none)
   /- First, cast the operand to registers -/
-  let (rewriter, opCastOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
-      #[] #[] () (some $ .before op)
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+      #[] #[] () none
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
-  let (rewriter, slliOp) ← rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
-      #[] #[] imm (some $ .before op)
-  let (rewriter, sraiOp) ← rewriter.createOp! (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]
-      #[] #[] imm (some $ .before op)
-  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast) #[t] #[sraiOp.getResult 0]
-      #[] #[] () (some $ .before op)
-  return rewriter.replaceOp! op castOp
+  let (ctx, slliOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
+      #[] #[] imm none
+  let (ctx, sraiOp) ← WfRewriter.createOp! ctx (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]
+      #[] #[] imm none
+  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[t] #[sraiOp.getResult 0]
+      #[] #[] () none
+  some (ctx, some (#[opCastOp, slliOp, sraiOp, castOp], #[castOp.getResult 0]))
+
+/-- llvm.sext x i1 to i64 -> srai (slli x 63) 63 -/
+def sext_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite sext_1_local rewriter op opInBounds
 
 /-! ## Division by a constant power of two
 
@@ -446,34 +523,37 @@ def matchUnsignedPow2Divisor (w : Nat) (v : Int) : Option Nat :=
     `DAGCombiner::visitUDIVLike`'s `fold (udiv x, (1 << c)) -> x >>u c` (via
     `BuildLogBase2`).
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5430-L5440 -/
-def udivPow2Gen (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties)
-    (width : Nat) (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchUdiv op rewriter.ctx | return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ width then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some k := matchUnsignedPow2Divisor width imm.value | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
+def udivPow2GenLocal (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties)
+    (width : Nat) (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchUdiv op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ width then return (ctx, none)
+  let some imm := matchConstantIntVal rhs ctx | return (ctx, none)
+  let some k := matchUnsignedPow2Divisor width imm.value | return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, shiftOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
-      #[] #[] (cast h.symm shamt) (some $ .before op)
-  replaceWithReg rewriter op (shiftOp.getResult 0)
+  let (ctx, shiftOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] (cast h.symm shamt) none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (shiftOp.getResult 0)
+  some (ctx, some (#[xCastOp, shiftOp, castBackOp], #[castBackOp.getResult 0]))
 
-def udivPow2 := udivPow2Gen .srli rfl 64
-def udivwPow2 := udivPow2Gen .srliw rfl 32
+def udivPow2 := RewritePattern.fromLocalRewrite (udivPow2GenLocal .srli rfl 64)
+def udivwPow2 := RewritePattern.fromLocalRewrite (udivPow2GenLocal .srliw rfl 32)
 
 /-- `riscv.sub 0, x` (`riscv.subw` at `i32`, selected via `negDst`): negates `x`.
     Used to correct the quotient of a `sdiv`-by-power-of-two lowering when the
-    divisor is negative. -/
-def negateReg (negDst : Riscv) (h : Riscv.propertiesOf negDst = Unit)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr) (x : ValuePtr) :
-    Option (PatternRewriter OpCode × OperationPtr) := do
+    divisor is negative. Returns the created operations (in insertion order) along
+    with the negation op, whose result the caller uses. -/
+def negateRegLocal (negDst : Riscv) (h : Riscv.propertiesOf negDst = Unit)
+    (ctx : WfIRContext OpCode) (x : ValuePtr) :
+    Option (WfIRContext OpCode × Array OperationPtr × OperationPtr) := do
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (rewriter, zeroOp) ← rewriter.createOp! (.riscv .li) #[RegisterType.mk] #[]
-      #[] #[] zero (some $ .before op)
-  rewriter.createOp! (.riscv negDst) #[RegisterType.mk] #[zeroOp.getResult 0, x]
-      #[] #[] (cast h.symm ()) (some $ .before op)
+  let (ctx, zeroOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+      #[] #[] zero none
+  let (ctx, negOp) ← WfRewriter.createOp! ctx (.riscv negDst) #[RegisterType.mk] #[zeroOp.getResult 0, x]
+      #[] #[] (cast h.symm ()) none
+  some (ctx, #[zeroOp, negOp], negOp)
 
 /-- `sdiv exact x, 2^k` -> `dst x, k` (`dst` = `riscv.srai`/`riscv.sraiw`); when the
     divisor is negative, negate the shifted result via `negDst`
@@ -485,27 +565,30 @@ def negateReg (negDst : Riscv) (h : Riscv.propertiesOf negDst = Unit)
     set, since it is cheaper.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5301
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/TargetLowering.cpp#L6454-L6510 -/
-def sdivPow2ExactGen (dst : Riscv) (hDst : Riscv.propertiesOf dst = RISCVImmediateProperties)
+def sdivPow2ExactGenLocal (dst : Riscv) (hDst : Riscv.propertiesOf dst = RISCVImmediateProperties)
     (negDst : Riscv) (hNeg : Riscv.propertiesOf negDst = Unit) (width : Nat)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
-  if ¬ props.exact then return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ width then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
+    (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, props) := matchSdiv op ctx | return (ctx, none)
+  if ¬ props.exact then return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ width then return (ctx, none)
+  let some imm := matchConstantIntVal rhs ctx | return (ctx, none)
+  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, sraOp) ← rewriter.createOp! (.riscv dst) #[RegisterType.mk] #[xReg]
-      #[] #[] (cast hDst.symm shamt) (some $ .before op)
-  if ¬ isNeg then replaceWithReg rewriter op (sraOp.getResult 0)
+  let (ctx, sraOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] (cast hDst.symm shamt) none
+  if ¬ isNeg then
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (sraOp.getResult 0)
+    some (ctx, some (#[xCastOp, sraOp, castBackOp], #[castBackOp.getResult 0]))
   else
-    let (rewriter, negOp) ← negateReg negDst hNeg rewriter op (sraOp.getResult 0)
-    replaceWithReg rewriter op (negOp.getResult 0)
+    let (ctx, negOps, negOp) ← negateRegLocal negDst hNeg ctx (sraOp.getResult 0)
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (negOp.getResult 0)
+    some (ctx, some (#[xCastOp, sraOp] ++ negOps ++ #[castBackOp], #[castBackOp.getResult 0]))
 
-def sdivPow2Exact := sdivPow2ExactGen .srai rfl .sub rfl 64
-def sdivwPow2Exact := sdivPow2ExactGen .sraiw rfl .subw rfl 32
+def sdivPow2Exact := RewritePattern.fromLocalRewrite (sdivPow2ExactGenLocal .srai rfl .sub rfl 64)
+def sdivwPow2Exact := RewritePattern.fromLocalRewrite (sdivPow2ExactGenLocal .sraiw rfl .subw rfl 32)
 
 /-- General `sdiv x, 2^k` (`exact` not set): bias negative dividends before
     shifting so truncation rounds toward zero, then negate for a negative divisor:
@@ -525,41 +608,45 @@ def sdivwPow2Exact := sdivPow2ExactGen .sraiw rfl .subw rfl 32
     sequence is what RV64 emits by default.
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/CodeGen/SelectionDAG/DAGCombiner.cpp#L5294-L5345
     https://github.com/llvm/llvm-project/blob/2e87cf8c2b8ec6453ccfa7e448d5b33f1d71a2ca/llvm/lib/Target/RISCV/RISCVISelLowering.cpp#L27055-L27074 -/
-def sdivPow2Gen (shiftDst : Riscv) (hShift : Riscv.propertiesOf shiftDst = RISCVImmediateProperties)
+def sdivPow2GenLocal (shiftDst : Riscv) (hShift : Riscv.propertiesOf shiftDst = RISCVImmediateProperties)
     (corrDst : Riscv) (hCorr : Riscv.propertiesOf corrDst = RISCVImmediateProperties)
     (addDst : Riscv) (hAdd : Riscv.propertiesOf addDst = Unit)
     (negDst : Riscv) (hNeg : Riscv.propertiesOf negDst = Unit) (width : Nat)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, props) := matchSdiv op rewriter.ctx | return rewriter
-  if props.exact then return rewriter
-  let .integerType t := ((op.getResult 0).get! rewriter.ctx.raw).type.val | return rewriter
-  if t.bitwidth ≠ width then return rewriter
-  let some imm := matchConstantIntVal rhs rewriter.ctx | return rewriter
-  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return rewriter
+    (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, props) := matchSdiv op ctx | return (ctx, none)
+  if props.exact then return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ width then return (ctx, none)
+  let some imm := matchConstantIntVal rhs ctx | return (ctx, none)
+  let some (k, isNeg) := matchSignedPow2Divisor imm.value | return (ctx, none)
   /- `k = 0` (divisor ±1) would need a shift by the full register width, which has
      no legal immediate encoding; middle-end optimizations always turn `sdiv x, ±1`
      into `x`/`-x` well before instruction selection, so this case does not arise. -/
-  if k = 0 then return rewriter
-  let (rewriter, xReg) ← castToReg rewriter op lhs
+  if k = 0 then return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shSign := RISCVImmediateProperties.mk (IntegerAttr.mk (width - 1) (IntegerType.mk 64))
-  let (rewriter, signOp) ← rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[xReg]
-      #[] #[] (cast hShift.symm shSign) (some $ .before op)
+  let (ctx, signOp) ← WfRewriter.createOp! ctx (.riscv shiftDst) #[RegisterType.mk] #[xCastOp.getResult 0]
+      #[] #[] (cast hShift.symm shSign) none
   let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (width - k) (IntegerType.mk 64))
-  let (rewriter, corrOp) ← rewriter.createOp! (.riscv corrDst) #[RegisterType.mk] #[signOp.getResult 0]
-      #[] #[] (cast hCorr.symm shCorr) (some $ .before op)
-  let (rewriter, biasedOp) ← rewriter.createOp! (.riscv addDst) #[RegisterType.mk]
-      #[xReg, corrOp.getResult 0] #[] #[] (cast hAdd.symm ()) (some $ .before op)
+  let (ctx, corrOp) ← WfRewriter.createOp! ctx (.riscv corrDst) #[RegisterType.mk] #[signOp.getResult 0]
+      #[] #[] (cast hCorr.symm shCorr) none
+  let (ctx, biasedOp) ← WfRewriter.createOp! ctx (.riscv addDst) #[RegisterType.mk]
+      #[xCastOp.getResult 0, corrOp.getResult 0] #[] #[] (cast hAdd.symm ()) none
   let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (rewriter, qOp) ← rewriter.createOp! (.riscv shiftDst) #[RegisterType.mk] #[biasedOp.getResult 0]
-      #[] #[] (cast hShift.symm shQ) (some $ .before op)
-  if ¬ isNeg then replaceWithReg rewriter op (qOp.getResult 0)
+  let (ctx, qOp) ← WfRewriter.createOp! ctx (.riscv shiftDst) #[RegisterType.mk] #[biasedOp.getResult 0]
+      #[] #[] (cast hShift.symm shQ) none
+  if ¬ isNeg then
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (qOp.getResult 0)
+    some (ctx, some (#[xCastOp, signOp, corrOp, biasedOp, qOp, castBackOp], #[castBackOp.getResult 0]))
   else
-    let (rewriter, negOp) ← negateReg negDst hNeg rewriter op (qOp.getResult 0)
-    replaceWithReg rewriter op (negOp.getResult 0)
+    let (ctx, negOps, negOp) ← negateRegLocal negDst hNeg ctx (qOp.getResult 0)
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (negOp.getResult 0)
+    some (ctx, some (#[xCastOp, signOp, corrOp, biasedOp, qOp] ++ negOps ++ #[castBackOp],
+      #[castBackOp.getResult 0]))
 
-def sdivPow2 := sdivPow2Gen .srai rfl .srli rfl .add rfl .sub rfl 64
-def sdivwPow2 := sdivPow2Gen .sraiw rfl .srliw rfl .addw rfl .subw rfl 32
+def sdivPow2 := RewritePattern.fromLocalRewrite (sdivPow2GenLocal .srai rfl .srli rfl .add rfl .sub rfl 64)
+def sdivwPow2 := RewritePattern.fromLocalRewrite (sdivPow2GenLocal .sraiw rfl .srliw rfl .addw rfl .subw rfl 32)
 
 /-! # Pass implementation -/
 


### PR DESCRIPTION
This is a first step to be able to reason about these patterns.
`LocalRewritePattern` are more constrained `RewritePattern` that return a list of operations and a list of values. The operations are inserted in place of the operation that was matched, and then the values replace the original operation.