### PR TITLE
feat: Prove correctness of 12 more instruction selection rewrites

### DIFF
--- a/Veir.lean
+++ b/Veir.lean
@@ -16,3 +16,4 @@ import Veir.Interpreter
 import Veir.Dominance
 import Veir.Passes.InstructionSelection.Proofs
 import Veir.Passes.CastsReconciliation.Reconciliation
+import Veir.Passes.InstructionSelection.RewriteProofs

--- a/Veir/Passes/InstructionSelection/RewriteProofs.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs.lean
@@ -1,0 +1,14 @@
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerAbs
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryReg
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryW
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBswap
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBitwiseReg
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerConst
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerExt
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerLoad
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerRotate
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerSignedMinMax
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUaddSat
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUnaryW
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUshlSat
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUsubSat

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonGraphLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonGraphLemmas.lean
@@ -70,9 +70,11 @@ theorem matchBinaryOp_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCod
     (hOperands : op.getOperands! ctx.raw = #[lhs, rhs])
     (hProps : props = op.getProperties! ctx.raw (.llvm srcOp))
     (hSemSrc : ∀ (bw : Nat) (x y : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
-        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
         Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw y] blockOperands mem
-          = some (.ok (#[.int bw (srcFn x y props)], mem, none)))
+          = some (.ok res) →
+        res = (#[.int bw (srcFn x y props)], mem, none))
     (hinterp : interpretOp op state opInBounds = some (.ok (newState, cf)))
     (hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType)
     (hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType) :
@@ -134,7 +136,7 @@ theorem matchBinaryOp_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCod
   simp only [OperationPtr.interpret] at hInterp'
   rw [hOpType] at hInterp'
   simp only [← hProps, interpretOp'] at hInterp'
-  rw [hSemSrc] at hInterp'
+  have hInterp' := hSemSrc _ _ _ _ _ _ _ _ hInterp'
   obtain ⟨rfl, rfl, rfl⟩ :
       resValues = #[RuntimeValue.int intType.bitwidth (srcFn x y props)] ∧
       mem' = state.memory ∧ cf = none := by grind
@@ -264,8 +266,9 @@ theorem matchNot_getVar?_of_EquationLemmaAt {ctx : WfIRContext OpCode}
       (srcFn := fun a b _ => Data.LLVM.Int.xor a b)
       (props := vPtr.op.getProperties! ctx.raw (.llvm .xor))
       hXorOpIn hXorType hXorNumResults hXorOperands rfl
-      (by intro bw a b props resultTypes blockOperands mem
-          simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure])
+      (by intro bw a b props resultTypes blockOperands mem res h
+          simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at h
+          grind)
       hInterpXor hyType hCstValType
   -- The constant's structural facts.
   have hCstIn : (ValuePtr.opResult cstPtr).InBounds ctx.raw := by

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonMatchEqns.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonMatchEqns.lean
@@ -1,0 +1,27 @@
+import Lean
+import Veir.Passes.InstructionSelection.RISCV64
+
+/-!
+# Pre-generated match equations for the RISC-V lowering combinators
+
+Tactics like `split` and `grind` realize the `match_n.eq_k` / `match_n.congr_eq_k`
+lemmas of a matcher on demand, in whichever module first needs them. The matchers of
+the lowering combinators live in `Veir.Passes.InstructionSelection.RISCV64`, so two
+sibling proof modules that both case on the same matcher each bake a private copy of
+these lemmas (and their `_sparseCasesOn_*` auxiliaries) into their own olean — and
+importing both modules together then fails with
+`environment already contains 'Veir.lowerUnaryWLocal.match_3.congr_eq_1._sparseCasesOn_2'`.
+
+Generating the lemmas here once, in a module that every rewrite proof imports, gives
+all of them a single shared copy.
+-/
+
+open Lean Meta in
+run_meta do
+  let env ← getEnv
+  let some modIdx := env.getModuleIdxFor? ``Veir.lowerUnaryWLocal
+    | throwError "expected `Veir.lowerUnaryWLocal` to be imported"
+  for n in env.header.moduleData[modIdx.toNat]!.constNames do
+    if isMatcherCore env n then
+      discard <| Match.getEquationsFor n
+      discard <| Match.genMatchCongrEqns n

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerAbs.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerAbs.lean
@@ -1,0 +1,195 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUnaryW
+
+namespace Veir
+
+/-!
+## Correctness of `abs_local`
+
+`llvm.intr.abs` on a 64-bit integer is lowered to
+`unrealized_conversion_cast` (to a register) → `riscv.neg` → `riscv.max` (of the original register and
+its negation) → `unrealized_conversion_cast` (back to the integer type), mirroring LLVM's RV64+Zbb
+`neg`/`max` expansion of `abs`.
+
+`abs` does not fit `lowerUnaryWLocal`: it is `i64`-only and emits *two* register ops whose second
+(`max`) is a binary op consuming both the cast register and the `neg` result. It is therefore proven
+bespoke; structurally it is the `lowerUnaryWLocal`/`bswap` `i64` shape with an extra
+`interpretOp_riscv_unaryReg_forward` (`neg`) step and a `interpretOp_riscv_binaryReg_forward` (`max`)
+step in place of the single unary-register forward step.
+-/
+
+/-- Correctness of the `max (neg ·) ·` lowering of a 64-bit `llvm.intr.abs`: the round trip
+    `int → reg → neg/max → int` refines `abs`. (`xt` is the possibly-more-defined target-side value
+    of the operand; `b` is the intrinsic's `is_int_min_poison` flag, which the lowering ignores: the
+    `neg` wraps `intMin` back to `intMin`, so both the poison and non-poison forms are refined.) -/
+theorem abs_isRefinedBy_toInt_max_neg {x xt : Data.LLVM.Int 64} {b : Bool} (h : x ⊒ xt) :
+    Data.LLVM.Int.abs x b ⊒
+      RISCV.Reg.toInt
+        (Data.RISCV.max (Data.RISCV.neg (LLVM.Int.toReg xt)) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_abs] at hnp; grind
+  have hvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  veir_bv_decide
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `abs_local` lowering: the `castToReg → neg → max → castBack` round trip
+    refines `llvm.intr.abs`. -/
+theorem abs_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics abs_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, abs_local, createRISCVUnitLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchAbs op ctx.raw).isSome := by
+    cases hM : matchAbs op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨operand, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands⟩ := matchAbs_implies hMatch
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, hResOperType, intType, isT, hResType⟩ :=
+    OperationPtr.Verified.llvm_intr__abs opVerif hOpType
+  -- The operand type is the integer type `intType`; resolve the type-destructuring match.
+  have hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [show operand.getType! ctx.raw = ⟨.integerType intType, isT⟩ from by grind]
+  -- The bitwidth guard matches on the *result* type; resolve it too.
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    rw [hResType]
+  rw [hResTypeVal] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand's value and `abs`.
+  obtain ⟨xVal, hxVal, hMem, hRes, hCf⟩ :=
+    matchUnaryOp_interpretOp_unfold
+      (srcFn := fun {_} x props => Data.LLVM.Int.abs x props.is_int_min_poison)
+      (props := op.getProperties! ctx.raw (.llvm .intr__abs))
+      opInBounds hOpType hNumResults hOperands rfl (fun _ _ _ _ _ _ => rfl) hinterp hOperandType
+  subst hCf
+  -- The matched operand dominates the rewrite point in the source context.
+  have hDomCtx : operand.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition' [hBw] hpattern
+  -- Source value: `op`'s single result is `abs` of its operand.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `operand` is not one of `op`'s results.
+  have vNotOp : ¬ operand ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the `castToReg`, `neg`, `max`, and `castBack` creations.
+  peelCastToRegLocal hpattern ctx₁ castOp hCast hDomCtx hDom₁
+  peelOpCreation! hpattern ctx₂ negOp hNeg hDom₁ hDom₂
+  peelOpCreation! hpattern ctx₃ maxOp hMax hDom₂ hDom₃
+  peelReplaceWithRegLocal hpattern ctx₄ castBackOp hCastBack hDom₃ hDom₄
+  cleanupHpattern hpattern
+  obtain ⟨xt, hOpVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+      hDomCtx hDom₄ vNotOp
+  obtain ⟨bw⟩ := intType; simp only at hBw; subst hBw
+  have hCastType : castOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by grind
+  have hNegType : negOp.getOpType! ctx₄.raw = .riscv .neg := by grind
+  have hMaxType : maxOp.getOpType! ctx₄.raw = .riscv .max := by grind
+  have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastOperands : castOp.getOperands! ctx₄.raw = #[operand] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hCast (operation := castOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hNeg (operation := castOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMax (operation := castOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := castOp)]
+  have hNegOperands :
+      negOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (castOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hNeg (operation := negOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMax (operation := negOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := negOp)]
+  have hMaxOperands :
+      maxOp.getOperands! ctx₄.raw
+        = #[ValuePtr.opResult (castOp.getResult 0), ValuePtr.opResult (negOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hMax (operation := maxOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := maxOp)]
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (maxOp.getResult 0)] := by grind
+  have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+      = (⟨Attribute.integerType { bitwidth := 64 }, isT⟩ : TypeAttr) := by
+    have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+        = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+      grind [ValuePtr.getType!_WfRewriter_createOp hMax
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hNeg
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp]
+    simpa only [ValuePtr.getType!_opResult, hResType] using h1
+  have hCastResTypes : castOp.getResultTypes! ctx₄.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hNeg (operation := castOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMax (operation := castOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castOp)]
+  have hNegResTypes : negOp.getResultTypes! ctx₄.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hNeg (operation := negOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMax (operation := negOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := negOp)]
+  have hMaxResTypes : maxOp.getResultTypes! ctx₄.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hMax (operation := maxOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := maxOp)]
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+      = #[⟨Attribute.integerType { bitwidth := 64 }, isT⟩] := by grind
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+    interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+      hCastType hCastOperands hCastResTypes hOpVal'
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, hOther₂⟩ :=
+    interpretOp_riscv_unaryReg_forward (state := s₁) (inBounds := by grind)
+      (f := Data.RISCV.neg) (fun _ _ _ _ => rfl) hNegType hNegOperands hNegResTypes hRes₁
+  -- `max`'s first operand is the cast register (`castOp`'s result); transport its value from `s₁`
+  -- through the `neg` step (`s₂`), which does not touch it since `castOp ≠ negOp`.
+  have hCastNotNegRes : ValuePtr.opResult (castOp.getResult 0) ∉ negOp.getResults! ctx₄.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+        (ValuePtr.opResult (castOp.getResult 0)) negOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hCastRes₂ : s₂.variables.getVar? (ValuePtr.opResult (castOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+    rw [hOther₂ _ hCastNotNegRes]; exact hRes₁
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.max r₂ r₁) (fun _ _ _ _ => rfl) hMaxType hMaxOperands
+      hMaxResTypes hCastRes₂ hRes₂
+  obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+    interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+  refine ⟨s₄, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt
+        (Data.RISCV.max (Data.RISCV.neg (LLVM.Int.toReg xt)) (LLVM.Int.toReg xt)) 64)], ?_, ?_⟩
+    · simp [hRes₄, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using abs_isRefinedBy_toInt_max_neg hxtRef⟩
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryReg.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryReg.lean
@@ -7,6 +7,7 @@ import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
@@ -113,7 +114,10 @@ theorem lowerBinaryRegLocal_preservesSemantics {srcOp : Llvm}
   simp only [] at hpattern
   -- Unfold the interpretation of the matched op: exposes the operand values and their `srcFn`.
   obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
-    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands rfl hSemSrc
+    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands rfl
+      (fun bw x y props rt bo mem res h => by
+        rw [hSemSrc bw x y props rt bo mem] at h
+        injection h with h; injection h with h; exact h.symm)
       hinterp hLhsType hRhsType
   subst hCf
   -- The matched operands dominate the rewrite point in the source context.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryW.lean
@@ -7,6 +7,7 @@ import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
@@ -52,9 +53,11 @@ theorem lowerBinaryWLocal_preservesSemantics {srcOp : Llvm}
         op.Verified ctx opInBounds → op.getOpType! ctx.raw = .llvm srcOp →
         op.IsVerifiedIntegerBinop ctx)
     (hSemSrc : ∀ (bw : Nat) (x y : Data.LLVM.Int bw) (props : propertiesOf (.llvm srcOp))
-        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
         Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw y] blockOperands mem
-          = some (.ok (#[.int bw (srcFn x y props)], mem, none)))
+          = some (.ok res) →
+        res = (#[.int bw (srcFn x y props)], mem, none))
     (hSemR64 : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op64)
         (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
         Riscv.interpretOp' op64 props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
@@ -444,7 +447,8 @@ theorem add_local_preservesSemantics :
     (f32 := fun r₁ r₂ => Data.RISCV.addw r₂ r₁)
     matchAdd_implies
     OperationPtr.Verified.llvm_add
-    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at h; grind)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ props h₁ h₂ => add_isRefinedBy_toInt_add props.nsw props.nuw h₁ h₂)
@@ -507,7 +511,8 @@ theorem xor_local_preservesSemantics :
     (f32 := fun r₁ r₂ => Data.RISCV.xor r₂ r₁)
     matchXor_implies
     OperationPtr.Verified.llvm_xor
-    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at h; grind)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ _ h₁ h₂ => xor_isRefinedBy_toInt_xor h₁ h₂)
@@ -569,7 +574,8 @@ theorem sub_local_preservesSemantics :
     (f32 := fun r₁ r₂ => Data.RISCV.subw r₂ r₁)
     matchSub_implies
     OperationPtr.Verified.llvm_sub
-    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at h; grind)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ props h₁ h₂ => sub_isRefinedBy_toInt_sub props.nsw props.nuw h₁ h₂)
@@ -642,10 +648,311 @@ theorem mul_local_preservesSemantics :
     (f32 := fun r₁ r₂ => Data.RISCV.mulw r₂ r₁)
     matchMul_implies
     OperationPtr.Verified.llvm_mul
-    (fun _ _ _ _ _ _ _ => by simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp])
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at h; grind)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ _ _ => rfl)
     (fun _ _ _ _ props h₁ h₂ => mul_isRefinedBy_toInt_mul props.nsw props.nuw h₁ h₂)
     (fun _ _ _ _ props h₁ h₂ => mul_isRefinedBy_toInt_mulw props.nsw props.nuw h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.udiv`
+
+`llvm.udiv` lowers to `riscv.divu`/`riscv.divuw`. Division by zero is UB in LLVM; the source
+interpreter signals `Interp.ub` in that case, so a successful source interpretation guarantees the
+divisor is non-zero, which is exactly the branch where `riscv.divu` computes an honest quotient.
+The two data-level refinement lemmas below only ever need this non-zero branch.
+-/
+
+/-- Correctness of the `riscv.divu` lowering of a 64-bit `llvm.udiv`. -/
+theorem udiv_isRefinedBy_toInt_divu {x y xt yt : Data.LLVM.Int 64} (exact : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.udiv x y exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hyne : y.getValueD ≠ 0 := by
+    rw [Data.LLVM.Int.isPoison_udiv] at hnp
+    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
+  rw [Data.LLVM.Int.getValue_udiv _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.divu, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  simp only [BitVec.setWidth_eq]
+  rw [if_neg (show ¬ y.getValueD = 0#64 from hyne)]
+
+/-- Correctness of the `riscv.divuw` lowering of a 32-bit `llvm.udiv`. -/
+theorem udiv_isRefinedBy_toInt_divuw {x y xt yt : Data.LLVM.Int 32} (exact : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.udiv x y exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.divuw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hyne : y.getValueD ≠ 0 := by
+    rw [Data.LLVM.Int.isPoison_udiv] at hnp
+    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
+  rw [Data.LLVM.Int.getValue_udiv _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.divuw, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  bv_decide
+
+theorem udiv_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics udiv_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .udiv)
+    (srcFn := fun x y props => Data.LLVM.Int.udiv x y props.exact)
+    (f64 := fun r₁ r₂ => Data.RISCV.divu r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.divuw r₂ r₁)
+    matchUdiv_implies
+    OperationPtr.Verified.llvm_udiv
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self] at h
+      split at h
+      · simp at h
+      · split at h
+        · nomatch h
+        · split at h
+          · nomatch h
+          · simpa [pure, Interp] using h.symm)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => udiv_isRefinedBy_toInt_divu props.exact h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => udiv_isRefinedBy_toInt_divuw props.exact h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.sdiv`
+
+`llvm.sdiv` lowers to `riscv.div`/`riscv.divw`. As with `udiv`, division by zero (and the signed
+`INT_MIN / -1` overflow) is UB in LLVM, so a successful source interpretation guarantees the RISC-V
+`div` takes its honest-quotient branch.
+-/
+
+/-- Correctness of the `riscv.div` lowering of a 64-bit `llvm.sdiv`. -/
+theorem sdiv_isRefinedBy_toInt_div {x y xt yt : Data.LLVM.Int 64} (exact : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.sdiv x y exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.div (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hyne : y.getValueD ≠ 0 := by
+    rw [Data.LLVM.Int.isPoison_sdiv] at hnp
+    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
+  rw [Data.LLVM.Int.getValue_sdiv _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.div, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  simp only [BitVec.setWidth_eq]
+  rw [if_neg (show ¬ y.getValueD = 0#64 from hyne)]
+
+/-- Correctness of the `riscv.divw` lowering of a 32-bit `llvm.sdiv`. -/
+theorem sdiv_isRefinedBy_toInt_divw {x y xt yt : Data.LLVM.Int 32} (exact : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.sdiv x y exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.divw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hyne : y.getValueD ≠ 0 := by
+    rw [Data.LLVM.Int.isPoison_sdiv] at hnp
+    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
+  rw [Data.LLVM.Int.getValue_sdiv _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.divw, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  bv_decide
+
+theorem sdiv_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics sdiv_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .sdiv)
+    (srcFn := fun x y props => Data.LLVM.Int.sdiv x y props.exact)
+    (f64 := fun r₁ r₂ => Data.RISCV.div r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.divw r₂ r₁)
+    matchSdiv_implies
+    OperationPtr.Verified.llvm_sdiv
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self] at h
+      repeat' split at h
+      all_goals first
+        | (simp only [pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h; exact h.symm)
+        | nomatch h)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => sdiv_isRefinedBy_toInt_div props.exact h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => sdiv_isRefinedBy_toInt_divw props.exact h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.urem`
+
+`llvm.urem` lowers to `riscv.remu`/`riscv.remuw`. Remainder by zero is UB in LLVM, and `riscv.remu`
+computes the unsigned remainder unconditionally, so the two agree whenever the source does not
+trigger UB.
+-/
+
+/-- Correctness of the `riscv.remu` lowering of a 64-bit `llvm.urem`. -/
+theorem urem_isRefinedBy_toInt_remu {x y xt yt : Data.LLVM.Int 64}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.urem x y
+      ⊒ RISCV.Reg.toInt (Data.RISCV.remu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  rw [Data.LLVM.Int.getValue_urem _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.remu, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  simp only [BitVec.setWidth_eq]
+
+/-- Correctness of the `riscv.remuw` lowering of a 32-bit `llvm.urem`. -/
+theorem urem_isRefinedBy_toInt_remuw {x y xt yt : Data.LLVM.Int 32}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.urem x y
+      ⊒ RISCV.Reg.toInt (Data.RISCV.remuw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  rw [Data.LLVM.Int.getValue_urem _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.remuw, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  bv_decide
+
+theorem urem_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics urem_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .urem)
+    (srcFn := fun x y _ => Data.LLVM.Int.urem x y)
+    (f64 := fun r₁ r₂ => Data.RISCV.remu r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.remuw r₂ r₁)
+    matchUrem_implies
+    OperationPtr.Verified.llvm_urem
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self] at h
+      repeat' split at h
+      all_goals first
+        | (simp only [pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h; exact h.symm)
+        | nomatch h)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ h₁ h₂ => urem_isRefinedBy_toInt_remu h₁ h₂)
+    (fun _ _ _ _ _ h₁ h₂ => urem_isRefinedBy_toInt_remuw h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.srem`
+
+`llvm.srem` lowers to `riscv.rem`/`riscv.remw`. Remainder by zero (and the `INT_MIN / -1` overflow)
+is UB in LLVM, and `riscv.rem` computes the signed remainder unconditionally, so the two agree
+whenever the source does not trigger UB.
+-/
+
+/-- Correctness of the `riscv.rem` lowering of a 64-bit `llvm.srem`. -/
+theorem srem_isRefinedBy_toInt_rem {x y xt yt : Data.LLVM.Int 64}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.srem x y
+      ⊒ RISCV.Reg.toInt (Data.RISCV.rem (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  rw [Data.LLVM.Int.getValue_srem _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.rem, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  simp only [BitVec.setWidth_eq]
+
+/-- Correctness of the `riscv.remw` lowering of a 32-bit `llvm.srem`. -/
+theorem srem_isRefinedBy_toInt_remw {x y xt yt : Data.LLVM.Int 32}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.srem x y
+      ⊒ RISCV.Reg.toInt (Data.RISCV.remw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
+  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
+  rw [Data.LLVM.Int.getValue_srem _ _ hnp, toInt_getValue]
+  simp only [Data.RISCV.remw, val_toReg,
+    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
+    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
+    Data.LLVM.Int.getValue_eq_getValueD]
+  rw [← hvd₁, ← hvd₂]
+  bv_decide
+
+theorem srem_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics srem_local h h₂ h₃ h₄ :=
+  lowerBinaryWLocal_preservesSemantics
+    (srcOp := .srem)
+    (srcFn := fun x y _ => Data.LLVM.Int.srem x y)
+    (f64 := fun r₁ r₂ => Data.RISCV.rem r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.remw r₂ r₁)
+    matchSrem_implies
+    OperationPtr.Verified.llvm_srem
+    (fun _ _ _ _ _ _ _ _ h => by
+      simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self] at h
+      repeat' split at h
+      all_goals first
+        | (simp only [pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h; exact h.symm)
+        | nomatch h)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ h₁ h₂ => srem_isRefinedBy_toInt_rem h₁ h₂)
+    (fun _ _ _ _ _ h₁ h₂ => srem_isRefinedBy_toInt_remw h₁ h₂)
 
 end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
@@ -120,7 +120,10 @@ theorem lowerBinopNotLocal_preservesSemantics {srcOp : Llvm}
     rw [← hOperand1, hOp1Type]
   -- Unfold the interpretation of the matched op: exposes both operand values and `srcFn`.
   obtain ⟨xlv, xrv, hlVal, hrVal, hMem, hRes, hCf⟩ :=
-    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands hProps hSemSrc
+    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands hProps
+      (fun bw x y props rt bo mem res h => by
+        rw [hSemSrc bw x y props rt bo mem] at h
+        injection h with h; injection h with h; exact h.symm)
       hinterp hLhsType hRhsType
   subst hCf
   -- Both matched operands dominate the rewrite point in the source context.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitwiseReg.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitwiseReg.lean
@@ -7,6 +7,7 @@ import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
@@ -115,7 +116,10 @@ theorem lowerBitwiseRegLocal_preservesSemantics {P : Type} {srcOp : Llvm}
   simp only [] at hpattern
   -- Unfold the interpretation of the matched op: exposes the operand values and their `srcFn`.
   obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
-    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands rfl hSemSrc
+    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands rfl
+      (fun bw x y props rt bo mem res h => by
+        rw [hSemSrc bw x y props rt bo mem] at h
+        injection h with h; injection h with h; exact h.symm)
       hinterp hLhsType hRhsType
   subst hCf
   -- The matched operands dominate the rewrite point in the source context.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBswap.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBswap.lean
@@ -1,0 +1,287 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUnaryW
+
+namespace Veir
+
+/-!
+## Correctness of `bswap_local`
+
+`llvm.intr.bswap` on a 64- or 32-bit integer is lowered to
+`unrealized_conversion_cast` (to a register) → `riscv.rev8`, and for `i32` an extra `riscv.srli 32`
+(because `rev8` reverses all 8 bytes, so an `i32`'s meaningful bytes land in the high 32 bits and
+must be shifted back down) → `unrealized_conversion_cast` (back to the integer type).
+
+`bswap` does not fit `lowerUnaryWLocal`: its `i32` branch emits *two* register ops (`rev8` then the
+immediate `srli 32`) rather than a single `W`-variant, so it is proven bespoke. The `i64` branch is
+structurally identical to a `lowerUnaryWLocal` `i64` branch (`castToReg → rev8 → castBack`); the
+`i32` branch threads one extra `interpretOp_riscv_srli_forward` step (the immediate analogue of the
+plain unary-register forward lemma) between `rev8` and the cast-back.
+-/
+
+/-- Forward-interpretation lemma for the immediate `riscv.srli`. Unlike
+    `interpretOp_riscv_unaryReg_forward`, the emitted register is a function of the op's *shift
+    immediate*, read from its properties, so the caller supplies that immediate as `k` together with
+    the reduction `hImm` of the op's stored property value. Interpreting the op succeeds, leaves
+    memory untouched, binds the result to `.reg (Data.RISCV.srli k r)`, and leaves every non-result
+    value unchanged. -/
+theorem interpretOp_riscv_srli_forward
+    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r : Data.RISCV.Reg} {k : BitVec 6}
+    (hType : theOp.getOpType! ctx.raw = .riscv .srli)
+    (hImm : BitVec.ofInt 6 (theOp.getProperties! ctx.raw (.riscv .srli)).value.value = k)
+    (hOperands : theOp.getOperands! ctx.raw = #[v])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (Data.RISCV.srli k r)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r]) (results := #[.reg (Data.RISCV.srli k r)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', Riscv.interpretOp', Interp, hImm, pure])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Correctness of the `riscv.rev8` lowering of a 64-bit `llvm.intr.bswap`: the round trip
+    `int → reg → rev8 → int` refines `bswap`. (`xt` is the possibly-more-defined target-side value
+    of the operand.) -/
+theorem bswap_isRefinedBy_toInt_rev8 {x xt : Data.LLVM.Int 64} (h : x ⊒ xt) :
+    Data.LLVM.Int.bswap x ⊒ RISCV.Reg.toInt (Data.RISCV.rev8 (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_bswap] at hnp; exact hnp
+  have hvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.rev8]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.srli 32 (rev8 ·)` lowering of a 32-bit `llvm.intr.bswap`: `rev8`
+    reverses all 8 register bytes, so the reversed `i32` lands in the high word; `srli 32` shifts it
+    back down before the truncating cast reads the low 32 bits. -/
+theorem bswap_isRefinedBy_toInt_srli_rev8 {x xt : Data.LLVM.Int 32} (h : x ⊒ xt) :
+    Data.LLVM.Int.bswap x ⊒
+      RISCV.Reg.toInt (Data.RISCV.srli (BitVec.ofInt 6 32) (Data.RISCV.rev8 (LLVM.Int.toReg xt)))
+        32 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
+  obtain ⟨hp, hv⟩ := h
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_bswap] at hnp; exact hnp
+  have hvd : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.rev8, Data.RISCV.srli]
+  veir_bv_decide
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `bswap_local` lowering: the `castToReg → rev8 (→ srli 32 for i32) → castBack`
+    round trip refines `llvm.intr.bswap`. -/
+theorem bswap_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics bswap_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, bswap_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchBswap op ctx.raw).isSome := by
+    cases hM : matchBswap op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨operand, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands⟩ := matchBswap_implies hMatch
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, hResOperType, intType, isT, hResType⟩ :=
+    OperationPtr.Verified.llvm_intr__bswap opVerif hOpType
+  -- The operand type is the integer type `intType`; resolve the type-destructuring match.
+  have hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [show operand.getType! ctx.raw = ⟨.integerType intType, isT⟩ from by grind]
+  rw [hOperandType] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand's value and `bswap`.
+  obtain ⟨xVal, hxVal, hMem, hRes, hCf⟩ :=
+    matchUnaryOp_interpretOp_unfold (srcFn := fun {_} x _ => Data.LLVM.Int.bswap x)
+      opInBounds hOpType hNumResults hOperands rfl (fun _ _ _ _ _ _ => rfl) hinterp hOperandType
+  subst hCf
+  -- The matched operand dominates the rewrite point in the source context.
+  have hDomCtx : operand.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition [hBw] hpattern
+  -- Source value: `op`'s single result is `bswap` of its operand.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `operand` is not one of `op`'s results.
+  have vNotOp : ¬ operand ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the `castToReg` and the `rev8` creations shared by both branches.
+  peelCastToRegLocal hpattern ctx₁ castOp hCast hDomCtx hDom₁
+  peelOpCreation! hpattern ctx₂ rev8Op hRev8 hDom₁ hDom₂
+  have hBwCases : intType.bitwidth = 64 ∨ intType.bitwidth = 32 := by omega
+  rcases hBwCases with hbw | hbw
+  · -- 64-bit case: `castToReg → rev8 → castBack`.
+    rw [if_neg (show ¬intType.bitwidth = 32 by omega)] at hpattern
+    simp only [] at hpattern
+    peelReplaceWithRegLocal hpattern ctx₃ castBackOp hCastBack hDom₂ hDom₃
+    cleanupHpattern hpattern
+    obtain ⟨xt, hOpVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+        hDomCtx hDom₃ vNotOp
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    have hCastType : castOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by grind
+    have hRev8Type : rev8Op.getOpType! ctx₃.raw = .riscv .rev8 := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hCastOperands : castOp.getOperands! ctx₃.raw = #[operand] := by grind
+    have hRev8Operands :
+        rev8Op.getOperands! ctx₃.raw = #[ValuePtr.opResult (castOp.getResult 0)] := by grind
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (rev8Op.getResult 0)] := by grind
+    have hCBType : ((op.getResult 0).get! ctx₂.raw).type
+        = (⟨Attribute.integerType { bitwidth := 64 }, isT⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₂.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hRev8
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastResTypes : castOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRev8 (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castOp)]
+    have hRev8ResTypes : rev8Op.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rev8Op),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRev8 (operation := rev8Op)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₃.raw
+        = #[⟨Attribute.integerType { bitwidth := 64 }, isT⟩] := by grind
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        hCastType hCastOperands hCastResTypes hOpVal'
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := s₁) (inBounds := by grind)
+        (f := Data.RISCV.rev8) (fun _ _ _ _ => rfl) hRev8Type hRev8Operands hRev8ResTypes hRes₁
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+      interpretOp_castBack_forward (state := s₂) (inBounds := by grind)
+        hCastBackType hCastBackOperands hCastBackResTypes hRes₂
+    refine ⟨s₃, ?_, by grind, ?_⟩
+    · simp [interpretOpList_cons, hI₁, hI₂, hI₃, liftM, monadLift, MonadLift.monadLift, Interp]
+    · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt (Data.RISCV.rev8 (LLVM.Int.toReg xt)) 64)],
+        ?_, ?_⟩
+      · simp [hRes₃, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using bswap_isRefinedBy_toInt_rev8 hxtRef⟩
+  · -- 32-bit case: `castToReg → rev8 → srli 32 → castBack`.
+    rw [if_pos hbw] at hpattern
+    simp only [] at hpattern
+    peelOpCreation! hpattern ctx₃ srliOp hSrli hDom₂ hDom₃
+    peelReplaceWithRegLocal hpattern ctx₄ castBackOp hCastBack hDom₃ hDom₄
+    cleanupHpattern hpattern
+    obtain ⟨xt, hOpVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+        hDomCtx hDom₄ vNotOp
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    have hCastType : castOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by grind
+    have hRev8Type : rev8Op.getOpType! ctx₄.raw = .riscv .rev8 := by grind
+    have hSrliType : srliOp.getOpType! ctx₄.raw = .riscv .srli := by grind
+    have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+      grind
+    have hCastOperands : castOp.getOperands! ctx₄.raw = #[operand] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hCast (operation := castOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hRev8 (operation := castOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hSrli (operation := castOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := castOp)]
+    have hRev8Operands :
+        rev8Op.getOperands! ctx₄.raw = #[ValuePtr.opResult (castOp.getResult 0)] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hRev8 (operation := rev8Op),
+        OperationPtr.getOperands!_WfRewriter_createOp hSrli (operation := rev8Op),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rev8Op)]
+    have hSrliOperands :
+        srliOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (rev8Op.getResult 0)] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hSrli (operation := srliOp),
+        OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := srliOp)]
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (srliOp.getResult 0)] := by grind
+    have hSrliProps : srliOp.getProperties! ctx₄.raw (.riscv .srli)
+        = RISCVImmediateProperties.mk (IntegerAttr.mk 32 (IntegerType.mk 64)) := by
+      rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind)]
+      grind [OperationPtr.getProperties!_WfRewriter_createOp hSrli (operation := srliOp)]
+    have hSrliImm : BitVec.ofInt 6 (srliOp.getProperties! ctx₄.raw (.riscv .srli)).value.value
+        = BitVec.ofInt 6 32 := by rw [hSrliProps]
+    have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+        = (⟨Attribute.integerType { bitwidth := 32 }, isT⟩ : TypeAttr) := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hSrli
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp hRev8
+            (value := ValuePtr.opResult (op.getResult 0)),
+          ValuePtr.getType!_WfRewriter_createOp]
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastResTypes : castOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hRev8 (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hSrli (operation := castOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castOp)]
+    have hRev8ResTypes : rev8Op.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRev8 (operation := rev8Op),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hSrli (operation := rev8Op),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rev8Op)]
+    have hSrliResTypes : srliOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hSrli (operation := srliOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := srliOp)]
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+        = #[⟨Attribute.integerType { bitwidth := 32 }, isT⟩] := by grind
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+        hCastType hCastOperands hCastResTypes hOpVal'
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := s₁) (inBounds := by grind)
+        (f := Data.RISCV.rev8) (fun _ _ _ _ => rfl) hRev8Type hRev8Operands hRev8ResTypes hRes₁
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+      interpretOp_riscv_srli_forward (state := s₂) (inBounds := by grind)
+        (k := BitVec.ofInt 6 32) hSrliType hSrliImm hSrliOperands hSrliResTypes hRes₂
+    obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+      interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+        hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+    refine ⟨s₄, ?_, by grind, ?_⟩
+    · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift, Interp]
+    · refine ⟨#[RuntimeValue.int 32 (RISCV.Reg.toInt
+          (Data.RISCV.srli (BitVec.ofInt 6 32) (Data.RISCV.rev8 (LLVM.Int.toReg xt))) 32)], ?_, ?_⟩
+      · simp [hRes₄, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using bswap_isRefinedBy_toInt_srli_rev8 hxtRef⟩
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerConst.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerConst.lean
@@ -104,7 +104,7 @@ theorem constant_local_preservesSemantics :
   -- Second width guard (on `retTy.bitwidth`) is false.
   peelSplittableCondition [hW2] hpattern
   have hRetLe : retTy.bitwidth ≤ 64 := by
-    simp only [ne_eq, not_and, Decidable.not_not] at hW2 ⊢
+    simp only [not_and, Decidable.not_not] at hW2 ⊢
     omega
   -- The op's result types, for the source interpretation.
   have hResTypes : op.getResultTypes! ctx.raw = #[⟨Attribute.integerType retTy, (by grind)⟩] := by

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerConst.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerConst.lean
@@ -1,0 +1,302 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Data.Casting
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+
+namespace Veir
+
+/-! ## Correctness of `constant_local` (`llvm.mlir.constant` → `riscv.li` → cast) -/
+
+/-- Nullary `riscv.li` specialization of `interpretOp_forward`: a `riscv.li` op with no operands and
+a single `!riscv.reg` result binds that result to `.reg (Data.RISCV.li (BitVec.ofInt 64 imm))`,
+where `imm` is the op's immediate property value, leaving memory and every other value unchanged. -/
+theorem interpretOp_riscv_li_forward
+    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {rt : RegisterType} {hIsTy}
+    {props : HasDialectOpInfo.propertiesOf Riscv.li}
+    (hType : theOp.getOpType! ctx.raw = .riscv .li)
+    (hProps : theOp.getProperties! ctx.raw (.riscv .li) = props)
+    (hOperands : theOp.getOperands! ctx.raw = #[])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩]) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (Data.RISCV.li (BitVec.ofInt 64 props.value.value))) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[]) (results := #[.reg (Data.RISCV.li (BitVec.ofInt 64 props.value.value))])
+      (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp only [interpretOp', Riscv.interpretOp', hProps, Interp]
+          rfl)
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  have hNRes : 0 < theOp.getNumResults! ctx.raw := by
+    rw [← OperationPtr.getResultTypes!.size_eq_getNumResults!, hResTypes]; simp
+  grind
+
+/-- The `riscv.li` lowering of an `llvm.mlir.constant` of result width `retW ≤ 64` is correct: the
+64-bit immediate `BitVec.ofInt 64 c`, cast back to `i{retW}`, equals the LLVM constant. -/
+theorem constant_isRefinedBy_toInt_li {retW : Nat} (hle : retW ≤ 64) (c : Int) :
+    Data.LLVM.Int.constant retW c
+      ⊒ RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 c)) retW := by
+  rw [Data.LLVM.Int.isRefinedBy_iff]
+  refine ⟨fun _ => toInt_isPoison, fun _ _ => ?_⟩
+  rw [Data.LLVM.Int.getValue_constant, toInt_getValue]
+  simp only [Data.RISCV.li]
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_setWidth, BitVec.toNat_ofInt, BitVec.toNat_ofInt]
+  have hdvd : ((2 ^ retW : Nat) : Int) ∣ ((2 ^ 64 : Nat) : Int) := by
+    exact_mod_cast Nat.pow_dvd_pow 2 hle
+  have key : c % ((2 ^ 64 : Nat) : Int) % ((2 ^ retW : Nat) : Int) = c % ((2 ^ retW : Nat) : Int) :=
+    Int.emod_emod_of_dvd c hdvd
+  have h64 : (2 ^ 64 : Nat) ≠ 0 := Nat.pos_iff_ne_zero.mp (Nat.two_pow_pos 64)
+  have hnn : (0 : Int) ≤ c % ((2 ^ 64 : Nat) : Int) :=
+    Int.emod_nonneg c (by exact_mod_cast h64)
+  rw [← key, Int.toNat_emod hnn, Int.toNat_natCast]
+  exact_mod_cast Nat.zero_le _
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `constant_local` lowering: `llvm.mlir.constant` (integer) lowers to
+`riscv.li` of the 64-bit immediate followed by a cast back to the (`≤ 64`-bit) integer result
+type, and the round trip refines the LLVM constant. -/
+theorem constant_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics constant_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, constant_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchConstantIntOp op ctx.raw).isSome := by
+    cases hM : matchConstantIntOp op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨const, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Syntactic + verification facts.
+  have ⟨hOpType, hPropVal⟩ := matchConstantIntOp_implies hMatch
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg⟩ := OperationPtr.Verified.llvm_mlir__constant opVerif hOpType
+  -- First width guard (on `const.type.bitwidth`) is false.
+  peelSplittableCondition [hW1] hpattern
+  -- Resolve the result-type destructuring match: the result type is an integer type.
+  obtain ⟨retTy, hResIntTy⟩ :=
+    OperationPtr.Verified.llvm_mlir__constant_resultType opVerif hOpType hPropVal
+  rw [hResIntTy] at hpattern
+  simp only [] at hpattern
+  -- Second width guard (on `retTy.bitwidth`) is false.
+  peelSplittableCondition [hW2] hpattern
+  have hRetLe : retTy.bitwidth ≤ 64 := by
+    simp only [ne_eq, not_and, Decidable.not_not] at hW2 ⊢
+    omega
+  -- The op's result types, for the source interpretation.
+  have hResTypes : op.getResultTypes! ctx.raw = #[⟨Attribute.integerType retTy, (by grind)⟩] := by
+    apply Array.ext
+    · simp [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNRes]
+    · intro i h1 h2
+      simp only [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNRes] at h1
+      obtain rfl : i = 0 := by omega
+      simp only [OperationPtr.getResultTypes!.getElem_eq, Array.getElem_singleton]
+      exact Subtype.ext hResIntTy
+  -- Source value: `op`'s single result is `constant retTy.bitwidth const.value`.
+  have hOpVals : state.variables.getOperandValues op = some #[] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    exact ⟨by simp [hNOper], fun i hi => by rw [hNOper] at hi; omega⟩
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨ov, resValues, mem', vs', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [interpretOp', Llvm.interpretOp', hResTypes, hPropVal] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ :
+      resValues = #[RuntimeValue.int retTy.bitwidth
+        (Data.LLVM.Int.constant retTy.bitwidth const.value)] ∧ mem' = state.memory ∧ cf = none := by
+    simp only [Interp, pure] at hInterp'
+    grind
+  have hResVal : newState.variables.getVar? (op.getResult 0)
+      = some (.int retTy.bitwidth (Data.LLVM.Int.constant retTy.bitwidth const.value)) := by
+    rw [hNew, VariableState.getVar?_getResult_of_setResultValues? (by rw [hNRes]; omega) hSet]; simp
+  -- Source values array.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hResVal] at hsourceValues
+  subst sourceValues
+  -- Peel the two created ops: the `riscv.li` and the cast-back.
+  peelOpCreation hpattern ctx₁ liOp hLi
+  rw [WfRewriter.createOp!_none_eq (by clear hpattern; grind) (by clear hpattern; simp)
+    (by clear hpattern; simp)] at hLi
+  peelOpCreation hpattern ctx₂ castOp hCast
+  rw [WfRewriter.createOp!_none_eq (by clear hpattern; grind) (by clear hpattern; simp)
+    (by clear hpattern; simp)] at hCast
+  cleanupHpattern hpattern
+  -- Structural facts about the two created ops in the final context `ctx₂`.
+  have hLiType : liOp.getOpType! ctx₂.raw = .riscv .li := by grind
+  have hCastType : castOp.getOpType! ctx₂.raw = .builtin .unrealized_conversion_cast := by grind
+  have hLiOperands : liOp.getOperands! ctx₂.raw = #[] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hLi (operation := liOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCast (operation := liOp)]
+  have hCastOperands : castOp.getOperands! ctx₂.raw = #[ValuePtr.opResult (liOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hCast (operation := castOp)]
+  have hLiProps : liOp.getProperties! ctx₂.raw (.riscv .li) = { value := const } := by
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hLi (operation := liOp),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hCast]
+  have hLiResTypes : liOp.getResultTypes! ctx₂.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLi (operation := liOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := liOp)]
+  have hCastResTypes : castOp.getResultTypes! ctx₂.raw
+      = #[⟨Attribute.integerType retTy, (by grind)⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp)]
+  -- Interpretation tail: execute `interpretOpList [liOp, castOp]` in `state'`.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+    interpretOp_riscv_li_forward (state := state') (inBounds := by grind)
+      hLiType hLiProps hLiOperands hLiResTypes
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+    interpretOp_castBack_forward (state := s₁) (inBounds := by grind)
+      hCastType hCastOperands hCastResTypes hRes₁
+  refine ⟨s₂, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int retTy.bitwidth
+        (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 const.value)) retTy.bitwidth)], ?_, ?_⟩
+    · simp [hRes₂, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using constant_isRefinedBy_toInt_li hRetLe const.value⟩
+
+/-! ## Correctness of `poisonConst_local` (`llvm.mlir.poison` → `riscv.li 0` → cast) -/
+
+/-- The `llvm.mlir.poison` value (which is poison) is refined by any concretisation, in particular
+by the round trip through `riscv.li 0`. -/
+theorem mlir_poison_isRefinedBy {w : Nat} (r : Data.RISCV.Reg) :
+    Data.LLVM.Int.mlir_poison w ⊒ RISCV.Reg.toInt r w := by
+  rw [Data.LLVM.Int.isRefinedBy_iff]
+  refine ⟨fun h => ?_, fun h _ => ?_⟩ <;> simp [Data.LLVM.Int.isPoison_poison] at h
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `poisonConst_local` lowering: `llvm.mlir.poison` (integer) lowers to
+`riscv.li 0` followed by a cast back to the integer result type; the source value is poison, so it
+is refined by the round trip. -/
+theorem poisonConst_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics poisonConst_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, poisonConst_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher.
+  have hMatchSome : (matchPoison op ctx.raw).isSome := by
+    cases hM : matchPoison op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨u, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  have ⟨hOpType, hNOper, hNRes⟩ := matchPoison_implies hMatch
+  -- The op's single result type, as an array.
+  have hResTypesArr : op.getResultTypes! ctx.raw = #[((op.getResult 0).get! ctx.raw).type] := by
+    apply Array.ext
+    · simp [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNRes]
+    · intro i h1 h2
+      simp only [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNRes] at h1
+      obtain rfl : i = 0 := by omega
+      simp [OperationPtr.getResultTypes!.getElem_eq]
+  -- Source value: unfold the interpretation of `llvm.mlir.poison`; the result type must be integer.
+  have hOpVals : state.variables.getOperandValues op = some #[] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    exact ⟨by simp [hNOper], fun i hi => by rw [hNOper] at hi; omega⟩
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨ov, resValues, mem', vs', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [interpretOp', Llvm.interpretOp', hResTypesArr] at hInterp'
+  rw [show (#[((op.getResult 0).get! ctx.raw).type] : Array TypeAttr)[0]?
+      = some ((op.getResult 0).get! ctx.raw).type from rfl] at hInterp'
+  dsimp only at hInterp'
+  -- The result type is an integer type; extract its width and the poison source value.
+  obtain ⟨retTy, hResIntTy⟩ :
+      ∃ retTy : IntegerType, ((op.getResult 0).get! ctx.raw).type.val = .integerType retTy := by
+    cases hv : ((op.getResult 0).get! ctx.raw).type.val with
+    | integerType retTy => exact ⟨retTy, rfl⟩
+    | _ => rw [hv] at hInterp'; simp [Interp] at hInterp'
+  rw [hResIntTy] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ :
+      resValues = #[RuntimeValue.int retTy.bitwidth
+        (Data.LLVM.Int.mlir_poison retTy.bitwidth)] ∧ mem' = state.memory ∧ cf = none := by
+    simp only [Interp, pure] at hInterp'
+    grind
+  have hResVal : newState.variables.getVar? (op.getResult 0)
+      = some (.int retTy.bitwidth (Data.LLVM.Int.mlir_poison retTy.bitwidth)) := by
+    rw [hNew, VariableState.getVar?_getResult_of_setResultValues? (by rw [hNRes]; omega) hSet]; simp
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hResVal] at hsourceValues
+  subst sourceValues
+  -- Peel the two created ops: `riscv.li` and the `replaceWithRegLocal` cast-back.
+  peelOpCreation hpattern ctx₁ liOp hLi
+  rw [WfRewriter.createOp!_none_eq (by clear hpattern; grind) (by clear hpattern; simp)
+    (by clear hpattern; simp)] at hLi
+  peelOpCreation hpattern ctx₂ castOp hCast
+  simp only [replaceWithRegLocal] at hCast
+  rw [WfRewriter.createOp!_none_eq (by clear hpattern; grind) (by clear hpattern; simp)
+    (by clear hpattern; simp)] at hCast
+  cleanupHpattern hpattern
+  have hLiType : liOp.getOpType! ctx₂.raw = .riscv .li := by grind
+  have hCastType : castOp.getOpType! ctx₂.raw = .builtin .unrealized_conversion_cast := by grind
+  have hLiOperands : liOp.getOperands! ctx₂.raw = #[] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hLi (operation := liOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCast (operation := liOp)]
+  have hCastOperands : castOp.getOperands! ctx₂.raw = #[ValuePtr.opResult (liOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hCast (operation := castOp)]
+  have hLiProps : liOp.getProperties! ctx₂.raw (.riscv .li)
+      = { value := IntegerAttr.mk 0 (IntegerType.mk 64) } := by
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hLi (operation := liOp),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hCast]
+  have hLiResTypes : liOp.getResultTypes! ctx₂.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLi (operation := liOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := liOp)]
+  have hCastResTypes : castOp.getResultTypes! ctx₂.raw
+      = #[⟨Attribute.integerType retTy, (by grind)⟩] := by
+    have hty1 : ((op.getResult 0).get! ctx₁.raw).type = ⟨Attribute.integerType retTy, by grind⟩ := by
+      have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₁.raw
+          = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+        grind [ValuePtr.getType!_WfRewriter_createOp hLi
+          (value := ValuePtr.opResult (op.getResult 0))]
+      simp only [ValuePtr.getType!_opResult] at h1
+      rw [h1]; exact Subtype.ext hResIntTy
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := castOp)]
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+    interpretOp_riscv_li_forward (state := state') (inBounds := by grind)
+      hLiType hLiProps hLiOperands hLiResTypes
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+    interpretOp_castBack_forward (state := s₁) (inBounds := by grind)
+      hCastType hCastOperands hCastResTypes hRes₁
+  refine ⟨s₂, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int retTy.bitwidth
+        (RISCV.Reg.toInt (Data.RISCV.li (BitVec.ofInt 64 (IntegerAttr.mk 0 (IntegerType.mk 64)).value))
+          retTy.bitwidth)], ?_, ?_⟩
+    · simp [hRes₂, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr ⟨rfl, by simpa using mlir_poison_isRefinedBy _⟩
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerExt.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerExt.lean
@@ -9,6 +9,7 @@ import Veir.Data.LLVM.Int.Lemmas
 import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Data.Casting
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerLoad.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerLoad.lean
@@ -8,6 +8,7 @@ import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
 import Veir.Data.Casting
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerRotate.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerRotate.lean
@@ -9,6 +9,7 @@ import Veir.Data.LLVM.Int.Lemmas
 import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Data.Casting
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerSignedMinMax.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerSignedMinMax.lean
@@ -7,6 +7,7 @@ import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
@@ -117,7 +118,10 @@ theorem lowerSignedMinMaxLocal_preservesSemantics {srcOp : Llvm}
   simp only [] at hpattern
   -- Unfold the interpretation of the matched op: exposes the operand values and their `srcFn`.
   obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
-    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands rfl hSemSrc
+    matchBinaryOp_interpretOp_unfold opInBounds hOpType hNumResults hOperands rfl
+      (fun bw x y props rt bo mem res h => by
+        rw [hSemSrc bw x y props rt bo mem] at h
+        injection h with h; injection h with h; exact h.symm)
       hinterp hLhsType hRhsType
   subst hCf
   -- The matched operands dominate the rewrite point in the source context.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUaddSat.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUaddSat.lean
@@ -1,0 +1,411 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryW
+
+namespace Veir
+
+/-!
+## Correctness of `uaddSat_local`
+
+`llvm.intr.uadd.sat` on a 64-bit integer is lowered to LLVM's RV64+Zbb `umin` idiom
+`uadd.sat(a, b) -> umin(a, ~b) + b`:
+`unrealized_conversion_cast` (each operand to a register) → `riscv.xori -1` (bitwise-not of the
+second register, `~b`) → `riscv.minu` (of the first register and `~b`) → `riscv.add` (that min plus
+the second register) → `unrealized_conversion_cast` (back to the integer type).
+
+`uaddSat` fits neither `lowerBinaryRegLocal` (it emits *three* register ops, not one) nor `abs_local`
+(it has *two* operands, not one). It is therefore proven bespoke, in the same shape as the sibling
+`usubSat_local` proof: the two-operand `castToRegLocal`/`castToRegLocal` prefix followed by a
+straight-line register chain, except here the chain has an extra immediate step (`xori -1`, the
+immediate analogue of the plain unary-register forward lemma) and the second cast register (`rReg`)
+must be kept alive across the `xori`/`minu` steps to reach the final `add`. It is `i64`-only, so
+there is no bitwidth branch.
+-/
+
+/-- Forward-interpretation lemma for the immediate `riscv.xori`. Like
+    `interpretOp_riscv_srli_forward`, the emitted register is a function of the op's *immediate*,
+    read from its properties (as a `BitVec 12`), so the caller supplies that immediate as `k`
+    together with the reduction `hImm` of the op's stored property value. Interpreting the op
+    succeeds, leaves memory untouched, binds the result to `.reg (Data.RISCV.xori k r)`, and leaves
+    every non-result value unchanged. -/
+theorem interpretOp_riscv_xori_forward
+    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r : Data.RISCV.Reg} {k : BitVec 12}
+    (hType : theOp.getOpType! ctx.raw = .riscv .xori)
+    (hImm : BitVec.ofInt 12 (theOp.getProperties! ctx.raw (.riscv .xori)).value.value = k)
+    (hOperands : theOp.getOperands! ctx.raw = #[v])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (Data.RISCV.xori k r)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r]) (results := #[.reg (Data.RISCV.xori k r)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', Riscv.interpretOp', Interp, hImm, pure])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Correctness of the `add (minu (xori -1 ·) ·) ·` lowering of a 64-bit `llvm.intr.uadd.sat`: the
+    round trip `int × int → reg × reg → xori/minu/add → int` refines `uaddSat`. (`xt`/`yt` are the
+    possibly-more-defined target-side values of the operands.) The interpreter applies each binary
+    data-level op as `RISCV.op op2 op1`, so the target expression takes `(toReg yt)` first in `add`
+    and `(xori -1 (toReg yt))` first in `minu`. -/
+theorem uaddSat_isRefinedBy_toInt_add_minu {x y xt yt : Data.LLVM.Int 64}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.uaddSat x y ⊒
+      RISCV.Reg.toInt
+        (Data.RISCV.add (LLVM.Int.toReg yt)
+          (Data.RISCV.minu (Data.RISCV.xori (BitVec.ofInt 12 (-1)) (LLVM.Int.toReg yt))
+            (LLVM.Int.toReg xt))) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_uaddSat] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_uaddSat] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.add, Data.RISCV.minu, Data.RISCV.xori]
+  veir_bv_decide
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `uaddSat_local` lowering: the `castToReg → castToReg → xori -1 → minu → add →
+    castBack` round trip refines `llvm.intr.uadd.sat`. -/
+theorem uaddSat_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics uaddSat_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, uaddSat_local, createRISCVUnitLocal,
+    createRISCVImmLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchUaddSat op ctx.raw).isSome := by
+    cases hM : matchUaddSat op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands⟩ := matchUaddSat_implies hMatch
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, intType, hResType, hOp0Type, hOp1Type⟩ :=
+    OperationPtr.Verified.llvm_intr__uadd__sat opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- Both operand types and the result type are the integer type `intType`.
+  have hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand0, hOp0Type]
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand1, hOp1Type]
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    rw [hResType]
+  -- Resolve the result-type-destructuring match on `intType`.
+  rw [hResTypeVal] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand values and their `uaddSat`.
+  obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+    matchBinaryOp_interpretOp_unfold
+      (srcFn := fun {_} x y _ => Data.LLVM.Int.uaddSat x y)
+      (props := op.getProperties! ctx.raw (.llvm .intr__uadd__sat))
+      opInBounds hOpType hNumResults hOperands rfl
+      (fun bw x y props rt bo mem res h => by
+        have hEq : Llvm.interpretOp' .intr__uadd__sat props rt #[.int bw x, .int bw y] bo mem
+            = some (.ok (#[.int bw (Data.LLVM.Int.uaddSat x y)], mem, none)) := by
+          simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp]
+        rw [hEq] at h; injection h with h; injection h with h; exact h.symm)
+      hinterp hLhsType hRhsType
+  subst hCf
+  -- The matched operands dominate the rewrite point in the source context.
+  have hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition' [hBw] hpattern
+  -- Source value: `op`'s single result is `uaddSat` of its operands.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `lhs`/`rhs` are not among `op`'s results.
+  have lNotOp : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have rNotOp : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the two `castToRegLocal` creations, transporting both operand dominance facts through.
+  peelCastToRegLocal₂ hpattern ctx₁ lcastOp hLCast hDomCtxL hDomL₁ hDomCtxR hDomR₁
+  peelCastToRegLocal₂ hpattern ctx₂ rcastOp hRCast hDomL₁ hDomL₂ hDomR₁ hDomR₂
+  -- Freshness facts, used to keep earlier values alive across later interpretation steps.
+  have hLCastFresh : ¬ lcastOp.InBounds ctx.raw :=
+    WfRewriter.createOp_new_not_inBounds lcastOp hLCast
+  have hRhsIn : rhs.InBounds ctx.raw := by clear hpattern; grind
+  have hRhsNeLCastRes : ∀ i, rhs ≠ ValuePtr.opResult (lcastOp.getResult i) := by
+    intro i heq
+    rw [heq] at hRhsIn
+    rw [ValuePtr.inBounds_opResult] at hRhsIn
+    obtain ⟨hIn, -⟩ := hRhsIn
+    exact hLCastFresh hIn
+  -- Peel the `xori`, the `minu`, the `add`, and the `replaceWithRegLocal` creations.
+  peelOpCreation!₂ hpattern ctx₃ xoriOp hXori hDomL₂ hDomL₃ hDomR₂ hDomR₃
+  peelOpCreation!₂ hpattern ctx₄ minuOp hMinu hDomL₃ hDomL₄ hDomR₃ hDomR₄
+  peelOpCreation!₂ hpattern ctx₅ addOp hAdd hDomL₄ hDomL₅ hDomR₄ hDomR₅
+  -- `op` and `addOp`'s result stay in bounds across the five createOps; grind's e-matching cannot
+  -- chain this far on its own, so establish the facts the final peel's dischargers need up front.
+  have hOpIn₁ : op.InBounds ctx₁.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hLCast opInBounds
+  have hOpIn₂ : op.InBounds ctx₂.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hRCast hOpIn₁
+  have hOpIn₃ : op.InBounds ctx₃.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hXori hOpIn₂
+  have hOpIn₄ : op.InBounds ctx₄.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hMinu hOpIn₃
+  have hOpInBounds₅ : op.InBounds ctx₅.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hAdd hOpIn₄
+  have hAddIn₅ : addOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds addOp hAdd
+  have hAddNRes₅ : addOp.getNumResults! ctx₅.raw = 1 := by
+    grind [OperationPtr.getNumResults!_WfRewriter_createOp hAdd (operation := addOp)]
+  have hAddResIn₅ : (ValuePtr.opResult (addOp.getResult 0)).InBounds ctx₅.raw := by
+    rw [ValuePtr.inBounds_opResult]
+    exact OperationPtr.getResult_inBounds addOp hAddIn₅ 0
+      (by rw [← OperationPtr.getNumResults!_eq_getNumResults hAddIn₅, hAddNRes₅]; decide)
+  peelReplaceWithRegLocal₂ hpattern ctx₆ castBackOp hCastBack hDomL₅ hDomL₆ hDomR₅ hDomR₆
+  cleanupHpattern hpattern
+  -- Read the refined values `xt`/`yt` of `lhs`/`rhs` in the target state `state'`.
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+      hDomCtxL hDomL₆ lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+      hDomCtxR hDomR₆ rNotOp
+  obtain ⟨bw⟩ := intType; simp only at hBw; subst hBw
+  -- Structural facts about the six created ops (opcode transports seeded explicitly).
+  have hLCastType : lcastOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hXori (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hMinu (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAdd (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastType : rcastOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hXori (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hMinu (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAdd (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hXoriType : xoriOp.getOpType! ctx₆.raw = .riscv .xori := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hXori (operation := xoriOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hMinu (operation := xoriOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAdd (operation := xoriOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := xoriOp)]
+  have hMinuType : minuOp.getOpType! ctx₆.raw = .riscv .minu := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hMinu (operation := minuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAdd (operation := minuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := minuOp)]
+  have hAddType : addOp.getOpType! ctx₆.raw = .riscv .add := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hAdd (operation := addOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := addOp)]
+  have hCastBackType : castBackOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hLCastOperands : lcastOp.getOperands! ctx₆.raw = #[lhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hXori (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMinu (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAdd (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastOperands : rcastOp.getOperands! ctx₆.raw = #[rhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hXori (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMinu (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAdd (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hXoriOperands : xoriOp.getOperands! ctx₆.raw
+      = #[ValuePtr.opResult (rcastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hXori (operation := xoriOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMinu (operation := xoriOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAdd (operation := xoriOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := xoriOp)]
+  have hMinuOperands : minuOp.getOperands! ctx₆.raw
+      = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (xoriOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hMinu (operation := minuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAdd (operation := minuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := minuOp)]
+  have hAddOperands : addOp.getOperands! ctx₆.raw
+      = #[ValuePtr.opResult (minuOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hAdd (operation := addOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := addOp)]
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₆.raw = #[ValuePtr.opResult (addOp.getResult 0)] := by grind
+  -- The `xori` immediate is `-1`.
+  have hXoriProps : xoriOp.getProperties! ctx₆.raw (.riscv .xori) = mkRISCVImm (-1) := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hAdd (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hMinu (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp hXori (operation := xoriOp)]
+    rw [if_pos rfl]; rfl
+  have hXoriImm : BitVec.ofInt 12 (xoriOp.getProperties! ctx₆.raw (.riscv .xori)).value.value
+      = BitVec.ofInt 12 (-1) := by rw [hXoriProps]; simp [mkRISCVImm]
+  -- The cast-back op's result type is the integer type `i64`.
+  have hCBType : ((op.getResult 0).get! ctx₅.raw).type
+      = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+    have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₅.raw
+        = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+      grind [ValuePtr.getType!_WfRewriter_createOp hAdd
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hMinu
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hXori
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hRCast
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hLCast
+          (value := ValuePtr.opResult (op.getResult 0))]
+    simpa only [ValuePtr.getType!_opResult, hResType] using h1
+  have hLCastResTypes : lcastOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hXori (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMinu (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAdd (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastResTypes : rcastOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hXori (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMinu (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAdd (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hXoriResTypes : xoriOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hXori (operation := xoriOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMinu (operation := xoriOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAdd (operation := xoriOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := xoriOp)]
+  have hMinuResTypes : minuOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hMinu (operation := minuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAdd (operation := minuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := minuOp)]
+  have hAddResTypes : addOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hAdd (operation := addOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := addOp)]
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+  -- Interpretation tail: execute `interpretOpList [lcast, rcast, xori, minu, add, castBack]` in
+  -- `state'`. The frame clauses carry earlier bindings across later steps.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+    interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+      hLCastType hLCastOperands hLCastResTypes hLVal'
+  have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₆.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₆.raw rhs lcastOp
+      with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (hRhsNeLCastRes i)
+  have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 64 yt) := by
+    rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+    interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+      hRCastType hRCastOperands hRCastResTypes hRVal₁
+  -- Carry the `lcast` register through the `rcast` and `xori` steps (needed by `minu`).
+  have hLCastNotRCastRes :
+      ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₆.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₆.raw
+        (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+    rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+  -- The `xori` step: `~(toReg yt)`.
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+    interpretOp_riscv_xori_forward (state := s₂) (inBounds := by grind)
+      (k := BitVec.ofInt 12 (-1)) hXoriType hXoriImm hXoriOperands hXoriResTypes hRes₂
+  have hLCastNotXoriRes :
+      ValuePtr.opResult (lcastOp.getResult 0) ∉ xoriOp.getResults! ctx₆.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₆.raw
+        (ValuePtr.opResult (lcastOp.getResult 0)) xoriOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hLRes₃ : s₃.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+    rw [hFrame₃ _ hLCastNotXoriRes]; exact hLRes₂
+  have hRCastNotXoriRes :
+      ValuePtr.opResult (rcastOp.getResult 0) ∉ xoriOp.getResults! ctx₆.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₆.raw
+        (ValuePtr.opResult (rcastOp.getResult 0)) xoriOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hRRes₃ : s₃.variables.getVar? (ValuePtr.opResult (rcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg yt)) := by
+    rw [hFrame₃ _ hRCastNotXoriRes]; exact hRes₂
+  -- The `minu` step: `minu (~(toReg yt)) (toReg xt)`.
+  obtain ⟨s₄, hI₄, hMem₄, hRes₄, hFrame₄⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₃) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.minu r₂ r₁) (fun _ _ _ _ => rfl) hMinuType hMinuOperands
+      hMinuResTypes hLRes₃ hRes₃
+  -- Carry the `rcast` register through the `minu` step (needed by `add`).
+  have hRCastNotMinuRes :
+      ValuePtr.opResult (rcastOp.getResult 0) ∉ minuOp.getResults! ctx₆.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₆.raw
+        (ValuePtr.opResult (rcastOp.getResult 0)) minuOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hRRes₄ : s₄.variables.getVar? (ValuePtr.opResult (rcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg yt)) := by
+    rw [hFrame₄ _ hRCastNotMinuRes]; exact hRRes₃
+  -- The `add` step: `add (toReg yt) (minu …)`.
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, hFrame₅⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₄) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.add r₂ r₁) (fun _ _ _ _ => rfl) hAddType hAddOperands
+      hAddResTypes hRes₄ hRRes₄
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, -⟩ :=
+    interpretOp_castBack_forward (state := s₅) (inBounds := by grind)
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₅
+  refine ⟨s₆, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, hI₅, hI₆, liftM, monadLift,
+      MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt
+        (Data.RISCV.add (LLVM.Int.toReg yt)
+          (Data.RISCV.minu (Data.RISCV.xori (BitVec.ofInt 12 (-1)) (LLVM.Int.toReg yt))
+            (LLVM.Int.toReg xt))) 64)], ?_, ?_⟩
+    · simp [hRes₆, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using uaddSat_isRefinedBy_toInt_add_minu hxtRef hytRef⟩
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUnaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUnaryW.lean
@@ -7,6 +7,7 @@ import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUshlSat.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUshlSat.lean
@@ -1,0 +1,759 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryW
+
+namespace Veir
+
+/-!
+## Correctness of `ushlSat_local`
+
+`llvm.intr.ushl.sat` on a 64-bit integer is lowered to LLVM's RV64 unsigned saturating-shl idiom
+(`expandShlSat`): shift, then detect the lost high bits and OR in an all-ones mask on overflow.
+
+`unrealized_conversion_cast` (each operand to a register) →
+`riscv.sll`  (`shifted = lhs << rhs`) →
+`riscv.srl`  (`unshifted = shifted >>u rhs`) →
+`riscv.xor`  (`lostBits = lhs ^ unshifted`) →
+`riscv.sltiu 1` (`noOverflow = (lostBits == 0)`) →
+`riscv.addi -1` (`overflowMask = noOverflow - 1`, i.e. `0` or all-ones) →
+`riscv.or`   (`overflowMask | shifted`) →
+`unrealized_conversion_cast` (back to the integer type).
+
+Like the sibling `uaddSat_local`/`usubSat_local`, it fits no combinator, so it is proven bespoke: the
+two-operand `castToRegLocal` prefix followed by a straight-line register chain, here of six RISC-V
+ops (two of them the immediate `sltiu`/`addi`). It is `i64`-only, so there is no bitwidth branch.
+
+Soundness of the RISC-V shift-amount masking: `ushlSat x y` is *poison* whenever the shift amount
+`y ≥ 64`, so the two-argument shifts (which mask the amount to 6 bits) only need to agree with LLVM
+for `y < 64`, where masking is the identity.
+-/
+
+/-- Forward-interpretation lemma for the immediate `riscv.sltiu` (mirrors
+    `interpretOp_riscv_xori_forward`). The emitted register is `Data.RISCV.sltiu k r` for the op's
+    stored immediate `k`. -/
+theorem interpretOp_riscv_sltiu_forward
+    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r : Data.RISCV.Reg} {k : BitVec 12}
+    (hType : theOp.getOpType! ctx.raw = .riscv .sltiu)
+    (hImm : BitVec.ofInt 12 (theOp.getProperties! ctx.raw (.riscv .sltiu)).value.value = k)
+    (hOperands : theOp.getOperands! ctx.raw = #[v])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (Data.RISCV.sltiu k r)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r]) (results := #[.reg (Data.RISCV.sltiu k r)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', Riscv.interpretOp', Interp, hImm, pure])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Forward-interpretation lemma for the immediate `riscv.addi` (mirrors
+    `interpretOp_riscv_xori_forward`). The emitted register is `Data.RISCV.addi k r` for the op's
+    stored immediate `k`. -/
+theorem interpretOp_riscv_addi_forward
+    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {r : Data.RISCV.Reg} {k : BitVec 12}
+    (hType : theOp.getOpType! ctx.raw = .riscv .addi)
+    (hImm : BitVec.ofInt 12 (theOp.getProperties! ctx.raw (.riscv .addi)).value.value = k)
+    (hOperands : theOp.getOperands! ctx.raw = #[v])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.reg (Data.RISCV.addi k r)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r]) (results := #[.reg (Data.RISCV.addi k r)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [interpretOp', Riscv.interpretOp', Interp, hImm, pure])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Correctness of the RV64 unsigned saturating-shl lowering of a 64-bit `llvm.intr.ushl.sat`: the
+    register chain `or (sll ·) (addi -1 (sltiu 1 (xor (srl ·) ·)))` refines `ushlSat`. (`xt`/`yt`
+    are the possibly-more-defined target-side values of the operands.) The interpreter applies each
+    binary data-level op as `RISCV.op op2 op1`, which fixes the operand order in each subterm. -/
+theorem ushlSat_isRefinedBy_toInt {x y xt yt : Data.LLVM.Int 64}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.ushlSat x y ⊒
+      RISCV.Reg.toInt
+        (Data.RISCV.or
+          (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt))
+          (Data.RISCV.addi (BitVec.ofInt 12 (-1))
+            (Data.RISCV.sltiu (BitVec.ofInt 12 1)
+              (Data.RISCV.xor
+                (Data.RISCV.srl (LLVM.Int.toReg yt)
+                  (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)))
+                (LLVM.Int.toReg xt))))) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_ushlSat] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_ushlSat] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  -- The shift amount is `< 64` in the non-poison case, so the RISC-V shift-amount masking (to 6
+  -- bits) agrees with LLVM's full-width shift.
+  have hyb : ¬ (y.getValueD ≥ (64 : BitVec 64)) := by
+    have hh := hnp
+    rw [Data.LLVM.Int.isPoison_ushlSat] at hh
+    simp only [hxnp, hynp, or_self, Bool.false_eq_true, dite_false, decide_eq_false_iff_not,
+      Data.LLVM.Int.getValue_eq_getValueD] at hh
+    exact hh
+  simp only [Data.RISCV.or, Data.RISCV.sll, Data.RISCV.srl, Data.RISCV.xor, Data.RISCV.sltiu,
+    Data.RISCV.addi]
+  veir_bv_decide
+
+set_option maxHeartbeats 2000000 in
+/-- Correctness of the `ushlSat_local` lowering: the
+    `castToReg → castToReg → sll → srl → xor → sltiu 1 → addi -1 → or → castBack` round trip refines
+    `llvm.intr.ushl.sat`. -/
+theorem ushlSat_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics ushlSat_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, ushlSat_local, createRISCVUnitLocal,
+    createRISCVImmLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchUshlSat op ctx.raw).isSome := by
+    cases hM : matchUshlSat op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands⟩ := matchUshlSat_implies hMatch
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, intType, hResType, hOp0Type, hOp1Type⟩ :=
+    OperationPtr.Verified.llvm_intr__ushl__sat opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- Both operand types and the result type are the integer type `intType`.
+  have hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand0, hOp0Type]
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand1, hOp1Type]
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    rw [hResType]
+  -- Resolve the result-type-destructuring match on `intType`.
+  rw [hResTypeVal] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand values and their `ushlSat`.
+  obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+    matchBinaryOp_interpretOp_unfold
+      (srcFn := fun {_} x y _ => Data.LLVM.Int.ushlSat x y)
+      (props := op.getProperties! ctx.raw (.llvm .intr__ushl__sat))
+      opInBounds hOpType hNumResults hOperands rfl
+      (fun bw x y props rt bo mem res h => by
+        have hEq : Llvm.interpretOp' .intr__ushl__sat props rt #[.int bw x, .int bw y] bo mem
+            = some (.ok (#[.int bw (Data.LLVM.Int.ushlSat x y)], mem, none)) := by
+          simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp]
+        rw [hEq] at h; injection h with h; injection h with h; exact h.symm)
+      hinterp hLhsType hRhsType
+  subst hCf
+  -- The matched operands dominate the rewrite point in the source context.
+  have hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition' [hBw] hpattern
+  -- Source value: `op`'s single result is `ushlSat` of its operands.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `lhs`/`rhs` are not among `op`'s results.
+  have lNotOp : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have rNotOp : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the two `castToRegLocal` creations, transporting both operand dominance facts through.
+  peelCastToRegLocal₂ hpattern ctx₁ lcastOp hLCast hDomCtxL hDomL₁ hDomCtxR hDomR₁
+  peelCastToRegLocal₂ hpattern ctx₂ rcastOp hRCast hDomL₁ hDomL₂ hDomR₁ hDomR₂
+  -- Freshness facts, used to keep `rhs` alive across the first cast.
+  have hLCastFresh : ¬ lcastOp.InBounds ctx.raw :=
+    WfRewriter.createOp_new_not_inBounds lcastOp hLCast
+  have hLhsIn : lhs.InBounds ctx.raw := by clear hpattern; grind
+  have hRhsIn : rhs.InBounds ctx.raw := by clear hpattern; grind
+  have hRhsNeLCastRes : ∀ i, rhs ≠ ValuePtr.opResult (lcastOp.getResult i) := by
+    intro i heq
+    rw [heq] at hRhsIn
+    rw [ValuePtr.inBounds_opResult] at hRhsIn
+    obtain ⟨hIn, -⟩ := hRhsIn
+    exact hLCastFresh hIn
+  -- Peel the first three RISC-V ops with the macro (their dominance transports chain `op.InBounds`
+  -- across ≤ 4 createOps, which grind handles on its own).
+  peelOpCreation!₂ hpattern ctx₃ sllOp hSll hDomL₂ hDomL₃ hDomR₂ hDomR₃
+  peelOpCreation!₂ hpattern ctx₄ srlOp hSrl hDomL₃ hDomL₄ hDomR₃ hDomR₄
+  peelOpCreation!₂ hpattern ctx₅ xorOp hXor hDomL₄ hDomL₅ hDomR₄ hDomR₅
+  -- The remaining peels reach `op.InBounds` five or more creations deep, which grind cannot chain,
+  -- and any `InBounds` hypothesis in context perturbs the macro's `grind` dischargers (their
+  -- non-monotonicity). So peel `sltiu`/`addi`/`or`/cast-back manually: discharge each operand's
+  -- in-bounds inline (seeding the op-in-bounds and result-count facts directly) and build every
+  -- `op.InBounds` witness inline, clearing it before continuing.
+  -- `sltiu 1`
+  have ⟨⟨ctx₆, sltiuOp⟩, hSltiu, pat'⟩ := hpattern
+  clear hpattern; have hpattern := pat'; clear pat'
+  rw [WfRewriter.createOp!_none_eq
+    (by clear hpattern; intro oper ho
+        simp only [List.mem_toArray, List.mem_cons, List.not_mem_nil, or_false] at ho
+        rcases ho with rfl
+        have hIn : xorOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds xorOp hXor
+        have hNum : xorOp.getNumResults! ctx₅.raw = 1 :=
+          by grind [OperationPtr.getNumResults!_WfRewriter_createOp hXor (operation := xorOp)]
+        grind)
+    (by clear hpattern; simp) (by clear hpattern; simp)] at hSltiu
+  have hOpIn₅ : op.InBounds ctx₅.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hXor
+      (WfRewriter.createOp_inBounds_mono (ptr := .operation op) hSrl
+        (WfRewriter.createOp_inBounds_mono (ptr := .operation op) hSll
+          (WfRewriter.createOp_inBounds_mono (ptr := .operation op) hRCast
+            (WfRewriter.createOp_inBounds_mono (ptr := .operation op) hLCast opInBounds))))
+  have hOpNeSltiu : op ≠ sltiuOp := fun heq =>
+    WfRewriter.createOp_new_not_inBounds sltiuOp hSltiu (heq ▸ hOpIn₅)
+  have hDomL₆ :=
+    (ValuePtr.dominatesIp_before_WfRewriter_createOp hSltiu hOpIn₅ hOpNeSltiu).mpr hDomL₅
+  have hDomR₆ :=
+    (ValuePtr.dominatesIp_before_WfRewriter_createOp hSltiu hOpIn₅ hOpNeSltiu).mpr hDomR₅
+  have hOpIn₆ : op.InBounds ctx₆.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hSltiu hOpIn₅
+  clear hOpNeSltiu hOpIn₅
+  -- `addi -1`
+  have ⟨⟨ctx₇, addiOp⟩, hAddi, pat'⟩ := hpattern
+  clear hpattern; have hpattern := pat'; clear pat'
+  rw [WfRewriter.createOp!_none_eq
+    (by clear hpattern; intro oper ho
+        simp only [List.mem_toArray, List.mem_cons, List.not_mem_nil, or_false] at ho
+        rcases ho with rfl
+        have hIn : sltiuOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds sltiuOp hSltiu
+        have hNum : sltiuOp.getNumResults! ctx₆.raw = 1 :=
+          by grind [OperationPtr.getNumResults!_WfRewriter_createOp hSltiu (operation := sltiuOp)]
+        grind)
+    (by clear hpattern; simp) (by clear hpattern; simp)] at hAddi
+  have hOpNeAddi : op ≠ addiOp := fun heq =>
+    WfRewriter.createOp_new_not_inBounds addiOp hAddi (heq ▸ hOpIn₆)
+  have hDomL₇ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hAddi hOpIn₆ hOpNeAddi).mpr hDomL₆
+  have hDomR₇ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hAddi hOpIn₆ hOpNeAddi).mpr hDomR₆
+  have hOpIn₇ : op.InBounds ctx₇.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hAddi hOpIn₆
+  clear hOpNeAddi hOpIn₆
+  -- `or`
+  have ⟨⟨ctx₈, orOp⟩, hOr, pat'⟩ := hpattern
+  clear hpattern; have hpattern := pat'; clear pat'
+  rw [WfRewriter.createOp!_none_eq
+    (by clear hpattern; intro oper ho
+        simp only [List.mem_toArray, List.mem_cons, List.not_mem_nil, or_false] at ho
+        rcases ho with rfl | rfl
+        · have hIn : addiOp.InBounds ctx₇.raw := WfRewriter.createOp_new_inBounds addiOp hAddi
+          have hNum : addiOp.getNumResults! ctx₇.raw = 1 :=
+            by grind [OperationPtr.getNumResults!_WfRewriter_createOp hAddi (operation := addiOp)]
+          rw [ValuePtr.inBounds_opResult]
+          exact OperationPtr.getResult_inBounds addiOp hIn 0
+            (by rw [← OperationPtr.getNumResults!_eq_getNumResults hIn, hNum]; decide)
+        · have hIn : sllOp.InBounds ctx₇.raw :=
+            WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hAddi
+              (WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hSltiu
+                (WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hXor
+                  (WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hSrl
+                    (WfRewriter.createOp_new_inBounds sllOp hSll))))
+          have hNum : sllOp.getNumResults! ctx₇.raw = 1 :=
+            by grind [OperationPtr.getNumResults!_WfRewriter_createOp hSll (operation := sllOp),
+              OperationPtr.getNumResults!_WfRewriter_createOp hSrl (operation := sllOp),
+              OperationPtr.getNumResults!_WfRewriter_createOp hXor (operation := sllOp),
+              OperationPtr.getNumResults!_WfRewriter_createOp hSltiu (operation := sllOp),
+              OperationPtr.getNumResults!_WfRewriter_createOp hAddi (operation := sllOp)]
+          rw [ValuePtr.inBounds_opResult]
+          exact OperationPtr.getResult_inBounds sllOp hIn 0
+            (by rw [← OperationPtr.getNumResults!_eq_getNumResults hIn, hNum]; decide))
+    (by clear hpattern; simp) (by clear hpattern; simp)] at hOr
+  have hOpNeOr : op ≠ orOp := fun heq =>
+    WfRewriter.createOp_new_not_inBounds orOp hOr (heq ▸ hOpIn₇)
+  have hDomL₈ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hOr hOpIn₇ hOpNeOr).mpr hDomL₇
+  have hDomR₈ := (ValuePtr.dominatesIp_before_WfRewriter_createOp hOr hOpIn₇ hOpNeOr).mpr hDomR₇
+  have hOpIn₈ : op.InBounds ctx₈.raw :=
+    WfRewriter.createOp_inBounds_mono (ptr := .operation op) hOr hOpIn₇
+  clear hOpNeOr hOpIn₇
+  -- cast-back
+  have ⟨⟨ctx₉, castBackOp⟩, hCastBack, pat'⟩ := hpattern
+  clear hpattern; have hpattern := pat'; clear pat'
+  simp only [replaceWithRegLocal] at hCastBack
+  rw [WfRewriter.createOp!_none_eq
+    (by clear hpattern; intro oper ho
+        simp only [List.mem_toArray, List.mem_cons, List.not_mem_nil, or_false] at ho
+        rcases ho with rfl
+        have hIn : orOp.InBounds ctx₈.raw := WfRewriter.createOp_new_inBounds orOp hOr
+        have hNum : orOp.getNumResults! ctx₈.raw = 1 := by
+          simpa using OperationPtr.getNumResults!_WfRewriter_createOp hOr (operation := orOp)
+        rw [ValuePtr.inBounds_opResult]
+        exact OperationPtr.getResult_inBounds orOp hIn 0
+          (by rw [← OperationPtr.getNumResults!_eq_getNumResults hIn, hNum]; decide))
+    (by clear hpattern; simp) (by clear hpattern; simp)] at hCastBack
+  have hOpNeCB : op ≠ castBackOp := fun heq =>
+    WfRewriter.createOp_new_not_inBounds castBackOp hCastBack (heq ▸ hOpIn₈)
+  have hDomL₉ :=
+    (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastBack hOpIn₈ hOpNeCB).mpr hDomL₈
+  have hDomR₉ :=
+    (ValuePtr.dominatesIp_before_WfRewriter_createOp hCastBack hOpIn₈ hOpNeCB).mpr hDomR₈
+  clear hOpNeCB hOpIn₈
+  cleanupHpattern hpattern
+  -- Read the refined values `xt`/`yt` of `lhs`/`rhs` in the target state `state'`.
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hLhsIn hxVal
+      hDomCtxL hDomL₉ lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hRhsIn hyVal
+      hDomCtxR hDomR₉ rNotOp
+  -- The refinement obligations are discharged; drop `valueRefinement`/`state'Wf`/`state'Dom` and the
+  -- intermediate dominance facts, which otherwise bloat every downstream `grind`.
+  clear valueRefinement state'Wf state'Dom hDomL₉ hDomR₉ hDomL₈ hDomR₈ hDomL₇ hDomR₇
+    hDomL₆ hDomR₆ hDomL₅ hDomR₅ hDomL₄ hDomR₄ hDomL₃ hDomR₃ hDomL₂ hDomR₂ hDomL₁ hDomR₁
+  obtain ⟨bw⟩ := intType; simp only at hBw; subst hBw
+  -- Each created op stays in bounds in every later context, and each is fresh in its own creation
+  -- context. Together these give (to `grind`) the pairwise distinctness of all nine ops, which the
+  -- property transports below need but `grind` cannot chain nine creations deep on its own; the
+  -- `…ctx₉` facts also discharge the forward-interpretation `inBounds` obligations.
+  have iOp1 : op.InBounds ctx₁.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hLCast opInBounds
+  have iOp2 : op.InBounds ctx₂.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hRCast iOp1
+  have iOp3 : op.InBounds ctx₃.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hSll iOp2
+  have iOp4 : op.InBounds ctx₄.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hSrl iOp3
+  have iOp5 : op.InBounds ctx₅.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hXor iOp4
+  have iOp6 : op.InBounds ctx₆.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hSltiu iOp5
+  have iOp7 : op.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hAddi iOp6
+  have iOp8 : op.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation op) hOr iOp7
+  have iL1 : lcastOp.InBounds ctx₁.raw := WfRewriter.createOp_new_inBounds lcastOp hLCast
+  have iL2 : lcastOp.InBounds ctx₂.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hRCast iL1
+  have iL3 : lcastOp.InBounds ctx₃.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hSll iL2
+  have iL4 : lcastOp.InBounds ctx₄.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hSrl iL3
+  have iL5 : lcastOp.InBounds ctx₅.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hXor iL4
+  have iL6 : lcastOp.InBounds ctx₆.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hSltiu iL5
+  have iL7 : lcastOp.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hAddi iL6
+  have iL8 : lcastOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hOr iL7
+  have iL9 : lcastOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation lcastOp) hCastBack iL8
+  have iR2 : rcastOp.InBounds ctx₂.raw := WfRewriter.createOp_new_inBounds rcastOp hRCast
+  have iR3 : rcastOp.InBounds ctx₃.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hSll iR2
+  have iR4 : rcastOp.InBounds ctx₄.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hSrl iR3
+  have iR5 : rcastOp.InBounds ctx₅.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hXor iR4
+  have iR6 : rcastOp.InBounds ctx₆.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hSltiu iR5
+  have iR7 : rcastOp.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hAddi iR6
+  have iR8 : rcastOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hOr iR7
+  have iR9 : rcastOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation rcastOp) hCastBack iR8
+  have iS3 : sllOp.InBounds ctx₃.raw := WfRewriter.createOp_new_inBounds sllOp hSll
+  have iS4 : sllOp.InBounds ctx₄.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hSrl iS3
+  have iS5 : sllOp.InBounds ctx₅.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hXor iS4
+  have iS6 : sllOp.InBounds ctx₆.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hSltiu iS5
+  have iS7 : sllOp.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hAddi iS6
+  have iS8 : sllOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hOr iS7
+  have iS9 : sllOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sllOp) hCastBack iS8
+  have iT4 : srlOp.InBounds ctx₄.raw := WfRewriter.createOp_new_inBounds srlOp hSrl
+  have iT5 : srlOp.InBounds ctx₅.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation srlOp) hXor iT4
+  have iT6 : srlOp.InBounds ctx₆.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation srlOp) hSltiu iT5
+  have iT7 : srlOp.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation srlOp) hAddi iT6
+  have iT8 : srlOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation srlOp) hOr iT7
+  have iT9 : srlOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation srlOp) hCastBack iT8
+  have iX5 : xorOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds xorOp hXor
+  have iX6 : xorOp.InBounds ctx₆.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation xorOp) hSltiu iX5
+  have iX7 : xorOp.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation xorOp) hAddi iX6
+  have iX8 : xorOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation xorOp) hOr iX7
+  have iX9 : xorOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation xorOp) hCastBack iX8
+  have iU6 : sltiuOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds sltiuOp hSltiu
+  have iU7 : sltiuOp.InBounds ctx₇.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sltiuOp) hAddi iU6
+  have iU8 : sltiuOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sltiuOp) hOr iU7
+  have iU9 : sltiuOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation sltiuOp) hCastBack iU8
+  have iA7 : addiOp.InBounds ctx₇.raw := WfRewriter.createOp_new_inBounds addiOp hAddi
+  have iA8 : addiOp.InBounds ctx₈.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation addiOp) hOr iA7
+  have iA9 : addiOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation addiOp) hCastBack iA8
+  have iO8 : orOp.InBounds ctx₈.raw := WfRewriter.createOp_new_inBounds orOp hOr
+  have iO9 : orOp.InBounds ctx₉.raw := WfRewriter.createOp_inBounds_mono (ptr := .operation orOp) hCastBack iO8
+  have iC9 : castBackOp.InBounds ctx₉.raw := WfRewriter.createOp_new_inBounds castBackOp hCastBack
+  have fRc : ¬ rcastOp.InBounds ctx₁.raw := WfRewriter.createOp_new_not_inBounds rcastOp hRCast
+  have fSll : ¬ sllOp.InBounds ctx₂.raw := WfRewriter.createOp_new_not_inBounds sllOp hSll
+  have fSrl : ¬ srlOp.InBounds ctx₃.raw := WfRewriter.createOp_new_not_inBounds srlOp hSrl
+  have fXor : ¬ xorOp.InBounds ctx₄.raw := WfRewriter.createOp_new_not_inBounds xorOp hXor
+  have fSltiu : ¬ sltiuOp.InBounds ctx₅.raw := WfRewriter.createOp_new_not_inBounds sltiuOp hSltiu
+  have fAddi : ¬ addiOp.InBounds ctx₆.raw := WfRewriter.createOp_new_not_inBounds addiOp hAddi
+  have fOr : ¬ orOp.InBounds ctx₇.raw := WfRewriter.createOp_new_not_inBounds orOp hOr
+  have fCb : ¬ castBackOp.InBounds ctx₈.raw := WfRewriter.createOp_new_not_inBounds castBackOp hCastBack
+  -- Structural facts about the nine created ops (opcode/operand/result-type transports seeded
+  -- explicitly through each op created afterwards).
+  have hLCastType : lcastOp.getOpType! ctx₉.raw = .builtin .unrealized_conversion_cast := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSll (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSrl (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hXor (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSltiu (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastType : rcastOp.getOpType! ctx₉.raw = .builtin .unrealized_conversion_cast := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSll (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSrl (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hXor (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSltiu (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hSllType : sllOp.getOpType! ctx₉.raw = .riscv .sll := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hSll (operation := sllOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSrl (operation := sllOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hXor (operation := sllOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSltiu (operation := sllOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := sllOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := sllOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := sllOp)]
+  have hSrlType : srlOp.getOpType! ctx₉.raw = .riscv .srl := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hSrl (operation := srlOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hXor (operation := srlOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSltiu (operation := srlOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := srlOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := srlOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := srlOp)]
+  have hXorType : xorOp.getOpType! ctx₉.raw = .riscv .xor := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hXor (operation := xorOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSltiu (operation := xorOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := xorOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := xorOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := xorOp)]
+  have hSltiuType : sltiuOp.getOpType! ctx₉.raw = .riscv .sltiu := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hSltiu (operation := sltiuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := sltiuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := sltiuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := sltiuOp)]
+  have hAddiType : addiOp.getOpType! ctx₉.raw = .riscv .addi := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hAddi (operation := addiOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := addiOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := addiOp)]
+  have hOrType : orOp.getOpType! ctx₉.raw = .riscv .or := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hOr (operation := orOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := orOp)]
+  have hCastBackType : castBackOp.getOpType! ctx₉.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hLCastOperands : lcastOp.getOperands! ctx₉.raw = #[lhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSll (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSrl (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hXor (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSltiu (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastOperands : rcastOp.getOperands! ctx₉.raw = #[rhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSll (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSrl (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hXor (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSltiu (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hSllOperands : sllOp.getOperands! ctx₉.raw
+      = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hSll (operation := sllOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSrl (operation := sllOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hXor (operation := sllOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSltiu (operation := sllOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := sllOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := sllOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := sllOp)]
+  have hSrlOperands : srlOp.getOperands! ctx₉.raw
+      = #[ValuePtr.opResult (sllOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hSrl (operation := srlOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hXor (operation := srlOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSltiu (operation := srlOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := srlOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := srlOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := srlOp)]
+  have hXorOperands : xorOp.getOperands! ctx₉.raw
+      = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (srlOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hXor (operation := xorOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSltiu (operation := xorOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := xorOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := xorOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := xorOp)]
+  have hSltiuOperands : sltiuOp.getOperands! ctx₉.raw
+      = #[ValuePtr.opResult (xorOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hSltiu (operation := sltiuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := sltiuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := sltiuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := sltiuOp)]
+  have hAddiOperands : addiOp.getOperands! ctx₉.raw
+      = #[ValuePtr.opResult (sltiuOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hAddi (operation := addiOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := addiOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := addiOp)]
+  have hOrOperands : orOp.getOperands! ctx₉.raw
+      = #[ValuePtr.opResult (addiOp.getResult 0), ValuePtr.opResult (sllOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hOr (operation := orOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := orOp)]
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₉.raw = #[ValuePtr.opResult (orOp.getResult 0)] := by grind
+  -- The `sltiu` immediate is `1`, the `addi` immediate is `-1`.
+  have hSltiuProps : sltiuOp.getProperties! ctx₉.raw (.riscv .sltiu) = mkRISCVImm 1 := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hOr (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hAddi (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp hSltiu (operation := sltiuOp)]
+    rw [if_pos rfl]; rfl
+  have hSltiuImm : BitVec.ofInt 12 (sltiuOp.getProperties! ctx₉.raw (.riscv .sltiu)).value.value
+      = BitVec.ofInt 12 1 := by rw [hSltiuProps]; simp [mkRISCVImm]
+  have hAddiProps : addiOp.getProperties! ctx₉.raw (.riscv .addi) = mkRISCVImm (-1) := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hOr (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp hAddi (operation := addiOp)]
+    rw [if_pos rfl]; rfl
+  have hAddiImm : BitVec.ofInt 12 (addiOp.getProperties! ctx₉.raw (.riscv .addi)).value.value
+      = BitVec.ofInt 12 (-1) := by rw [hAddiProps]; simp [mkRISCVImm]
+  -- The cast-back op's result type is the integer type `i64`.
+  have hCBType : ((op.getResult 0).get! ctx₈.raw).type
+      = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+    have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₈.raw
+        = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+      grind [ValuePtr.getType!_WfRewriter_createOp hOr
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hAddi
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hSltiu
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hXor
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hSrl
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hSll
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hRCast
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hLCast
+          (value := ValuePtr.opResult (op.getResult 0))]
+    simpa only [ValuePtr.getType!_opResult, hResType] using h1
+  have hLCastResTypes : lcastOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSll (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSrl (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hXor (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSltiu (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastResTypes : rcastOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSll (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSrl (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hXor (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSltiu (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hSllResTypes : sllOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hSll (operation := sllOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSrl (operation := sllOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hXor (operation := sllOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSltiu (operation := sllOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := sllOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := sllOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := sllOp)]
+  have hSrlResTypes : srlOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hSrl (operation := srlOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hXor (operation := srlOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSltiu (operation := srlOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := srlOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := srlOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := srlOp)]
+  have hXorResTypes : xorOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hXor (operation := xorOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSltiu (operation := xorOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := xorOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := xorOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := xorOp)]
+  have hSltiuResTypes : sltiuOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hSltiu (operation := sltiuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := sltiuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := sltiuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := sltiuOp)]
+  have hAddiResTypes : addiOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hAddi (operation := addiOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := addiOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := addiOp)]
+  have hOrResTypes : orOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hOr (operation := orOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := orOp)]
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₉.raw
+      = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+  -- Interpretation tail: execute the nine-op list in `state'`. The frame clauses carry earlier
+  -- register bindings across later steps, notably `lReg` (to `xor`) and `shifted` (to `or`).
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+    interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+      hLCastType hLCastOperands hLCastResTypes hLVal'
+  have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw rhs lcastOp
+      with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (hRhsNeLCastRes i)
+  have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 64 yt) := by
+    rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+    interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+      hRCastType hRCastOperands hRCastResTypes hRVal₁
+  -- `sll` reads `lReg` (through the `rcast` step) and `rReg`.
+  have hLCastNotRCastRes :
+      ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+    rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.sll r₂ r₁) (fun _ _ _ _ => rfl) hSllType hSllOperands
+      hSllResTypes hLRes₂ hRes₂
+  -- `srl` reads `shifted` and `rReg` (through the `sll` step).
+  have hRCastNotSllRes :
+      ValuePtr.opResult (rcastOp.getResult 0) ∉ sllOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (rcastOp.getResult 0)) sllOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hRRes₃ : s₃.variables.getVar? (ValuePtr.opResult (rcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg yt)) := by
+    rw [hFrame₃ _ hRCastNotSllRes]; exact hRes₂
+  obtain ⟨s₄, hI₄, hMem₄, hRes₄, hFrame₄⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₃) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.srl r₂ r₁) (fun _ _ _ _ => rfl) hSrlType hSrlOperands
+      hSrlResTypes hRes₃ hRRes₃
+  -- `xor` reads `unshifted` and `lReg` (through the `sll` and `srl` steps).
+  have hLCastNotSllRes :
+      ValuePtr.opResult (lcastOp.getResult 0) ∉ sllOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (lcastOp.getResult 0)) sllOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hLCastNotSrlRes :
+      ValuePtr.opResult (lcastOp.getResult 0) ∉ srlOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (lcastOp.getResult 0)) srlOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hLRes₄ : s₄.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+    rw [hFrame₄ _ hLCastNotSrlRes, hFrame₃ _ hLCastNotSllRes]; exact hLRes₂
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, hFrame₅⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₄) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.xor r₂ r₁) (fun _ _ _ _ => rfl) hXorType hXorOperands
+      hXorResTypes hLRes₄ hRes₄
+  -- `sltiu 1` reads `lostBits`.
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, hFrame₆⟩ :=
+    interpretOp_riscv_sltiu_forward (state := s₅) (inBounds := by grind)
+      (k := BitVec.ofInt 12 1) hSltiuType hSltiuImm hSltiuOperands hSltiuResTypes hRes₅
+  -- `addi -1` reads `noOverflow`.
+  obtain ⟨s₇, hI₇, hMem₇, hRes₇, hFrame₇⟩ :=
+    interpretOp_riscv_addi_forward (state := s₆) (inBounds := by grind)
+      (k := BitVec.ofInt 12 (-1)) hAddiType hAddiImm hAddiOperands hAddiResTypes hRes₆
+  -- `or` reads `overflowMask` and `shifted` (carried through the `srl`/`xor`/`sltiu`/`addi` steps).
+  have hSllNotSrlRes :
+      ValuePtr.opResult (sllOp.getResult 0) ∉ srlOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (sllOp.getResult 0)) srlOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hSllNotXorRes :
+      ValuePtr.opResult (sllOp.getResult 0) ∉ xorOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (sllOp.getResult 0)) xorOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hSllNotSltiuRes :
+      ValuePtr.opResult (sllOp.getResult 0) ∉ sltiuOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (sllOp.getResult 0)) sltiuOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hSllNotAddiRes :
+      ValuePtr.opResult (sllOp.getResult 0) ∉ addiOp.getResults! ctx₉.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₉.raw
+        (ValuePtr.opResult (sllOp.getResult 0)) addiOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hShifted₇ : s₇.variables.getVar? (ValuePtr.opResult (sllOp.getResult 0))
+      = some (RuntimeValue.reg (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt))) := by
+    rw [hFrame₇ _ hSllNotAddiRes, hFrame₆ _ hSllNotSltiuRes, hFrame₅ _ hSllNotXorRes,
+      hFrame₄ _ hSllNotSrlRes]
+    exact hRes₃
+  obtain ⟨s₈, hI₈, hMem₈, hRes₈, hFrame₈⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₇) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.or r₂ r₁) (fun _ _ _ _ => rfl) hOrType hOrOperands
+      hOrResTypes hRes₇ hShifted₇
+  obtain ⟨s₉, hI₉, hMem₉, hRes₉, -⟩ :=
+    interpretOp_castBack_forward (state := s₈) (inBounds := by grind)
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₈
+  refine ⟨s₉, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, hI₅, hI₆, hI₇, hI₈, hI₉, liftM, monadLift,
+      MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt
+        (Data.RISCV.or (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt))
+          (Data.RISCV.addi (BitVec.ofInt 12 (-1))
+            (Data.RISCV.sltiu (BitVec.ofInt 12 1)
+              (Data.RISCV.xor
+                (Data.RISCV.srl (LLVM.Int.toReg yt)
+                  (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)))
+                (LLVM.Int.toReg xt))))) 64)], ?_, ?_⟩
+    · simp [hRes₉, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using ushlSat_isRefinedBy_toInt hxtRef hytRef⟩
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUsubSat.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUsubSat.lean
@@ -1,0 +1,299 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryW
+
+namespace Veir
+
+/-!
+## Correctness of `usubSat_local`
+
+`llvm.intr.usub.sat` on a 64-bit integer is lowered to LLVM's RV64+Zbb `umax`/`sub` idiom
+`usub.sat(a, b) -> umax(a, b) - b`:
+`unrealized_conversion_cast` (each operand to a register) → `riscv.maxu` (of the two registers) →
+`riscv.sub` (the max minus the second register) → `unrealized_conversion_cast` (back to the integer
+type).
+
+`usubSat` fits neither `lowerBinaryRegLocal` (it emits *two* register ops, not one) nor `abs_local`
+(it has *two* operands, not one). It is therefore proven bespoke: structurally it is the two-operand
+`lowerBinaryRegLocal` `castToRegLocal`/`castToRegLocal` prefix followed by the `abs_local`-style
+two-riscv-op chain, except the second op (`sub`) consumes the `maxu` result together with the second
+cast register (`rReg`), which must be kept alive across the `maxu` step via its frame clause. It is
+`i64`-only, so there is no bitwidth branch.
+-/
+
+/-- Correctness of the `sub (maxu ·) ·` lowering of a 64-bit `llvm.intr.usub.sat`: the round trip
+    `int × int → reg × reg → maxu/sub → int` refines `usubSat`. (`xt`/`yt` are the possibly-more-
+    defined target-side values of the operands.) The interpreter applies each data-level op as
+    `RISCV.op op2 op1`, so the target expression takes `(toReg yt)` first in each op. -/
+theorem usubSat_isRefinedBy_toInt_sub_maxu {x y xt yt : Data.LLVM.Int 64}
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.usubSat x y ⊒
+      RISCV.Reg.toInt
+        (Data.RISCV.sub (LLVM.Int.toReg yt)
+          (Data.RISCV.maxu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt))) 64 := by
+  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
+  obtain ⟨hp₁, hv₁⟩ := h₁
+  obtain ⟨hp₂, hv₂⟩ := h₂
+  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
+  have hxnp : x.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_usubSat] at hnp; grind
+  have hynp : y.isPoison = false := by
+    rw [Data.LLVM.Int.isPoison_usubSat] at hnp; grind
+  have hvd₁ : x.getValueD = xt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  have hvd₂ : y.getValueD = yt.getValueD := by
+    grind [Data.LLVM.Int.getValueD_eq]
+  simp only [Data.RISCV.sub, Data.RISCV.maxu]
+  veir_bv_decide
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `usubSat_local` lowering: the `castToReg → castToReg → maxu → sub → castBack`
+    round trip refines `llvm.intr.usub.sat`. -/
+theorem usubSat_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics usubSat_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, usubSat_local, createRISCVUnitLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchUsubSat op ctx.raw).isSome := by
+    cases hM : matchUsubSat op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands⟩ := matchUsubSat_implies hMatch
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, intType, hResType, hOp0Type, hOp1Type⟩ :=
+    OperationPtr.Verified.llvm_intr__usub__sat opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- Both operand types and the result type are the integer type `intType`.
+  have hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand0, hOp0Type]
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand1, hOp1Type]
+  have hResTypeVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    rw [hResType]
+  -- Resolve the result-type-destructuring match on `intType`.
+  rw [hResTypeVal] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand values and their `usubSat`.
+  obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+    matchBinaryOp_interpretOp_unfold
+      (srcFn := fun {_} x y _ => Data.LLVM.Int.usubSat x y)
+      (props := op.getProperties! ctx.raw (.llvm .intr__usub__sat))
+      opInBounds hOpType hNumResults hOperands rfl
+      (fun bw x y props rt bo mem res h => by
+        have hEq : Llvm.interpretOp' .intr__usub__sat props rt #[.int bw x, .int bw y] bo mem
+            = some (.ok (#[.int bw (Data.LLVM.Int.usubSat x y)], mem, none)) := by
+          simp [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp]
+        rw [hEq] at h; injection h with h; injection h with h; exact h.symm)
+      hinterp hLhsType hRhsType
+  subst hCf
+  -- The matched operands dominate the rewrite point in the source context.
+  have hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition' [hBw] hpattern
+  -- Source value: `op`'s single result is `usubSat` of its operands.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `lhs`/`rhs` are not among `op`'s results.
+  have lNotOp : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have rNotOp : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Peel the two `castToRegLocal` creations, transporting both operand dominance facts through.
+  peelCastToRegLocal₂ hpattern ctx₁ lcastOp hLCast hDomCtxL hDomL₁ hDomCtxR hDomR₁
+  peelCastToRegLocal₂ hpattern ctx₂ rcastOp hRCast hDomL₁ hDomL₂ hDomR₁ hDomR₂
+  -- Freshness facts, used to keep earlier values alive across later interpretation steps.
+  -- Established here (before the later peels and `cleanupHpattern`) so `clear hpattern` succeeds.
+  have hLCastFresh : ¬ lcastOp.InBounds ctx.raw :=
+    WfRewriter.createOp_new_not_inBounds lcastOp hLCast
+  have hRhsIn : rhs.InBounds ctx.raw := by clear hpattern; grind
+  have hRhsNeLCastRes : ∀ i, rhs ≠ ValuePtr.opResult (lcastOp.getResult i) := by
+    intro i heq
+    rw [heq] at hRhsIn
+    rw [ValuePtr.inBounds_opResult] at hRhsIn
+    obtain ⟨hIn, -⟩ := hRhsIn
+    exact hLCastFresh hIn
+  -- Peel the `maxu`, the `sub`, and the `replaceWithRegLocal` creations.
+  peelOpCreation!₂ hpattern ctx₃ maxuOp hMaxu hDomL₂ hDomL₃ hDomR₂ hDomR₃
+  peelOpCreation!₂ hpattern ctx₄ subOp hSub hDomL₃ hDomL₄ hDomR₃ hDomR₄
+  peelReplaceWithRegLocal₂ hpattern ctx₅ castBackOp hCastBack hDomL₄ hDomL₅ hDomR₄ hDomR₅
+  cleanupHpattern hpattern
+  -- Read the refined values `xt`/`yt` of `lhs`/`rhs` in the target state `state'`.
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+      hDomCtxL hDomL₅ lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+      hDomCtxR hDomR₅ rNotOp
+  obtain ⟨bw⟩ := intType; simp only at hBw; subst hBw
+  -- Structural facts about the five created ops. The opcode transports are seeded explicitly
+  -- because plain `grind` no longer chains them for ops created several contexts back.
+  have hLCastType : lcastOp.getOpType! ctx₅.raw = .builtin .unrealized_conversion_cast := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hMaxu (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSub (operation := lcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastType : rcastOp.getOpType! ctx₅.raw = .builtin .unrealized_conversion_cast := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hMaxu (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSub (operation := rcastOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hMaxuType : maxuOp.getOpType! ctx₅.raw = .riscv .maxu := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hMaxu (operation := maxuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hSub (operation := maxuOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := maxuOp)]
+  have hSubType : subOp.getOpType! ctx₅.raw = .riscv .sub := by
+    grind [OperationPtr.getOpType!_WfRewriter_createOp hSub (operation := subOp),
+      OperationPtr.getOpType!_WfRewriter_createOp hCastBack (operation := subOp)]
+  have hCastBackType : castBackOp.getOpType! ctx₅.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hLCastOperands : lcastOp.getOperands! ctx₅.raw = #[lhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMaxu (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSub (operation := lcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastOperands : rcastOp.getOperands! ctx₅.raw = #[rhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hMaxu (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSub (operation := rcastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hMaxuOperands : maxuOp.getOperands! ctx₅.raw
+      = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hMaxu (operation := maxuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hSub (operation := maxuOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := maxuOp)]
+  have hSubOperands : subOp.getOperands! ctx₅.raw
+      = #[ValuePtr.opResult (maxuOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hSub (operation := subOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := subOp)]
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₅.raw = #[ValuePtr.opResult (subOp.getResult 0)] := by grind
+  -- The cast-back op's result type is the integer type `i64`.
+  have hCBType : ((op.getResult 0).get! ctx₄.raw).type
+      = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+    have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₄.raw
+        = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+      grind [ValuePtr.getType!_WfRewriter_createOp hSub
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hMaxu
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hRCast
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hLCast
+          (value := ValuePtr.opResult (op.getResult 0))]
+    simpa only [ValuePtr.getType!_opResult, hResType] using h1
+  have hLCastResTypes : lcastOp.getResultTypes! ctx₅.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMaxu (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSub (operation := lcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+  have hRCastResTypes : rcastOp.getResultTypes! ctx₅.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hMaxu (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSub (operation := rcastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+  have hMaxuResTypes : maxuOp.getResultTypes! ctx₅.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hMaxu (operation := maxuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hSub (operation := maxuOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := maxuOp)]
+  have hSubResTypes : subOp.getResultTypes! ctx₅.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hSub (operation := subOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := subOp)]
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₅.raw
+      = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+  -- Interpretation tail: execute `interpretOpList [lcastOp, rcastOp, maxuOp, subOp, castBackOp]`
+  -- in `state'`. The frame clauses carry earlier bindings across later steps.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+    interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+      hLCastType hLCastOperands hLCastResTypes hLVal'
+  have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₅.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₅.raw rhs lcastOp
+      with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (hRhsNeLCastRes i)
+  have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 64 yt) := by
+    rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+    interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+      hRCastType hRCastOperands hRCastResTypes hRVal₁
+  -- `maxu`'s first operand is the `lcast` register; transport its value through the `rcast` step.
+  have hLCastNotRCastRes :
+      ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₅.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₅.raw
+        (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+    rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.maxu r₂ r₁) (fun _ _ _ _ => rfl) hMaxuType hMaxuOperands
+      hMaxuResTypes hLRes₂ hRes₂
+  -- `sub`'s second operand is again the `rcast` register; transport it through the `maxu` step.
+  have hRCastNotMaxuRes :
+      ValuePtr.opResult (rcastOp.getResult 0) ∉ maxuOp.getResults! ctx₅.raw := by
+    rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₅.raw
+        (ValuePtr.opResult (rcastOp.getResult 0)) maxuOp with hres | ⟨i, hi, heq⟩
+    · exact hres
+    · exact absurd heq (by grind [OperationPtr.getResult])
+  have hRRes₃ : s₃.variables.getVar? (ValuePtr.opResult (rcastOp.getResult 0))
+      = some (RuntimeValue.reg (LLVM.Int.toReg yt)) := by
+    rw [hFrame₃ _ hRCastNotMaxuRes]; exact hRes₂
+  obtain ⟨s₄, hI₄, hMem₄, hRes₄, hFrame₄⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₃) (inBounds := by grind)
+      (f := fun r₁ r₂ => Data.RISCV.sub r₂ r₁) (fun _ _ _ _ => rfl) hSubType hSubOperands
+      hSubResTypes hRes₃ hRRes₃
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, -⟩ :=
+    interpretOp_castBack_forward (state := s₄) (inBounds := by grind)
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₄
+  refine ⟨s₅, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, hI₅, liftM, monadLift, MonadLift.monadLift,
+      Interp]
+  · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt
+        (Data.RISCV.sub (LLVM.Int.toReg yt)
+          (Data.RISCV.maxu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt))) 64)], ?_, ?_⟩
+    · simp [hRes₅, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using usubSat_isRefinedBy_toInt_sub_maxu hxtRef hytRef⟩
+
+end Veir

--- a/Veir/Passes/Matching/Lemmas.lean
+++ b/Veir/Passes/Matching/Lemmas.lean
@@ -242,6 +242,36 @@ theorem matchUmin_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs}
   simp only [matchUmin, bind, Option.bind, pure] at hmatch
   grind
 
+/-- What matching `llvm.intr.usub.sat` (via `matchUsubSat`) syntactically guarantees. -/
+theorem matchUsubSat_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs} :
+    matchUsubSat op ctx = some (lhs, rhs) →
+    op.getOpType! ctx = .llvm .intr__usub__sat ∧
+    op.getNumResults! ctx = 1 ∧
+    op.getOperands! ctx = #[lhs, rhs] := by
+  intro hmatch
+  simp only [matchUsubSat, bind, Option.bind, pure] at hmatch
+  grind
+
+/-- What matching `llvm.intr.ushl.sat` (via `matchUshlSat`) syntactically guarantees. -/
+theorem matchUshlSat_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs} :
+    matchUshlSat op ctx = some (lhs, rhs) →
+    op.getOpType! ctx = .llvm .intr__ushl__sat ∧
+    op.getNumResults! ctx = 1 ∧
+    op.getOperands! ctx = #[lhs, rhs] := by
+  intro hmatch
+  simp only [matchUshlSat, bind, Option.bind, pure] at hmatch
+  grind
+
+/-- What matching `llvm.intr.uadd.sat` (via `matchUaddSat`) syntactically guarantees. -/
+theorem matchUaddSat_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs} :
+    matchUaddSat op ctx = some (lhs, rhs) →
+    op.getOpType! ctx = .llvm .intr__uadd__sat ∧
+    op.getNumResults! ctx = 1 ∧
+    op.getOperands! ctx = #[lhs, rhs] := by
+  intro hmatch
+  simp only [matchUaddSat, bind, Option.bind, pure] at hmatch
+  grind
+
 /-- What matching `llvm.intr.fshl` (via `matchFshl`) syntactically guarantees. -/
 theorem matchFshl_implies {op : OperationPtr} {ctx : IRContext OpCode} {a b amt} :
     matchFshl op ctx = some (a, b, amt) →
@@ -447,6 +477,16 @@ theorem matchBswap_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand
     op.getOperands! ctx = #[operand] := by
   intro hmatch
   simp only [matchBswap, bind, Option.bind, pure] at hmatch
+  grind
+
+/-- What matching `llvm.intr.abs` (via `matchAbs`) syntactically guarantees. -/
+theorem matchAbs_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand} :
+    matchAbs op ctx = some operand →
+    op.getOpType! ctx = .llvm .intr__abs ∧
+    op.getNumResults! ctx = 1 ∧
+    op.getOperands! ctx = #[operand] := by
+  intro hmatch
+  simp only [matchAbs, bind, Option.bind, pure] at hmatch
   grind
 
 /-- What matching `llvm.intr.bitreverse` (via `matchBitreverse`) syntactically guarantees. -/

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1080,6 +1080,22 @@ theorem OperationPtr.Verified.arith_constant {op : OperationPtr} {opInBounds}
   simp only [TypeAttr.inj]
   grind
 
+/-- A verified `llvm.mlir.constant` whose value attribute is an integer has an integer result type. -/
+theorem OperationPtr.Verified.llvm_mlir__constant_resultType {op : OperationPtr} {opInBounds}
+    {intAttr : IntegerAttr}
+    (opVerify : op.Verified ctx opInBounds)
+    (opType : op.getOpType! ctx.raw = .llvm .mlir__constant)
+    (hProp : (op.getProperties! ctx.raw (.llvm .mlir__constant)).value = .integer intAttr) :
+    ∃ intTy : IntegerType, ((op.getResult 0).get! ctx.raw).type.val = .integerType intTy := by
+  simp only [Verified, verifyLocalInvariants, ← getOpType!_eq_getOpType, opType, verifyPlainOpCounts,
+    hProp, ne_eq, bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure, Except.pure]
+    at opVerify
+  cases hty : ((op.getResult 0).get! ctx.raw).type.val with
+  | integerType intTy => exact ⟨intTy, rfl⟩
+  | _ =>
+    rw [hty] at opVerify
+    split at opVerify <;> simp_all [reduceCtorEq]
+
 /--
   Every integer binary operation's `Verified.*` lemma: given that the operation is verified and
   has the given binary-operation opcode, it satisfies `IsVerifiedIntegerBinop`. Each is a thin
@@ -1244,6 +1260,24 @@ theorem OperationPtr.Verified.llvm_intr__umin {op : OperationPtr} {opInBounds}
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
     simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
 
+theorem OperationPtr.Verified.llvm_intr__usub__sat {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (opType : op.getOpType! ctx.raw = .llvm .intr__usub__sat) :
+    op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+
+theorem OperationPtr.Verified.llvm_intr__uadd__sat {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (opType : op.getOpType! ctx.raw = .llvm .intr__uadd__sat) :
+    op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+
+theorem OperationPtr.Verified.llvm_intr__ushl__sat {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (opType : op.getOpType! ctx.raw = .llvm .intr__ushl__sat) :
+    op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+
 /--
   The structural facts shared by every integer unary operation: exactly 1 operand and 1 result,
   no regions or successors, the result type matches the operand type, and that type is an integer
@@ -1309,6 +1343,32 @@ theorem OperationPtr.Verified.llvm_intr__ctpop {op : OperationPtr} {opInBounds}
     op.IsVerifiedIntegerUnop ctx := by
   obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
     simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  exact op.verifyIntegerUnop_eq_ok hty
+
+/-- Structural facts from the verifier for a verified `llvm.intr.abs`. Its verifier arm is exactly
+    the shared `verifyIntegerUnop >>= pure` shape (the `is_int_min_poison` property is not checked
+    structurally), so it reduces like the `ctlz`/`cttz`/`ctpop` lemmas. -/
+theorem OperationPtr.Verified.llvm_intr__abs {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__abs) :
+    op.IsVerifiedIntegerUnop ctx := by
+  obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  exact op.verifyIntegerUnop_eq_ok hty
+
+/-- Structural facts from the verifier for a verified `llvm.intr.bswap`. Unlike the other unary
+    intrinsics, `bswap`'s verifier arm performs an extra bitwidth check *after* the shared
+    `verifyIntegerUnop`, so it is not exactly the `verifyIntegerUnop >>= pure` shape; we extract
+    the successful `verifyIntegerUnop` by hand from the leading bind. -/
+theorem OperationPtr.Verified.llvm_intr__bswap {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__bswap) :
+    op.IsVerifiedIntegerUnop ctx := by
+  rw [Verified] at opVerify
+  simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType, bind, Except.bind]
+    at opVerify
+  obtain ⟨ty, hty⟩ : ∃ ty, op.verifyIntegerUnop ctx opInBounds = .ok ty := by
+    cases hb : op.verifyIntegerUnop ctx opInBounds with
+    | ok ty => exact ⟨ty, rfl⟩
+    | error e => rw [hb] at opVerify; simp at opVerify
   exact op.verifyIntegerUnop_eq_ok hty
 
 /--


### PR DESCRIPTION
Additionally, add the files containing the instruction selection rewrites in the list of file to compile from `Veir.lean`.