### PR TITLE
chore(isel): rewrite `x.sdiv ((1#64) <<< k) ` to ift+shift

### DIFF
--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -778,6 +778,141 @@ theorem sdiv_neg_one_shl_eq_neg_biased_sshiftRight_bv {w₁ w₂ : Nat} (x : Bit
   rw [heq1, heq2]
   exact sdiv_neg_one_shl_eq_neg_biased_sshiftRight x k hk
 
+/-- When `x` is nonnegative, `sdiv_one_shl_eq_biased_sshiftRight`'s correction term is always `0`,
+    so `x.sdiv (2^k) = x.sshiftRight' k` outright — and unlike the general lemma, this needs no
+    bound on `k` at all: at the `k = 63` boundary (`2^k` wraps to `intMin`), both sides are
+    separately `0` (`x.toNat < 2^63` forces the shift to `0`, and `x ≠ intMin` forces the `sdiv`
+    to `0` too, via `BitVec.sdiv_intMin`). -/
+theorem sdiv_one_shl_eq_sshiftRight_of_msb_false (x : BitVec 64) (k : BitVec 6)
+    (hx : x.msb = false) :
+    x.sdiv ((1#64) <<< k) = x.sshiftRight' k := by
+  by_cases hk : k.toNat + 1 < 64
+  · have hcorr0 : x.sshiftRight 63 >>> (64 - k.toNat) = 0#64 := by
+      apply BitVec.eq_of_toNat_eq
+      rw [toNat_sign_mask_shift x k.toNat (by omega), if_neg (by simp [hx])]
+      rfl
+    rw [sdiv_one_shl_eq_biased_sshiftRight x k hk]
+    show (x + (x.sshiftRight (63 : Nat) >>> (64 - k.toNat))).sshiftRight k.toNat =
+      x.sshiftRight k.toNat
+    rw [hcorr0, BitVec.add_zero]
+  · have hk63 : k = (-1 : BitVec 6) := by bv_omega
+    subst hk63
+    have hy : (1#64) <<< (-1 : BitVec 6) = BitVec.intMin 64 := by
+      apply BitVec.eq_of_toNat_eq
+      decide
+    rw [hy, BitVec.sdiv_intMin]
+    have hxne : x ≠ BitVec.intMin 64 := by
+      intro h; rw [h] at hx; simp [BitVec.msb_intMin] at hx
+    rw [if_neg hxne]
+    apply BitVec.eq_of_toNat_eq
+    show (0 : BitVec 64).toNat = (x.sshiftRight (-1 : BitVec 6).toNat).toNat
+    rw [BitVec.toNat_sshiftRight_of_msb_false hx]
+    have heq : (-1 : BitVec 6).toNat = 63 := by decide
+    rw [heq]
+    have hxlt : x.toNat < 2 ^ 63 := BitVec.toNat_lt_of_msb_false hx
+    rw [Nat.shiftRight_eq_div_pow, Nat.div_eq_of_lt (by omega)]
+    rfl
+
+/-- `sdiv_one_shl_eq_biased_sshiftRight_bv`, specialized to the `i64` register width (`w₁ = 64`,
+    `w₂ = 6`) and restated as an `if` on `x.msb` instead of always adding the (possibly-zero)
+    correction term: whenever the correction isn't needed the RHS is a bare `sshiftRight'`, no
+    `add` required — that's the `x.msb = false` case (any `k`, via
+    `sdiv_one_shl_eq_sshiftRight_of_msb_false`) and the `k = 0` case (dividing by `1` is always
+    exact, regardless of sign). The only case that can't be phrased as a shift is `x.msb = true`
+    at `k = 63`, where `2^k` wraps to `intMin` and the identity genuinely doesn't hold (a real
+    counterexample: `x = intMin` gives `sdiv = 1` but the shift form gives `-1`); there the `if`
+    resolves to `BitVec.sdiv_intMin`'s closed form directly, so the RHS never needs `sdiv` at all. -/
+@[veir_bv_normalize_post]
+theorem sdiv_one_shl_eq_ite_sshiftRight (x : BitVec 64) (k : BitVec 6) :
+    x.sdiv ((1#64) <<< k) =
+      if x.msb then
+        if k = 0 then
+          x.sshiftRight' k
+        else if k ≠ (-1 : BitVec 6) then
+          (x + (x.sshiftRight' (-1 : BitVec 6) >>> (-k))).sshiftRight' k
+        else
+          if x = BitVec.intMin 64 then 1#64 else 0#64
+      else
+        x.sshiftRight' k := by
+  by_cases hx : x.msb
+  · rw [if_pos hx]
+    by_cases hk0 : k = 0
+    · rw [if_pos hk0, hk0]
+      simp [BitVec.sshiftRight_eq', BitVec.sdiv_one]
+    · rw [if_neg hk0]
+      by_cases hk63 : k ≠ (-1 : BitVec 6)
+      · rw [if_pos hk63]
+        have hk0' : 0 < k.toNat := by bv_omega
+        have hk' : k.toNat + 1 < 64 := by bv_omega
+        have h1 : (1 : BitVec 6).toNat = 1 := BitVec.toNat_one (by decide)
+        have heq1 : (-1 : BitVec 6).toNat = 63 := by
+          rw [toNat_neg_eq_sub _ (by omega), h1]
+        have heq2 : (-k : BitVec 6).toNat = 64 - k.toNat := by
+          rw [toNat_neg_eq_sub _ hk0']
+        show x.sdiv ((1#64) <<< k) =
+          (x + (x.sshiftRight (-1 : BitVec 6).toNat >>> (-k : BitVec 6).toNat)).sshiftRight k.toNat
+        rw [heq1, heq2]
+        exact sdiv_one_shl_eq_biased_sshiftRight x k hk'
+      · rw [if_neg hk63]
+        have hk63' : k = (-1 : BitVec 6) := Decidable.not_not.mp hk63
+        have hy : (1#64) <<< k = BitVec.intMin 64 := by rw [hk63']; decide
+        rw [hy, BitVec.sdiv_intMin]
+  · rw [if_neg hx]
+    exact sdiv_one_shl_eq_sshiftRight_of_msb_false x k (by simpa using hx)
+
+/-- Negative-divisor analogue of `sdiv_one_shl_eq_sshiftRight_of_msb_false`: when `x` is
+    nonnegative, `sdiv_neg_one_shl_eq_neg_biased_sshiftRight`'s correction term is always `0`, for
+    *any* `k` — unlike the positive-divisor case, there's no `k = 63` boundary to worry about here,
+    since `-2^63` is itself a valid divisor (negating `intMin` just gives `intMin` back). -/
+theorem sdiv_neg_one_shl_eq_neg_sshiftRight_of_msb_false (x : BitVec 64) (k : BitVec 6)
+    (hx : x.msb = false) :
+    x.sdiv (-((1#64) <<< k)) = -(x.sshiftRight' k) := by
+  have hk : k.toNat < 64 := k.isLt
+  have hcorr0 : x.sshiftRight 63 >>> (64 - k.toNat) = 0#64 := by
+    apply BitVec.eq_of_toNat_eq
+    rw [toNat_sign_mask_shift x k.toNat (by omega), if_neg (by simp [hx])]
+    rfl
+  rw [sdiv_neg_one_shl_eq_neg_biased_sshiftRight x k hk, hcorr0, BitVec.add_zero]
+
+/-- Negative-divisor analogue of `sdiv_one_shl_eq_ite_sshiftRight`. Simpler than the positive
+    case: there's no `sdiv` fallback branch needed at all, since `sdiv_neg_one_shl_eq_neg_biased_sshiftRight`
+    already holds for every `k` (no `k = 63` exclusion) — the only special case is `k = 0`
+    (dividing by `-1` is always exact, via `BitVec.sdiv_neg`/`BitVec.sdiv_one`), where the
+    correction term isn't well-defined as written (`-k = 0` shifts by `0` instead of the intended
+    "shift out everything"), so it's spelled out directly rather than going through the general
+    correction formula. -/
+@[veir_bv_normalize_post]
+theorem sdiv_neg_one_shl_eq_ite_sshiftRight (x : BitVec 64) (k : BitVec 6) :
+    x.sdiv (-((1#64) <<< k)) =
+      if x.msb then
+        if k = 0 then
+          -(x.sshiftRight' k)
+        else
+          -((x + (x.sshiftRight' (-1 : BitVec 6) >>> (-k))).sshiftRight' k)
+      else
+        -(x.sshiftRight' k) := by
+  by_cases hx : x.msb
+  · rw [if_pos hx]
+    by_cases hk0 : k = 0
+    · rw [if_pos hk0, hk0]
+      have hy : (-((1#64) <<< (0 : BitVec 6))) = (-1 : BitVec 64) := by simp
+      rw [hy, BitVec.sdiv_neg (by decide)]
+      simp [BitVec.sdiv_one, BitVec.sshiftRight_eq']
+    · rw [if_neg hk0]
+      have hk0' : 0 < k.toNat := by bv_omega
+      have hk' : k.toNat < 64 := k.isLt
+      have h1 : (1 : BitVec 6).toNat = 1 := BitVec.toNat_one (by decide)
+      have heq1 : (-1 : BitVec 6).toNat = 63 := by
+        rw [toNat_neg_eq_sub _ (by omega), h1]
+      have heq2 : (-k : BitVec 6).toNat = 64 - k.toNat := by
+        rw [toNat_neg_eq_sub _ hk0']
+      show x.sdiv (-((1#64) <<< k)) =
+        -((x + (x.sshiftRight (-1 : BitVec 6).toNat >>> (-k : BitVec 6).toNat)).sshiftRight k.toNat)
+      rw [heq1, heq2]
+      exact sdiv_neg_one_shl_eq_neg_biased_sshiftRight x k hk'
+  · rw [if_neg hx]
+    exact sdiv_neg_one_shl_eq_neg_sshiftRight_of_msb_false x k (by simpa using hx)
+
 @[veir_bv_normalize]
 theorem setWidth_ofInt_32_64 (v : Int) :
     BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by

--- a/Veir/ForLean.lean
+++ b/Veir/ForLean.lean
@@ -512,6 +512,272 @@ theorem sdiv_neg_one_shl_of_smod_eq_zero {w₁ w₂ : Nat} (x : BitVec w₁) (k 
     Int.tdiv_eq_ediv_of_dvd hdvd, ← Int.shiftRight_eq_div_pow,
     BitVec.toInt_neg, toInt_sshiftRight'']
 
+end BitVec
+
+/-- The Hacker's-Delight bias/shift identity underlying `sdivPow2`/`sdivwPow2`: truncating
+    division by a positive `p` equals floor division of the dividend biased by `p - 1` when the
+    dividend is negative (so the floor rounds toward zero instead of toward `-∞`). -/
+theorem Int.tdiv_eq_ediv_add_of_pos {a p : Int} (hp : 0 < p) :
+    a.tdiv p = (a + (if a < 0 then p - 1 else 0)) / p := by
+  have hpne : p ≠ 0 := by omega
+  rw [Int.tdiv_eq_ediv, Int.sign_eq_one_of_pos hp]
+  by_cases ha : a < 0
+  · rw [if_pos ha]
+    by_cases hdvd : p ∣ a
+    · rw [if_pos (Or.inr hdvd)]
+      obtain ⟨q, hq⟩ := hdvd
+      subst hq
+      have hrw : p * q + (p - 1) = (p - 1) + q * p := by
+        rw [Int.mul_comm q p, Int.add_comm]
+      rw [hrw, Int.add_mul_ediv_right (p - 1) q hpne]
+      have h1 : (0:Int) ≤ p - 1 := by omega
+      have h2 : p - 1 < p := by omega
+      rw [Int.ediv_eq_zero_of_lt h1 h2, Int.mul_ediv_cancel_left q hpne]
+      omega
+    · have hnotor : ¬ (0 ≤ a ∨ p ∣ a) := fun h => h.elim (fun h0 => absurd h0 (by omega)) hdvd
+      rw [if_neg hnotor]
+      have hr : a % p + a / p * p = a := Int.emod_add_ediv_mul a p
+      have hr0 : 0 ≤ a % p := Int.emod_nonneg a hpne
+      have hrlt : a % p < p := Int.emod_lt_of_pos a hp
+      have hrne : a % p ≠ 0 := fun h => hdvd (Int.dvd_of_emod_eq_zero h)
+      have key : a + (p - 1) = (a % p - 1) + (a / p + 1) * p := by
+        have expand : (a / p + 1) * p = a / p * p + p := by
+          rw [Int.add_mul, Int.one_mul]
+        rw [expand]
+        omega
+      rw [key, Int.add_mul_ediv_right (a % p - 1) (a / p + 1) hpne]
+      have h1 : (0:Int) ≤ a % p - 1 := by omega
+      have h2 : a % p - 1 < p := by omega
+      rw [Int.ediv_eq_zero_of_lt h1 h2]
+      simp
+  · have haux : 0 ≤ a ∨ p ∣ a := Or.inl (by omega)
+    rw [if_neg ha, if_pos haux, Int.add_zero, Int.add_zero]
+
+/-- A shifted-in-from-the-left all-ones mask (`(2^w - 1) >>> (w - k)`, i.e. the top `w - k` bits
+    of `allOnes w` cleared) is exactly the `k`-bit all-ones mask `2^k - 1`. Used to compute the
+    Hacker's-Delight sign-extension bias as a plain arithmetic shift. -/
+theorem Nat.shiftRight_two_pow_sub_one {w k : Nat} (hk : k < w) :
+    (2 ^ w - 1) >>> (w - k) = 2 ^ k - 1 := by
+  rw [Nat.shiftRight_eq_div_pow]
+  have hsplit : w - k + k = w := by omega
+  have hpow : 2 ^ (w - k) * 2 ^ k = 2 ^ w := by
+    rw [← Nat.pow_add, hsplit]
+  have hle : 2 ^ (w - k) ≤ 2 ^ w := Nat.pow_le_pow_right (by omega) (by omega)
+  have hge2 : 1 ≤ 2 ^ (w - k) := Nat.one_le_two_pow
+  have heq : 2 ^ w - 1 = 2 ^ (w - k) * (2 ^ k - 1) + (2 ^ (w - k) - 1) := by
+    rw [Nat.mul_sub_one, hpow]
+    omega
+  rw [heq, Nat.mul_add_div (by omega), Nat.div_eq_of_lt (by omega), Nat.add_zero]
+
+namespace BitVec
+
+/-- The bias term added before the arithmetic shift in the Hacker's-Delight bias/shift sequence
+    for signed division by `2^k`: `2^k - 1` when `x` is negative, `0` otherwise, computed as a
+    plain arithmetic-then-logical shift (mirroring `sign := srai 63 x; corr := srli (64-k) sign`
+    in the `sdivPow2`/`sdivwPow2` lowering). -/
+theorem toNat_sign_mask_shift {w₁ : Nat} (x : BitVec w₁) (k : Nat) (hk : k < w₁) :
+    (x.sshiftRight (w₁ - 1) >>> (w₁ - k)).toNat = if x.msb then 2 ^ k - 1 else 0 := by
+  have hdouble : 2 ^ (w₁ - 1) * 2 = 2 ^ w₁ := by
+    rw [← Nat.pow_succ]
+    congr 1
+    omega
+  rw [BitVec.toNat_ushiftRight]
+  by_cases hmsb : x.msb = true
+  · rw [if_pos hmsb, BitVec.toNat_sshiftRight_of_msb_true hmsb]
+    have hxge : 2 ^ (w₁ - 1) ≤ x.toNat := BitVec.le_toNat_of_msb_true hmsb
+    have hxlt : x.toNat < 2 ^ w₁ := x.isLt
+    have hzero : (2 ^ w₁ - 1 - x.toNat) >>> (w₁ - 1) = 0 := by
+      rw [Nat.shiftRight_eq_div_pow, Nat.div_eq_of_lt (by omega)]
+    rw [hzero, Nat.sub_zero]
+    exact Nat.shiftRight_two_pow_sub_one hk
+  · rw [if_neg hmsb]
+    have hmsb' : x.msb = false := by simpa using hmsb
+    rw [BitVec.toNat_sshiftRight_of_msb_false hmsb']
+    have hxlt : x.toNat < 2 ^ (w₁ - 1) := BitVec.toNat_lt_of_msb_false hmsb'
+    have hinner : x.toNat >>> (w₁ - 1) = 0 := by
+      rw [Nat.shiftRight_eq_div_pow]
+      exact Nat.div_eq_of_lt hxlt
+    rw [hinner, Nat.zero_shiftRight]
+
+/-- `sdivPow2` (general, non-`exact` positive divisor): dividing by `2^k` equals arithmetic-shifting
+    `x` biased by `2^k - 1` when `x` is negative (so truncation rounds toward zero instead of
+    toward `-∞`). Unlike `sdiv_one_shl_of_smod_eq_zero`, this holds for *every* `x` (no `smod = 0`
+    side condition), but — like it — needs `k.toNat + 1 < w₁` to keep `2^k` off `x`'s own `intMin`.
+    Stated with plain `Nat`-indexed shifts; see `sdiv_one_shl_eq_biased_sshiftRight_bv` for the
+    `BitVec`-typed-shift-amount form that `bv_decide` can actually bitblast. -/
+theorem sdiv_one_shl_eq_biased_sshiftRight {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂)
+    (hk : k.toNat + 1 < w₁) :
+    x.sdiv ((1#w₁) <<< k) =
+      (x + (x.sshiftRight (w₁ - 1) >>> (w₁ - k.toNat))).sshiftRight' k := by
+  have hy : ((1#w₁) <<< k).toInt = ((2 ^ k.toNat : Nat) : Int) := by
+    rw [BitVec.shiftLeft_eq', ← BitVec.twoPow_eq, BitVec.toInt_twoPow, if_neg (by omega),
+      if_neg (by omega)]
+    exact (Int.natCast_pow 2 k.toNat).symm
+  generalize hcorr_def : x.sshiftRight (w₁ - 1) >>> (w₁ - k.toNat) = corr
+  have hcorrNat : corr.toNat = if x.msb then 2 ^ k.toNat - 1 else 0 := by
+    rw [← hcorr_def]
+    exact toNat_sign_mask_shift x k.toNat (by omega)
+  have hple : (2:Nat) ^ k.toNat ≤ 2 ^ (w₁ - 1) := Nat.pow_le_pow_right (by omega) (by omega)
+  have hcorrInt : corr.toInt = if x.toInt < 0 then ((2 ^ k.toNat : Nat) : Int) - 1 else 0 := by
+    rw [BitVec.msb_eq_toInt] at hcorrNat
+    simp only [decide_eq_true_eq] at hcorrNat
+    by_cases hx : x.toInt < 0
+    · rw [if_pos hx] at hcorrNat
+      rw [if_pos hx]
+      have hlt : 2 * corr.toNat < 2 ^ w₁ := by
+        rw [hcorrNat]
+        have : 2 ^ (w₁ - 1) * 2 = 2 ^ w₁ := by
+          rw [← Nat.pow_succ]; congr 1; omega
+        omega
+      rw [BitVec.toInt_eq_toNat_of_lt hlt, hcorrNat]
+      exact Int.natCast_sub Nat.one_le_two_pow
+    · rw [if_neg hx] at hcorrNat
+      rw [if_neg hx]
+      have hlt : 2 * corr.toNat < 2 ^ w₁ := by
+        rw [hcorrNat]
+        have := Nat.two_pow_pos w₁
+        omega
+      rw [BitVec.toInt_eq_toNat_of_lt hlt, hcorrNat]
+      rfl
+  have hsum : (x + corr).toInt = x.toInt + corr.toInt := by
+    have hpleMul : (2:Nat) ^ k.toNat * 2 ≤ 2 ^ w₁ := by
+      have h1 : 2 ^ (k.toNat + 1) ≤ 2 ^ w₁ := Nat.pow_le_pow_right (by omega) (by omega)
+      rwa [Nat.pow_succ] at h1
+    have hpleInt : ((2 ^ k.toNat : Nat) : Int) * 2 ≤ ((2 ^ w₁ : Nat) : Int) := by
+      exact_mod_cast hpleMul
+    rw [BitVec.toInt_add]
+    have hxlt := BitVec.toInt_lt (x := x)
+    have hxge := BitVec.le_toInt (x := x)
+    have hdoubleNat : (2:Nat) ^ (w₁ - 1) * 2 = 2 ^ w₁ := by
+      rw [← Nat.pow_succ]; congr 1; omega
+    have hdouble : (2:Int) ^ (w₁ - 1) * 2 = ((2 ^ w₁ : Nat) : Int) := by exact_mod_cast hdoubleNat
+    rw [hcorrInt]
+    by_cases hx : x.toInt < 0
+    · rw [if_pos hx]
+      have hb1 : (0:Int) ≤ ((2 ^ k.toNat : Nat) : Int) - 1 := by
+        have : (1:Int) ≤ ((2 ^ k.toNat : Nat) : Int) := by exact_mod_cast Nat.one_le_two_pow
+        omega
+      apply Int.bmod_eq_of_le <;> omega
+    · rw [if_neg hx]
+      simp only [Int.add_zero]
+      apply Int.bmod_eq_of_le <;> omega
+  have hppos : (0:Int) < ((2 ^ k.toNat : Nat) : Int) := by
+    exact_mod_cast Nat.two_pow_pos k.toNat
+  apply BitVec.eq_of_toInt_eq
+  rw [BitVec.toInt_sdiv, hy, Int.tdiv_eq_ediv_add_of_pos hppos, ← hcorrInt, ← hsum,
+    ← Int.shiftRight_eq_div_pow, ← toInt_sshiftRight'']
+  exact BitVec.toInt_bmod_cancel _
+
+/-- Negative-divisor analogue of `sdiv_one_shl_eq_biased_sshiftRight` (`sdivPow2`, negative
+    divisor): negate the biased-shift result. Like `sdiv_neg_one_shl_of_smod_eq_zero`, no bound
+    relating `k` to `w` is needed beyond `k < w`: `-2^(w-1)` is itself a valid divisor here too.
+    Stated with plain `Nat`-indexed shifts; see `sdiv_neg_one_shl_eq_neg_biased_sshiftRight_bv`. -/
+theorem sdiv_neg_one_shl_eq_neg_biased_sshiftRight {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂)
+    (hk : k.toNat < w₁) :
+    x.sdiv (-((1#w₁) <<< k)) =
+      -((x + (x.sshiftRight (w₁ - 1) >>> (w₁ - k.toNat))).sshiftRight' k) := by
+  have hz : (-((1#w₁) <<< k)).toInt = -((2 ^ k.toNat : Nat) : Int) := toInt_neg_one_shl k hk
+  generalize hcorr_def : x.sshiftRight (w₁ - 1) >>> (w₁ - k.toNat) = corr
+  have hcorrNat : corr.toNat = if x.msb then 2 ^ k.toNat - 1 else 0 := by
+    rw [← hcorr_def]
+    exact toNat_sign_mask_shift x k.toNat hk
+  have hple : (2:Nat) ^ k.toNat ≤ 2 ^ (w₁ - 1) := Nat.pow_le_pow_right (by omega) (by omega)
+  have hcorrInt : corr.toInt = if x.toInt < 0 then ((2 ^ k.toNat : Nat) : Int) - 1 else 0 := by
+    rw [BitVec.msb_eq_toInt] at hcorrNat
+    simp only [decide_eq_true_eq] at hcorrNat
+    by_cases hx : x.toInt < 0
+    · rw [if_pos hx] at hcorrNat
+      rw [if_pos hx]
+      have hlt : 2 * corr.toNat < 2 ^ w₁ := by
+        rw [hcorrNat]
+        have : 2 ^ (w₁ - 1) * 2 = 2 ^ w₁ := by
+          rw [← Nat.pow_succ]; congr 1; omega
+        omega
+      rw [BitVec.toInt_eq_toNat_of_lt hlt, hcorrNat]
+      exact Int.natCast_sub Nat.one_le_two_pow
+    · rw [if_neg hx] at hcorrNat
+      rw [if_neg hx]
+      have hlt : 2 * corr.toNat < 2 ^ w₁ := by
+        rw [hcorrNat]
+        have := Nat.two_pow_pos w₁
+        omega
+      rw [BitVec.toInt_eq_toNat_of_lt hlt, hcorrNat]
+      rfl
+  have hsum : (x + corr).toInt = x.toInt + corr.toInt := by
+    have hpleMul : (2:Nat) ^ k.toNat * 2 ≤ 2 ^ w₁ := by
+      have h1 : 2 ^ (w₁ - 1) * 2 = 2 ^ w₁ := by rw [← Nat.pow_succ]; congr 1; omega
+      calc (2:Nat) ^ k.toNat * 2 ≤ 2 ^ (w₁ - 1) * 2 := Nat.mul_le_mul_right 2 hple
+        _ = 2 ^ w₁ := h1
+    have hpleInt : ((2 ^ k.toNat : Nat) : Int) * 2 ≤ ((2 ^ w₁ : Nat) : Int) := by
+      exact_mod_cast hpleMul
+    rw [BitVec.toInt_add]
+    have hxlt := BitVec.toInt_lt (x := x)
+    have hxge := BitVec.le_toInt (x := x)
+    have hdoubleNat : (2:Nat) ^ (w₁ - 1) * 2 = 2 ^ w₁ := by
+      rw [← Nat.pow_succ]; congr 1; omega
+    have hdouble : (2:Int) ^ (w₁ - 1) * 2 = ((2 ^ w₁ : Nat) : Int) := by exact_mod_cast hdoubleNat
+    rw [hcorrInt]
+    by_cases hx : x.toInt < 0
+    · rw [if_pos hx]
+      have hb1 : (0:Int) ≤ ((2 ^ k.toNat : Nat) : Int) - 1 := by
+        have : (1:Int) ≤ ((2 ^ k.toNat : Nat) : Int) := by exact_mod_cast Nat.one_le_two_pow
+        omega
+      apply Int.bmod_eq_of_le <;> omega
+    · rw [if_neg hx]
+      simp only [Int.add_zero]
+      apply Int.bmod_eq_of_le <;> omega
+  have hppos : (0:Int) < ((2 ^ k.toNat : Nat) : Int) := by
+    exact_mod_cast Nat.two_pow_pos k.toNat
+  apply BitVec.eq_of_toInt_eq
+  rw [BitVec.toInt_sdiv, hz, Int.tdiv_neg, Int.tdiv_eq_ediv_add_of_pos hppos, ← hcorrInt, ← hsum,
+    ← Int.shiftRight_eq_div_pow, ← toInt_sshiftRight'', BitVec.toInt_neg]
+
+/-- `(-v).toNat` in terms of `v.toNat`, for `v` nonzero (no `% 2^w` needed: `2^w - v.toNat` is
+    already in range). -/
+theorem toNat_neg_eq_sub {w : Nat} (v : BitVec w) (hv : 0 < v.toNat) :
+    (-v).toNat = 2 ^ w - v.toNat := by
+  rw [BitVec.toNat_neg]
+  exact Nat.mod_eq_of_lt (Nat.sub_lt (Nat.two_pow_pos w) hv)
+
+/-- `BitVec`-typed-shift-amount form of `sdiv_one_shl_eq_biased_sshiftRight`, matching the shape
+    `sdivPow2`/`sdivwPow2` actually lower to: RISC-V immediates are register-width-sized (`w₂` bits
+    for a `2^w₂`-bit register), so the source's `srai (w₁-1) x`/`srli (w₁-k) sign` are literally
+    `sshiftRight' (-1)`/`ushiftRight (-k)` once the `w₁`-valued immediate wraps to `0` in `w₂` bits.
+    `bv_decide` can only bitblast a shift by a genuine `BitVec` value (not a symbolic `Nat`
+    expression like `w₁ - k.toNat`), so this is the form registered for `veir_bv_normalize`. -/
+@[veir_bv_normalize_post]
+theorem sdiv_one_shl_eq_biased_sshiftRight_bv {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂)
+    (hw2 : 0 < w₂) (hk0 : 0 < k.toNat) (hk : k.toNat + 1 < w₁) (hw : w₁ = 2 ^ w₂) :
+    x.sdiv ((1#w₁) <<< k) =
+      (x + (x.sshiftRight' (-1 : BitVec w₂) >>> (-k))).sshiftRight' k := by
+  have h1 : (1 : BitVec w₂).toNat = 1 := BitVec.toNat_one hw2
+  have heq1 : (-1 : BitVec w₂).toNat = w₁ - 1 := by
+    rw [toNat_neg_eq_sub _ (by omega), hw, h1]
+  have heq2 : (-k : BitVec w₂).toNat = w₁ - k.toNat := by
+    rw [toNat_neg_eq_sub _ hk0, hw]
+  show x.sdiv ((1#w₁) <<< k) =
+    (x + (x.sshiftRight (-1 : BitVec w₂).toNat >>> (-k : BitVec w₂).toNat)).sshiftRight k.toNat
+  rw [heq1, heq2]
+  exact sdiv_one_shl_eq_biased_sshiftRight x k hk
+
+/-- `BitVec`-typed-shift-amount form of `sdiv_neg_one_shl_eq_neg_biased_sshiftRight`; see
+    `sdiv_one_shl_eq_biased_sshiftRight_bv` for why this form (rather than the `Nat`-indexed one)
+    is what gets registered for `veir_bv_normalize`. -/
+@[veir_bv_normalize_post]
+theorem sdiv_neg_one_shl_eq_neg_biased_sshiftRight_bv {w₁ w₂ : Nat} (x : BitVec w₁) (k : BitVec w₂)
+    (hw2 : 0 < w₂) (hk0 : 0 < k.toNat) (hk : k.toNat < w₁) (hw : w₁ = 2 ^ w₂) :
+    x.sdiv (-((1#w₁) <<< k)) =
+      -((x + (x.sshiftRight' (-1 : BitVec w₂) >>> (-k))).sshiftRight' k) := by
+  have h1 : (1 : BitVec w₂).toNat = 1 := BitVec.toNat_one hw2
+  have heq1 : (-1 : BitVec w₂).toNat = w₁ - 1 := by
+    rw [toNat_neg_eq_sub _ (by omega), hw, h1]
+  have heq2 : (-k : BitVec w₂).toNat = w₁ - k.toNat := by
+    rw [toNat_neg_eq_sub _ hk0, hw]
+  show x.sdiv (-((1#w₁) <<< k)) =
+    -((x + (x.sshiftRight (-1 : BitVec w₂).toNat >>> (-k : BitVec w₂).toNat)).sshiftRight k.toNat)
+  rw [heq1, heq2]
+  exact sdiv_neg_one_shl_eq_neg_biased_sshiftRight x k hk
+
 @[veir_bv_normalize]
 theorem setWidth_ofInt_32_64 (v : Int) :
     BitVec.setWidth 32 (BitVec.ofInt 64 v) = BitVec.ofInt 32 v := by

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -14,32 +14,11 @@ Preprocessing happens in two stages because rewrites are generally
 easier to state with the dependently-typed `Int.getValue`, but `bv_decide` works
 better with the non-dependent `Int.getValueD`. Thus, `veir_bv_normalize_post`
 contains `Int.getValue_eq_getValueD`, which rewrites the former into the latter.
-
-Exception: conditional rewrites whose side condition only becomes available *after*
-unfolding poison-checks into a chain of hypotheses (e.g. `isPoison_sdiv`) must go in
-`veir_bv_normalize_post` instead, since only its `simp` call runs with `+contextual`
-(threading those hypotheses forward as it descends) and has a discharger that lets
-such a lemma's side condition draw on both the threaded hypotheses and any ambient
-local hypotheses (e.g. a range bound on a shift amount) that aren't part of that chain,
-by scanning the whole local context, not just the current subgoal, the way `bv_omega`
-does. The first-phase `simp` is plain (no `+contextual`, no discharger), so such lemmas
-silently fail to fire there.
-
-Note: the discharger is `(try simp -implicitDefEqProofs only [bitvec_to_nat] at *); omega`
-rather than plain `bv_omega`, even though it is otherwise identical to `bv_omega`'s
-definition. `simp`'s discharger mechanism is supposed to fail gracefully (treat the
-conditional rewrite as inapplicable) when the discharger tactic can't close a side
-condition, but that graceful handling breaks when the discharger tactic is built with
-`<;>` (as `bv_omega` is) instead of plain sequencing: `omega`'s failure message then
-leaks through as a hard tactic error instead of being absorbed, aborting the whole
-`veir_bv_normalize` call rather than just skipping the one inapplicable rewrite. Using
-`;` here instead of `bv_omega`'s `<;>` avoids that.
 -/
 @[expose] macro "veir_bv_normalize" : tactic =>
   `(tactic| ((
       simp -failIfUnchanged only [veir_bv_normalize] <;>
       simp +contextual -failIfUnchanged
-        (discharger := (try simp -implicitDefEqProofs only [bitvec_to_nat] at *); omega)
         only [veir_bv_normalize_post, reduceIte])))
 /-
 The lack of `only` is copied from the previous version of this tactic, and indeed

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -18,18 +18,28 @@ contains `Int.getValue_eq_getValueD`, which rewrites the former into the latter.
 Exception: conditional rewrites whose side condition only becomes available *after*
 unfolding poison-checks into a chain of hypotheses (e.g. `isPoison_sdiv`) must go in
 `veir_bv_normalize_post` instead, since only its `simp` call runs with `+contextual`
-(threading those hypotheses forward as it descends). Its `discharger := bv_omega` lets
+(threading those hypotheses forward as it descends) and has a discharger that lets
 such a lemma's side condition draw on both the threaded hypotheses and any ambient
 local hypotheses (e.g. a range bound on a shift amount) that aren't part of that chain,
-since `bv_omega` scans the whole local context, not just the current subgoal. The
-first-phase `simp` is plain (no `+contextual`, no discharger), so such lemmas silently
-fail to fire there.
+by scanning the whole local context, not just the current subgoal, the way `bv_omega`
+does. The first-phase `simp` is plain (no `+contextual`, no discharger), so such lemmas
+silently fail to fire there.
+
+Note: the discharger is `(try simp -implicitDefEqProofs only [bitvec_to_nat] at *); omega`
+rather than plain `bv_omega`, even though it is otherwise identical to `bv_omega`'s
+definition. `simp`'s discharger mechanism is supposed to fail gracefully (treat the
+conditional rewrite as inapplicable) when the discharger tactic can't close a side
+condition, but that graceful handling breaks when the discharger tactic is built with
+`<;>` (as `bv_omega` is) instead of plain sequencing: `omega`'s failure message then
+leaks through as a hard tactic error instead of being absorbed, aborting the whole
+`veir_bv_normalize` call rather than just skipping the one inapplicable rewrite. Using
+`;` here instead of `bv_omega`'s `<;>` avoids that.
 -/
 @[expose] macro "veir_bv_normalize" : tactic =>
   `(tactic| ((
       simp -failIfUnchanged only [veir_bv_normalize] <;>
       simp +contextual -failIfUnchanged
-        (discharger := bv_omega)
+        (discharger := (try simp -implicitDefEqProofs only [bitvec_to_nat] at *); omega)
         only [veir_bv_normalize_post, reduceIte])))
 /-
 The lack of `only` is copied from the previous version of this tactic, and indeed

--- a/Veir/Meta/BVDecide.lean
+++ b/Veir/Meta/BVDecide.lean
@@ -32,7 +32,7 @@ Veir types into a form suitable for bitblasting, via `veir_bv_normalize`, and
 then calls `bv_decide` to automatically close the goal.
 -/
 @[expose] macro "veir_bv_decide" : tactic =>
-  `(tactic| ((veir_bv_normalize <;> bv_decide)))
+  `(tactic| ((veir_bv_normalize <;> bv_decide (config := { timeout := 300 }))))
 
 attribute [veir_bv_normalize] Bool.false_eq_true false_and or_self decide_false
   dite_eq_ite Bool.if_false_right Bool.and_true implies_true

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -385,7 +385,7 @@ theorem sdivPow2Exact_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) :
       (RISCV.Reg.toInt (Data.RISCV.neg (Data.RISCV.srai k (LLVM.Int.toReg x))) 64) := by
   veir_bv_decide
 
-set_option warn.sorry false in
+set_option maxHeartbeats 1000000 in
 /--
   General (non-`exact`) `sdiv x, 2^k` -> the Hacker's-Delight bias/shift sequence
   (`sdivPow2`, positive divisor): bias a negative dividend by `2^k - 1` before the
@@ -401,9 +401,10 @@ theorem sdivPow2_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) (
          let corr := Data.RISCV.srli (64 - k) sign
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.srai k biased) 64) := by
-  sorry -- bv_decide needs a non-default timeout (300s) to close this goal
+  veir_bv_normalize
+  bv_decide (config := { timeout := 300 })
 
-set_option warn.sorry false in
+set_option maxHeartbeats 1000000 in
 /--
   Negative-divisor case of `sdivPow2_pos_refinement`: negate the biased-shift result.
 -/
@@ -414,7 +415,8 @@ theorem sdivPow2_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) :
          let corr := Data.RISCV.srli (64 - k) sign
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.neg (Data.RISCV.srai k biased)) 64) := by
-  sorry -- bv_decide needs a non-default timeout (300s) to close this goal
+  veir_bv_normalize
+  bv_decide (config := { timeout := 300 })
 
 /--
   Prove the correctness of the `udiv` lowering pattern.
@@ -1171,7 +1173,6 @@ theorem sdivwPow2Exact_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) :
       (RISCV.Reg.toInt (Data.RISCV.negw (Data.RISCV.sraiw k (LLVM.Int.toReg x))) 32) := by
   veir_bv_decide
 
-set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2_pos_refinement` (`sdivwPow2`, positive divisor). -/
 theorem sdivwPow2_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) (hk31 : k < 31) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val ((1#32) <<< k)) false) ⊒
@@ -1180,9 +1181,8 @@ theorem sdivwPow2_pos_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) 
          let corr := Data.RISCV.srliw (32 - k) sign
          let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
          Data.RISCV.sraiw k biased) 32) := by
-  sorry -- bv_decide needs a non-default timeout (300s) to close this goal
+  veir_bv_decide
 
-set_option warn.sorry false in
 /-- `i32` analogue of `sdivPow2_neg_refinement` (`sdivwPow2`, negative divisor). -/
 theorem sdivwPow2_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) :
     (Data.LLVM.Int.sdiv x (LLVM.Int.val (-((1#32) <<< k))) false) ⊒
@@ -1191,7 +1191,7 @@ theorem sdivwPow2_neg_refinement {x : LLVM.Int 32} (k : BitVec 5) (hk0 : 0 < k) 
          let corr := Data.RISCV.srliw (32 - k) sign
          let biased := Data.RISCV.addw corr (LLVM.Int.toReg x)
          Data.RISCV.negw (Data.RISCV.sraiw k biased)) 32) := by
-  sorry -- bv_decide times out with the default timeout on this goal
+  veir_bv_decide
 
 theorem srem_refinement_32 {x y : LLVM.Int 32} :
     (Data.LLVM.Int.srem x y) ⊒

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -385,7 +385,6 @@ theorem sdivPow2Exact_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) :
       (RISCV.Reg.toInt (Data.RISCV.neg (Data.RISCV.srai k (LLVM.Int.toReg x))) 64) := by
   veir_bv_decide
 
-set_option maxHeartbeats 1000000 in
 /--
   General (non-`exact`) `sdiv x, 2^k` -> the Hacker's-Delight bias/shift sequence
   (`sdivPow2`, positive divisor): bias a negative dividend by `2^k - 1` before the
@@ -401,10 +400,8 @@ theorem sdivPow2_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) (
          let corr := Data.RISCV.srli (64 - k) sign
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.srai k biased) 64) := by
-  veir_bv_normalize
-  bv_decide (config := { timeout := 1000 })
+  veir_bv_decide
 
-set_option maxHeartbeats 1000000 in
 /--
   Negative-divisor case of `sdivPow2_pos_refinement`: negate the biased-shift result.
 -/
@@ -415,8 +412,7 @@ theorem sdivPow2_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) :
          let corr := Data.RISCV.srli (64 - k) sign
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.neg (Data.RISCV.srai k biased)) 64) := by
-  veir_bv_normalize
-  bv_decide (config := { timeout := 1000 })
+  veir_bv_decide
 
 /--
   Prove the correctness of the `udiv` lowering pattern.

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -402,7 +402,7 @@ theorem sdivPow2_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) (
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.srai k biased) 64) := by
   veir_bv_normalize
-  bv_decide (config := { timeout := 500 })
+  bv_decide (config := { timeout := 1000 })
 
 set_option maxHeartbeats 1000000 in
 /--
@@ -416,7 +416,7 @@ theorem sdivPow2_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) :
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.neg (Data.RISCV.srai k biased)) 64) := by
   veir_bv_normalize
-  bv_decide (config := { timeout := 500 })
+  bv_decide (config := { timeout := 1000 })
 
 /--
   Prove the correctness of the `udiv` lowering pattern.

--- a/Veir/Passes/InstructionSelection/Proofs.lean
+++ b/Veir/Passes/InstructionSelection/Proofs.lean
@@ -402,7 +402,7 @@ theorem sdivPow2_pos_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) (
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.srai k biased) 64) := by
   veir_bv_normalize
-  bv_decide (config := { timeout := 300 })
+  bv_decide (config := { timeout := 500 })
 
 set_option maxHeartbeats 1000000 in
 /--
@@ -416,7 +416,7 @@ theorem sdivPow2_neg_refinement {x : LLVM.Int 64} (k : BitVec 6) (hk0 : 0 < k) :
          let biased := Data.RISCV.add corr (LLVM.Int.toReg x)
          Data.RISCV.neg (Data.RISCV.srai k biased)) 64) := by
   veir_bv_normalize
-  bv_decide (config := { timeout := 300 })
+  bv_decide (config := { timeout := 500 })
 
 /--
   Prove the correctness of the `udiv` lowering pattern.


### PR DESCRIPTION
In case of signed divisions by (negative) one shifted to the left by `k`, we can find a division-free statement that uses just shifts on the RHS. The precise RHS differs based on various factors. Hence, we rewrite the RHS to an if statement.
In particular:

```lean
  if x.msb then
    if k = 0 then
      x.sshiftRight' k
    else if k ≠ (-1 : BitVec 6) then
      (x + (x.sshiftRight' (-1 : BitVec 6) >>> (-k))).sshiftRight' k
    else
      if x = BitVec.intMin 64 then 1#64 else 0#64
  else
    x.sshiftRight' k
```

While the RHS has several branches, `sdiv` is fully eliminated, which means this rewrite should terminate. We apply this rewrite in the post-normalization phase to not prevent simplifications on sdiv to trigger.

This also avoids the need of complex dischargers in `veir_bv_normalize`, which is something too fragile to use in a normalizer.

We add a similar rewrite for the `-1`. Together, they close the remaining open instruction selection proofs.
