### PR TITLE
feat: lowering patterns for libdiv

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/and.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/and.mlir
@@ -19,4 +19,22 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
+    "func.func"()  <{function_type = (i8, i8) -> ()}> ({
+    ^bb(%a: i8, %b: i8):
+        %and8 = "llvm.and"(%a, %b) : (i8, i8) -> i8
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.and"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
+        "func.return"() : () -> ()
+    }) : () -> ()
+    "func.func"()  <{function_type = (i1, i1) -> ()}> ({
+    ^bb(%a: i1, %b: i1):
+        %and1 = "llvm.and"(%a, %b) : (i1, i1) -> i1
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i1) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i1) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.and"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i1
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
@@ -24,7 +24,7 @@
         %ashr8 = "llvm.ashr"(%a, %b) : (i8, i8) -> i8
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
-        // CHECK-NEXT: %{{.*}} = "riscv.sraw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sra"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
@@ -19,4 +19,13 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
+    "func.func"()  <{function_type = (i8, i8) -> ()}> ({
+    ^bb(%a: i8, %b: i8):
+        %ashr8 = "llvm.ashr"(%a, %b) : (i8, i8) -> i8
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sraw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
@@ -24,6 +24,7 @@
         %ashr8 = "llvm.ashr"(%a, %b) : (i8, i8) -> i8
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.sextb"(%{{.*}}) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.sra"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
         "func.return"() : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/const.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/const.mlir
@@ -1,0 +1,17 @@
+// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+
+"builtin.module"() ({
+    "func.func"()  <{function_type = () -> ()}> ({
+    ^bb():
+        %c1 = "llvm.mlir.constant"() <{"value" = -1 : i64 }> : () -> i64
+        // CHECK: %[[A:.*]] = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"(%[[A]]) : (!riscv.reg) -> i64
+        %c2 = "llvm.mlir.constant"() <{"value" = -1 : i32 }> : () -> i32
+        // CHECK: %[[A:.*]] = "riscv.li"() <{"value" = -1 : i32}> : () -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"(%[[A]]) : (!riscv.reg) -> i32
+        %c3 = "llvm.mlir.constant"() <{"value" = -1 : i8 }> : () -> i8
+        // CHECK: %[[A:.*]] = "riscv.li"() <{"value" = -1 : i8}> : () -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"(%[[A]]) : (!riscv.reg) -> i8
+        "func.return"() : () -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/const.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/const.mlir
@@ -12,6 +12,9 @@
         %c3 = "llvm.mlir.constant"() <{"value" = -1 : i8 }> : () -> i8
         // CHECK: %[[A:.*]] = "riscv.li"() <{"value" = -1 : i8}> : () -> !riscv.reg
         // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"(%[[A]]) : (!riscv.reg) -> i8
+        %c4 = "llvm.mlir.constant"() <{"value" = -1 : i1 }> : () -> i1
+        // CHECK: %[[A:.*]] = "riscv.li"() <{"value" = -1 : i1}> : () -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"(%[[A]]) : (!riscv.reg) -> i1
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/or.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or.mlir
@@ -25,4 +25,22 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
+        "func.func"()  <{function_type = (i8, i8) -> ()}> ({
+    ^bb(%a: i8, %b: i8):
+        %and8 = "llvm.or"(%a, %b) : (i8, i8) -> i8
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
+        "func.return"() : () -> ()
+    }) : () -> ()
+    "func.func"()  <{function_type = (i1, i1) -> ()}> ({
+    ^bb(%a: i1, %b: i1):
+        %and1 = "llvm.or"(%a, %b) : (i1, i1) -> i1
+        // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i1) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i1) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i1
+        "func.return"() : () -> ()
+    }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
@@ -57,5 +57,15 @@
         // CHECK-DAG: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         "func.return"() : () -> ()
     }) : () -> ()
+    
+    // i1: general select
+    "func.func"()  <{function_type = (i1, i1, i1) -> ()}> ({
+    ^bb0(%c: i1, %t: i1, %f: i1):
+        %r = "llvm.select"(%c, %t, %f) : (i1, i1, i1) -> i1
+        // CHECK-DAG: %{{.*}} = "riscv.czeroeqz"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-DAG: %{{.*}} = "riscv.czeronez"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-DAG: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        "func.return"() : () -> ()
+    }) : () -> ()
 
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sext.mlir
@@ -7,7 +7,8 @@
         %sextb = "llvm.sext"(%b) : (i16) -> i32
         %sextc = "llvm.sext"(%c) : (i32) -> i64
         %sextd = "llvm.sext"(%a) : (i1) -> i64
-        %sexte = "llvm.sext"(%e) : (i8) -> i64
+        %sexte = "llvm.sext"(%a) : (i1) -> i32
+        %sextf = "llvm.sext"(%e) : (i8) -> i64
         // CHECK:           ^{{.*}}([[A:.*]] : i1, [[B:.*]] : i16, [[C:.*]] : i32, [[D:.*]] : i42, [[E:.*]] : i8):
         // CHECK-NEXT:      %[[F:.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (i16) -> !riscv.reg
         // CHECK-NEXT:      %[[G:.*]] = "riscv.sexth"(%[[F]]) : (!riscv.reg) -> !riscv.reg
@@ -19,12 +20,16 @@
         // CHECK-NEXT:      %[[M:.*]] = "riscv.sextw"(%[[L]]) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[N:.*]] = "builtin.unrealized_conversion_cast"(%[[M]]) : (!riscv.reg) -> i64
         // CHECK-NEXT:      %[[O:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
-        // CHECK-NEXT:      %[[P:.*]] = "riscv.slli"(%[[O]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[Q:.*]] = "riscv.srai"(%[[P]]) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[P:.*]] = "riscv.slli"(%[[O]]) <{"value" = 63 : i6}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[Q:.*]] = "riscv.srai"(%[[P]]) <{"value" = 63 : i6}> : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:      %[[R:.*]] = "builtin.unrealized_conversion_cast"(%[[Q]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:      %[[S:.*]] = "builtin.unrealized_conversion_cast"([[E]]) : (i8) -> !riscv.reg
-        // CHECK-NEXT:      %[[T:.*]] = "riscv.sextb"(%[[S]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:      %[[U:.*]] = "builtin.unrealized_conversion_cast"(%[[T]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:      %[[S:.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (i1) -> !riscv.reg
+        // CHECK-NEXT:      %[[T:.*]] = "riscv.slli"(%[[S]]) <{"value" = 63 : i6}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[U:.*]] = "riscv.srai"(%[[T]]) <{"value" = 63 : i6}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[V:.*]] = "builtin.unrealized_conversion_cast"(%[[U]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:      %[[W:.*]] = "builtin.unrealized_conversion_cast"([[E]]) : (i8) -> !riscv.reg
+        // CHECK-NEXT:      %[[X:.*]] = "riscv.sextb"(%[[W]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:      %[[Y:.*]] = "builtin.unrealized_conversion_cast"(%[[X]]) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -528,6 +528,14 @@ theorem setWidth_ofInt_8_64 (v : Int) :
     BitVec.toInt_ofInt]
   grind
 
+@[veir_bv_normalize]
+theorem setWidth_ofInt_1_64 (v : Int) :
+    BitVec.setWidth 1 (BitVec.ofInt 64 v) = BitVec.ofInt 1 v := by
+  rw [← BitVec.toInt_inj]
+  simp only [BitVec.toInt_setWidth, BitVec.toNat_ofInt, Nat.reducePow, Int.cast_ofNat_Int, Int.ofNat_toNat,
+    BitVec.toInt_ofInt]
+  grind
+
 @[grind =]
 theorem eq_setWidth_zero (x : BitVec w) :
     x = 0#w → x.setWidth w' = 0#w' := by

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -520,6 +520,14 @@ theorem setWidth_ofInt_32_64 (v : Int) :
     BitVec.toInt_ofInt]
   grind
 
+@[veir_bv_normalize]
+theorem setWidth_ofInt_8_64 (v : Int) :
+    BitVec.setWidth 8 (BitVec.ofInt 64 v) = BitVec.ofInt 8 v := by
+  rw [← BitVec.toInt_inj]
+  simp only [BitVec.toInt_setWidth, BitVec.toNat_ofInt, Nat.reducePow, Int.cast_ofNat_Int, Int.ofNat_toNat,
+    BitVec.toInt_ofInt]
+  grind
+
 @[grind =]
 theorem eq_setWidth_zero (x : BitVec w) :
     x = 0#w → x.setWidth w' = 0#w' := by

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -145,6 +145,10 @@ theorem ashr_refinement {x y : LLVM.Int 64} :
     (Data.LLVM.Int.ashr x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.sra (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
   veir_bv_decide
 
+theorem ashr_refinement_1 {x y : LLVM.Int 1} :
+    (Data.LLVM.Int.ashr x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.sra (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 1) := by
+  veir_bv_decide
+
 /--
   Prove the correctness of the `icmp` lowering pattern with `eq`.
 -/
@@ -720,6 +724,11 @@ theorem sext_refinement_32_64 {x : LLVM.Int 32} :
 theorem sext_refinement_1_64 {x : LLVM.Int 1} :
     (Data.LLVM.Int.sext x 64 h) ⊒
       (RISCV.Reg.toInt (Data.RISCV.srai 63#6 (Data.RISCV.slli 63#6 (LLVM.Int.toReg x))) 64) := by
+  veir_bv_decide
+
+theorem sext_refinement_1_32 {x : LLVM.Int 1} :
+    (Data.LLVM.Int.sext x 32 h) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.srai 63#6 (Data.RISCV.slli 63#6 (LLVM.Int.toReg x))) 32) := by
   veir_bv_decide
 
 /--
@@ -1303,6 +1312,83 @@ theorem icmp_refinement_ugt_32 {x y : LLVM.Int 32} :
   veir_bv_decide
 
 theorem icmp_refinement_uge_32 {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.uge) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.sltu
+          (Data.RISCV.sextw (LLVM.Int.toReg y))
+          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1) := by
+  veir_bv_decide
+
+theorem icmp_refinement_eq_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.eq) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltiu 1#12
+        (Data.RISCV.xor
+          (Data.RISCV.sextw (LLVM.Int.toReg y))
+          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1) := by
+  veir_bv_decide
+
+theorem icmp_refinement_ne_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ne) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu
+        (Data.RISCV.xor
+          (Data.RISCV.sextw (LLVM.Int.toReg y))
+          (Data.RISCV.sextw (LLVM.Int.toReg x)))
+        (Data.RISCV.li 0#64)) 1) := by
+  veir_bv_decide
+
+-- theorem icmp_refinement_slt_8 {x y : LLVM.Int 8} :
+--     (Data.LLVM.Int.icmp x y LLVM.IntPred.slt) ⊒
+--       (RISCV.Reg.toInt (Data.RISCV.slt
+--         (Data.RISCV.sextw (LLVM.Int.toReg y))
+--         (Data.RISCV.sextw (LLVM.Int.toReg x))) 1) := by
+--   veir_bv_decide
+
+-- theorem icmp_refinement_sle_8 {x y : LLVM.Int 8} :
+--     (Data.LLVM.Int.icmp x y LLVM.IntPred.sle) ⊒
+--       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
+--         (Data.RISCV.slt
+--           (Data.RISCV.sextw (LLVM.Int.toReg x))
+--           (Data.RISCV.sextw (LLVM.Int.toReg y)))) 1) := by
+--   veir_bv_decide
+
+-- theorem icmp_refinement_sgt_8 {x y : LLVM.Int 8} :
+--     (Data.LLVM.Int.icmp x y LLVM.IntPred.sgt) ⊒
+--       (RISCV.Reg.toInt (Data.RISCV.slt
+--         (Data.RISCV.sextw (LLVM.Int.toReg x))
+--         (Data.RISCV.sextw (LLVM.Int.toReg y))) 1) := by
+--   veir_bv_decide
+
+-- theorem icmp_refinement_sge_8 {x y : LLVM.Int 8} :
+--     (Data.LLVM.Int.icmp x y LLVM.IntPred.sge) ⊒
+--       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
+--         (Data.RISCV.slt
+--           (Data.RISCV.sextw (LLVM.Int.toReg y))
+--           (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1) := by
+--   veir_bv_decide
+
+theorem icmp_refinement_ult_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ult) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu
+        (Data.RISCV.sextw (LLVM.Int.toReg y))
+        (Data.RISCV.sextw (LLVM.Int.toReg x))) 1) := by
+  veir_bv_decide
+
+theorem icmp_refinement_ule_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ule) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.sltu
+          (Data.RISCV.sextw (LLVM.Int.toReg x))
+          (Data.RISCV.sextw (LLVM.Int.toReg y)))) 1) := by
+  veir_bv_decide
+
+theorem icmp_refinement_ugt_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.ugt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.sltu
+        (Data.RISCV.sextw (LLVM.Int.toReg x))
+        (Data.RISCV.sextw (LLVM.Int.toReg y))) 1) := by
+  veir_bv_decide
+
+theorem icmp_refinement_uge_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.uge) ⊒
       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
         (Data.RISCV.sltu

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -1452,6 +1452,14 @@ theorem select_refinement_32 {c : LLVM.Int 1} {t f : LLVM.Int 32} :
           (Data.RISCV.czeroeqz (LLVM.Int.toReg c) (LLVM.Int.toReg t))) 32) := by
   veir_bv_decide
 
+theorem select_refinement_1 {c : LLVM.Int 1} {t f : LLVM.Int 1} :
+    (Data.LLVM.Int.select c t f) ⊒
+      (RISCV.Reg.toInt
+        (Data.RISCV.or
+          (Data.RISCV.czeronez (LLVM.Int.toReg c) (LLVM.Int.toReg f))
+          (Data.RISCV.czeroeqz (LLVM.Int.toReg c) (LLVM.Int.toReg t))) 1) := by
+  veir_bv_decide
+
 theorem freeze_refinement_32 {a : LLVM.Int 32} :
     (Data.LLVM.Int.freeze a) ⊒
       (RISCV.Reg.toInt (LLVM.Int.toReg a) 32) := by

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -39,6 +39,10 @@ theorem constant_refinement_32 {v : Int} :
     (LLVM.Int.constant 32 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 32) := by
   veir_bv_decide
 
+theorem constant_refinement_8 {v : Int} :
+    (LLVM.Int.constant 8 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 8) := by
+  veir_bv_decide
+
 /--
   Prove the correctness of the `add` lowering pattern.
 -/
@@ -62,6 +66,19 @@ theorem addw_refinement {x y : LLVM.Int 32} :
 theorem and_refinement{x y : LLVM.Int 64} :
     (Data.LLVM.Int.and x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 64) := by
   veir_bv_decide
+
+theorem and_refinement_32 {x y : LLVM.Int 32} :
+    (Data.LLVM.Int.and x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
+  veir_bv_decide
+
+theorem and_refinement_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.and x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 8) := by
+  veir_bv_decide
+
+theorem and_refinement_1 {x y : LLVM.Int 1} :
+    (Data.LLVM.Int.and x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 1) := by
+  veir_bv_decide
+
 
 /--
   Prove the correctness of the `ctlz` intrinsic lowering pattern.
@@ -282,6 +299,14 @@ theorem or_refinement {x y : LLVM.Int 64} :
 -/
 theorem or_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.or x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
+  veir_bv_decide
+
+theorem or_refinement_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.or x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 8) := by
+  veir_bv_decide
+
+theorem or_refinement_1 {x y : LLVM.Int 1} :
+    (Data.LLVM.Int.or x y) ⊒ (RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 1) := by
   veir_bv_decide
 
 /--

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -43,6 +43,10 @@ theorem constant_refinement_8 {v : Int} :
     (LLVM.Int.constant 8 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 8) := by
   veir_bv_decide
 
+theorem constant_refinement_1 {v : Int} :
+    (LLVM.Int.constant 1 v) ⊒ (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 v)) 1) := by
+  veir_bv_decide
+
 /--
   Prove the correctness of the `add` lowering pattern.
 -/
@@ -1116,11 +1120,6 @@ theorem freeze_refinement {a : LLVM.Int 64} :
   register (`LLVM.Int.toReg`), so signed operations that inspect the sign
   bit must first `sextw`-extend the low 32 bits.
 -/
-
-theorem and_refinement_32 {x y : LLVM.Int 32} :
-    (Data.LLVM.Int.and x y) ⊒
-      (RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg y) (LLVM.Int.toReg x)) 32) := by
-  veir_bv_decide
 
 theorem ashr_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.ashr x y) ⊒

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -1323,77 +1323,77 @@ theorem icmp_refinement_eq_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.eq) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sltiu 1#12
         (Data.RISCV.xor
-          (Data.RISCV.sextw (LLVM.Int.toReg y))
-          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1) := by
+          (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))) 1) := by
   veir_bv_decide
 
 theorem icmp_refinement_ne_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.ne) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sltu
         (Data.RISCV.xor
-          (Data.RISCV.sextw (LLVM.Int.toReg y))
-          (Data.RISCV.sextw (LLVM.Int.toReg x)))
+          (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))
         (Data.RISCV.li 0#64)) 1) := by
   veir_bv_decide
 
--- theorem icmp_refinement_slt_8 {x y : LLVM.Int 8} :
---     (Data.LLVM.Int.icmp x y LLVM.IntPred.slt) ⊒
---       (RISCV.Reg.toInt (Data.RISCV.slt
---         (Data.RISCV.sextw (LLVM.Int.toReg y))
---         (Data.RISCV.sextw (LLVM.Int.toReg x))) 1) := by
---   veir_bv_decide
+theorem icmp_refinement_slt_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.slt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.slt
+        (Data.RISCV.sextb (LLVM.Int.toReg y))
+        (Data.RISCV.sextb (LLVM.Int.toReg x))) 1) := by
+  veir_bv_decide
 
--- theorem icmp_refinement_sle_8 {x y : LLVM.Int 8} :
---     (Data.LLVM.Int.icmp x y LLVM.IntPred.sle) ⊒
---       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
---         (Data.RISCV.slt
---           (Data.RISCV.sextw (LLVM.Int.toReg x))
---           (Data.RISCV.sextw (LLVM.Int.toReg y)))) 1) := by
---   veir_bv_decide
+theorem icmp_refinement_sle_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.sle) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.slt
+          (Data.RISCV.sextb (LLVM.Int.toReg x))
+          (Data.RISCV.sextb (LLVM.Int.toReg y)))) 1) := by
+  veir_bv_decide
 
--- theorem icmp_refinement_sgt_8 {x y : LLVM.Int 8} :
---     (Data.LLVM.Int.icmp x y LLVM.IntPred.sgt) ⊒
---       (RISCV.Reg.toInt (Data.RISCV.slt
---         (Data.RISCV.sextw (LLVM.Int.toReg x))
---         (Data.RISCV.sextw (LLVM.Int.toReg y))) 1) := by
---   veir_bv_decide
+theorem icmp_refinement_sgt_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.sgt) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.slt
+        (Data.RISCV.sextb (LLVM.Int.toReg x))
+        (Data.RISCV.sextb (LLVM.Int.toReg y))) 1) := by
+  veir_bv_decide
 
--- theorem icmp_refinement_sge_8 {x y : LLVM.Int 8} :
---     (Data.LLVM.Int.icmp x y LLVM.IntPred.sge) ⊒
---       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
---         (Data.RISCV.slt
---           (Data.RISCV.sextw (LLVM.Int.toReg y))
---           (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1) := by
---   veir_bv_decide
+theorem icmp_refinement_sge_8 {x y : LLVM.Int 8} :
+    (Data.LLVM.Int.icmp x y LLVM.IntPred.sge) ⊒
+      (RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.slt
+          (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))) 1) := by
+  veir_bv_decide
 
 theorem icmp_refinement_ult_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.ult) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sltu
-        (Data.RISCV.sextw (LLVM.Int.toReg y))
-        (Data.RISCV.sextw (LLVM.Int.toReg x))) 1) := by
+        (Data.RISCV.sextb (LLVM.Int.toReg y))
+        (Data.RISCV.sextb (LLVM.Int.toReg x))) 1) := by
   veir_bv_decide
 
 theorem icmp_refinement_ule_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.ule) ⊒
       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
         (Data.RISCV.sltu
-          (Data.RISCV.sextw (LLVM.Int.toReg x))
-          (Data.RISCV.sextw (LLVM.Int.toReg y)))) 1) := by
+          (Data.RISCV.sextb (LLVM.Int.toReg x))
+          (Data.RISCV.sextb (LLVM.Int.toReg y)))) 1) := by
   veir_bv_decide
 
 theorem icmp_refinement_ugt_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.ugt) ⊒
       (RISCV.Reg.toInt (Data.RISCV.sltu
-        (Data.RISCV.sextw (LLVM.Int.toReg x))
-        (Data.RISCV.sextw (LLVM.Int.toReg y))) 1) := by
+        (Data.RISCV.sextb (LLVM.Int.toReg x))
+        (Data.RISCV.sextb (LLVM.Int.toReg y))) 1) := by
   veir_bv_decide
 
 theorem icmp_refinement_uge_8 {x y : LLVM.Int 8} :
     (Data.LLVM.Int.icmp x y LLVM.IntPred.uge) ⊒
       (RISCV.Reg.toInt (Data.RISCV.xori 1#12
         (Data.RISCV.sltu
-          (Data.RISCV.sextw (LLVM.Int.toReg y))
-          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1) := by
+          (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))) 1) := by
   veir_bv_decide
 
 theorem smax_refinement_32 {x y : LLVM.Int 32} :

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -289,6 +289,14 @@ def ashr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
       #[] #[] () none
   let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
       #[] #[] () none
+  if type'.bitwidth = 8 then
+    let (ctx, lsOp) ← WfRewriter.createOp! ctx (.riscv .sextb) #[RegisterType.mk] #[lcastOp.getResult 0]
+          #[] #[] () none
+    let (ctx, sraOp) ← WfRewriter.createOp! ctx (.riscv .sra) #[RegisterType.mk] #[lsOp.getResult 0, rcastOp.getResult 0]
+          #[] #[] () none
+    let (ctx, castSraOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
+      #[] #[] () none
+    return (ctx, some (#[lcastOp, rcastOp, lsOp, sraOp, castSraOp], #[castSraOp.getResult 0]))
   /- sraw for i32 (sign-extends result), sra for i64 -/
   let (ctx, sraOp) ←
     if type'.bitwidth = 32 then
@@ -297,10 +305,10 @@ def ashr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     else
       WfRewriter.createOp! ctx (.riscv .sra) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () none
-  /- Cast back result for type consistency-/
+  /- Cast back result for type consistency -/
   let (ctx, castSraOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
       #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, sraOp, castSraOp], #[castSraOp.getResult 0]))
+  return (ctx, some (#[lcastOp, rcastOp, sraOp, castSraOp], #[castSraOp.getResult 0]))
 
 /-- llvm.ashr -> riscv.sra -/
 def ashr (rewriter : PatternRewriter OpCode) (op : OperationPtr)

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -278,12 +278,12 @@ def ashr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, _) := matchAshr op ctx | return (ctx, none)
   /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 ∧ ltype.bitwidth ≠ 8 then return (ctx, none)
   let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 ∧ rtype.bitwidth ≠ 8 then return (ctx, none)
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return (ctx, none)
   /- First, cast the operands to registers -/
   let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () none

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -1103,7 +1103,7 @@ def selectCzeronez_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tval, fval) := matchSelect op ctx | return (ctx, none)
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
-  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
+  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 ∧ t.bitwidth ≠ 1 then return (ctx, none)
   let some _ := matchConstantZero tval ctx | return (ctx, none)
   let (ctx, fCastOp) ← castToRegLocal ctx fval
   let (ctx, condCastOp) ← castToRegLocal ctx cond

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -1103,7 +1103,7 @@ def selectCzeronez_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tval, fval) := matchSelect op ctx | return (ctx, none)
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
-  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 ∧ t.bitwidth ≠ 1 then return (ctx, none)
+  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
   let some _ := matchConstantZero tval ctx | return (ctx, none)
   let (ctx, fCastOp) ← castToRegLocal ctx fval
   let (ctx, condCastOp) ← castToRegLocal ctx cond
@@ -1127,7 +1127,7 @@ def selectGeneral_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tval, fval) := matchSelect op ctx | return (ctx, none)
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
-  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
+  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 ∧ t.bitwidth ≠ 1 then return (ctx, none)
   let (ctx, tCastOp) ← castToRegLocal ctx tval
   let (ctx, fCastOp) ← castToRegLocal ctx fval
   let (ctx, condCastOp) ← castToRegLocal ctx cond

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -248,12 +248,12 @@ def and_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, _) := matchAnd op ctx | return (ctx, none)
   /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 ∧ ltype.bitwidth ≠ 8 ∧ ltype.bitwidth ≠ 1 then return (ctx, none)
   let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 ∧ rtype.bitwidth ≠ 8 ∧ rtype.bitwidth ≠ 1 then return (ctx, none)
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 ∧ type'.bitwidth ≠ 1 then return (ctx, none)
   /- First, cast the operands to registers -/
   let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () none
@@ -471,12 +471,12 @@ def or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, _) := matchOr op ctx | return (ctx, none)
   /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 ∧ ltype.bitwidth ≠ 8 ∧ ltype.bitwidth ≠ 1 then return (ctx, none)
   let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 ∧ rtype.bitwidth ≠ 8 ∧ rtype.bitwidth ≠ 1 then return (ctx, none)
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 ∧ type'.bitwidth ≠ 1 then return (ctx, none)
   /- First, cast the operands to registers -/
   let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () none

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -335,10 +335,16 @@ def icmp_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   /- For i32, sign-extend operands so both signed and unsigned comparisons work correctly.
      Zero-extended i32 negatives look positive in 64-bit signed arithmetic without this. -/
   let (ctx, extOps, lCmpReg, rCmpReg) ←
-    if ltype.bitwidth = 32 ∨ ltype.bitwidth = 8 then do
+    if ltype.bitwidth = 32 then do
       let (ctx, ls) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[lcastOp.getResult 0]
           #[] #[] () none
       let (ctx, rs) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[rcastOp.getResult 0]
+          #[] #[] () none
+      pure (ctx, #[ls, rs], ls.getResult 0, rs.getResult 0)
+    else if ltype.bitwidth = 8 then do
+      let (ctx, ls) ← WfRewriter.createOp! ctx (.riscv .sextb) #[RegisterType.mk] #[lcastOp.getResult 0]
+          #[] #[] () none
+      let (ctx, rs) ← WfRewriter.createOp! ctx (.riscv .sextb) #[RegisterType.mk] #[rcastOp.getResult 0]
           #[] #[] () none
       pure (ctx, #[ls, rs], ls.getResult 0, rs.getResult 0)
     else

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -192,10 +192,10 @@ def constant_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some const := matchConstantIntOp op ctx
       | return (ctx, none)
-  if const.type.bitwidth ≠ 64 ∧ const.type.bitwidth ≠ 32 ∧ const.type.bitwidth ≠ 8 then return (ctx, none)
+  if const.type.bitwidth ≠ 64 ∧ const.type.bitwidth ≠ 32 ∧ const.type.bitwidth ≠ 8 ∧ const.type.bitwidth ≠ 1 then return (ctx, none)
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return (ctx, none)
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 ∧ type'.bitwidth ≠ 1 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] {value := const} none
   let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type]

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -324,9 +324,9 @@ def icmp_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, property) := matchIcmp op ctx | return (ctx, none)
   /- support `i64` and `i32` -/
   let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 ∧ ltype.bitwidth ≠ 8 then return (ctx, none)
   let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 ∧ rtype.bitwidth ≠ 8 then return (ctx, none)
   /- Casting is necessary regardless of the predicate. -/
   let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
       #[] #[] () none
@@ -335,7 +335,7 @@ def icmp_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   /- For i32, sign-extend operands so both signed and unsigned comparisons work correctly.
      Zero-extended i32 negatives look positive in 64-bit signed arithmetic without this. -/
   let (ctx, extOps, lCmpReg, rCmpReg) ←
-    if ltype.bitwidth = 32 then do
+    if ltype.bitwidth = 32 ∨ ltype.bitwidth = 8 then do
       let (ctx, ls) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[lcastOp.getResult 0]
           #[] #[] () none
       let (ctx, rs) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[rcastOp.getResult 0]

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -192,10 +192,10 @@ def constant_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some const := matchConstantIntOp op ctx
       | return (ctx, none)
-  if const.type.bitwidth ≠ 64 ∧ const.type.bitwidth ≠ 32 then return (ctx, none)
+  if const.type.bitwidth ≠ 64 ∧ const.type.bitwidth ≠ 32 ∧ const.type.bitwidth ≠ 8 then return (ctx, none)
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
+  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
       #[] #[] {value := const} none
   let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type]

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -463,13 +463,13 @@ def sext_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (operand, _) := matchSext op ctx | return (ctx, none)
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
-  if t.bitwidth ≠ 64 then return (ctx, none)
+  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
   let .integerType opType := (operand.getType! ctx.raw).val | return (ctx, none)
   if opType.bitwidth ≠ 1 then return (ctx, none)
   /- First, cast the operand to registers -/
   let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () none
-  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 64))
+  let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 6))
   let (ctx, slliOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
       #[] #[] imm none
   let (ctx, sraiOp) ← WfRewriter.createOp! ctx (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]


### PR DESCRIPTION
Support i8 and i1 types in lowering `and`, `or`, `constant`. 
Support i8 type in lowering `ashr`, `icmp`. 
Support i1 type in lowering `select`, `sext to i32`.