### PR TITLE
feat(riscv): lower the funnel shift general case

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/fshl_general.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshl_general.mlir
@@ -1,15 +1,52 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 // A funnel shift with distinct data operands is a true funnel shift, not a
-// rotate. Lowering it needs a multi-instruction expansion, which we don't
-// implement, so isel must leave the intrinsic untouched (no riscv.rol/ror).
+// rotate, so there is no single Zbb instruction for it. Mirroring LLVM's generic
+// `TargetLowering::expandFunnelShift`, we lower it to a shift/or expansion:
+//   fshl x y z -> (x << z) | ((y >> 1) >> ~z)
+//   fshr x y z -> ((x << 1) << ~z) | (y >> z)
+// The RISC-V shifts mask their amount modulo the width, so `z % w` is `z` and
+// `(w-1) - (z % w)` is `~z`. These fire only after the rotate/const-rotate
+// matchers, so identical-operand and constant-amount cases still select rol/ror.
 
 "builtin.module"() ({
+
+    // General i64 fshl -> sll / (srli 1 + srl ~z) / or, no rotate instruction.
     "func.func"()  <{function_type = (i64, i64, i64) -> ()}> ({
     ^bb0(%a: i64, %b: i64, %s: i64):
         %r = "llvm.intr.fshl"(%a, %b, %s) : (i64, i64, i64) -> i64
-        // CHECK: %{{.*}} = "llvm.intr.fshl"(%{{.*}}, %{{.*}}, %{{.*}}) : (i64, i64, i64) -> i64
+        // CHECK: %[[NOTZ:.*]] = "riscv.xori"(%[[Z:.*]]) <{"value" = -1 : i64}>
+        // CHECK: %[[SHX:.*]] = "riscv.sll"(%{{.*}}, %[[Z]])
+        // CHECK: %[[Y1:.*]] = "riscv.srli"(%{{.*}}) <{"value" = 1 : i64}>
+        // CHECK: %[[SHY:.*]] = "riscv.srl"(%[[Y1]], %[[NOTZ]])
+        // CHECK: %{{.*}} = "riscv.or"(%[[SHX]], %[[SHY]])
         // CHECK-NOT: riscv.rol
         "func.return"() : () -> ()
     }) : () -> ()
+
+    // General i64 fshr -> (slli 1 + sll ~z) / srl / or, no rotate instruction.
+    "func.func"()  <{function_type = (i64, i64, i64) -> ()}> ({
+    ^bb0(%a: i64, %b: i64, %s: i64):
+        %r = "llvm.intr.fshr"(%a, %b, %s) : (i64, i64, i64) -> i64
+        // CHECK: %[[NOTZ:.*]] = "riscv.xori"(%[[Z:.*]]) <{"value" = -1 : i64}>
+        // CHECK: %[[X1:.*]] = "riscv.slli"(%{{.*}}) <{"value" = 1 : i64}>
+        // CHECK: %[[SHX:.*]] = "riscv.sll"(%[[X1]], %[[NOTZ]])
+        // CHECK: %[[SHY:.*]] = "riscv.srl"(%{{.*}}, %[[Z]])
+        // CHECK: %{{.*}} = "riscv.or"(%[[SHX]], %[[SHY]])
+        // CHECK-NOT: riscv.ror
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // General i32 fshl -> the `w`-suffixed shifts (sllw / srliw / srlw / or).
+    "func.func"()  <{function_type = (i32, i32, i32) -> ()}> ({
+    ^bb0(%a: i32, %b: i32, %s: i32):
+        %r = "llvm.intr.fshl"(%a, %b, %s) : (i32, i32, i32) -> i32
+        // CHECK: %[[NOTZ:.*]] = "riscv.xori"(%[[Z:.*]]) <{"value" = -1 : i64}>
+        // CHECK: %[[SHX:.*]] = "riscv.sllw"(%{{.*}}, %[[Z]])
+        // CHECK: %[[Y1:.*]] = "riscv.srliw"(%{{.*}}) <{"value" = 1 : i64}>
+        // CHECK: %[[SHY:.*]] = "riscv.srlw"(%[[Y1]], %[[NOTZ]])
+        // CHECK: %{{.*}} = "riscv.or"(%[[SHX]], %[[SHY]])
+        "func.return"() : () -> ()
+    }) : () -> ()
+
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/fshl_general_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshl_general_exec.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: filecheck %s --check-prefix=ISEL --input-file=%t
+
+// General (distinct-operand) funnel shift left: not a rotate, so it lowers to the
+// shift/or expansion (sll / srli 1 / srl ~z / or), mirroring LLVM.
+// fshl(0x123456789ABCDEF0, 0xFEDCBA9876543210, 8)
+//   = (x << 8) | (y >> 56) = 0x3456789ABCDEF0FE.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i64}> ({
+    %a = "llvm.mlir.constant"() <{value = 1311768467463790320 : i64}> : () -> i64
+    %b = "llvm.mlir.constant"() <{value = -81985529216486896 : i64}> : () -> i64
+    %x = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
+    %y = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
+    %s = "llvm.add"(%x, %y) : (i64, i64) -> i64
+    %r = "llvm.intr.fshl"(%a, %b, %s) : (i64, i64, i64) -> i64
+    "func.return"(%r) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0x3456789abcdef0fe#64]
+// CHECK: Program output: #[0x3456789abcdef0fe#64]
+
+// ISEL: "riscv.sll"
+// ISEL-NOT: "riscv.rol"

--- a/Test/Passes/InstructionSelection/RISCV64/fshr_general_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshr_general_exec.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: filecheck %s --check-prefix=ISEL --input-file=%t
+
+// General (distinct-operand) funnel shift right: not a rotate, so it lowers to the
+// shift/or expansion (slli 1 / sll ~z / srl / or), mirroring LLVM.
+// fshr(0x123456789ABCDEF0, 0xFEDCBA9876543210, 8)
+//   = (x << 56) | (y >> 8) = 0xF0FEDCBA98765432.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i64}> ({
+    %a = "llvm.mlir.constant"() <{value = 1311768467463790320 : i64}> : () -> i64
+    %b = "llvm.mlir.constant"() <{value = -81985529216486896 : i64}> : () -> i64
+    %x = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
+    %y = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
+    %s = "llvm.add"(%x, %y) : (i64, i64) -> i64
+    %r = "llvm.intr.fshr"(%a, %b, %s) : (i64, i64, i64) -> i64
+    "func.return"(%r) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC:   Program output: #[0xf0fedcba98765432#64]
+// CHECK: Program output: #[0xf0fedcba98765432#64]
+
+// ISEL: "riscv.srl"
+// ISEL-NOT: "riscv.ror"

--- a/Tools/vsmith_generate.py
+++ b/Tools/vsmith_generate.py
@@ -23,8 +23,6 @@ ICMP_PREDS = tuple(range(10))
 # type. `ctlz`/`cttz` additionally carry an `is_zero_poison` flag, and `bswap`
 # is only defined for the byte-swappable widths below.
 INTRINSIC_BINARY = ("llvm.intr.smax", "llvm.intr.smin", "llvm.intr.umax", "llvm.intr.umin")
-# Funnel shifts are only ever emitted in their rotate form (the first two
-# operands equal), since veir can't yet select the general funnel shift.
 INTRINSIC_TERNARY = ("llvm.intr.fshl", "llvm.intr.fshr")
 INTRINSIC_COUNT = ("llvm.intr.ctpop", "llvm.intr.bitreverse")
 INTRINSIC_ZERO_POISON = ("llvm.intr.ctlz", "llvm.intr.cttz")
@@ -320,11 +318,12 @@ class Generator:
             op = self.rng.choice(INTRINSIC_TERNARY)
             typ = self.rand_type()
             width = bitwidth(typ)
-            # veir can't yet select the general funnel shift, only the rotate
-            # special case where the two shifted operands are equal.
-            value = self.random_dominating_value(width)
+            # General funnel shift: two independent data operands (when they
+            # happen to be equal this degenerates to the rotate special case).
+            hi = self.random_dominating_value(width)
+            lo = self.random_dominating_value(width)
             amount = self.random_dominating_value(width)
-            self.add_operation(op, [value, value, amount], [typ, typ, typ], typ)
+            self.add_operation(op, [hi, lo, amount], [typ, typ, typ], typ)
         elif r < 0.78:
             op = self.rng.choice(INTRINSIC_ZERO_POISON)
             typ = self.rand_type()

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -905,13 +905,17 @@ theorem abs_refinement {x : LLVM.Int 64} {is_int_min_poison : Bool} :
   veir_bv_decide
 
 /-!
-  The funnel-shift rotate lowerings cannot use `veir_bv_decide` directly: its
-  simp normalization rewrites the BitVec shift in the funnel-shift semantics into
-  a *symbolic* `Nat` shift (`c.toNat % w`) on the `2*w`-bit concatenation, which
-  `bv_decide` cannot bit-blast. Instead we reduce the refinement to a pure-BitVec
-  goal by hand (discharging the poison cases from the non-poison hypothesis on the
-  result, and keeping the shift amounts as `BitVec`s) and finish with bare
-  `bv_decide`.
+  ## Funnel-shift lowerings
+
+  These cover both the rotate special cases (identical data operands, selecting
+  `rol`/`ror`/`rori`/`roriw`) and the general distinct-operand funnel shifts
+  (selecting LLVM's `expandFunnelShift` shift/or sequence).
+
+  `veir_bv_decide` closes all of them directly. Its `veir_bv_normalize` phase
+  rewrites the funnel-shift semantics (via `getValue_fshl`/`getValue_fshr`) into a
+  BitVec shift by the `BitVec` amount `c.getValue % w` on the `2*w`-bit
+  concatenation `a ++ b`, which `bv_decide` bit-blasts as a barrel shifter and
+  proves equal to the RISC-V register expression. No manual reduction is needed.
 -/
 
 /--
@@ -974,6 +978,90 @@ theorem fshl_roriw_refinement {a c : LLVM.Int 32} :
     (Data.LLVM.Int.fshl a a c) ⊒
       (RISCV.Reg.toInt
         (Data.RISCV.roriw (-(BitVec.extractLsb 4 0 (LLVM.Int.toReg c).val)) (LLVM.Int.toReg a)) 32) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the general (distinct-operand) i64 `fshl` lowering,
+  mirroring LLVM's generic `expandFunnelShift`:
+
+    fshl a b c = (a << c) | ((b >> 1) >> ~c)
+
+  The RISC-V shifts mask their amount modulo 64, so `c` stands for `c % 64` and
+  `~c` (the `xori a, -1`) stands for `(63 - c % 64)`; the `>> 1` pre-shift keeps
+  the `c % 64 = 0` case (where `shy` shifts fully out to zero) correct.
+-/
+theorem fshlGeneral_refinement {a b c : LLVM.Int 64} :
+    (Data.LLVM.Int.fshl a b c) ⊒
+      (RISCV.Reg.toInt
+        (let x0 := LLVM.Int.toReg a
+         let y0 := LLVM.Int.toReg b
+         let z0 := LLVM.Int.toReg c
+         let notz := Data.RISCV.xori (BitVec.ofInt 12 (-1)) z0
+         let shx := Data.RISCV.sll z0 x0
+         let y1 := Data.RISCV.srli 1#6 y0
+         let shy := Data.RISCV.srl notz y1
+         Data.RISCV.or shx shy) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the general (distinct-operand) i64 `fshr` lowering,
+  mirroring LLVM's generic `expandFunnelShift`:
+
+    fshr a b c = ((a << 1) << ~c) | (b >> c)
+
+  The RISC-V shifts mask their amount modulo 64, so `c` stands for `c % 64` and
+  `~c` (the `xori a, -1`) stands for `(63 - c % 64)`; the `<< 1` pre-shift keeps
+  the `c % 64 = 0` case (where `shx` shifts fully out to zero) correct.
+-/
+theorem fshrGeneral_refinement {a b c : LLVM.Int 64} :
+    (Data.LLVM.Int.fshr a b c) ⊒
+      (RISCV.Reg.toInt
+        (let x0 := LLVM.Int.toReg a
+         let y0 := LLVM.Int.toReg b
+         let z0 := LLVM.Int.toReg c
+         let notz := Data.RISCV.xori (BitVec.ofInt 12 (-1)) z0
+         let x1 := Data.RISCV.slli 1#6 x0
+         let shx := Data.RISCV.sll notz x1
+         let shy := Data.RISCV.srl z0 y0
+         Data.RISCV.or shx shy) 64) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the general (distinct-operand) i32 `fshl` lowering: the
+  i64 expansion using the `w`-suffixed shifts (`sllw`/`srliw`/`srlw`), which mask
+  their amount modulo 32. Only the low 32 bits of the `or` are observed (`toInt …
+  32`), so the sign-extension the `w` shifts produce is harmless.
+-/
+theorem fshlGeneralw_refinement {a b c : LLVM.Int 32} :
+    (Data.LLVM.Int.fshl a b c) ⊒
+      (RISCV.Reg.toInt
+        (let x0 := LLVM.Int.toReg a
+         let y0 := LLVM.Int.toReg b
+         let z0 := LLVM.Int.toReg c
+         let notz := Data.RISCV.xori (BitVec.ofInt 12 (-1)) z0
+         let shx := Data.RISCV.sllw z0 x0
+         let y1 := Data.RISCV.srliw 1#5 y0
+         let shy := Data.RISCV.srlw notz y1
+         Data.RISCV.or shx shy) 32) := by
+  veir_bv_decide
+
+/--
+  Prove the correctness of the general (distinct-operand) i32 `fshr` lowering: the
+  i64 expansion using the `w`-suffixed shifts (`slliw`/`sllw`/`srlw`), which mask
+  their amount modulo 32. Only the low 32 bits of the `or` are observed (`toInt …
+  32`), so the sign-extension the `w` shifts produce is harmless.
+-/
+theorem fshrGeneralw_refinement {a b c : LLVM.Int 32} :
+    (Data.LLVM.Int.fshr a b c) ⊒
+      (RISCV.Reg.toInt
+        (let x0 := LLVM.Int.toReg a
+         let y0 := LLVM.Int.toReg b
+         let z0 := LLVM.Int.toReg c
+         let notz := Data.RISCV.xori (BitVec.ofInt 12 (-1)) z0
+         let x1 := Data.RISCV.slliw 1#5 x0
+         let shx := Data.RISCV.sllw notz x1
+         let shy := Data.RISCV.srlw z0 y0
+         Data.RISCV.or shx shy) 32) := by
   veir_bv_decide
 
 /--

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -1633,6 +1633,122 @@ def fshlConst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite fshlConst_local rewriter op opInBounds
 
+/-! ## General (distinct-operand) funnel shift
+
+  A funnel shift whose two data operands differ is a true funnel shift, not a
+  rotate, so there is no single Zbb instruction for it. We mirror LLVM's generic
+  `TargetLowering::expandFunnelShift` (`SelectionDAG/TargetLowering.cpp`), which
+  is the path RV64 baseline takes since `FSHL`/`FSHR` are marked `Expand`. For a
+  power-of-two bit width `w` and a variable shift amount `z` (the case a register
+  operand always lands in), the expansion is
+
+    fshl x y z = (x << (z % w)) | ((y >> 1) >> ((w-1) - (z % w)))
+    fshr x y z = ((x << 1) << ((w-1) - (z % w))) | (y >> (z % w))
+
+  The RISC-V shifts already reduce their amount modulo the register width, so
+  `z % w` is just `z` and `(w-1) - (z % w)` is `~z` (both masked by the hardware).
+  The `>> 1` / `<< 1` pre-shifts keep the `z % w = 0` case correct (they push the
+  inverse shift to a full-width shift-out of zero). i32 uses the `w`-suffixed
+  shifts; only the low `w` bits of the `or` matter, so their sign-extension is
+  harmless.
+
+  These run after the rotate/const-rotate matchers, so the identical-operand and
+  constant-amount special cases still select the cheaper `rol`/`ror`/`rori`. -/
+
+/-- General `llvm.intr.fshl x y z` -> `(x << z) | ((y >> 1) >> ~z)` (see the
+    section comment). Handles i64 and i32; the i32 form uses the `w` shifts. -/
+def fshlGeneral_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (a, b, amt) := matchFshl op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx a
+  let (ctx, yCastOp) ← castToRegLocal ctx b
+  let (ctx, zCastOp) ← castToRegLocal ctx amt
+  /- ~z, the inverse shift amount; the shift instruction masks it modulo `w`. -/
+  let notImm := RISCVImmediateProperties.mk (IntegerAttr.mk (-1) (IntegerType.mk 64))
+  let (ctx, notzOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[zCastOp.getResult 0]
+      #[] #[] notImm none
+  let oneImm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
+  /- shx = x << z ; shy = (y >> 1) >> ~z ; result = shx | shy. The i32 form uses
+     the `w` shifts (only the low 32 bits of the `or` are observed). -/
+  if t.bitwidth = 32 then
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sllw) #[RegisterType.mk] #[xCastOp.getResult 0, zCastOp.getResult 0]
+        #[] #[] () none
+    let (ctx, y1Op) ← WfRewriter.createOp! ctx (.riscv .srliw) #[RegisterType.mk] #[yCastOp.getResult 0]
+        #[] #[] oneImm none
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srlw) #[RegisterType.mk] #[y1Op.getResult 0, notzOp.getResult 0]
+        #[] #[] () none
+    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+        #[] #[] () none
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
+    some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, shxOp, y1Op, shyOp, orOp, castBackOp],
+      #[castBackOp.getResult 0]))
+  else
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sll) #[RegisterType.mk] #[xCastOp.getResult 0, zCastOp.getResult 0]
+        #[] #[] () none
+    let (ctx, y1Op) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk] #[yCastOp.getResult 0]
+        #[] #[] oneImm none
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srl) #[RegisterType.mk] #[y1Op.getResult 0, notzOp.getResult 0]
+        #[] #[] () none
+    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+        #[] #[] () none
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
+    some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, shxOp, y1Op, shyOp, orOp, castBackOp],
+      #[castBackOp.getResult 0]))
+
+/-- General `llvm.intr.fshl` -> shift/or expansion (see `fshlGeneral_local`). -/
+def fshlGeneral (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite fshlGeneral_local rewriter op opInBounds
+
+/-- General `llvm.intr.fshr x y z` -> `((x << 1) << ~z) | (y >> z)` (see the
+    section comment). Handles i64 and i32; the i32 form uses the `w` shifts. -/
+def fshrGeneral_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (a, b, amt) := matchFshr op ctx | return (ctx, none)
+  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
+  let (ctx, xCastOp) ← castToRegLocal ctx a
+  let (ctx, yCastOp) ← castToRegLocal ctx b
+  let (ctx, zCastOp) ← castToRegLocal ctx amt
+  /- ~z, the inverse shift amount; the shift instruction masks it modulo `w`. -/
+  let notImm := RISCVImmediateProperties.mk (IntegerAttr.mk (-1) (IntegerType.mk 64))
+  let (ctx, notzOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[zCastOp.getResult 0]
+      #[] #[] notImm none
+  let oneImm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
+  /- shx = (x << 1) << ~z ; shy = y >> z ; result = shx | shy. The i32 form uses
+     the `w` shifts (only the low 32 bits of the `or` are observed). -/
+  if t.bitwidth = 32 then
+    let (ctx, x1Op) ← WfRewriter.createOp! ctx (.riscv .slliw) #[RegisterType.mk] #[xCastOp.getResult 0]
+        #[] #[] oneImm none
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sllw) #[RegisterType.mk] #[x1Op.getResult 0, notzOp.getResult 0]
+        #[] #[] () none
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srlw) #[RegisterType.mk] #[yCastOp.getResult 0, zCastOp.getResult 0]
+        #[] #[] () none
+    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+        #[] #[] () none
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
+    some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, x1Op, shxOp, shyOp, orOp, castBackOp],
+      #[castBackOp.getResult 0]))
+  else
+    let (ctx, x1Op) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[xCastOp.getResult 0]
+        #[] #[] oneImm none
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sll) #[RegisterType.mk] #[x1Op.getResult 0, notzOp.getResult 0]
+        #[] #[] () none
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srl) #[RegisterType.mk] #[yCastOp.getResult 0, zCastOp.getResult 0]
+        #[] #[] () none
+    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+        #[] #[] () none
+    let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
+    some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, x1Op, shxOp, shyOp, orOp, castBackOp],
+      #[castBackOp.getResult 0]))
+
+/-- General `llvm.intr.fshr` -> shift/or expansion (see `fshrGeneral_local`). -/
+def fshrGeneral (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite fshrGeneral_local rewriter op opInBounds
+
 
 /-- llvm.mlir.poison -> riscv.li 0 -/
 def poisonConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
@@ -1682,7 +1798,7 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral, ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, load, getelementptr, store,
     smax, smin, umax, umin, saddSat, ssubSat, uaddSat, usubSat, sshlSat, ushlSat, abs,
-    fshlConst, fshrConst, fshl, fshr, poisonConst, freeze]
+    fshlConst, fshrConst, fshl, fshr, fshlGeneral, fshrGeneral, poisonConst, freeze]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx


### PR DESCRIPTION
this adds funnel shift lowering to risc-v for the general case, for 32 and 64 bits. 