### PR TITLE
feat(riscv): verify the rewrites in RISCV64Sdag.lean

### DIFF
--- a/Veir/Dominance.lean
+++ b/Veir/Dominance.lean
@@ -101,6 +101,21 @@ axiom OperationPtr.dominatesIp_before :
 grind_pattern OperationPtr.dominatesIp_before => op₁.dominatesIp (.before op₂) ctx
 
 /--
+Strict dominance between operations is transitive.
+-/
+axiom OperationPtr.strictlyDominates_trans {op₃ : OperationPtr} :
+  op₁.strictlyDominates op₂ ctx → op₂.strictlyDominates op₃ ctx →
+  op₁.strictlyDominates op₃ ctx
+
+/--
+A value dominating the program point before an operation `op₁` also dominates the program
+point before any operation `op₂` strictly dominated by `op₁`.
+-/
+axiom ValuePtr.dominatesIp_before_of_strictlyDominates {value : ValuePtr} :
+  value.dominatesIp (InsertPoint.before op₁) ctx → op₁.strictlyDominates op₂ ctx →
+  value.dominatesIp (InsertPoint.before op₂) ctx
+
+/--
 If an operation `op₁` dominates an operation `op₂`, it dominates the operation after `op₂`,
 if it exists.
 -/

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -20,11 +20,19 @@ def singleSetBit (x : BitVec 64) : Option Int :=
 /-! # SelectionDAG Lowering Patterns  -/
 
 /--
-  `and x (not y)` -> `riscv.andn x y`. The `not` may appear on either operand.
+  Shared shape of the Zbb negated-operand lowerings (`andn`/`orn`/`xnor`): match a binary LLVM
+  op on `i64` one of whose operands is a `not` (`xor _, -1`), cast the plain operand `x` and the
+  `not`'s operand `y` to registers, apply the binary reg-reg riscv op `dst`, and cast the result
+  back to `i64`. Lowerings of this shape share the correctness proof of
+  `lowerBinopNotLocal_preservesSemantics`, so proving a new one only requires the per-op
+  data-level refinement lemmas.
 -/
-def andn_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+def lowerBinopNotLocal {P : Type}
+    (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))
+    (dst : Riscv) (props : propertiesOf (.riscv dst))
+    (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchAnd op ctx | return (ctx, none)
+  let some (lhs, rhs, _) := match? op ctx | return (ctx, none)
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ 64 then return (ctx, none)
   let some (x, y) :=
@@ -35,10 +43,17 @@ def andn_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
                | none => none) | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx x
   let (ctx, yCastOp) ← castToRegLocal ctx y
-  let (ctx, andnOp) ← WfRewriter.createOp! ctx (.riscv .andn) #[RegisterType.mk]
-      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] () none
-  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (andnOp.getResult 0)
-  some (ctx, some (#[xCastOp, yCastOp, andnOp, castBackOp], #[castBackOp.getResult 0]))
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk]
+      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] props none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
+  some (ctx, some (#[xCastOp, yCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
+
+/--
+  `and x (not y)` -> `riscv.andn x y`. The `not` may appear on either operand.
+-/
+def andn_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinopNotLocal matchAnd .andn () ctx op
 
 /--
   `and x (not y)` -> `riscv.andn x y`. The `not` may appear on either operand.
@@ -51,22 +66,8 @@ def andn (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   `or x (not y)` -> `riscv.orn x y`. The `not` may appear on either operand.
 -/
 def orn_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchOr op ctx | return (ctx, none)
-  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
-  if t.bitwidth ≠ 64 then return (ctx, none)
-  let some (x, y) :=
-    (match matchNot rhs ctx with
-     | some y => some (lhs, y)
-     | none => match matchNot lhs ctx with
-               | some y => some (rhs, y)
-               | none => none) | return (ctx, none)
-  let (ctx, xCastOp) ← castToRegLocal ctx x
-  let (ctx, yCastOp) ← castToRegLocal ctx y
-  let (ctx, ornOp) ← WfRewriter.createOp! ctx (.riscv .orn) #[RegisterType.mk]
-      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] () none
-  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (ornOp.getResult 0)
-  some (ctx, some (#[xCastOp, yCastOp, ornOp, castBackOp], #[castBackOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinopNotLocal matchOr .orn () ctx op
 
 /--
   `or x (not y)` -> `riscv.orn x y`. The `not` may appear on either operand.
@@ -79,22 +80,8 @@ def orn (rewriter : PatternRewriter OpCode) (op : OperationPtr)
   `xor x (not y)` -> `riscv.xnor x y`. The `not` may appear on either operand.
 -/
 def xnor_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (lhs, rhs, _) := matchXor op ctx | return (ctx, none)
-  let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
-  if t.bitwidth ≠ 64 then return (ctx, none)
-  let some (x, y) :=
-    (match matchNot rhs ctx with
-     | some y => some (lhs, y)
-     | none => match matchNot lhs ctx with
-               | some y => some (rhs, y)
-               | none => none) | return (ctx, none)
-  let (ctx, xCastOp) ← castToRegLocal ctx x
-  let (ctx, yCastOp) ← castToRegLocal ctx y
-  let (ctx, xnorOp) ← WfRewriter.createOp! ctx (.riscv .xnor) #[RegisterType.mk]
-      #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] () none
-  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (xnorOp.getResult 0)
-  some (ctx, some (#[xCastOp, yCastOp, xnorOp, castBackOp], #[castBackOp.getResult 0]))
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
+  lowerBinopNotLocal matchXor .xnor () ctx op
 
 /--
   `xor x (not y)` -> `riscv.xnor x y`. The `not` may appear on either operand.

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -23,9 +23,7 @@ def singleSetBit (x : BitVec 64) : Option Int :=
   Shared shape of the Zbb negated-operand lowerings (`andn`/`orn`/`xnor`): match a binary LLVM
   op on `i64` one of whose operands is a `not` (`xor _, -1`), cast the plain operand `x` and the
   `not`'s operand `y` to registers, apply the binary reg-reg riscv op `dst`, and cast the result
-  back to `i64`. Lowerings of this shape share the correctness proof of
-  `lowerBinopNotLocal_preservesSemantics`, so proving a new one only requires the per-op
-  data-level refinement lemmas.
+  back to `i64`.
 -/
 def lowerBinopNotLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
@@ -45,6 +45,19 @@ theorem LocalRewritePattern.exists_refined_int_getVar?
     grind [LocalRewritePattern.mapping, valueRefinement v]
   grind [RuntimeValue.int_of_isRefinedBy hRef]
 
+/-- A value that exists in a context `ctx` is never a result of an operation that is *not* in
+bounds of `ctx` (e.g. a freshly created op), in any context `ctx'`: result membership pins the
+value's operation pointer, and an in-bounds `opResult` value forces its operation in bounds.
+Used to discharge the frame-clause side conditions when symbolically executing a chain of
+created ops. -/
+theorem ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds
+    {value : ValuePtr} {op : OperationPtr} {ctx ctx' : IRContext OpInfo}
+    (hval : value.InBounds ctx) (hop : ¬ op.InBounds ctx) :
+    value ∉ op.getResults! ctx' := by
+  intro hmem
+  obtain ⟨i, -, rfl⟩ := (OperationPtr.getResults!.mem_iff_exists_index).mp hmem
+  exact hop (by grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult])
+
 /-- `createEmptyOp` leaves a pre-existing operation's properties (at every op code) untouched: it only
 `set`s the fresh `newOp`'s record. The shipped `getProperties!_createEmptyOp` is code-specific. -/
 theorem OperationPtr.getProperties!_createEmptyOp_ne

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
@@ -80,6 +80,41 @@ theorem interpretOp_castBack_forward
       (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
   grind
 
+/-- Binary register-to-register `riscv` op specialization of `interpretOp_forward`: `theOp` is any
+`riscv` op `rop` whose interpretation maps two register operands `r₁ r₂` to `f r₁ r₂` (hypothesis
+`hSem`, discharged by `rfl` at each concrete opcode), with a single `!riscv.reg` result.
+Interpreting it always succeeds, leaves memory untouched, binds the result to `.reg (f r₁ r₂)`,
+and leaves every non-result value unchanged. This covers `riscv.andn`/`orn`/`xnor` and any
+future binary reg-reg op (`add`/`sub`/`max`/…) with no new lemma needed. -/
+theorem interpretOp_riscv_binaryReg_forward
+    {ctx : WfIRContext OpCode} {rop : Riscv} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v₁ v₂ : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r₁ r₂ : Data.RISCV.Reg} {f : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg}
+    (hSem : ∀ (props : HasDialectOpInfo.propertiesOf rop) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' rop props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f r₁ r₂)], mem, none)))
+    (hType : theOp.getOpType! ctx.raw = .riscv rop)
+    (hOperands : theOp.getOperands! ctx.raw = #[v₁, v₂])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal₁ : state.variables.getVar? v₁ = some (.reg r₁))
+    (hVal₂ : state.variables.getVar? v₂ = some (.reg r₂)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (f r₁ r₂)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r₁, .reg r₂]) (results := #[.reg (f r₁ r₂)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal₁, hVal₂])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', hSem, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
 /-- Unary register-to-register `riscv` op specialization of `interpretOp_forward`: `theOp` is any
 `riscv` op `rop` whose interpretation maps a single register operand `r` to `f r` (hypothesis
 `hSem`, discharged by `rfl` at each concrete opcode), with a single `!riscv.reg` result.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonGraphLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonGraphLemmas.lean
@@ -189,7 +189,7 @@ set_option maxHeartbeats 1000000 in
     `PreservesSemantics` proof needs to read `y`'s refined value in the target state. -/
 theorem matchNot_getVar?_of_EquationLemmaAt {ctx : WfIRContext OpCode}
     (ctxDom : ctx.Dom) (ctxVerif : ctx.Verified)
-    {op : OperationPtr} {opInBounds : op.InBounds ctx.raw}
+    {op : OperationPtr} (opInBounds : op.InBounds ctx.raw)
     {state : InterpreterState ctx}
     (stateWf : state.EquationLemmaAt (InsertPoint.before op) (by grind))
     {v y : ValuePtr} {intType : IntegerType}

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonGraphLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonGraphLemmas.lean
@@ -1,0 +1,322 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Dominance
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+
+/-!
+# Semantic facts about matched subgraphs
+
+A `PreservesSemantics` proof receives a source state satisfying `EquationLemmaAt` at the match
+point: every *pure* operation dominating that point has already been interpreted consistently
+into the state. The lemmas in this file exploit that invariant to recover the *runtime* values
+of operands that a pattern matched only *syntactically* through their defining operations
+(`matchNot`, `matchConstantIntVal`, …). This is the extra ingredient that multi-op (DAG)
+matching patterns need over the single-op lowerings.
+
+The file provides three layers:
+- `OperationPtr.Pure.*`: per-opcode purity facts (required to invoke `EquationLemmaAt`);
+- `*_interpretOp_unfold`: unfold one successful `interpretOp` of a given shape into its result
+  bindings (usable both for the matched op itself and, at `newState := state`, for the
+  `EquationHolds` fact of a matched defining op);
+- `matchNot_getVar?_of_EquationLemmaAt`: the packaged graph lemma for `matchNot`.
+-/
+
+namespace Veir
+
+/-! ## Purity of the matched defining ops -/
+
+/-- `llvm.xor` is pure: its interpretation neither reads nor writes memory. -/
+theorem OperationPtr.Pure.llvm_xor {op : OperationPtr} {ctx : IRContext OpCode}
+    (hType : op.getOpType! ctx = .llvm .xor) : op.Pure ctx := by
+  unfold OperationPtr.Pure
+  rw [hType]
+  intro operands memory₁ memory₂
+  simp only [interpretOp', Llvm.interpretOp']
+  split
+  · split <;> simp [Interp.map, Option.map, UBOr.map, pure]
+  · simp [Interp.map, Option.map]
+
+/-- `llvm.mlir.constant` is pure: its interpretation neither reads nor writes memory. -/
+theorem OperationPtr.Pure.llvm_mlir__constant {op : OperationPtr} {ctx : IRContext OpCode}
+    (hType : op.getOpType! ctx = .llvm .mlir__constant) : op.Pure ctx := by
+  unfold OperationPtr.Pure
+  rw [hType]
+  intro operands memory₁ memory₂
+  simp only [interpretOp', Llvm.interpretOp']
+  repeat' split
+  all_goals first
+    | rfl
+    | simp [Interp.map, Option.map, UBOr.map, pure, bind, Option.bind]
+
+/-! ## Forward unfolding of one interpretation step -/
+
+/-- Interpreting a matched two-operand LLVM op (of opcode `srcOp`, interpreted by `srcFn` per
+    `hSemSrc`) whose operands both have integer type `intType` reads the operands' `i{bw}`
+    values `x`/`y` and stores `srcFn x y props` in the result variable, leaving memory and
+    control flow untouched. The operand values are derived internally (from the successful
+    interpretation and the operand types), so they are exposed as existential outputs rather
+    than required as inputs. The binop analogue of `matchUnaryOp_interpretOp_unfold`. -/
+theorem matchBinaryOp_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCode}
+    {op : OperationPtr} {lhs rhs : ValuePtr} {props : propertiesOf (.llvm srcOp)} {intType}
+    {srcFn : ∀ {bw : Nat},
+      Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) → Data.LLVM.Int bw}
+    {state newState : InterpreterState ctx} {cf} (opInBounds : op.InBounds ctx.raw)
+    (hOpType : op.getOpType! ctx.raw = .llvm srcOp)
+    (hNumResults : op.getNumResults! ctx.raw = 1)
+    (hOperands : op.getOperands! ctx.raw = #[lhs, rhs])
+    (hProps : props = op.getProperties! ctx.raw (.llvm srcOp))
+    (hSemSrc : ∀ (bw : Nat) (x y : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw y] blockOperands mem
+          = some (.ok (#[.int bw (srcFn x y props)], mem, none)))
+    (hinterp : interpretOp op state opInBounds = some (.ok (newState, cf)))
+    (hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType)
+    (hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType) :
+    ∃ x y, state.variables.getVar? lhs = some (RuntimeValue.int intType.bitwidth x) ∧
+      state.variables.getVar? rhs = some (RuntimeValue.int intType.bitwidth y) ∧
+      state.memory = newState.memory ∧
+      newState.variables.getVar? (op.getResult 0) =
+        some (RuntimeValue.int intType.bitwidth (srcFn x y props)) ∧
+      cf = none := by
+  have hNumOperands : op.getNumOperands! ctx.raw = 2 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  -- Derive the operands' `i{bw}` values from the successful interpretation and their types.
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize0 : 0 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  have hsize1 : 1 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨lval, hlval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize0
+  obtain ⟨rval, hrval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 1 hsize1
+  have hlGetVar : state.variables.getVar? lhs = some lval := by
+    rw [hLhsEq, show (op.getOperands! ctx.raw)[0]! = (op.getOperands! ctx.raw)[0] from by grind]
+    exact hlval
+  have hrGetVar : state.variables.getVar? rhs = some rval := by
+    rw [hRhsEq, show (op.getOperands! ctx.raw)[1]! = (op.getOperands! ctx.raw)[1] from by grind]
+    exact hrval
+  have hlconf := VariableState.getVar?_conforms hlGetVar
+  rw [show lhs.getType! ctx.raw = ⟨.integerType intType, hLhsType ▸ (lhs.getType! ctx.raw).2⟩
+        from Subtype.ext hLhsType] at hlconf
+  obtain ⟨x, rfl⟩ := RuntimeValue.Conforms.integerType hlconf
+  have hrconf := VariableState.getVar?_conforms hrGetVar
+  rw [show rhs.getType! ctx.raw = ⟨.integerType intType, hRhsType ▸ (rhs.getType! ctx.raw).2⟩
+        from Subtype.ext hRhsType] at hrconf
+  obtain ⟨y, rfl⟩ := RuntimeValue.Conforms.integerType hrconf
+  refine ⟨x, y, hlGetVar, hrGetVar, ?_⟩
+  -- With the values in hand, unfold the interpretation of the matched op.
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues op
+      = some #[RuntimeValue.int intType.bitwidth x, RuntimeValue.int intType.bitwidth y] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    match i, hi with
+    | 0, _ => simpa [hOperand0] using hlGetVar
+    | 1, _ => simpa [hOperand1] using hrGetVar
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [← hProps, interpretOp'] at hInterp'
+  rw [hSemSrc] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ :
+      resValues = #[RuntimeValue.int intType.bitwidth (srcFn x y props)] ∧
+      mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  refine ⟨rfl, ?_, rfl⟩
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
+/-- Interpreting an `llvm.mlir.constant` with integer value attribute `intAttr` and integer
+    result type `intType` binds its result to the (never-poison) constant value. Applied at
+    `newState := state` this unfolds the `EquationHolds` fact of a matched constant. -/
+theorem constantOp_interpretOp_unfold {ctx : WfIRContext OpCode} {cstOp : OperationPtr}
+    {intAttr : IntegerAttr} {intType : IntegerType} {hIsTy}
+    {state newState : InterpreterState ctx} {cf} (inBounds : cstOp.InBounds ctx.raw)
+    (hOpType : cstOp.getOpType! ctx.raw = .llvm .mlir__constant)
+    (hNumResults : cstOp.getNumResults! ctx.raw = 1)
+    (hProps : (cstOp.getProperties! ctx.raw (.llvm .mlir__constant)).value = .integer intAttr)
+    (hResType : ((cstOp.getResult 0).get! ctx.raw).type = ⟨.integerType intType, hIsTy⟩)
+    (hinterp : interpretOp cstOp state inBounds = some (.ok (newState, cf))) :
+    newState.variables.getVar? (cstOp.getResult 0) =
+      some (RuntimeValue.int intType.bitwidth
+        (Data.LLVM.Int.constant intType.bitwidth intAttr.value)) := by
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues, resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  have hResTypes0 : (cstOp.getResultTypes! ctx.raw)[0]?
+      = some ⟨.integerType intType, hIsTy⟩ := by
+    have hsz : (cstOp.getResultTypes! ctx.raw).size = 1 := by
+      rw [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNumResults]
+    have helem := OperationPtr.getResultTypes!.getElem!_eq (op := cstOp) (ctx := ctx.raw)
+      (index := 0) (by omega)
+    rw [Array.getElem?_eq_getElem (by omega),
+      show (cstOp.getResultTypes! ctx.raw)[0] = (cstOp.getResultTypes! ctx.raw)[0]! from by grind,
+      helem, hResType]
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [interpretOp', Llvm.interpretOp', hResTypes0, hProps, pure, Interp] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ :
+      resValues = #[RuntimeValue.int intType.bitwidth
+        (Data.LLVM.Int.constant intType.bitwidth intAttr.value)] ∧
+      mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
+/-! ## The packaged graph lemma for `matchNot` -/
+
+set_option maxHeartbeats 1000000 in
+/-- Semantic content of a successful `matchNot v = some y` at a program point dominated by `v`:
+    in any source state satisfying `EquationLemmaAt` before `op` (with `v` an operand of `op`),
+    the runtime value of `v` is `xor yv (-1)` where `yv` is the runtime value of `y`. The
+    accompanying structural facts (type, dominance, in-bounds, not-a-result) are exactly what a
+    `PreservesSemantics` proof needs to read `y`'s refined value in the target state. -/
+theorem matchNot_getVar?_of_EquationLemmaAt {ctx : WfIRContext OpCode}
+    (ctxDom : ctx.Dom) (ctxVerif : ctx.Verified)
+    {op : OperationPtr} {opInBounds : op.InBounds ctx.raw}
+    {state : InterpreterState ctx}
+    (stateWf : state.EquationLemmaAt (InsertPoint.before op) (by grind))
+    {v y : ValuePtr} {intType : IntegerType}
+    (hMatch : matchNot v ctx.raw = some y)
+    (hOperand : v ∈ op.getOperands! ctx.raw)
+    (hVType : (v.getType! ctx.raw).val = Attribute.integerType intType) :
+    ∃ yv, state.variables.getVar? y = some (RuntimeValue.int intType.bitwidth yv) ∧
+      state.variables.getVar? v = some (RuntimeValue.int intType.bitwidth
+        (Data.LLVM.Int.xor yv (Data.LLVM.Int.constant intType.bitwidth (-1)))) ∧
+      (y.getType! ctx.raw).val = Attribute.integerType intType ∧
+      y.dominatesIp (InsertPoint.before op) ctx ∧
+      y.InBounds ctx.raw ∧
+      y ∉ op.getResults! ctx.raw := by
+  -- Syntactic facts from the match.
+  obtain ⟨vPtr, cst, cstAttr, rfl, hXori, hCstMatch, hCstVal⟩ := matchNot_implies hMatch
+  obtain ⟨hXorType, hXorNumResults, hXorOperands⟩ := matchXori_implies hXori
+  obtain ⟨cstPtr, rfl, hCstOp⟩ := matchConstantIntVal_implies hCstMatch
+  obtain ⟨hCstType, hCstProps⟩ := matchConstantIntOp_implies hCstOp
+  -- In-bounds facts for the two matched defining ops.
+  have hvIn : (ValuePtr.opResult vPtr).InBounds ctx.raw := by grind
+  have hXorOpIn : vPtr.op.InBounds ctx.raw := by grind [OpResultPtr.InBounds]
+  -- `v` is the unique result of the matched `xor`.
+  have hvIdx : vPtr.index < vPtr.op.getNumResults! ctx.raw := by
+    grind [OpResultPtr.inBounds_OperationPtr_getNumResults!]
+  have hvEq : vPtr = vPtr.op.getResult 0 := by
+    have hidx : vPtr.index = 0 := by omega
+    cases vPtr
+    simp only [OperationPtr.getResult, OpResultPtr.mk.injEq]
+    exact ⟨trivial, hidx⟩
+  -- The matched `xor` is a verified integer binop; extract its structural facts.
+  have hXorVerified : vPtr.op.Verified ctx hXorOpIn := by grind
+  obtain ⟨-, -, -, -, xorIntType, hXorResType, hXorOperand0Type, hXorOperand1Type⟩ :=
+    OperationPtr.Verified.llvm_xor hXorVerified hXorType
+  -- The binop's integer type is the type of `v`, i.e. `intType`.
+  have hVTypeEq : (ValuePtr.opResult vPtr).getType! ctx.raw
+      = ((vPtr.op.getResult 0).get! ctx.raw).type := by
+    rw [hvEq]; rfl
+  have hIntTypeEq : intType = xorIntType := by
+    rw [hVTypeEq, hXorResType] at hVType
+    grind
+  subst hIntTypeEq
+  -- Operand access: the `xor`'s operands are `y` and the constant.
+  have hyIdxEq : y = (vPtr.op.getOperands! ctx.raw)[0]! := by rw [hXorOperands]; rfl
+  have hCstIdxEq : ValuePtr.opResult cstPtr = (vPtr.op.getOperands! ctx.raw)[1]! := by
+    rw [hXorOperands]; rfl
+  have hXorOperand0 : vPtr.op.getOperand! ctx.raw 0 = y := by
+    rw [hyIdxEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hXorOperand1 : vPtr.op.getOperand! ctx.raw 1 = ValuePtr.opResult cstPtr := by
+    rw [hCstIdxEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hyType : (y.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hXorOperand0, hXorOperand0Type]
+  have hCstValType : ((ValuePtr.opResult cstPtr).getType! ctx.raw).val
+      = Attribute.integerType intType := by
+    rw [← hXorOperand1, hXorOperand1Type]
+  -- Dominance: the `xor` strictly dominates `op`, so it has been interpreted into `state`.
+  have hXorDefines : (ValuePtr.opResult vPtr).getDefiningOp! ctx.raw = some vPtr.op := by
+    have hOwner := (ctx.wellFormed.operations vPtr.op hXorOpIn).result_owner 0
+      (by grind)
+    grind [ValuePtr.getDefiningOp!]
+  have hXorSDom : vPtr.op.strictlyDominates op ctx :=
+    OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands! ctxDom
+      hXorDefines hOperand
+  have hXorDomIp : vPtr.op.dominatesIp (InsertPoint.before op) ctx := by
+    grind
+  have hXorPure : vPtr.op.Pure ctx.raw := OperationPtr.Pure.llvm_xor hXorType
+  obtain ⟨cfX, hInterpXor⟩ := stateWf vPtr.op hXorOpIn hXorPure hXorDomIp
+  -- Unfold the `xor`'s interpretation (`newState := state`).
+  obtain ⟨yv, cv, hyVal, hcVal, -, hXorResVal, -⟩ :=
+    matchBinaryOp_interpretOp_unfold (srcOp := .xor)
+      (srcFn := fun a b _ => Data.LLVM.Int.xor a b)
+      (props := vPtr.op.getProperties! ctx.raw (.llvm .xor))
+      hXorOpIn hXorType hXorNumResults hXorOperands rfl
+      (by intro bw a b props resultTypes blockOperands mem
+          simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure])
+      hInterpXor hyType hCstValType
+  -- The constant's structural facts.
+  have hCstIn : (ValuePtr.opResult cstPtr).InBounds ctx.raw := by
+    grind [OperationPtr.getOperands!]
+  have hCstOpIn : cstPtr.op.InBounds ctx.raw := by grind [OpResultPtr.InBounds]
+  have hCstVerified : cstPtr.op.Verified ctx hCstOpIn := by grind
+  obtain ⟨hCstNumResults, -, -, -⟩ :=
+    OperationPtr.Verified.llvm_mlir__constant hCstVerified hCstType
+  have hCstIdx : cstPtr.index < cstPtr.op.getNumResults! ctx.raw := by
+    grind [OpResultPtr.inBounds_OperationPtr_getNumResults!]
+  have hCstEq : cstPtr = cstPtr.op.getResult 0 := by
+    have hidx : cstPtr.index = 0 := by omega
+    cases cstPtr
+    simp only [OperationPtr.getResult, OpResultPtr.mk.injEq]
+    exact ⟨trivial, hidx⟩
+  have hCstResType : ((cstPtr.op.getResult 0).get! ctx.raw).type
+      = ⟨.integerType intType, by grind⟩ := by
+    have : ((ValuePtr.opResult cstPtr).getType! ctx.raw)
+        = ((cstPtr.op.getResult 0).get! ctx.raw).type := by
+      rw [hCstEq]; rfl
+    grind [Subtype.ext]
+  -- Dominance: the constant strictly dominates the `xor`, hence `op` (transitivity).
+  have hCstDefines : (ValuePtr.opResult cstPtr).getDefiningOp! ctx.raw = some cstPtr.op := by
+    have hOwner := (ctx.wellFormed.operations cstPtr.op hCstOpIn).result_owner 0
+      (by grind)
+    grind [ValuePtr.getDefiningOp!]
+  have hCstSDomXor : cstPtr.op.strictlyDominates vPtr.op ctx :=
+    OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands! ctxDom
+      hCstDefines (by grind [OperationPtr.getOperands!])
+  have hCstSDom : cstPtr.op.strictlyDominates op ctx :=
+    OperationPtr.strictlyDominates_trans hCstSDomXor hXorSDom
+  have hCstDomIp : cstPtr.op.dominatesIp (InsertPoint.before op) ctx := by
+    grind
+  have hCstPure : cstPtr.op.Pure ctx.raw := OperationPtr.Pure.llvm_mlir__constant hCstType
+  obtain ⟨cfC, hInterpCst⟩ := stateWf cstPtr.op hCstOpIn hCstPure hCstDomIp
+  -- Unfold the constant's interpretation: its result is the non-poison `-1`.
+  have hCstResVal :=
+    constantOp_interpretOp_unfold hCstOpIn hCstType hCstNumResults hCstProps hCstResType
+      hInterpCst
+  -- The two reads of the constant's value agree, pinning `cv`.
+  have hcvEq : cv = Data.LLVM.Int.constant intType.bitwidth cstAttr.value := by
+    rw [hCstEq] at hcVal
+    grind
+  -- Assemble.
+  refine ⟨yv, hyVal, ?_, hyType, ?_, ?_, ?_⟩
+  · rw [hvEq, hXorResVal, hcvEq, hCstVal]
+  · exact ValuePtr.dominatesIp_before_of_strictlyDominates
+      (ctxDom.operand_dominates_op hXorOpIn (by grind [OperationPtr.getOperands!])) hXorSDom
+  · grind [OperationPtr.getOperands!]
+  · exact IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom
+      (OperationPtr.dominates_of_strictlyDominates hXorSDom) y
+      (by grind [OperationPtr.getOperands!])
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
@@ -1,0 +1,378 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64Sdag
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonGraphLemmas
+
+namespace Veir
+
+/-!
+## Generic correctness of `lowerBinopNotLocal`
+
+`lowerBinopNotLocal match? dst props` lowers a two-operand LLVM integer op on `i64`, one of
+whose operands is a `not` (`xor _, -1`), to `unrealized_conversion_cast` ×2 (both operands to
+registers) → binary reg-reg `riscv` op `dst` → `unrealized_conversion_cast` (back to `i64`).
+Its `PreservesSemantics` proof is shared: instantiating it for a concrete lowering
+(`andn_local`, `orn_local`, `xnor_local`) only requires the matcher facts, the interpreter
+computation facts (discharged by `rfl`/`simp` at concrete opcodes), and the two data-level
+refinement lemmas (one per `not`-operand orientation).
+
+Unlike the unary lowerings, the pattern matches *through* a defining op (`matchNot`), so the
+proof is the first to use the `EquationLemmaAt` hypothesis of `PreservesSemantics`, via
+`matchNot_getVar?_of_EquationLemmaAt` (`CommonGraphLemmas.lean`).
+-/
+
+set_option maxHeartbeats 1600000 in
+/-- Shared correctness proof for every `lowerBinopNotLocal` lowering: the round trip
+    `int ×2 → reg ×2 → dst → int` refines `srcFn` applied to the matched op's operands, one of
+    which is semantically `xor y (-1)`.
+
+    Per-lowering inputs: the matcher's syntactic facts (`hMatchImplies`), the verifier facts
+    (`hVerified`), the interpreter computation facts for the source op and the riscv op
+    (`hSemSrc`/`hSemR`), and the two data-level refinement lemmas (`hRefineR` for
+    `srcOp x (not y)`, `hRefineL` for `srcOp (not y) x`). -/
+theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
+    {match? : OperationPtr → IRContext OpCode →
+      Option (ValuePtr × ValuePtr × propertiesOf (.llvm srcOp))}
+    {dst : Riscv} {props : propertiesOf (.riscv dst)}
+    {f : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg}
+    {srcFn : ∀ {bw : Nat},
+      Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) → Data.LLVM.Int bw}
+    (hMatchImplies : ∀ {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs props},
+        match? op ctx = some (lhs, rhs, props) →
+        op.getOpType! ctx = .llvm srcOp ∧
+        op.getNumResults! ctx = 1 ∧
+        op.getOperands! ctx = #[lhs, rhs] ∧
+        props = op.getProperties! ctx (.llvm srcOp))
+    (hVerified : ∀ {ctx : WfIRContext OpCode} {op : OperationPtr}
+        {opInBounds : op.InBounds ctx.raw},
+        op.Verified ctx opInBounds → op.getOpType! ctx.raw = .llvm srcOp →
+        op.IsVerifiedIntegerBinop ctx)
+    (hSemSrc : ∀ (bw : Nat) (x y : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw y] blockOperands mem
+          = some (.ok (#[.int bw (srcFn x y props)], mem, none)))
+    (hSemR : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf dst)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' dst props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f r₁ r₂)], mem, none)))
+    (hRefineR : ∀ (x y xt yt : Data.LLVM.Int 64) (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcFn x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) props
+          ⊒ RISCV.Reg.toInt (f (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)
+    (hRefineL : ∀ (x y xt yt : Data.LLVM.Int 64) (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcFn (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x props
+          ⊒ RISCV.Reg.toInt (f (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)
+    {h : LocalRewritePattern.ReturnOps (lowerBinopNotLocal match? dst props)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (lowerBinopNotLocal match? dst props)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds (lowerBinopNotLocal match? dst props)}
+    {h₄ : LocalRewritePattern.ReturnValues (lowerBinopNotLocal match? dst props)} :
+    LocalRewritePattern.PreservesSemantics (lowerBinopNotLocal match? dst props) h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, lowerBinopNotLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (match? op ctx.raw).isSome := by
+    cases hM : match? op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs, matchProps⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := hMatchImplies hMatch
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, intType, hResType, hOp0Type, hOp1Type⟩ :=
+    hVerified opVerif hOpType
+  -- Resolve the result-type destructuring match in the pattern.
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType :=
+    congrArg Subtype.val hResType
+  rw [hResTypeVal] at hpattern
+  simp only [] at hpattern
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition [hBw] hpattern
+  -- Both operands have the integer type `intType`.
+  have hLhsIdx : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsIdx : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsIdx]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsIdx]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand0, hOp0Type]
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand1, hOp1Type]
+  -- Unfold the interpretation of the matched op: exposes both operand values and `srcFn`.
+  obtain ⟨xlv, xrv, hlVal, hrVal, hMem, hRes, hCf⟩ :=
+    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands hProps hSemSrc
+      hinterp hLhsType hRhsType
+  subst hCf
+  -- Both matched operands dominate the rewrite point in the source context.
+  have hDomLhs : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomRhs : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- Source value: `op`'s single result is `srcFn` of its operands.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- The matched operands are not results of `op`.
+  have vNotOpLhs : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have vNotOpRhs : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Split on the `not`-operand orientation.
+  cases hNotR : matchNot rhs ctx.raw with
+  | some y =>
+    -- Case A: `op x (not y)` with `x := lhs`.
+    rw [hNotR] at hpattern
+    simp only [] at hpattern
+    -- Graph semantics of the matched `not`: pins `rhs`'s runtime value to `xor yv (-1)`.
+    obtain ⟨yv, hyVal, hrhsVal, hyType, hyDomCtx, hyIn, hyNotRes⟩ :=
+      matchNot_getVar?_of_EquationLemmaAt ctxDom ctxVerif stateWf hNotR
+        (by rw [hOperands]; simp) hRhsType
+    obtain rfl : xrv = Data.LLVM.Int.xor yv (Data.LLVM.Int.constant intType.bitwidth (-1)) := by
+      have := hrVal.symm.trans hrhsVal
+      simpa using this
+    -- Peel the four op creations (in program order), transporting the dominance facts of
+    -- `lhs` (via the macros) and `y` (manually) through each creation.
+    peelCastToRegLocal hpattern ctx₁ xCastOp hCastX hDomLhs hDomLhs₁
+    have hDomY₁ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastX
+      (by clear hpattern; grind) (by clear hpattern; grind)).mpr hyDomCtx
+    peelCastToRegLocal hpattern ctx₂ yCastOp hCastY hDomLhs₁ hDomLhs₂
+    have hDomY₂ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastY
+      (by clear hpattern; grind) (by clear hpattern; grind)).mpr hDomY₁
+    peelOpCreation! hpattern ctx₃ retOp hRet hDomLhs₂ hDomLhs₃
+    have hDomY₃ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hRet
+      (by clear hpattern; grind) (by clear hpattern; grind)).mpr hDomY₂
+    peelReplaceWithRegLocal hpattern ctx₄ castBackOp hCastBack hDomLhs₃ hDomLhs₄
+    have hDomY₄ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastBack
+      (by clear hpattern; grind) (by clear hpattern; grind)).mpr hDomY₃
+    cleanupHpattern hpattern
+    -- Read the refined values `xt` (of `lhs`) and `yt` (of `y`) in the target state `state'`.
+    obtain ⟨xt, hXVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hlVal
+        hDomLhs hDomLhs₄ vNotOpLhs
+    obtain ⟨yt, hYVal', hytRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hyIn hyVal
+        hyDomCtx hDomY₄ hyNotRes
+    -- Normalise the bitwidth to the literal `64`.
+    obtain ⟨bw⟩ := intType; simp only at hBw
+    obtain rfl : bw = 64 := by omega
+    -- Structural facts about the four created ops.
+    have hCastXType : xCastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hCastYType : yCastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hRetType : retOp.getOpType! ctx₄.raw = .riscv dst := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hCastXOperands : xCastOp.getOperands! ctx₄.raw = #[lhs] := by grind
+    have hCastYOperands : yCastOp.getOperands! ctx₄.raw = #[y] := by grind
+    have hRetOperands : retOp.getOperands! ctx₄.raw
+        = #[ValuePtr.opResult (xCastOp.getResult 0), ValuePtr.opResult (yCastOp.getResult 0)] := by
+      grind
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+    -- The cast-back op's result type is `i64`.
+    have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+        = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hCastX
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hCastY
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hRet
+            (value := ValuePtr.opResult (op.getResult 0))]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastXResTypes : xCastOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastX (operation := xCastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastY (operation := xCastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := xCastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := xCastOp)]
+    have hCastYResTypes : yCastOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastY (operation := yCastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := yCastOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := yCastOp)]
+    have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+    -- Freshness facts for the frame clauses.
+    have hyNotXCast : y ∉ xCastOp.getResults! ctx₄.raw :=
+      ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hyIn (by clear hyIn; grind)
+    have hXCastNotYCast :
+        ValuePtr.opResult (xCastOp.getResult 0) ∉ yCastOp.getResults! ctx₄.raw :=
+      ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds (ctx := ctx₁.raw)
+        (by grind [ValuePtr.InBounds, OpResultPtr.InBounds]) (by grind)
+    -- Interpretation tail: execute
+    -- `interpretOpList [xCastOp, yCastOp, retOp, castBackOp]` in `state'`.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        hCastXType hCastXOperands hCastXResTypes hXVal'
+    have hYVal₁ : s₁.variables.getVar? y = some (RuntimeValue.int 64 yt) := by
+      rw [hFrame₁ y hyNotXCast]; exact hYVal'
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+      interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+        hCastYType hCastYOperands hCastYResTypes hYVal₁
+    have hRes₁' : s₂.variables.getVar? (ValuePtr.opResult (xCastOp.getResult 0))
+        = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+      rw [hFrame₂ _ hXCastNotYCast]; exact hRes₁
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+      interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+        (f := f) (hSemR _ _) hRetType hRetOperands hRetResTypes hRes₁' hRes₂
+    obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+      interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+        hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+    refine ⟨s₄, ?_, by grind, ?_⟩
+    · -- The list interpretation is the chain of the four op interpretations.
+      simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+        Interp]
+    · refine ⟨#[RuntimeValue.int 64
+          (RISCV.Reg.toInt (f (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)], ?_, ?_⟩
+      · simp [hRes₄, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using hRefineR xlv yv xt yt matchProps hxtRef hytRef⟩
+  | none =>
+    -- Case B: `op (not y) x` with `x := rhs`.
+    rw [hNotR] at hpattern
+    cases hNotL : matchNot lhs ctx.raw with
+    | none => rw [hNotL] at hpattern; simp at hpattern
+    | some y =>
+      rw [hNotL] at hpattern
+      simp only [] at hpattern
+      -- Graph semantics of the matched `not`: pins `lhs`'s runtime value to `xor yv (-1)`.
+      obtain ⟨yv, hyVal, hlhsVal, hyType, hyDomCtx, hyIn, hyNotRes⟩ :=
+        matchNot_getVar?_of_EquationLemmaAt ctxDom ctxVerif stateWf hNotL
+          (by rw [hOperands]; simp) hLhsType
+      obtain rfl : xlv = Data.LLVM.Int.xor yv (Data.LLVM.Int.constant intType.bitwidth (-1)) := by
+        have := hlVal.symm.trans hlhsVal
+        simpa using this
+      -- Peel the four op creations, transporting the dominance facts of `rhs` and `y`.
+      peelCastToRegLocal hpattern ctx₁ xCastOp hCastX hDomRhs hDomRhs₁
+      have hDomY₁ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastX
+        (by clear hpattern; grind) (by clear hpattern; grind)).mpr hyDomCtx
+      peelCastToRegLocal hpattern ctx₂ yCastOp hCastY hDomRhs₁ hDomRhs₂
+      have hDomY₂ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastY
+        (by clear hpattern; grind) (by clear hpattern; grind)).mpr hDomY₁
+      peelOpCreation! hpattern ctx₃ retOp hRet hDomRhs₂ hDomRhs₃
+      have hDomY₃ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hRet
+        (by clear hpattern; grind) (by clear hpattern; grind)).mpr hDomY₂
+      peelReplaceWithRegLocal hpattern ctx₄ castBackOp hCastBack hDomRhs₃ hDomRhs₄
+      have hDomY₄ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastBack
+        (by clear hpattern; grind) (by clear hpattern; grind)).mpr hDomY₃
+      cleanupHpattern hpattern
+      -- Read the refined values `xt` (of `rhs`) and `yt` (of `y`) in the target state `state'`.
+      obtain ⟨xt, hXVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hrVal
+          hDomRhs hDomRhs₄ vNotOpRhs
+      obtain ⟨yt, hYVal', hytRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hyIn hyVal
+          hyDomCtx hDomY₄ hyNotRes
+      -- Normalise the bitwidth to the literal `64`.
+      obtain ⟨bw⟩ := intType; simp only at hBw
+      obtain rfl : bw = 64 := by omega
+      -- Structural facts about the four created ops.
+      have hCastXType : xCastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hCastYType : yCastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRetType : retOp.getOpType! ctx₄.raw = .riscv dst := by grind
+      have hCastBackType :
+          castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hCastXOperands : xCastOp.getOperands! ctx₄.raw = #[rhs] := by grind
+      have hCastYOperands : yCastOp.getOperands! ctx₄.raw = #[y] := by grind
+      have hRetOperands : retOp.getOperands! ctx₄.raw
+          = #[ValuePtr.opResult (xCastOp.getResult 0),
+              ValuePtr.opResult (yCastOp.getResult 0)] := by
+        grind
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+      -- The cast-back op's result type is `i64`.
+      have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+          = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+        have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+            = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+          grind [ValuePtr.getType!_WfRewriter_createOp hCastX
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hCastY
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hRet
+              (value := ValuePtr.opResult (op.getResult 0))]
+        simpa only [ValuePtr.getType!_opResult, hResType] using h1
+      have hCastXResTypes : xCastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastX (operation := xCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastY (operation := xCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := xCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := xCastOp)]
+      have hCastYResTypes : yCastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastY (operation := yCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := yCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := yCastOp)]
+      have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp)]
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+      -- Freshness facts for the frame clauses.
+      have hyNotXCast : y ∉ xCastOp.getResults! ctx₄.raw :=
+        ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hyIn (by clear hyIn; grind)
+      have hXCastNotYCast :
+          ValuePtr.opResult (xCastOp.getResult 0) ∉ yCastOp.getResults! ctx₄.raw :=
+        ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds (ctx := ctx₁.raw)
+          (by grind [ValuePtr.InBounds, OpResultPtr.InBounds]) (by grind)
+      -- Interpretation tail: execute
+      -- `interpretOpList [xCastOp, yCastOp, retOp, castBackOp]` in `state'`.
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+        interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+          hCastXType hCastXOperands hCastXResTypes hXVal'
+      have hYVal₁ : s₁.variables.getVar? y = some (RuntimeValue.int 64 yt) := by
+        rw [hFrame₁ y hyNotXCast]; exact hYVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+        interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+          hCastYType hCastYOperands hCastYResTypes hYVal₁
+      have hRes₁' : s₂.variables.getVar? (ValuePtr.opResult (xCastOp.getResult 0))
+          = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+        rw [hFrame₂ _ hXCastNotYCast]; exact hRes₁
+      obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+        interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+          (f := f) (hSemR _ _) hRetType hRetOperands hRetResTypes hRes₁' hRes₂
+      obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+        interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+      refine ⟨s₄, ?_, by grind, ?_⟩
+      · -- The list interpretation is the chain of the four op interpretations.
+        simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+          Interp]
+      · refine ⟨#[RuntimeValue.int 64
+            (RISCV.Reg.toInt (f (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)], ?_, ?_⟩
+        · simp [hRes₄, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+            ⟨rfl, by simpa using hRefineL xrv yv xt yt matchProps hxtRef hytRef⟩
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
@@ -97,12 +97,14 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
   have ⟨hNRes, hNOper, hNSucc, hNReg, intType, hResType, hOp0Type, hOp1Type⟩ :=
     hVerified opVerif hOpType
   -- Resolve the result-type destructuring match in the pattern.
-  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType :=
-    congrArg Subtype.val hResType
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    rw [hResType]
   rw [hResTypeVal] at hpattern
   simp only [] at hpattern
   -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
-  peelSplittableCondition [hBw] hpattern
+  split at hpattern
+  case isFalse hne => simp at hpattern
+  rename_i hBw
   -- Both operands have the integer type `intType`.
   have hLhsIdx : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
   have hRhsIdx : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
@@ -145,7 +147,7 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
     simp only [] at hpattern
     -- Graph semantics of the matched `not`: pins `rhs`'s runtime value to `xor yv (-1)`.
     obtain ⟨yv, hyVal, hrhsVal, hyType, hyDomCtx, hyIn, hyNotRes⟩ :=
-      matchNot_getVar?_of_EquationLemmaAt ctxDom ctxVerif stateWf hNotR
+      matchNot_getVar?_of_EquationLemmaAt ctxDom ctxVerif opInBounds stateWf hNotR
         (by rw [hOperands]; simp) hRhsType
     obtain rfl : xrv = Data.LLVM.Int.xor yv (Data.LLVM.Int.constant intType.bitwidth (-1)) := by
       have := hrVal.symm.trans hrhsVal
@@ -174,7 +176,7 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
         hyDomCtx hDomY₄ hyNotRes
     -- Normalise the bitwidth to the literal `64`.
     obtain ⟨bw⟩ := intType; simp only at hBw
-    obtain rfl : bw = 64 := by omega
+    subst hBw
     -- Structural facts about the four created ops.
     have hCastXType : xCastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
       grind
@@ -183,11 +185,19 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
     have hRetType : retOp.getOpType! ctx₄.raw = .riscv dst := by grind
     have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
       grind
-    have hCastXOperands : xCastOp.getOperands! ctx₄.raw = #[lhs] := by grind
-    have hCastYOperands : yCastOp.getOperands! ctx₄.raw = #[y] := by grind
+    have hCastXOperands : xCastOp.getOperands! ctx₄.raw = #[lhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hCastX (operation := xCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastY (operation := xCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := xCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := xCastOp)]
+    have hCastYOperands : yCastOp.getOperands! ctx₄.raw = #[y] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hCastY (operation := yCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := yCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := yCastOp)]
     have hRetOperands : retOp.getOperands! ctx₄.raw
         = #[ValuePtr.opResult (xCastOp.getResult 0), ValuePtr.opResult (yCastOp.getResult 0)] := by
-      grind
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
     have hCastBackOperands :
         castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
     -- The cast-back op's result type is `i64`.
@@ -221,11 +231,13 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
         = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
     -- Freshness facts for the frame clauses.
     have hyNotXCast : y ∉ xCastOp.getResults! ctx₄.raw :=
-      ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hyIn (by clear hyIn; grind)
+      ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hyIn (by grind)
     have hXCastNotYCast :
         ValuePtr.opResult (xCastOp.getResult 0) ∉ yCastOp.getResults! ctx₄.raw :=
       ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds (ctx := ctx₁.raw)
-        (by grind [ValuePtr.InBounds, OpResultPtr.InBounds]) (by grind)
+        (by grind [ValuePtr.InBounds, OpResultPtr.InBounds,
+          OperationPtr.getNumResults!_WfRewriter_createOp hCastX (operation := xCastOp)])
+        (by grind)
     -- Interpretation tail: execute
     -- `interpretOpList [xCastOp, yCastOp, retOp, castBackOp]` in `state'`.
     obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
@@ -264,7 +276,7 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
       simp only [] at hpattern
       -- Graph semantics of the matched `not`: pins `lhs`'s runtime value to `xor yv (-1)`.
       obtain ⟨yv, hyVal, hlhsVal, hyType, hyDomCtx, hyIn, hyNotRes⟩ :=
-        matchNot_getVar?_of_EquationLemmaAt ctxDom ctxVerif stateWf hNotL
+        matchNot_getVar?_of_EquationLemmaAt ctxDom ctxVerif opInBounds stateWf hNotL
           (by rw [hOperands]; simp) hLhsType
       obtain rfl : xlv = Data.LLVM.Int.xor yv (Data.LLVM.Int.constant intType.bitwidth (-1)) := by
         have := hlVal.symm.trans hlhsVal
@@ -292,7 +304,7 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
           hyDomCtx hDomY₄ hyNotRes
       -- Normalise the bitwidth to the literal `64`.
       obtain ⟨bw⟩ := intType; simp only at hBw
-      obtain rfl : bw = 64 := by omega
+      subst hBw
       -- Structural facts about the four created ops.
       have hCastXType : xCastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
         grind
@@ -302,12 +314,20 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
       have hCastBackType :
           castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
         grind
-      have hCastXOperands : xCastOp.getOperands! ctx₄.raw = #[rhs] := by grind
-      have hCastYOperands : yCastOp.getOperands! ctx₄.raw = #[y] := by grind
+      have hCastXOperands : xCastOp.getOperands! ctx₄.raw = #[rhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hCastX (operation := xCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastY (operation := xCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := xCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := xCastOp)]
+      have hCastYOperands : yCastOp.getOperands! ctx₄.raw = #[y] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hCastY (operation := yCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := yCastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := yCastOp)]
       have hRetOperands : retOp.getOperands! ctx₄.raw
           = #[ValuePtr.opResult (xCastOp.getResult 0),
               ValuePtr.opResult (yCastOp.getResult 0)] := by
-        grind
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
       have hCastBackOperands :
           castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
       -- The cast-back op's result type is `i64`.
@@ -341,11 +361,13 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
           = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
       -- Freshness facts for the frame clauses.
       have hyNotXCast : y ∉ xCastOp.getResults! ctx₄.raw :=
-        ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hyIn (by clear hyIn; grind)
+        ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hyIn (by grind)
       have hXCastNotYCast :
           ValuePtr.opResult (xCastOp.getResult 0) ∉ yCastOp.getResults! ctx₄.raw :=
         ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds (ctx := ctx₁.raw)
-          (by grind [ValuePtr.InBounds, OpResultPtr.InBounds]) (by grind)
+          (by grind [ValuePtr.InBounds, OpResultPtr.InBounds,
+          OperationPtr.getNumResults!_WfRewriter_createOp hCastX (operation := xCastOp)])
+        (by grind)
       -- Interpretation tail: execute
       -- `interpretOpList [xCastOp, yCastOp, retOp, castBackOp]` in `state'`.
       obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
@@ -374,5 +396,237 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
         · simp [hRes₄, Option.bind, Option.map]
         · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
             ⟨rfl, by simpa using hRefineL xrv yv xt yt matchProps hxtRef hytRef⟩
+
+/-!
+## RISC-V lowering of `and x (not y)` (`riscv.andn`)
+
+The structural part of the proof is shared (`lowerBinopNotLocal_preservesSemantics`); only the
+two data-level refinement lemmas below (one per `not`-operand orientation) are `andn`-specific,
+and similarly for `orn`/`xnor` further down.
+-/
+
+/-- Correctness of the `riscv.andn` lowering of `and x (not y)`: the round trip
+    `int ×2 → reg ×2 → andn → int` refines `and x (xor y (-1))`. (`xt`/`yt` are the
+    possibly-more-defined target-side values of the operands.) -/
+theorem and_not_isRefinedBy_toInt_andn {x y xt yt : Data.LLVM.Int 64}
+    (hx : x ⊒ xt) (hy : y ⊒ yt) :
+    Data.LLVM.Int.and x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1)))
+      ⊒ RISCV.Reg.toInt (Data.RISCV.andn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
+  obtain ⟨hxp, hxv⟩ := hx
+  obtain ⟨hyp, hyv⟩ := hy
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hynp : y.isPoison = false := by grind
+  have hxvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  have hyvd : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.andn]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.andn` lowering of `and (not y) x` (the `not` on the left). -/
+theorem not_and_isRefinedBy_toInt_andn {x y xt yt : Data.LLVM.Int 64}
+    (hx : x ⊒ xt) (hy : y ⊒ yt) :
+    Data.LLVM.Int.and (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x
+      ⊒ RISCV.Reg.toInt (Data.RISCV.andn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
+  obtain ⟨hxp, hxv⟩ := hx
+  obtain ⟨hyp, hyv⟩ := hy
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hynp : y.isPoison = false := by grind
+  have hxvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  have hyvd : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.andn]
+  veir_bv_decide
+
+theorem andn_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics andn_local h h₂ h₃ h₄ :=
+  lowerBinopNotLocal_preservesSemantics
+    (srcOp := .and)
+    (srcFn := fun x y _ => Data.LLVM.Int.and x y)
+    (f := fun r₁ r₂ => Data.RISCV.andn r₂ r₁)
+    matchAnd_implies
+    OperationPtr.Verified.llvm_and
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ hx hy => and_not_isRefinedBy_toInt_andn hx hy)
+    (fun _ _ _ _ _ hx hy => not_and_isRefinedBy_toInt_andn hx hy)
+
+/--
+info: 'Veir.andn_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ OperationPtr.strictlyDominates_trans,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ ValuePtr.dominatesIp_before_of_strictlyDominates,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ and_not_isRefinedBy_toInt_andn._native.bv_decide.ax_1_13,
+ not_and_isRefinedBy_toInt_andn._native.bv_decide.ax_1_13,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms andn_local_preservesSemantics
+
+/-! ## RISC-V lowering of `or x (not y)` (`riscv.orn`) -/
+
+/-- Correctness of the `riscv.orn` lowering of `or x (not y)` (any `disjoint` flag): the round
+    trip `int ×2 → reg ×2 → orn → int` refines `or x (xor y (-1))`. -/
+theorem or_not_isRefinedBy_toInt_orn {x y xt yt : Data.LLVM.Int 64} (disjoint : Bool)
+    (hx : x ⊒ xt) (hy : y ⊒ yt) :
+    Data.LLVM.Int.or x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) disjoint
+      ⊒ RISCV.Reg.toInt (Data.RISCV.orn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
+  obtain ⟨hxp, hxv⟩ := hx
+  obtain ⟨hyp, hyv⟩ := hy
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hynp : y.isPoison = false := by grind
+  have hxvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  have hyvd : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.orn]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.orn` lowering of `or (not y) x` (the `not` on the left). -/
+theorem not_or_isRefinedBy_toInt_orn {x y xt yt : Data.LLVM.Int 64} (disjoint : Bool)
+    (hx : x ⊒ xt) (hy : y ⊒ yt) :
+    Data.LLVM.Int.or (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x disjoint
+      ⊒ RISCV.Reg.toInt (Data.RISCV.orn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
+  obtain ⟨hxp, hxv⟩ := hx
+  obtain ⟨hyp, hyv⟩ := hy
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hynp : y.isPoison = false := by grind
+  have hxvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  have hyvd : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.orn]
+  veir_bv_decide
+
+theorem orn_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics orn_local h h₂ h₃ h₄ :=
+  lowerBinopNotLocal_preservesSemantics
+    (srcOp := .or)
+    (srcFn := fun x y props => Data.LLVM.Int.or x y props.disjoint)
+    (f := fun r₁ r₂ => Data.RISCV.orn r₂ r₁)
+    matchOr_implies
+    OperationPtr.Verified.llvm_or
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props hx hy => or_not_isRefinedBy_toInt_orn props.disjoint hx hy)
+    (fun _ _ _ _ props hx hy => not_or_isRefinedBy_toInt_orn props.disjoint hx hy)
+
+/--
+info: 'Veir.orn_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ OperationPtr.strictlyDominates_trans,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ ValuePtr.dominatesIp_before_of_strictlyDominates,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ not_or_isRefinedBy_toInt_orn._native.bv_decide.ax_1_15,
+ or_not_isRefinedBy_toInt_orn._native.bv_decide.ax_1_15,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms orn_local_preservesSemantics
+
+/-! ## RISC-V lowering of `xor x (not y)` (`riscv.xnor`) -/
+
+/-- Correctness of the `riscv.xnor` lowering of `xor x (not y)`: the round trip
+    `int ×2 → reg ×2 → xnor → int` refines `xor x (xor y (-1))`. -/
+theorem xor_not_isRefinedBy_toInt_xnor {x y xt yt : Data.LLVM.Int 64}
+    (hx : x ⊒ xt) (hy : y ⊒ yt) :
+    Data.LLVM.Int.xor x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1)))
+      ⊒ RISCV.Reg.toInt (Data.RISCV.xnor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
+  obtain ⟨hxp, hxv⟩ := hx
+  obtain ⟨hyp, hyv⟩ := hy
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hynp : y.isPoison = false := by grind
+  have hxvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  have hyvd : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.xnor]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.xnor` lowering of `xor (not y) x` (the `not` on the left). -/
+theorem not_xor_isRefinedBy_toInt_xnor {x y xt yt : Data.LLVM.Int 64}
+    (hx : x ⊒ xt) (hy : y ⊒ yt) :
+    Data.LLVM.Int.xor (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x
+      ⊒ RISCV.Reg.toInt (Data.RISCV.xnor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
+  obtain ⟨hxp, hxv⟩ := hx
+  obtain ⟨hyp, hyv⟩ := hy
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by grind
+  have hynp : y.isPoison = false := by grind
+  have hxvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  have hyvd : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.xnor]
+  veir_bv_decide
+
+theorem xnor_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics xnor_local h h₂ h₃ h₄ :=
+  lowerBinopNotLocal_preservesSemantics
+    (srcOp := .xor)
+    (srcFn := fun x y _ => Data.LLVM.Int.xor x y)
+    (f := fun r₁ r₂ => Data.RISCV.xnor r₂ r₁)
+    matchXor_implies
+    OperationPtr.Verified.llvm_xor
+    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure])
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ hx hy => xor_not_isRefinedBy_toInt_xnor hx hy)
+    (fun _ _ _ _ _ hx hy => not_xor_isRefinedBy_toInt_xnor hx hy)
+
+/--
+info: 'Veir.xnor_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ OperationPtr.strictlyDominates_trans,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ ValuePtr.dominatesIp_before_of_strictlyDominates,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ not_xor_isRefinedBy_toInt_xnor._native.bv_decide.ax_1_13,
+ xor_not_isRefinedBy_toInt_xnor._native.bv_decide.ax_1_13,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms xnor_local_preservesSemantics
 
 end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -2,7 +2,9 @@
 
 This document describes the proof strategy used for the `lowerUnaryWLocal` lowerings
 (`ctlz_local`, `cttz_local`, `ctpop_local` in `Veir/Passes/InstructionSelection/RISCV64.lean`)
-and how to extend it to the other `*_local` lowerings (`add_local`, `and_local`, `bswap_local`, …).
+and the `lowerBinopNotLocal` lowerings (`andn_local`, `orn_local`, `xnor_local` in
+`Veir/Passes/InstructionSelection/RISCV64Sdag.lean`), and how to extend it to the other
+`*_local` lowerings (`add_local`, `bswap_local`, `selectBinopImmLocal`, …).
 
 ## What we prove
 
@@ -32,6 +34,13 @@ structural proof is done **once per combinator**. Currently:
   on `i64`/`i32`, then emit `castToRegLocal` → `op64` (or its `W` variant `op32` for `i32`) →
   `replaceWithRegLocal`. Its shared correctness proof is
   `lowerUnaryWLocal_preservesSemantics` (`RewriteProofs/LowerUnaryW.lean`).
+- `lowerBinopNotLocal match? dst props` (`RISCV64Sdag.lean`) — match a two-operand LLVM integer
+  op on `i64` one of whose operands is a `not` (`xor _, -1`, via `matchNot`, on either side),
+  then emit `castToRegLocal` ×2 → binary reg-reg `dst` → `replaceWithRegLocal`. Its shared
+  correctness proof is `lowerBinopNotLocal_preservesSemantics`
+  (`RewriteProofs/LowerBinopNot.lean`). This is the first *DAG-matching* proof: it recovers the
+  runtime value of the matched `not` from the `EquationLemmaAt` hypothesis (see
+  "Matched-subgraph semantics" below).
 
 The generic theorem is parameterized over everything opcode-specific:
 
@@ -114,6 +123,30 @@ syntactically — op type, number of results, `getOperands! = #[operand…]`, an
 equation. These exist for most matchers already; if one is missing, copy an existing one
 (the proof is `simp only [matchFoo, bind, Option.bind, pure]` + `grind`).
 
+### Layer 3 — Matched-subgraph semantics (per *matcher*, only for DAG-matching patterns)
+
+Patterns that inspect an operand's *defining op* (`matchNot`, `matchConstantIntVal`,
+`getDefiningOp` + `matchShl`/…) match more than the interpreted op, so their proofs need the
+*runtime* value of the matched subgraph, not just syntax. `PreservesSemantics` provides exactly
+the needed invariant: `state.EquationLemmaAt (InsertPoint.before op)` says every *pure* op
+dominating the match point has already been interpreted consistently into the source state.
+`RewriteProofs/CommonGraphLemmas.lean` packages this per matcher:
+
+- `OperationPtr.Pure.llvm_xor` / `.llvm_mlir__constant` — per-opcode purity facts (needed to
+  invoke `EquationLemmaAt`; one short `split`/`simp` proof per opcode);
+- `matchBinaryOp_interpretOp_unfold` / `constantOp_interpretOp_unfold` — unfold one successful
+  `interpretOp` of the given shape into its result bindings; applied at `newState := state`
+  they unfold an `EquationHolds` fact;
+- `matchNot_getVar?_of_EquationLemmaAt` — the packaged lemma: a successful `matchNot v = some y`
+  with `v` an operand of `op` yields `getVar? v = xor yv (-1)` where `yv` is `y`'s value, plus
+  the structural side conditions (`y`'s type, dominance at `before op`, in-bounds,
+  not-a-result-of-`op`) that `exists_refined_int_getVar?` needs.
+
+A new matcher (e.g. `matchConstantIntVal` for the immediate-selection patterns) gets one such
+lemma, built the same way: syntactic facts from the `match*_implies` lemma, dominance of the
+defining op via `strictlyDominates_of_getDefiningOp!_of_mem_getOperands!` (plus
+`strictlyDominates_trans` for deeper chains), purity, then `EquationHolds` unfolding.
+
 ## The shared machinery (already written, reused by every combinator proof)
 
 ### Source-interpretation unfolding
@@ -130,8 +163,10 @@ the matcher's syntactic facts, the `hSemSrc` computation fact, and a successful
 The operand value is *derived* inside the lemma — from `interpretOp_some_iff`, the matcher's
 `getOperands!` fact, and `VariableState.getVar?_conforms` + the operand's integer type
 (`RuntimeValue.Conforms.integerType` turns "conforms to `i{bw}`" into "`= .int bw x`") — so
-callers don't have to supply it. A binop combinator will need a binop analogue exposing two
-existentials, using two `Array.exists_mapM_option_eq_some_iff` reads (indices 0 and 1).
+callers don't have to supply it. The binop analogue is `matchBinaryOp_interpretOp_unfold`
+(`CommonGraphLemmas.lean`), exposing two existentials via two
+`Array.exists_mapM_option_eq_some_iff` reads (indices 0 and 1); it doubles as the
+`EquationHolds` unfolder for matched defining binops (Layer 3).
 
 ### Forward lemmas for the emitted ops
 
@@ -143,16 +178,25 @@ the generic `interpretOp_forward` (`Veir/Interpreter/Lemmas.lean`):
 - `interpretOp_riscv_unaryReg_forward` — **generic over the RISC-V opcode**: any unary
   reg-to-reg op whose `Riscv.interpretOp'` maps `.reg r` to `.reg (f r)` (hypothesis `hSem`,
   discharged by `rfl` at each concrete opcode). Covers `clz`/`clzw`/`ctz`/`ctzw`/`cpop`/`cpopw`
-  and any future unary Zbb op with **no new lemma needed**.
+  and any future unary Zbb op with **no new lemma needed**;
+- `interpretOp_riscv_binaryReg_forward` — the binary analogue: `.reg r₁, .reg r₂` ↦
+  `.reg (f r₁ r₂)`, two operand hypotheses. Covers `andn`/`orn`/`xnor` and any future binary
+  reg-reg op (`add`/`sub`/`max`/…) with no new lemma needed. Beware the interpreter's operand
+  order: `Riscv.interpretOp'` maps `[op1, op2]` to e.g. `RISCV.andn op2 op1`, so at
+  instantiation `f := fun r₁ r₂ => RISCV.andn r₂ r₁`.
 
 Each lemma's conclusion gives the successful one-step interpretation, memory unchanged, the
 result binding, and a **frame clause** (all non-result variables unchanged). The frame clause
-is what lets facts about earlier values survive to later ops in the chain — essential for
-binops (see below). New emitted-op *shapes* (binary reg ops, ops with immediates) need one new
+is what lets facts about earlier values survive to later ops in the chain — see the two-cast
+prefix of `lowerBinopNotLocal_preservesSemantics`, where the second cast's frame keeps the
+first cast's result binding and the first cast's frame keeps `y`'s value; the membership side
+conditions (`y ∉ xCastOp.getResults!`, `xCastOp.getResult 0 ∉ yCastOp.getResults!`) are
+discharged by `ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds`
+(`CommonBaseLemmas.lean`): a value existing *before* a `createOp` is never a result of the
+freshly created op. New emitted-op *shapes* (ops with immediates, `li`) need one new
 specialization each — ~20 lines of boilerplate: instantiate `interpretOp_forward` with explicit
 `vals := #[…]`, `results := #[…]`, `mem' := state.memory`, and discharge the three obligations
-with the same `simp` scripts as the existing ones. Binop variants take two operand hypotheses
-and `vals := #[.reg r₁, .reg r₂]`.
+with the same `simp` scripts as the existing ones.
 
 ### Peel tactics
 
@@ -193,6 +237,11 @@ namespace of `LowerUnaryW.lean`:
 5. **Axiom check**: `#guard_msgs in #print axioms foo_local_preservesSemantics` to pin the
    axiom footprint.
 
+**If it fits `lowerBinopNotLocal`** (two integer operands with a `not` on one side, one binary
+reg-to-reg RISC-V op at `i64`): same steps against `lowerBinopNotLocal_preservesSemantics` in
+`LowerBinopNot.lean`, with *two* Layer-0 lemmas (one per `not`-operand orientation; mind the
+riscv operand order, see the forward-lemma note above).
+
 **If it needs a new shape** (binop, longer chain, extra guards): first factor the lowering
 through a new combinator in `RISCV64.lean`, then prove that combinator's
 `PreservesSemantics` once, generic over the opcode-specific parameters, following
@@ -206,13 +255,16 @@ per lowering as above.
 
 ## Adapting to other lowering shapes
 
-- **Binops** (`add_local`, `and_local`, `mul_local`, …): two `castToRegLocal` peels, two
-  `exists_refined_int_getVar?` reads, two "operand is not a result of `op`" facts, a binop
-  analogue of `matchUnaryOp_interpretOp_unfold`, and a binop reg-to-reg forward lemma.
-  Crucially, when executing the chain, the value of the *first* cast's result must survive the
-  *second* cast's interpretation: keep the **frame clause** of the forward lemma (bind it as
-  `hFrame` instead of discarding with `-`) and rewrite the earlier result binding through it
-  before feeding the RISC-V op's forward lemma.
+- **Binops** (`add_local`, `mul_local`, …): everything needed is now in place — the binop
+  unfold lemma, the binary reg-reg forward lemma, and the frame-clause plumbing are all
+  demonstrated by `lowerBinopNotLocal_preservesSemantics`, which is the template to follow
+  (it is a plain binop proof plus one `matchNot` graph read). A plain binop combinator's proof
+  is that proof minus the `matchNot`/orientation parts.
+- **DAG-matching patterns** (`selectBinopImmLocal`, `bexti_local`, `orcb_local`, …): each
+  matcher applied to a *defining op* needs one Layer-3 lemma
+  (`match*_getVar?_of_EquationLemmaAt` style, see `matchNot_getVar?_of_EquationLemmaAt`);
+  constants additionally reuse `constantOp_interpretOp_unfold` and
+  `OperationPtr.Pure.llvm_mlir__constant` as-is.
 - **Longer chains** (`bswap_local` 32-bit emits `cast, rev8, srli, castBack`): one extra
   `peelOpCreation!` and one extra forward-lemma application per op; ops with an immediate
   (`srli`) need their forward lemma to take the properties (`RISCVImmediateProperties`) into
@@ -244,23 +296,40 @@ per lowering as above.
 - **Expected axioms**: `#print axioms` will list the dominance axioms
   (`OperationPtr.dominates*`, `ValuePtr.dominatesIp*`,
   `IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates`,
-  `ValuePtr.dominatesIp_before_WfRewriter_createOp`),
+  `ValuePtr.dominatesIp_before_WfRewriter_createOp`; DAG-matching proofs add
+  `OperationPtr.strictlyDominates_trans` and
+  `ValuePtr.dominatesIp_before_of_strictlyDominates`),
   `OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants`, `floatEqOfToBitsEq`,
   and a `…bv_decide.ax_…` native axiom per `bv_decide`/`veir_bv_decide` use (including
   `MemoryState.llvmLoad._native.bv_decide.ax_8` pulled in by the interpreter) — that's the
-  accepted baseline, pin it with `#guard_msgs`.
+  accepted baseline, pin it with `#guard_msgs` (see the end of `LowerBinopNot.lean`).
+- **Un-inferable implicits in packaged lemmas**: hypotheses whose only mention of a variable is
+  inside a `(by grind)` default argument (e.g. `opInBounds` in
+  `matchNot_getVar?_of_EquationLemmaAt`) must be *explicit* — unification cannot recover them
+  from proof terms at the call site.
+- **`simp` swaps negated `if` branches**: the initial `simp … at hpattern` applies
+  `ne_eq`/`ite_not`, so a source-level `if t.bitwidth ≠ 64 then bail else continue` becomes
+  `if t.bitwidth = 64 then continue else bail` — split it with
+  `split at hpattern; case isFalse hne => simp at hpattern` and `rename_i hBw`, rather than
+  assuming the source branch order (this is why `lowerBinopNotLocal_preservesSemantics` does
+  not use `peelSplittableCondition` for the bitwidth guard).
 
 ## File map
 
 | File | Contents | Growth per new lowering |
 |---|---|---|
-| `RewriteProofs/LowerUnaryW.lean` | `matchUnaryOp_interpretOp_unfold`, `lowerUnaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations (`Example` namespace) | two data lemmas + one instantiation (unary); new file per new *shape* |
-| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary reg-to-reg riscv op) | one lemma per new emitted-op *shape* |
+| `RewriteProofs/LowerUnaryW.lean` | `matchUnaryOp_interpretOp_unfold`, `lowerUnaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations | two data lemmas + one instantiation (unary); new file per new *shape* |
+| `RewriteProofs/LowerBinopNot.lean` | `lowerBinopNotLocal_preservesSemantics` (the DAG-matching template proof), per-lowering Layer-0 lemmas + instantiations (`andn`/`orn`/`xnor`), `#guard_msgs` axiom pins | two data lemmas + one instantiation (binop-with-not) |
+| `RewriteProofs/CommonGraphLemmas.lean` | Layer 3: `OperationPtr.Pure.llvm_*`, `matchBinaryOp_interpretOp_unfold`, `constantOp_interpretOp_unfold`, `matchNot_getVar?_of_EquationLemmaAt` | one packaged lemma per new *matcher* used on defining ops |
+| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary/binary reg-to-reg riscv ops) | one lemma per new emitted-op *shape* |
 | `RewriteProofs/CommonTactics.lean` | `peel*` macros, `cleanupHpattern` | rarely |
-| `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `createOp!` reduction, properties/dominance transport | rarely |
+| `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `not_mem_getResults!_of_inBounds_of_not_inBounds`, `createOp!` reduction, properties/dominance transport | rarely |
 | `RewriteProofs/CommonMatchLemmas.lean` | ctlz-specific unfold/peel lemmas — currently unused (superseded by the generic `matchUnaryOp_interpretOp_unfold`); candidate for deletion | — |
-| `Veir/Passes/InstructionSelection/RISCV64.lean` | the lowering combinators (`lowerUnaryWLocal`) and their instances | one `def` (or a new combinator) |
-| `Veir/Verifier.lean` | `IsVerified*` bundles + `Verified.llvm_*` extractors (Layer 1) | one 3-line lemma (unop/binop) |
+| `Veir/Passes/InstructionSelection/RISCV64.lean` | the GlobalISel lowering combinators (`lowerUnaryWLocal`) and their instances | one `def` (or a new combinator) |
+| `Veir/Passes/InstructionSelection/RISCV64Sdag.lean` | the SelectionDAG lowering combinators (`lowerBinopNotLocal`, `selectBinopImmLocal`, …) and their instances | one `def` (or a new combinator) |
+| `Veir/Verifier.lean` | `IsVerified*` bundles + `Verified.llvm_*` extractors (Layer 1; incl. `Verified.llvm_mlir__constant`) | one 3-line lemma (unop/binop) |
 | `Veir/Passes/Matching/Lemmas.lean` | `match*_implies` (Layer 2) | usually nothing |
 | `Veir/Interpreter/Lemmas.lean` | generic `interpretOp_forward`, `interpretOpList_cons` | nothing |
+| `Veir/Interpreter/EquationLemma.lean` | `Pure`, `EquationHolds`, `EquationLemmaAt` (the Layer-3 invariant) | nothing |
+| `Veir/Dominance.lean` | dominance axioms (incl. `strictlyDominates_trans`, `dominatesIp_before_of_strictlyDominates`) | nothing |
 | `Veir/PatternRewriter/Semantics.lean` | `PreservesSemantics` | nothing |

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1208,6 +1208,22 @@ theorem OperationPtr.Verified.llvm_xor {op : OperationPtr} {opInBounds}
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
     simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
 
+/--
+  Structural facts guaranteed by the verifier for `llvm.mlir.constant`: no operands, one
+  result, no successors or regions.
+-/
+theorem OperationPtr.Verified.llvm_mlir__constant {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (opType : op.getOpType! ctx.raw = .llvm .mlir__constant) :
+    op.getNumResults! ctx.raw = 1 ∧
+    op.getNumOperands! ctx.raw = 0 ∧
+    op.getNumSuccessors! ctx.raw = 0 ∧
+    op.getNumRegions! ctx.raw = 0 := by
+  simp only [Verified, verifyLocalInvariants, ← getOpType!_eq_getOpType, opType,
+    verifyPlainOpCounts, ne_eq, bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure,
+    Except.pure] at opVerify
+  grind
+
 theorem OperationPtr.Verified.llvm_intr__smax {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__smax) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by


### PR DESCRIPTION
well, I think the interesting part of this PR is that claude seems to have created some useful infrastructure for matching multi-instruction patterns on the LHS. 

on the other hand there are some truly horrific-looking proofs in here. 

also @math-fehr I let claude rewrite your markdown file-- let me know if I should revert that.