### PR TITLE
feat: Prove soundness of `xor`, `sub`, `mul`, and `add` instruction selection patterns

### DIFF
--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -23,8 +23,6 @@ def isLegalExtOpWidth (w : Nat) : Bool :=
   Shared shape of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`): match a single-operand
   LLVM op whose operand has integer type `i64` or `i32`, cast the operand to a register, apply
   `op64` (or its `W` variant `op32` for `i32`), and cast the result back to the source type.
-  Lowerings of this shape share the correctness proof of `lowerUnaryWLocal`, so proving a new
-  one only requires the per-op data-level refinement lemmas.
 -/
 def lowerUnaryWLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × P))
@@ -45,6 +43,35 @@ def lowerUnaryWLocal {P : Type}
           #[] #[] props64 none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
   some (ctx, some (#[castOp, retOp, castBackOp], #[castBackOp.getResult 0]))
+
+/--
+  Shared shape of the binary RISC-V lowerings (`add`/`sub`/`mul`/`sdiv`/…): match a two-operand
+  LLVM op whose operands have integer type `i64` or `i32`, cast both operands to registers, apply
+  `op64` (or its `W` variant `op32` for `i32`) to the two registers, and cast the result back to
+  the source type. Ops without a `W` variant (e.g. `xor`) pass the same opcode twice.
+-/
+def lowerBinaryWLocal {P : Type}
+    (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))
+    (op64 op32 : Riscv)
+    (props64 : propertiesOf (.riscv op64)) (props32 : propertiesOf (.riscv op32))
+    (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := match? op ctx | return (ctx, none)
+  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
+  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
+  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
+  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
+  let (ctx, lcastOp) ← castToRegLocal ctx lhs
+  let (ctx, rcastOp) ← castToRegLocal ctx rhs
+  let (ctx, retOp) ←
+    if ltype.bitwidth = 32 then
+      WfRewriter.createOp! ctx (.riscv op32) #[RegisterType.mk]
+          #[lcastOp.getResult 0, rcastOp.getResult 0] #[] #[] props32 none
+    else
+      WfRewriter.createOp! ctx (.riscv op64) #[RegisterType.mk]
+          #[lcastOp.getResult 0, rcastOp.getResult 0] #[] #[] props64 none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
+  some (ctx, some (#[lcastOp, rcastOp, retOp, castBackOp], #[castBackOp.getResult 0]))
 
 /--
   `llvm.intr.ctlz` -> `riscv.clz`.
@@ -198,35 +225,10 @@ def constant (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite constant_local rewriter op opInBounds
 
-/-- llvm.add -> riscv.add -/
+/-- llvm.add -> riscv.add (riscv.addw for i32, keeps the result sign-extended) -/
 def add_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchAdd op ctx | return (ctx, none)
-  /- support `i64` and `i32` (experiment) -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- 64-bit add, or its 32-bit `W` variant for i32 (keeps the result sign-extended) -/
-  let (ctx, addOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .addw) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
-        #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .add) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
-        #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castAddOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[addOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, addOp, castAddOp], #[castAddOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchAdd .add .addw () () ctx op
 
 /-- llvm.add -> riscv.add -/
 def add (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -500,240 +502,70 @@ def or (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite or_local rewriter op opInBounds
 
-/-- llvm.xor -> riscv.xor -/
+/-- llvm.xor -> riscv.xor (no `W` variant needed: xor is bitwise) -/
 def xor_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchXor op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- Actual `riscv.xor` -/
-  let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xor) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
-      #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castXorOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[xorOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, xorOp, castXorOp], #[castXorOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchXor .xor .xor () () ctx op
 
 /-- llvm.xor -> riscv.xor -/
 def xor (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite xor_local rewriter op opInBounds
 
-/-- llvm.mul -> riscv.mul -/
+/-- llvm.mul -> riscv.mul (riscv.mulw for i32, sign-extends the result) -/
 def mul_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchMul op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- mulw for i32 (sign-extends result), mul for i64 -/
-  let (ctx, mulOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .mulw) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
-          #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .mul) #[RegisterType.mk] #[rcastOp.getResult 0, lcastOp.getResult 0]
-          #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, mulOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchMul .mul .mulw () () ctx op
 
 /-- llvm.mul -> riscv.mul -/
 def mul (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite mul_local rewriter op opInBounds
 
-/-- llvm.sdiv -> riscv.div -/
+/-- llvm.sdiv -> riscv.div (riscv.divw for i32) -/
 def sdiv_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchSdiv op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- divw for i32, div for i64 -/
-  let (ctx, divOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .divw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .div) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[divOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, divOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchSdiv .div .divw () () ctx op
 
 /-- llvm.sdiv -> riscv.div -/
 def sdiv (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite sdiv_local rewriter op opInBounds
 
-/-- llvm.udiv -> riscv.divu -/
+/-- llvm.udiv -> riscv.divu (riscv.divuw for i32) -/
 def udiv_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchUdiv op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- divuw for i32, divu for i64 -/
-  let (ctx, divuOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .divuw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .divu) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[divuOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, divuOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchUdiv .divu .divuw () () ctx op
 
 /-- llvm.udiv -> riscv.divu -/
 def udiv (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite udiv_local rewriter op opInBounds
 
-/-- llvm.srem -> riscv.rem -/
+/-- llvm.srem -> riscv.rem (riscv.remw for i32) -/
 def srem_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchSrem op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- remw for i32, rem for i64 -/
-  let (ctx, remOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .remw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .rem) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[remOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, remOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchSrem .rem .remw () () ctx op
 
 /-- llvm.srem -> riscv.rem -/
 def srem (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite srem_local rewriter op opInBounds
 
-/-- llvm.urem -> riscv.remu -/
+/-- llvm.urem -> riscv.remu (riscv.remuw for i32) -/
 def urem_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchUrem op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- remuw for i32, remu for i64 -/
-  let (ctx, remuOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .remuw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .remu) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-          #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[remuOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, remuOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchUrem .remu .remuw () () ctx op
 
 /-- llvm.urem -> riscv.remu -/
 def urem (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite urem_local rewriter op opInBounds
 
-/-- llvm.sub -> riscv.sub -/
+/-- llvm.sub -> riscv.sub (riscv.subw for i32) -/
 def sub_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchSub op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- 64-bit sub, or its 32-bit `W` variant for i32 -/
-  let (ctx, subOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .subw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-        #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .sub) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-        #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[subOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, subOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchSub .sub .subw () () ctx op
 
 /-- llvm.sub -> riscv.sub -/
 def sub (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -858,68 +690,18 @@ def trunc (rewriter : PatternRewriter OpCode) (op : OperationPtr)
 
 /-- llvm.shl -> riscv.sll -/
 def shl_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchShl op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- 64-bit shift-left, or its 32-bit `W` variant for i32 -/
-  let (ctx, mulOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .sllw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-        #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .sll) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-        #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, mulOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchShl .sll .sllw () () ctx op
 
 /-- llvm.shl -> riscv.sll -/
 def shl (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite shl_local rewriter op opInBounds
 
-/-- llvm.shl -> riscv.srl -/
+/-- llvm.lshr -> riscv.srl (riscv.srlw for i32) -/
 def lshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchLshr op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
-  let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
-  if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 then return (ctx, none)
-  let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
-  if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 then return (ctx, none)
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType type' := type.val | return (ctx, none)
-  if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 then return (ctx, none)
-  /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- 64-bit logical shift-right, or its 32-bit `W` variant for i32 -/
-  let (ctx, mulOp) ←
-    if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .srlw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-        #[] #[] () none
-    else
-      WfRewriter.createOp! ctx (.riscv .srl) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
-        #[] #[] () none
-  /- Cast back result for type consistency-/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[mulOp.getResult 0]
-      #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp, mulOp, castOp], #[castOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinaryWLocal matchLshr .srl .srlw () () ctx op
 
 /-- llvm.shl -> riscv.srl -/
 def lshr (rewriter : PatternRewriter OpCode) (op : OperationPtr)

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
@@ -80,6 +80,42 @@ theorem interpretOp_castBack_forward
       (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
   grind
 
+/-- Binary register-to-register `riscv` op specialization of `interpretOp_forward`: `theOp` is any
+`riscv` op `rop` whose interpretation maps two register operands `r₁`, `r₂` to `f r₁ r₂`
+(hypothesis `hSem`, discharged by `rfl` at each concrete opcode; note the interpreter applies the
+data-level op as `RISCV.op op2 op1`, so `f` is typically `fun r₁ r₂ => RISCV.op r₂ r₁`), with a
+single `!riscv.reg` result. Interpreting it always succeeds, leaves memory untouched, binds the
+result to `.reg (f r₁ r₂)`, and leaves every non-result value unchanged. This covers
+`riscv.add`/`sub`/`mul`/`div`/`rem`/`sll`/`srl` and their `W`/unsigned variants. -/
+theorem interpretOp_riscv_binaryReg_forward
+    {ctx : WfIRContext OpCode} {rop : Riscv} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v₁ v₂ : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r₁ r₂ : Data.RISCV.Reg} {f : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg}
+    (hSem : ∀ (props : HasDialectOpInfo.propertiesOf rop) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' rop props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f r₁ r₂)], mem, none)))
+    (hType : theOp.getOpType! ctx.raw = .riscv rop)
+    (hOperands : theOp.getOperands! ctx.raw = #[v₁, v₂])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal₁ : state.variables.getVar? v₁ = some (.reg r₁))
+    (hVal₂ : state.variables.getVar? v₂ = some (.reg r₂)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (f r₁ r₂)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r₁, .reg r₂]) (results := #[.reg (f r₁ r₂)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal₁, hVal₂])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', hSem, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
 /-- Unary register-to-register `riscv` op specialization of `interpretOp_forward`: `theOp` is any
 `riscv` op `rop` whose interpretation maps a single register operand `r` to `f r` (hypothesis
 `hSem`, discharged by `rfl` at each concrete opcode), with a single `!riscv.reg` result.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonTactics.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonTactics.lean
@@ -103,3 +103,39 @@ macro "peelReplaceWithRegLocal" hpattern:ident newCtx:ident newOp:ident hCastBac
       have $newDom:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hCastBack:ident
         (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom:ident
      ))
+
+open Lean in
+/-- Like `peelCastToRegLocal`, but transports *two* dominance hypotheses (one per matched
+    operand of a binary lowering) through the creation step. -/
+macro "peelCastToRegLocal₂" hpattern:ident newCtx:ident newOp:ident hCast:ident
+    oldDom₁:ident newDom₁:ident oldDom₂:ident newDom₂:ident : tactic =>
+  `(tactic| (
+      peelCastToRegLocal $hpattern:ident $newCtx:ident $newOp:ident $hCast:ident
+        $oldDom₁:ident $newDom₁:ident
+      have $newDom₂:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hCast:ident
+        (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom₂:ident
+     ))
+
+open Lean in
+/-- Like `peelOpCreation!`, but transports *two* dominance hypotheses (one per matched operand of
+    a binary lowering) through the creation step. -/
+macro "peelOpCreation!₂" hpattern:ident newCtx:ident newOp:ident hNewCtx:ident
+    oldDom₁:ident newDom₁:ident oldDom₂:ident newDom₂:ident : tactic =>
+  `(tactic| (
+      peelOpCreation! $hpattern:ident $newCtx:ident $newOp:ident $hNewCtx:ident
+        $oldDom₁:ident $newDom₁:ident
+      have $newDom₂:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hNewCtx:ident
+        (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom₂:ident
+     ))
+
+open Lean in
+/-- Like `peelReplaceWithRegLocal`, but transports *two* dominance hypotheses (one per matched
+    operand of a binary lowering) through the creation step. -/
+macro "peelReplaceWithRegLocal₂" hpattern:ident newCtx:ident newOp:ident hCastBack:ident
+    oldDom₁:ident newDom₁:ident oldDom₂:ident newDom₂:ident : tactic =>
+  `(tactic| (
+      peelReplaceWithRegLocal $hpattern:ident $newCtx:ident $newOp:ident $hCastBack:ident
+        $oldDom₁:ident $newDom₁:ident
+      have $newDom₂:ident := (ValuePtr.dominatesIp_before_WfRewriter_createOp $hCastBack:ident
+        (by clear $hpattern:ident; grind) (by clear $hpattern:ident; grind)).mpr $oldDom₂:ident
+     ))

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryW.lean
@@ -1,0 +1,742 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+
+namespace Veir
+
+/-!
+## Generic correctness of `lowerBinaryWLocal`
+
+`lowerBinaryWLocal match? op64 op32` lowers a two-operand LLVM integer op to
+`unrealized_conversion_cast` (each operand to a register) → `riscv` op (`op64`, or its `W` variant
+`op32` for `i32`) → `unrealized_conversion_cast` (back to the integer type). Its
+`PreservesSemantics` proof is shared: instantiating it for a concrete lowering (`add_local`,
+`xor_local`, …) only requires the matcher facts, the interpreter computation facts, and the two
+data-level refinement lemmas.
+-/
+
+/-- Interpreting a matched two-operand LLVM op (of opcode `srcOp`, interpreted by `srcFn` per
+    `hSemSrc`) whose operands both have integer type `intType` reads the operands' `i{bw}` values
+    `x` and `y` and stores `srcFn x y props` in the result variable, leaving memory and control
+    flow untouched. The operand values are derived internally (from the successful interpretation
+    and the operands' types), so they are exposed as existential outputs rather than required as
+    inputs. -/
+theorem matchBinaryOp_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCode}
+    {op : OperationPtr} {lhs rhs : ValuePtr} {props : propertiesOf (.llvm srcOp)} {intType}
+    {srcFn : ∀ {bw : Nat}, Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) →
+      Data.LLVM.Int bw}
+    {state : InterpreterState ctx} {newState cf} (opInBounds : op.InBounds ctx.raw)
+    (hOpType : op.getOpType! ctx.raw = .llvm srcOp)
+    (hNumResults : op.getNumResults! ctx.raw = 1)
+    (hOperands : op.getOperands! ctx.raw = #[lhs, rhs])
+    (hProps : props = op.getProperties! ctx.raw (.llvm srcOp))
+    (hSemSrc : ∀ (bw : Nat) (x y : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw y] blockOperands mem
+          = some (.ok (#[.int bw (srcFn x y props)], mem, none)))
+    (hinterp : interpretOp op state opInBounds = some (newState, cf))
+    (hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType)
+    (hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType) :
+    ∃ x y, state.variables.getVar? lhs = some (RuntimeValue.int intType.bitwidth x) ∧
+      state.variables.getVar? rhs = some (RuntimeValue.int intType.bitwidth y) ∧
+      state.memory = newState.memory ∧
+      newState.variables.getVar? (op.getResult 0) =
+        some (RuntimeValue.int intType.bitwidth (srcFn x y props)) ∧
+      cf = none := by
+  have hNumOperands : op.getNumOperands! ctx.raw = 2 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by
+    rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by
+    rw [hOperands]; rfl
+  simp only [liftM, monadLift, MonadLift.monadLift] at hinterp
+  -- Derive the operands' `i{bw}` values from the successful interpretation and their types.
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize0 : 0 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  have hsize1 : 1 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨lval, hlval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize0
+  obtain ⟨rval, hrval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 1 hsize1
+  have hlGetVar : state.variables.getVar? lhs = some lval := by
+    rw [hLhsEq, show (op.getOperands! ctx.raw)[0]! = (op.getOperands! ctx.raw)[0] from by grind]
+    exact hlval
+  have hrGetVar : state.variables.getVar? rhs = some rval := by
+    rw [hRhsEq, show (op.getOperands! ctx.raw)[1]! = (op.getOperands! ctx.raw)[1] from by grind]
+    exact hrval
+  have hlconf := VariableState.getVar?_conforms hlGetVar
+  rw [show lhs.getType! ctx.raw = ⟨.integerType intType, hLhsType ▸ (lhs.getType! ctx.raw).2⟩
+        from Subtype.ext hLhsType] at hlconf
+  obtain ⟨x, rfl⟩ := RuntimeValue.Conforms.integerType hlconf
+  have hrconf := VariableState.getVar?_conforms hrGetVar
+  rw [show rhs.getType! ctx.raw = ⟨.integerType intType, hRhsType ▸ (rhs.getType! ctx.raw).2⟩
+        from Subtype.ext hRhsType] at hrconf
+  obtain ⟨y, rfl⟩ := RuntimeValue.Conforms.integerType hrconf
+  refine ⟨x, y, hlGetVar, hrGetVar, ?_⟩
+  -- With the values in hand, unfold the interpretation of the matched op.
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues op
+      = some #[RuntimeValue.int intType.bitwidth x, RuntimeValue.int intType.bitwidth y] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    have : i = 0 ∨ i = 1 := by omega
+    rcases this with rfl | rfl
+    · simpa [hOperand0] using hlGetVar
+    · simpa [hOperand1] using hrGetVar
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [← hProps, interpretOp'] at hInterp'
+  rw [hSemSrc] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ : resValues = #[RuntimeValue.int intType.bitwidth (srcFn x y props)] ∧
+      mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  refine ⟨rfl, ?_, rfl⟩
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
+set_option maxHeartbeats 1000000 in
+/-- Shared correctness proof for every `lowerBinaryWLocal` lowering: the round trip
+    `int × int → reg × reg → op64/op32 → int` refines `srcFn`.
+
+    Per-lowering inputs: the matcher's syntactic facts (`hMatchImplies`), the verifier facts
+    (`hVerified`), the interpreter computation facts for the source op and the two riscv ops
+    (`hSemSrc`/`hSemR64`/`hSemR32`, discharged by `simp`/`rfl` at concrete opcodes), and the two
+    data-level refinement lemmas (`hRefine64`/`hRefine32`). -/
+theorem lowerBinaryWLocal_preservesSemantics {srcOp : Llvm}
+    {match? : OperationPtr → IRContext OpCode →
+      Option (ValuePtr × ValuePtr × propertiesOf (.llvm srcOp))}
+    {op64 op32 : Riscv}
+    {props64 : propertiesOf (.riscv op64)} {props32 : propertiesOf (.riscv op32)}
+    {f64 f32 : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg}
+    {srcFn : ∀ {bw : Nat}, Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) →
+      Data.LLVM.Int bw}
+    (hMatchImplies : ∀ {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs props},
+        match? op ctx = some (lhs, rhs, props) →
+        op.getOpType! ctx = .llvm srcOp ∧
+        op.getNumResults! ctx = 1 ∧
+        op.getOperands! ctx = #[lhs, rhs] ∧
+        props = op.getProperties! ctx (.llvm srcOp))
+    (hVerified : ∀ {ctx : WfIRContext OpCode} {op : OperationPtr}
+        {opInBounds : op.InBounds ctx.raw},
+        op.Verified ctx opInBounds → op.getOpType! ctx.raw = .llvm srcOp →
+        op.IsVerifiedIntegerBinop ctx)
+    (hSemSrc : ∀ (bw : Nat) (x y : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw y] blockOperands mem
+          = some (.ok (#[.int bw (srcFn x y props)], mem, none)))
+    (hSemR64 : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op64)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' op64 props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f64 r₁ r₂)], mem, none)))
+    (hSemR32 : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op32)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' op32 props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f32 r₁ r₂)], mem, none)))
+    (hRefine64 : ∀ (x y xt yt : Data.LLVM.Int 64) (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcFn x y props ⊒ RISCV.Reg.toInt (f64 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)
+    (hRefine32 : ∀ (x y xt yt : Data.LLVM.Int 32) (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcFn x y props ⊒ RISCV.Reg.toInt (f32 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 32)
+    {h : LocalRewritePattern.ReturnOps (lowerBinaryWLocal match? op64 op32 props64 props32)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (lowerBinaryWLocal match? op64 op32 props64 props32)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds
+      (lowerBinaryWLocal match? op64 op32 props64 props32)}
+    {h₄ : LocalRewritePattern.ReturnValues (lowerBinaryWLocal match? op64 op32 props64 props32)} :
+    LocalRewritePattern.PreservesSemantics
+      (lowerBinaryWLocal match? op64 op32 props64 props32) h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, lowerBinaryWLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (match? op ctx.raw).isSome := by
+    cases hM : match? op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs, props⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := hMatchImplies hMatch
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by
+    rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by
+    rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, intType, hResType, hOp0Type, hOp1Type⟩ :=
+    hVerified opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- Both operand types are the integer type `intType`; resolve the type-destructuring matches.
+  have hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand0, hOp0Type]
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand1, hOp1Type]
+  rw [hLhsType, hRhsType] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand values and their `srcFn`.
+  obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands hProps hSemSrc
+      hinterp hLhsType hRhsType
+  subst hCf
+  -- The matched operands dominate the rewrite point in the source context.
+  have hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guards must be false (otherwise the RHS would be `some (ctx, none)`); both
+  -- guards check the same condition (`lhs`/`rhs` share `intType`), so one split resolves both.
+  peelSplittableCondition [hBw] hpattern
+  -- Source value: `op`'s single result is `srcFn` of its operands.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `lhs`/`rhs` are not among `op`'s results.
+  have lNotOp : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have rNotOp : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the two `castToRegLocal` creations (`builtin.unrealized_conversion_cast`s), transporting
+  -- both operand dominance facts into `ctx₁` and then `ctx₂`.
+  peelCastToRegLocal₂ hpattern ctx₁ lcastOp hLCast hDomCtxL hDomL₁ hDomCtxR hDomR₁
+  peelCastToRegLocal₂ hpattern ctx₂ rcastOp hRCast hDomL₁ hDomL₂ hDomR₁ hDomR₂
+  -- Freshness facts, used to keep values of earlier ops alive across later interpretation steps:
+  -- `rhs` (in bounds in the original context) is not a result of the fresh `lcastOp`, and the two
+  -- cast ops are distinct.
+  have hLCastFresh : ¬ lcastOp.InBounds ctx.raw :=
+    WfRewriter.createOp_new_not_inBounds lcastOp hLCast
+  have hRhsIn : rhs.InBounds ctx.raw := by clear hpattern; grind
+  have hRhsNeLCastRes : ∀ i, rhs ≠ ValuePtr.opResult (lcastOp.getResult i) := by
+    intro i heq
+    rw [heq] at hRhsIn
+    rw [ValuePtr.inBounds_opResult] at hRhsIn
+    obtain ⟨hIn, -⟩ := hRhsIn
+    exact hLCastFresh hIn
+  have hLCastNeRCast : lcastOp ≠ rcastOp := by clear hpattern; grind
+  have hBwCases : intType.bitwidth = 64 ∨ intType.bitwidth = 32 := by omega
+  rcases hBwCases with hbw | hbw
+  · -- 64-bit case: lowered to `op64`
+    rw [if_neg (show ¬intType.bitwidth = 32 by omega)] at hpattern
+    simp only [] at hpattern
+    -- Peel the `op64` creation and the `replaceWithRegLocal` cast-back, converting each
+    -- from the `createOp!`/helper form to plain `createOp`.
+    peelOpCreation!₂ hpattern ctx₃ retOp hRet hDomL₂ hDomL₃ hDomR₂ hDomR₃
+    peelReplaceWithRegLocal₂ hpattern ctx₄ castBackOp hCastBack hDomL₃ hDomL₄ hDomR₃ hDomR₄
+    cleanupHpattern hpattern
+    -- Read the refined values `xt`/`yt` of `lhs`/`rhs` in the target state `state'`.
+    obtain ⟨xt, hLVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+        hDomCtxL hDomL₄ lNotOp
+    obtain ⟨yt, hRVal', hytRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+        hDomCtxR hDomR₄ rNotOp
+    -- Normalise the bitwidth to the literal `64`.
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    -- Structural facts about the four created ops.
+    have hLCastType : lcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hRCastType : rcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hRetType : retOp.getOpType! ctx₄.raw = .riscv op64 := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hLCastOperands : lcastOp.getOperands! ctx₄.raw = #[lhs] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := lcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+    have hRCastOperands : rcastOp.getOperands! ctx₄.raw = #[rhs] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := rcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+    have hRetOperands : retOp.getOperands! ctx₄.raw
+        = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+    -- The cast-back op's result type is `i64`.
+    have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+        = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hRet
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hRCast
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hLCast
+            (value := ValuePtr.opResult (op.getResult 0))]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hLCastResTypes : lcastOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := lcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+    have hRCastResTypes : rcastOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := rcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+    have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+    -- Interpretation tail: execute `interpretOpList [lcastOp, rcastOp, retOp, castBackOp]` in
+    -- `state'`: one cast-forward lemma per cast, the binary forward lemma for the riscv op. The
+    -- frame clauses carry earlier bindings across later steps.
+    -- `lcastOp` reads `lhs = .int 64 xt` and casts it to `.reg (toReg xt)`.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        hLCastType hLCastOperands hLCastResTypes hLVal'
+    -- `rhs`'s value survives `lcastOp`'s interpretation: `rhs` (in bounds in the original
+    -- context) cannot be a result of the freshly created `lcastOp`.
+    have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₄.raw := by
+      rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw rhs lcastOp
+        with hres | ⟨i, hi, heq⟩
+      · exact hres
+      · exact absurd heq (hRhsNeLCastRes i)
+    have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 64 yt) := by
+      rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+    -- `rcastOp` reads `rhs = .int 64 yt` and casts it to `.reg (toReg yt)`.
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+      interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+        hRCastType hRCastOperands hRCastResTypes hRVal₁
+    -- `lcastOp`'s result survives `rcastOp`'s interpretation: the two cast ops are distinct.
+    have hLCastNotRCastRes :
+        ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₄.raw := by
+      rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+          (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+      · exact hres
+      · exact absurd heq (by grind [OperationPtr.getResult])
+    have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+        = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+      rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+    -- `retOp` (`op64`) maps `.reg r₁`, `.reg r₂` to `.reg (f64 r₁ r₂)`.
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+      interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+        (f := f64) (hSemR64 _ _) hRetType hRetOperands hRetResTypes hLRes₂ hRes₂
+    -- `castBackOp` casts `.reg (f64 (toReg xt) (toReg yt))` back to the `i64` result.
+    obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+      interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+        hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+    refine ⟨s₄, ?_, by grind, ?_⟩
+    · -- The list interpretation is the chain of the four op interpretations.
+      simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+        Interp]
+    · refine ⟨#[RuntimeValue.int 64
+          (RISCV.Reg.toInt (f64 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)], ?_, ?_⟩
+      · simp [hRes₄, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using hRefine64 xVal yVal xt yt props hxtRef hytRef⟩
+  · -- 32-bit case: lowered to `op32`
+    rw [if_pos hbw] at hpattern
+    simp only [] at hpattern
+    -- Peel the `op32` creation and the `replaceWithRegLocal` cast-back, converting each
+    -- from the `createOp!`/helper form to plain `createOp`.
+    peelOpCreation!₂ hpattern ctx₃ retOp hRet hDomL₂ hDomL₃ hDomR₂ hDomR₃
+    peelReplaceWithRegLocal₂ hpattern ctx₄ castBackOp hCastBack hDomL₃ hDomL₄ hDomR₃ hDomR₄
+    cleanupHpattern hpattern
+    -- Read the refined values `xt`/`yt` of `lhs`/`rhs` in the target state `state'`.
+    obtain ⟨xt, hLVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+        hDomCtxL hDomL₄ lNotOp
+    obtain ⟨yt, hRVal', hytRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+        hDomCtxR hDomR₄ rNotOp
+    -- Normalise the bitwidth to the literal `32`.
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    -- Structural facts about the four created ops.
+    have hLCastType : lcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hRCastType : rcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hRetType : retOp.getOpType! ctx₄.raw = .riscv op32 := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hLCastOperands : lcastOp.getOperands! ctx₄.raw = #[lhs] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := lcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+    have hRCastOperands : rcastOp.getOperands! ctx₄.raw = #[rhs] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := rcastOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+    have hRetOperands : retOp.getOperands! ctx₄.raw
+        = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+    -- The cast-back op's result type is `i32`.
+    have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+        = (⟨Attribute.integerType { bitwidth := 32 }, by grind⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hRet
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hRCast
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hLCast
+            (value := ValuePtr.opResult (op.getResult 0))]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hLCastResTypes : lcastOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := lcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+    have hRCastResTypes : rcastOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := rcastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+    have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.integerType { bitwidth := 32 }, by grind⟩] := by grind
+    -- Interpretation tail: execute `interpretOpList [lcastOp, rcastOp, retOp, castBackOp]` in
+    -- `state'`.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        hLCastType hLCastOperands hLCastResTypes hLVal'
+    have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₄.raw := by
+      rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw rhs lcastOp
+        with hres | ⟨i, hi, heq⟩
+      · exact hres
+      · exact absurd heq (hRhsNeLCastRes i)
+    have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 32 yt) := by
+      rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+      interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+        hRCastType hRCastOperands hRCastResTypes hRVal₁
+    have hLCastNotRCastRes :
+        ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₄.raw := by
+      rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+          (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+      · exact hres
+      · exact absurd heq (by grind [OperationPtr.getResult])
+    have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+        = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+      rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+      interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+        (f := f32) (hSemR32 _ _) hRetType hRetOperands hRetResTypes hLRes₂ hRes₂
+    obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+      interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+        hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+    refine ⟨s₄, ?_, by grind, ?_⟩
+    · -- The list interpretation is the chain of the four op interpretations.
+      simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+        Interp]
+    · refine ⟨#[RuntimeValue.int 32
+          (RISCV.Reg.toInt (f32 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 32)], ?_, ?_⟩
+      · simp [hRes₄, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using hRefine32 xVal yVal xt yt props hxtRef hytRef⟩
+
+/-!
+## RISC-V lowering of `llvm.add`
+
+`llvm.add` on 64- or 32-bit integers is lowered to two `unrealized_conversion_cast`s (operands to
+registers) → `riscv.add`/`riscv.addw` → `unrealized_conversion_cast` (back to the integer type).
+This is the actual `Veir.add_local` pattern from `Veir.Passes.InstructionSelection.RISCV64`.
+
+The structural part of the proof is shared with the other binary lowerings
+(`lowerBinaryWLocal_preservesSemantics`); only the two data-level refinement lemmas below are
+`add`-specific. Note the operand swap in the RISC-V ops: the interpreter applies
+`RISCV.add op2 op1`, so the lemmas take `(toReg yt)` first.
+-/
+
+/-- Correctness of the `riscv.add` lowering of a 64-bit `llvm.add`: the round trip
+    `int × int → reg × reg → add → int` refines `add` (with any `nsw`/`nuw` flags — if the source
+    overflows into poison, refinement is trivial). -/
+theorem add_isRefinedBy_toInt_add {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.add x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.add]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.addw` lowering of a 32-bit `llvm.add`. -/
+theorem add_isRefinedBy_toInt_addw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.add x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.addw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.addw]
+  veir_bv_decide
+
+theorem add_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics add_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .add)
+    (srcFn := fun x y props => Data.LLVM.Int.add x y props.nsw props.nuw)
+    (f64 := fun r₁ r₂ => Data.RISCV.add r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.addw r₂ r₁)
+    matchAdd_implies
+    OperationPtr.Verified.llvm_add
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => add_isRefinedBy_toInt_add props.nsw props.nuw h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => add_isRefinedBy_toInt_addw props.nsw props.nuw h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.xor`
+
+`llvm.xor` is bitwise, so both bitwidths lower to plain `riscv.xor` (no `W` variant needed). The
+structural part of the proof is shared with the other binary lowerings; only the two data-level
+refinement lemmas below are `xor`-specific.
+-/
+
+/-- Correctness of the `riscv.xor` lowering of a 64-bit `llvm.xor`. -/
+theorem xor_isRefinedBy_toInt_xor {x y xt yt : Data.LLVM.Int 64}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.xor x y
+      ⊒ RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.xor]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.xor` lowering of a 32-bit `llvm.xor`. -/
+theorem xor_isRefinedBy_toInt_xor_32 {x y xt yt : Data.LLVM.Int 32}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.xor x y
+      ⊒ RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.xor]
+  veir_bv_decide
+
+theorem xor_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics xor_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .xor)
+    (srcFn := fun x y _ => Data.LLVM.Int.xor x y)
+    (f64 := fun r₁ r₂ => Data.RISCV.xor r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.xor r₂ r₁)
+    matchXor_implies
+    OperationPtr.Verified.llvm_xor
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ h₁ h₂ => xor_isRefinedBy_toInt_xor h₁ h₂)
+    (fun _ _ _ _ _ h₁ h₂ => xor_isRefinedBy_toInt_xor_32 h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.sub`
+
+`llvm.sub` lowers to `riscv.sub`/`riscv.subw`. Only the two data-level refinement lemmas below
+are `sub`-specific.
+-/
+
+/-- Correctness of the `riscv.sub` lowering of a 64-bit `llvm.sub`. -/
+theorem sub_isRefinedBy_toInt_sub {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.sub x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.sub (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.sub]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.subw` lowering of a 32-bit `llvm.sub`. -/
+theorem sub_isRefinedBy_toInt_subw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.sub x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.subw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.subw]
+  veir_bv_decide
+
+theorem sub_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics sub_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .sub)
+    (srcFn := fun x y props => Data.LLVM.Int.sub x y props.nsw props.nuw)
+    (f64 := fun r₁ r₂ => Data.RISCV.sub r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.subw r₂ r₁)
+    matchSub_implies
+    OperationPtr.Verified.llvm_sub
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => sub_isRefinedBy_toInt_sub props.nsw props.nuw h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => sub_isRefinedBy_toInt_subw props.nsw props.nuw h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.mul`
+
+`llvm.mul` lowers to `riscv.mul`/`riscv.mulw`. Only the two data-level refinement lemmas below
+are `mul`-specific.
+-/
+
+/-- Correctness of the `riscv.mul` lowering of a 64-bit `llvm.mul`. -/
+theorem mul_isRefinedBy_toInt_mul {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.mul x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.mul (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  -- Avoid bitblasting the 64-bit multiplier: rewrite both sides to the same product instead.
+  rw [Data.LLVM.Int.getValue_mul _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.mul, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    BitVec.truncate_eq_setWidth, BitVec.setWidth_eq]
+  rw [hvd₁, hvd₂]
+
+/-- Correctness of the `riscv.mulw` lowering of a 32-bit `llvm.mul`. -/
+theorem mul_isRefinedBy_toInt_mulw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.mul x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.mulw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  -- Rewrite both sides to the same 32-bit product first, so `bv_decide` sees two structurally
+  -- identical multipliers instead of proving a 64-bit multiplier equivalence.
+  rw [Data.LLVM.Int.getValue_mul _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.mulw, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp])]
+  rw [hvd₁, hvd₂]
+  bv_decide
+
+theorem mul_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics mul_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .mul)
+    (srcFn := fun x y props => Data.LLVM.Int.mul x y props.nsw props.nuw)
+    (f64 := fun r₁ r₂ => Data.RISCV.mul r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.mulw r₂ r₁)
+    matchMul_implies
+    OperationPtr.Verified.llvm_mul
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => mul_isRefinedBy_toInt_mul props.nsw props.nuw h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => mul_isRefinedBy_toInt_mulw props.nsw props.nuw h₁ h₂)
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -2,7 +2,8 @@
 
 This document describes the proof strategy used for the `lowerUnaryWLocal` lowerings
 (`ctlz_local`, `cttz_local`, `ctpop_local` in `Veir/Passes/InstructionSelection/RISCV64.lean`)
-and how to extend it to the other `*_local` lowerings (`add_local`, `and_local`, `bswap_local`, …).
+and the `lowerBinaryWLocal` lowerings (`add_local`, `sub_local`, `mul_local`, `xor_local`, …),
+and how to extend it to the other `*_local` lowerings (`and_local`, `bswap_local`, …).
 
 ## What we prove
 
@@ -32,6 +33,15 @@ structural proof is done **once per combinator**. Currently:
   on `i64`/`i32`, then emit `castToRegLocal` → `op64` (or its `W` variant `op32` for `i32`) →
   `replaceWithRegLocal`. Its shared correctness proof is
   `lowerUnaryWLocal_preservesSemantics` (`RewriteProofs/LowerUnaryW.lean`).
+- `lowerBinaryWLocal match? op64 op32 props64 props32` — the two-operand analogue: match a
+  binary LLVM integer op on `i64`/`i32`, emit `castToRegLocal` for each operand → `op64`/`op32`
+  applied to the two cast results (in `#[lhs, rhs]` order) → `replaceWithRegLocal`. Instances:
+  `add`, `sub`, `mul`, `sdiv`, `udiv`, `srem`, `urem`, `xor`, `shl`, `lshr` (ops without a `W`
+  variant, like `xor`, pass the same opcode twice). Its shared correctness proof is
+  `lowerBinaryWLocal_preservesSemantics` (`RewriteProofs/LowerBinaryW.lean`), instantiated so
+  far for `add`, `sub`, `mul`, `xor`. The div/rem instances cannot use the current proof: their
+  LLVM interpretation has UB branches (division by zero, `intMin / -1`), so they do not satisfy
+  the total-success `hSemSrc` hypothesis and need a combinator proof variant that propagates UB.
 
 The generic theorem is parameterized over everything opcode-specific:
 
@@ -130,8 +140,14 @@ the matcher's syntactic facts, the `hSemSrc` computation fact, and a successful
 The operand value is *derived* inside the lemma — from `interpretOp_some_iff`, the matcher's
 `getOperands!` fact, and `VariableState.getVar?_conforms` + the operand's integer type
 (`RuntimeValue.Conforms.integerType` turns "conforms to `i{bw}`" into "`= .int bw x`") — so
-callers don't have to supply it. A binop combinator will need a binop analogue exposing two
-existentials, using two `Array.exists_mapM_option_eq_some_iff` reads (indices 0 and 1).
+callers don't have to supply it. `matchBinaryOp_interpretOp_unfold` (`LowerBinaryW.lean`) is the
+binop analogue exposing two existentials, via two `Array.exists_mapM_option_eq_some_iff` reads
+(indices 0 and 1).
+
+Note: for binops the `hSemSrc` computation fact is *not* `rfl` — the interpreter's binop arms
+check the two operand bitwidths against each other (`if h : bw' ≠ bw then none else … rhs.cast …`),
+which is stuck on a variable bitwidth. Instantiations discharge it with
+`by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp]` instead.
 
 ### Forward lemmas for the emitted ops
 
@@ -143,7 +159,11 @@ the generic `interpretOp_forward` (`Veir/Interpreter/Lemmas.lean`):
 - `interpretOp_riscv_unaryReg_forward` — **generic over the RISC-V opcode**: any unary
   reg-to-reg op whose `Riscv.interpretOp'` maps `.reg r` to `.reg (f r)` (hypothesis `hSem`,
   discharged by `rfl` at each concrete opcode). Covers `clz`/`clzw`/`ctz`/`ctzw`/`cpop`/`cpopw`
-  and any future unary Zbb op with **no new lemma needed**.
+  and any future unary Zbb op with **no new lemma needed**;
+- `interpretOp_riscv_binaryReg_forward` — the binary analogue: two register operands mapped to
+  `.reg (f r₁ r₂)`. Beware the operand swap: the interpreter applies the data-level op as
+  `RISCV.op op2 op1`, so instantiations pass `f := fun r₁ r₂ => RISCV.op r₂ r₁` and the Layer-0
+  lemmas are stated with `(toReg yt)` first.
 
 Each lemma's conclusion gives the successful one-step interpretation, memory unchanged, the
 result binding, and a **frame clause** (all non-result variables unchanged). The frame clause
@@ -165,6 +185,9 @@ and `vals := #[.reg r₁, .reg r₂]`.
   context, the new op, and the creation hypothesis (the `!` form also rewrites `createOp!` to
   plain `createOp` and transports a dominance hypothesis into the new context);
 - `peelCastToRegLocal` / `peelReplaceWithRegLocal` — same, specialized to the two cast helpers;
+- `peelCastToRegLocal₂` / `peelOpCreation!₂` / `peelReplaceWithRegLocal₂` — binary-lowering
+  variants that transport *two* dominance hypotheses (one per matched operand) through each
+  creation step;
 - `cleanupHpattern` — substitute the final `newOps`/`newValues`/`newCtx` equalities.
 
 The matcher itself is peeled inline in the generic proof (case on `match? op ctx.raw`, the
@@ -193,6 +216,17 @@ namespace of `LowerUnaryW.lean`:
 5. **Axiom check**: `#guard_msgs in #print axioms foo_local_preservesSemantics` to pin the
    axiom footprint.
 
+**If it fits `lowerBinaryWLocal`** (two integer operands of the same type, one binary reg-to-reg
+RISC-V op per bitwidth, total LLVM interpretation — no UB branches): same recipe against
+`lowerBinaryWLocal_preservesSemantics` in `LowerBinaryW.lean`, with the differences:
+
+- Layer-0 lemmas take two refined operands and are stated with the target registers swapped
+  (`RISCV.op (toReg yt) (toReg xt)`, matching the interpreter's `RISCV.op op2 op1`);
+- `hSemSrc` is `by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp]` (see above),
+  `hSemR64`/`hSemR32` stay `rfl` with `f64 := fun r₁ r₂ => RISCV.op64 r₂ r₁` (same for `f32`);
+- `matchFoo_implies` returns the two operands (`op.getOperands! ctx = #[lhs, rhs]`), and Layer 1
+  is `IsVerifiedIntegerBinop` (`Verified.llvm_add`/`llvm_sub`/… exist for all merged ops).
+
 **If it needs a new shape** (binop, longer chain, extra guards): first factor the lowering
 through a new combinator in `RISCV64.lean`, then prove that combinator's
 `PreservesSemantics` once, generic over the opcode-specific parameters, following
@@ -206,13 +240,21 @@ per lowering as above.
 
 ## Adapting to other lowering shapes
 
-- **Binops** (`add_local`, `and_local`, `mul_local`, …): two `castToRegLocal` peels, two
-  `exists_refined_int_getVar?` reads, two "operand is not a result of `op`" facts, a binop
-  analogue of `matchUnaryOp_interpretOp_unfold`, and a binop reg-to-reg forward lemma.
-  Crucially, when executing the chain, the value of the *first* cast's result must survive the
-  *second* cast's interpretation: keep the **frame clause** of the forward lemma (bind it as
-  `hFrame` instead of discarding with `-`) and rewrite the earlier result binding through it
-  before feeding the RISC-V op's forward lemma.
+- **Binops**: done — `lowerBinaryWLocal_preservesSemantics` (`LowerBinaryW.lean`). The proof
+  follows the unary template with: two `castToRegLocal` peels (via the `peel*₂` macros carrying
+  both operands' dominance), two `exists_refined_int_getVar?` reads, two "operand is not a
+  result of `op`" facts, `matchBinaryOp_interpretOp_unfold`, and
+  `interpretOp_riscv_binaryReg_forward`. Crucially, when executing the chain, the value of `rhs`
+  must survive the first cast and the *first* cast's result must survive the *second* cast's
+  interpretation: keep the **frame clause** of the forward lemmas (bind it as `hFrame` instead
+  of discarding with `-`) and rewrite the earlier bindings through it. The membership side
+  conditions (`rhs ∉ lcastOp.getResults! …`, `lcastOp.getResult 0 ∉ rcastOp.getResults! …`) are
+  *not* one-shot `grind`s: establish the freshness facts once before the bitwidth split
+  (`createOp_new_not_inBounds` + `ValuePtr.inBounds_opResult`) and case on
+  `getResults!_not_mem_or_eq_getResult` in each branch.
+  Ops whose LLVM interpretation can raise UB (`sdiv`, `udiv`, `srem`, `urem`) do not fit the
+  total `hSemSrc` hypothesis; they are merged into the combinator *definition* but still need a
+  UB-aware proof variant.
 - **Longer chains** (`bswap_local` 32-bit emits `cast, rev8, srli, castBack`): one extra
   `peelOpCreation!` and one extra forward-lemma application per op; ops with an immediate
   (`srli`) need their forward lemma to take the properties (`RISCVImmediateProperties`) into
@@ -239,6 +281,16 @@ per lowering as above.
   passed explicitly to `grind [...]`, instantiated at the right creation hypothesis.
 - **Bitwidth literals**: destructure `intType` (`obtain ⟨bw⟩ := intType`) and `subst` the
   branch hypothesis before applying the Layer-0 lemmas, which are stated at literal `64`/`32`.
+- **Identical guards split together**: in `lowerBinaryWLocal` both operands share `intType`, so
+  the two bitwidth guards have syntactically equal conditions and a single
+  `peelSplittableCondition` resolves both (a second one fails: nothing left to split).
+- **`bv_decide` and multipliers**: the SAT solver times out on 64-bit multiplier equivalence
+  (`mul_isRefinedBy_toInt_mul`). Rewrite both sides to the *same* product first
+  (`getValue_mul`, `toInt_getValue`, `val_toReg`, `BitVec.setWidth_eq`), so the goal closes by
+  `rw`/`rfl` (64-bit) or `bv_decide` sees structurally identical multipliers (32-bit `mulw`).
+- **Structural facts through 4 creations**: plain `grind` no longer finds the transports for
+  ops created three contexts back; seed `OperationPtr.getOperands!_WfRewriter_createOp` (and the
+  `getResultTypes!` analogue) explicitly at each creation hypothesis, as in `LowerBinaryW.lean`.
 - **`maxHeartbeats`**: the combinator theorem needs `set_option maxHeartbeats 1000000` (many
   `grind` calls over a large context).
 - **Expected axioms**: `#print axioms` will list the dominance axioms
@@ -255,11 +307,12 @@ per lowering as above.
 | File | Contents | Growth per new lowering |
 |---|---|---|
 | `RewriteProofs/LowerUnaryW.lean` | `matchUnaryOp_interpretOp_unfold`, `lowerUnaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations (`Example` namespace) | two data lemmas + one instantiation (unary); new file per new *shape* |
-| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary reg-to-reg riscv op) | one lemma per new emitted-op *shape* |
-| `RewriteProofs/CommonTactics.lean` | `peel*` macros, `cleanupHpattern` | rarely |
+| `RewriteProofs/LowerBinaryW.lean` | `matchBinaryOp_interpretOp_unfold`, `lowerBinaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations (`add`, `sub`, `mul`, `xor`) | two data lemmas + one instantiation (binary) |
+| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary/binary reg-to-reg riscv ops) | one lemma per new emitted-op *shape* |
+| `RewriteProofs/CommonTactics.lean` | `peel*` macros (incl. the two-dominance `peel*₂` variants), `cleanupHpattern` | rarely |
 | `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `createOp!` reduction, properties/dominance transport | rarely |
 | `RewriteProofs/CommonMatchLemmas.lean` | ctlz-specific unfold/peel lemmas — currently unused (superseded by the generic `matchUnaryOp_interpretOp_unfold`); candidate for deletion | — |
-| `Veir/Passes/InstructionSelection/RISCV64.lean` | the lowering combinators (`lowerUnaryWLocal`) and their instances | one `def` (or a new combinator) |
+| `Veir/Passes/InstructionSelection/RISCV64.lean` | the lowering combinators (`lowerUnaryWLocal`, `lowerBinaryWLocal`) and their instances | one `def` (or a new combinator) |
 | `Veir/Verifier.lean` | `IsVerified*` bundles + `Verified.llvm_*` extractors (Layer 1) | one 3-line lemma (unop/binop) |
 | `Veir/Passes/Matching/Lemmas.lean` | `match*_implies` (Layer 2) | usually nothing |
 | `Veir/Interpreter/Lemmas.lean` | generic `interpretOp_forward`, `interpretOpList_cons` | nothing |


### PR DESCRIPTION
Also, merge a few binary operation lowerings in `RISCV64.lean`, which helps making this proof more general.