### PR TITLE
feat: Add lemmas about `RuntimeValue.isRefinedBy`

### DIFF
--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -16,6 +16,26 @@ theorem RuntimeValue.arrayIsRefinedBy_refl (a : Array RuntimeValue) : a ⊒ a :=
   simp [arrayIsRefinedBy]
 
 @[simp, grind .]
+theorem RuntimeValue.arrayIsRefinedBy_nil :
+    #[] ⊒ #[] := by
+  simp [arrayIsRefinedBy]
+
+@[simp, grind =]
+theorem RuntimeValue.arrayIsRefinedBy_singleton {a b : RuntimeValue} :
+    #[a] ⊒ #[b] ↔ a ⊒ b := by
+  simp [arrayIsRefinedBy]
+
+@[simp, grind =]
+theorem RuntimeValue.arrayIsRefinedBy_cons {a b : RuntimeValue} {as bs : List RuntimeValue} :
+    List.toArray (a :: as) ⊒ List.toArray (b :: bs) ↔
+    a ⊒ b ∧ List.toArray as ⊒ List.toArray bs := by
+  simp [arrayIsRefinedBy]
+  constructor
+  · rintro ⟨h₁, h₂⟩
+    grind [h₂ 0]
+  · grind
+
+@[simp, grind .]
 theorem FunctionResult.isRefinedBy_refl (r : MemoryState × Array RuntimeValue) : r ⊒ r := by
   simp [FunctionResult.isRefinedBy]
 
@@ -84,6 +104,49 @@ theorem OperationPtr.isModuleRefinedBy_trans
     (h23 : isModuleRefinedBy mod₂ ctx₂ mod₃ ctx₃) :
     isModuleRefinedBy mod₁ ctx₁ mod₃ ctx₃ := by
   grind [isModuleRefinedBy, isRefinedByAsFunction_trans]
+
+/-! ## Inversion
+
+Inversion lemmas for `RuntimeValue.isRefinedBy`: given a refinement hypothesis `v ⊒ tv`
+where the source value `v` has a known constructor, these lemmas recover the shape of the
+target value `tv`.
+-/
+
+/--
+A runtime value `tv` that refines an integer runtime value `v` is itself an integer of the same
+width, and the underlying integer value refines `v`.
+-/
+theorem RuntimeValue.int_of_isRefinedBy {bw : Nat} {v : Data.LLVM.Int bw} {tv : RuntimeValue}
+    (h : RuntimeValue.int bw v ⊒ tv) :
+    ∃ t : Data.LLVM.Int bw, tv = RuntimeValue.int bw t ∧ v ⊒ t := by
+  cases tv <;> grind [RuntimeValue.isRefinedBy]
+
+/--
+A runtime value `tv` that refines a byte runtime value `v` is itself a byte of the same
+width, and the underlying byte value refines `v`.
+-/
+theorem RuntimeValue.byte_of_isRefinedBy {bw : Nat} {v : Data.LLVM.Byte bw} {tv : RuntimeValue}
+    (h : RuntimeValue.byte bw v ⊒ tv) :
+    ∃ t : Data.LLVM.Byte bw, tv = RuntimeValue.byte bw t ∧ v ⊒ t := by
+  cases tv <;> grind [RuntimeValue.isRefinedBy]
+
+/-- A runtime value `tv` that refines a float runtime value `v` is equal to it. -/
+theorem RuntimeValue.float_of_isRefinedBy {bw : Nat} {v : Float} {tv : RuntimeValue}
+    (h : RuntimeValue.float bw v ⊒ tv) :
+    tv = RuntimeValue.float bw v := by
+  cases tv <;> grind [RuntimeValue.isRefinedBy]
+
+/-- A runtime value `tv` that refines an address runtime value `v` is equal to it. -/
+theorem RuntimeValue.addr_of_isRefinedBy {v : UInt64} {tv : RuntimeValue}
+    (h : RuntimeValue.addr v ⊒ tv) :
+    tv = RuntimeValue.addr v := by
+  cases tv <;> grind [RuntimeValue.isRefinedBy]
+
+/-- A runtime value `tv` that refines a register runtime value `v` is equal to it. -/
+theorem RuntimeValue.reg_of_isRefinedBy {v : Data.RISCV.Reg} {tv : RuntimeValue}
+    (h : RuntimeValue.reg v ⊒ tv) :
+    tv = RuntimeValue.reg v := by
+  cases tv <;> grind [RuntimeValue.isRefinedBy]
 
 /-! ## Interp refinements -/
 


### PR DESCRIPTION
* Add lemmas on how to unfold `RuntimeValue.arrayIsRefinedBy`
* Add lemmas about inversion of expressions of the form `RuntimeValue.concreteType x >= tv`, which give the information that `tv` is also a `concreteType`.