### PR TITLE
Prove correctness of zext i1->i64 instruction selection

### DIFF
--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
@@ -150,3 +150,39 @@ theorem interpretOp_riscv_unaryReg_forward
           simp [interpretOp', hSem, Interp])
       (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
   grind
+
+/-- Immediate-form unary register-to-register `riscv` op specialization of `interpretOp_forward`:
+`theOp` is any `riscv` op `rop` with a *fixed* property bundle `props` (typically the immediate)
+whose interpretation maps a single register operand `r` to `res` (hypothesis `hSem`, discharged by
+`rfl`/`simp` at each concrete opcode-and-immediate), with a single `!riscv.reg` result. Unlike
+`interpretOp_riscv_unaryReg_forward`, the result depends on the op's properties, so the op's
+actual property bundle is required as an input (`hProps`). Interpreting it always succeeds, leaves
+memory untouched, binds the result to `.reg res`, and leaves every non-result value unchanged. This
+covers the immediate forms `riscv.andi`/`ori`/`xori`/`slli`/`srli`/`srai`/`addi`/… . -/
+theorem interpretOp_riscv_unaryReg_imm_forward
+    {ctx : WfIRContext OpCode} {rop : Riscv} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r res : Data.RISCV.Reg} {props : HasDialectOpInfo.propertiesOf rop}
+    (hSem : ∀ (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' rop props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg res], mem, none)))
+    (hType : theOp.getOpType! ctx.raw = .riscv rop)
+    (hProps : theOp.getProperties! ctx.raw (.riscv rop) = props)
+    (hOperands : theOp.getOperands! ctx.raw = #[v])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg res) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r]) (results := #[.reg res]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType, hProps]
+          simp [interpretOp', hSem, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerZextOne.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerZextOne.lean
@@ -1,0 +1,215 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64Sdag
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerExt
+
+namespace Veir
+
+/-!
+## Correctness of `zext_1_local`
+
+`zext_1_local` lowers `llvm.zext %x : i1 to i64` to
+`unrealized_conversion_cast` (to a register) → `riscv.andi _, 1` →
+`unrealized_conversion_cast` (back to `i64`). It is a SelectionDAG pattern
+(`Veir.Passes.InstructionSelection.RISCV64Sdag`): masking the low bit with `andi 1` realizes the
+zero extension of an `i1`.
+
+The proof follows the `lowerExtLocal` template (single-operand extension: cast → riscv op → cast
+back) but for the concrete `i1 → i64` widths, and with the middle op an *immediate*-form
+`riscv.andi` rather than a plain unary reg-to-reg op. The source-interpretation unfolding
+(`matchExtOp_interpretOp_unfold`) and the data-level zero-extension refinement lemma
+(`zextLike_isRefinedBy_toInt`) are both reused from `LowerExt.lean`; only the `andi`-specific value
+characterisation below is new.
+-/
+
+/-- `riscv.andi _, 1` masks off all but the low bit, i.e. it is the zero extension of the low bit
+    of its register operand. -/
+theorem andi_one_val (r : Data.RISCV.Reg) :
+    (Data.RISCV.andi (BitVec.ofInt 12 1) r).val
+      = BitVec.setWidth 64 (BitVec.setWidth 1 r.val) := by
+  simp only [Data.RISCV.andi]
+  bv_decide
+
+/-- Correctness of the `riscv.andi _, 1` lowering of an `llvm.zext` from `i1` to `i64`: the round
+    trip `i1 → reg → andi 1 → i64` refines `llvm.zext`. (`xt` is the possibly-more-defined
+    target-side value of the operand.) -/
+theorem zext1_isRefinedBy_toInt_andi {nneg : Bool} {x xt : Data.LLVM.Int 1} (h : x ⊒ xt) :
+    Data.LLVM.Int.zext x 64 nneg (by omega)
+      ⊒ RISCV.Reg.toInt (Data.RISCV.andi (BitVec.ofInt 12 1) (LLVM.Int.toReg xt)) 64 :=
+  zextLike_isRefinedBy_toInt (by omega) (by omega) andi_one_val h
+
+/-- Interpreter computation fact for `riscv.andi` at the immediate `1`. -/
+theorem andi_one_interpretOp' (r : Data.RISCV.Reg) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState) :
+    Riscv.interpretOp' .andi (RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64)))
+        resultTypes #[.reg r] blockOperands mem
+      = some (.ok (#[.reg (Data.RISCV.andi (BitVec.ofInt 12 1) r)], mem, none)) := rfl
+
+set_option maxHeartbeats 1000000 in
+theorem zext_1_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps zext_1_local}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges zext_1_local}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds zext_1_local}
+    {h₄ : LocalRewritePattern.ReturnValues zext_1_local} :
+    LocalRewritePattern.PreservesSemantics zext_1_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, zext_1_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchZext op ctx.raw).isSome := by
+    cases hM : matchZext op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨operand, props⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := matchZext_implies hMatch
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by
+    rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, opIntTy, retIntTy, hOperTy, hResTy, hWlt⟩ :=
+    OperationPtr.Verified.llvm_zext opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = operand := by
+    rw [hOperandEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- The result type is the integer type `retIntTy`; resolve the type-destructuring match.
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType retIntTy := by
+    rw [hResTy]
+  rw [hResTypeVal] at hpattern
+  simp only [] at hpattern
+  -- The result-width guard fixes the result width to `i64` (the initial `simp` swapped the
+  -- negated `if`, so the continue branch is first).
+  peelSplittableCondition' [hBw64] hpattern
+  -- The operand type is the integer type `opIntTy`; resolve the type-destructuring match.
+  have hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType opIntTy := by
+    rw [← hOperand0, hOperTy]
+  rw [hOperandType] at hpattern
+  simp only [] at hpattern
+  -- The operand-width guard fixes the operand width to `i1`.
+  peelSplittableCondition' [hBw1] hpattern
+  -- The op's result types, as needed by the width-dependent source interpretation.
+  have hResTypes : op.getResultTypes! ctx.raw
+      = #[⟨Attribute.integerType retIntTy, (by grind)⟩] := by
+    apply Array.ext
+    · simp [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNumResults]
+    · intro i h1 h2
+      simp only [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNumResults] at h1
+      obtain rfl : i = 0 := by omega
+      have := OperationPtr.getResultTypes!.getElem!_eq (op := op) (ctx := ctx.raw) (index := 0)
+        (by omega)
+      grind
+  -- Unfold the interpretation of the matched op: exposes the operand's value and its `zext`.
+  obtain ⟨xVal, hxVal, hMem, hRes, hCf⟩ :=
+    matchExtOp_interpretOp_unfold (srcOp := .zext)
+      (srcFn := fun x hw props => Data.LLVM.Int.zext x _ props.nneg hw)
+      opInBounds hOpType hNumResults hOperands hProps hResTypes hWlt zext_interpretOp'
+      hinterp hOperandType
+  subst hCf
+  -- The matched operand dominates the rewrite point in the source context.
+  have hDomCtx : operand.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- Source value: `op`'s single result is the zero extension of its operand.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `operand` is not one of `op`'s results.
+  have vNotOp : ¬ operand ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the three op creations (cast to register, `andi`, cast back), transporting the operand's
+  -- dominance fact `hDomCtx` all the way into `ctx₃` as `hDom₃`.
+  peelOpCreation! hpattern ctx₁ castOp hCast hDomCtx hDom₁
+  peelOpCreation! hpattern ctx₂ andiOp hAndi hDom₁ hDom₂
+  peelOpCreation! hpattern ctx₃ castBackOp hCastBack hDom₂ hDom₃
+  cleanupHpattern hpattern
+  -- Read the refined value `xt` of `operand` in the target state `state'`.
+  obtain ⟨xt, hOpVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+      hDomCtx hDom₃ vNotOp
+  -- Normalise the operand/result bitwidths to the literals `1`/`64`.
+  obtain ⟨obw⟩ := opIntTy; simp only at hBw1; subst hBw1
+  obtain ⟨rbw⟩ := retIntTy; simp only at hBw64; subst hBw64
+  -- Structural facts about the three created ops.
+  have hCastType : castOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by grind
+  have hAndiType : andiOp.getOpType! ctx₃.raw = .riscv .andi := by grind
+  have hCastBackType : castBackOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastOperands : castOp.getOperands! ctx₃.raw = #[operand] := by grind
+  have hAndiOperands : andiOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (castOp.getResult 0)] := by
+    grind
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (andiOp.getResult 0)] := by grind
+  have hAndiProps : andiOp.getProperties! ctx₃.raw (.riscv .andi)
+      = RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64)) := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind)]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hAndi (operation := andiOp)]
+  have hCastResTypes : castOp.getResultTypes! ctx₃.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAndi (operation := castOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castOp)]
+  have hAndiResTypes : andiOp.getResultTypes! ctx₃.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := andiOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAndi (operation := andiOp)]
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₃.raw
+      = #[⟨Attribute.integerType { bitwidth := 64 }, (by grind)⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castBackOp)]
+  -- Interpretation tail: execute `interpretOpList [castOp, andiOp, castBackOp]` in `state'`.
+  -- `castOp` reads `operand = .int 1 xt` and casts it to `.reg (toReg xt)`.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+    interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+      hCastType hCastOperands hCastResTypes hOpVal'
+  -- `andiOp` maps `.reg r` to `.reg (andi 1 r)`.
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+    interpretOp_riscv_unaryReg_imm_forward (state := s₁) (inBounds := by grind)
+      (res := Data.RISCV.andi (BitVec.ofInt 12 1) (LLVM.Int.toReg xt))
+      (fun rt bo mem => andi_one_interpretOp' _ rt bo mem)
+      hAndiType hAndiProps hAndiOperands hAndiResTypes hRes₁
+  -- `castBackOp` casts `.reg (andi 1 (toReg xt))` back to `.int 64 (toInt (andi 1 (toReg xt)) 64)`.
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+    interpretOp_castBack_forward (state := s₂) (inBounds := by grind)
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₂
+  refine ⟨s₃, ?_, by grind, ?_⟩
+  · -- The list interpretation is the chain of the three op interpretations.
+    simp [interpretOpList_cons, hI₁, hI₂, hI₃, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 64
+        (RISCV.Reg.toInt (Data.RISCV.andi (BitVec.ofInt 12 1) (LLVM.Int.toReg xt)) 64)], ?_, ?_⟩
+    · simp [hRes₃, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using zext1_isRefinedBy_toInt_andi hxtRef⟩
+
+/--
+info: 'Veir.zext_1_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ andi_one_val._native.bv_decide.ax_1_5,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms zext_1_local_preservesSemantics
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -116,6 +116,17 @@ structural proof is done **once per combinator**. Currently:
   (`RewriteProofs/LowerBinopNot.lean`). This is the first *DAG-matching* proof: it recovers the
   runtime value of the matched `not` from the `EquationLemmaAt` hypothesis (see
   "Matched-subgraph semantics" below).
+- `zext_1_local` (`RISCV64Sdag.lean`) — the concrete `llvm.zext %x : i1 to i64` ⟶
+  `unrealized_conversion_cast` → `riscv.andi _, 1` → `unrealized_conversion_cast` lowering (masking
+  the low bit realizes the zero extension of an `i1`). Not a combinator: it is a *standalone* proof
+  (`zext_1_local_preservesSemantics`, `RewriteProofs/LowerZextOne.lean`) modelled on the
+  `lowerExtLocal` single-operand-extension template, but at the fixed `i1 → i64` widths and with the
+  middle op an *immediate*-form `riscv.andi` rather than a plain unary reg-to-reg op. It *reuses*
+  `matchExtOp_interpretOp_unfold` and the data-level `zextLike_isRefinedBy_toInt` from
+  `LowerExt.lean`; the only new pieces are the `andi 1` value characterisation (`andi_one_val`) and
+  the immediate-op forward lemma `interpretOp_riscv_unaryReg_imm_forward`. It is the first proof of a
+  lowering that emits an immediate-form riscv op — the template for the `selectBinopImmLocal` family
+  (which additionally needs a `matchConstantIntVal` DAG-matching Layer-3 lemma).
 
 The generic theorem is parameterized over everything opcode-specific:
 
@@ -454,8 +465,9 @@ per lowering as above.
 | `RewriteProofs/LowerSignedMinMax.lean` | `lowerSignedMinMaxLocal_preservesSemantics` (signed min/max; `i64` = 4 ops, `i32` = 6 ops with two extra `riscv.sextw`) + `_64`/`_32` data lemmas + instantiations (`smax`, `smin`) | two data lemmas + one instantiation |
 | `RewriteProofs/LowerRotate.lean` | `matchTernaryOp_interpretOp_unfold` (ternary source unfold) + `lowerRotateLocal_preservesSemantics` (rotate; ternary source with `a = b`, result-type guard, `W`-variant bitwidth branch) + `_64`/`_32` data lemmas + instantiations (`fshl`, `fshr`) | two data lemmas + one instantiation |
 | `RewriteProofs/LowerBinopNot.lean` | `lowerBinopNotLocal_preservesSemantics` (the DAG-matching template proof), per-lowering Layer-0 lemmas + instantiations (`andn`/`orn`/`xnor`), `#guard_msgs` axiom pins | two data lemmas + one instantiation (binop-with-not) |
+| `RewriteProofs/LowerZextOne.lean` | `zext_1_local_preservesSemantics` (standalone `i1 → i64` zext ⟶ `andi 1`; first immediate-emitting proof), `andi_one_val` + `zext1_isRefinedBy_toInt_andi` (reusing `matchExtOp_interpretOp_unfold` / `zextLike_isRefinedBy_toInt` from `LowerExt.lean`), `#guard_msgs` axiom pin | — (one-off) |
 | `RewriteProofs/CommonGraphLemmas.lean` | `matchBinaryOp_interpretOp_unfold` (shared by the binary combinator proofs) + Layer 3: `OperationPtr.Pure.llvm_*`, `constantOp_interpretOp_unfold`, `matchNot_getVar?_of_EquationLemmaAt` | one packaged lemma per new *matcher* used on defining ops |
-| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary/binary reg-to-reg riscv ops) | one lemma per new emitted-op *shape* |
+| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary/binary reg-to-reg riscv ops + `interpretOp_riscv_unaryReg_imm_forward` for immediate-form unary ops) | one lemma per new emitted-op *shape* |
 | `RewriteProofs/CommonTactics.lean` | `peel*` macros (incl. the two-dominance `peel*₂` variants), `cleanupHpattern` | rarely |
 | `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `not_mem_getResults!_of_inBounds_of_not_inBounds`, `createOp!` reduction, properties/dominance transport | rarely |
 | `RewriteProofs/CommonMatchLemmas.lean` | ctlz-specific unfold/peel lemmas — currently unused (superseded by the generic `matchUnaryOp_interpretOp_unfold`); candidate for deletion | — |


### PR DESCRIPTION
## What

Prove `PreservesSemantics` for `zext_1_local`, the SelectionDAG lowering of `llvm.zext %x : i1 to i64` to `unrealized_conversion_cast` → `riscv.andi _, 1` → `unrealized_conversion_cast`. Masking the low bit with `andi 1` realizes the zero extension of an `i1`.

Previously, of the SelectionDAG patterns in `RISCV64Sdag.lean` only `andn`/`orn`/`xnor` (via `LowerBinopNot`) were proven; `zext_1_local` was unproven and not marked unsound.

## How

- **`RewriteProofs/LowerZextOne.lean`** (new) — `zext_1_local_preservesSemantics`, a standalone one-step forward-simulation modelled on the `lowerExtLocal` single-operand-extension template, at the fixed `i1 → i64` widths, with the middle op an *immediate*-form `riscv.andi`. It reuses `matchExtOp_interpretOp_unfold` (source unfolding) and `zextLike_isRefinedBy_toInt` (data refinement) from `LowerExt.lean`, so the only new data lemma is the `andi 1` value characterisation `andi_one_val` (closed by `bv_decide`).
- **`RewriteProofs/CommonForwardInterpret.lean`** — add `interpretOp_riscv_unaryReg_imm_forward`, the first forward lemma for an emitted op whose result depends on its properties (the immediate). This is the reusable template for the future `selectBinopImmLocal` family.
- **`ProofStrategy.md`** — document the new lowering, the new forward lemma, and a file-map row.

Two gotchas handled (both consistent with the existing strategy doc):
- the initial `simp` swaps the negated bitwidth `if`s → used `peelSplittableCondition'`;
- `getProperties!_WfRewriter_createOp` fixes the query op-code to the *creating* op's code, so it can't carry `andi`'s properties across the later cast-back creation → used `getProperties!_WfRewriter_createOp_ne` instead.

## Verification

- Both modified/new files build warning-clean (verified individually, per the known warning-caching quirk).
- `#print axioms zext_1_local_preservesSemantics` lands on the accepted dominance/`bv_decide` baseline — no `sorryAx` — pinned with `#guard_msgs`.

Note: `RewriteProofs` is not in the `lake build` graph, so it is checked by building the module explicitly: `lake build Veir.Passes.InstructionSelection.RewriteProofs.LowerZextOne`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)