### PR TITLE
chore(isel): simplify proofs by using `veir_bv_decide`

### DIFF
--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryReg.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryReg.lean
@@ -6,6 +6,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
@@ -277,19 +278,7 @@ theorem umax_isRefinedBy_toInt_maxu {x y xt yt : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.umax x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.maxu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umax] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umax] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.maxu]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.maxu` lowering of a 32-bit `llvm.intr.umax`. -/
@@ -297,19 +286,7 @@ theorem umax_isRefinedBy_toInt_maxu_32 {x y xt yt : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.umax x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.maxu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umax] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umax] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.maxu]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem umax_local_preservesSemantics :
@@ -330,19 +307,7 @@ theorem umin_isRefinedBy_toInt_minu {x y xt yt : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.umin x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.minu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umin] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umin] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.minu]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.minu` lowering of a 32-bit `llvm.intr.umin`. -/
@@ -350,19 +315,7 @@ theorem umin_isRefinedBy_toInt_minu_32 {x y xt yt : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.umin x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.minu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umin] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_umin] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.minu]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem umin_local_preservesSemantics :

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinaryW.lean
@@ -6,6 +6,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
@@ -403,19 +404,7 @@ theorem add_isRefinedBy_toInt_add {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.add x y nsw nuw
       ⊒ RISCV.Reg.toInt (Data.RISCV.add (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.add]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.addw` lowering of a 32-bit `llvm.add`. -/
@@ -423,19 +412,7 @@ theorem add_isRefinedBy_toInt_addw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Boo
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.add x y nsw nuw
       ⊒ RISCV.Reg.toInt (Data.RISCV.addw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_add] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.addw]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem add_local_preservesSemantics :
@@ -467,19 +444,7 @@ theorem xor_isRefinedBy_toInt_xor {x y xt yt : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.xor x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.xor]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.xor` lowering of a 32-bit `llvm.xor`. -/
@@ -487,19 +452,7 @@ theorem xor_isRefinedBy_toInt_xor_32 {x y xt yt : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.xor x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.xor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_xor] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.xor]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem xor_local_preservesSemantics :
@@ -530,19 +483,7 @@ theorem sub_isRefinedBy_toInt_sub {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.sub x y nsw nuw
       ⊒ RISCV.Reg.toInt (Data.RISCV.sub (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.sub]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.subw` lowering of a 32-bit `llvm.sub`. -/
@@ -550,19 +491,7 @@ theorem sub_isRefinedBy_toInt_subw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Boo
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.sub x y nsw nuw
       ⊒ RISCV.Reg.toInt (Data.RISCV.subw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_sub] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.subw]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem sub_local_preservesSemantics :
@@ -593,51 +522,16 @@ theorem mul_isRefinedBy_toInt_mul {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.mul x y nsw nuw
       ⊒ RISCV.Reg.toInt (Data.RISCV.mul (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  -- Avoid bitblasting the 64-bit multiplier: rewrite both sides to the same product instead.
-  rw [Data.LLVM.Int.getValue_mul _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.mul, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    BitVec.truncate_eq_setWidth, BitVec.setWidth_eq]
-  rw [hvd₁, hvd₂]
+  revert h₁ h₂
+  veir_bv_decide
 
 /-- Correctness of the `riscv.mulw` lowering of a 32-bit `llvm.mul`. -/
 theorem mul_isRefinedBy_toInt_mulw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Bool)
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.mul x y nsw nuw
       ⊒ RISCV.Reg.toInt (Data.RISCV.mulw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_mul] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  -- Rewrite both sides to the same 32-bit product first, so `bv_decide` sees two structurally
-  -- identical multipliers instead of proving a 64-bit multiplier equivalence.
-  rw [Data.LLVM.Int.getValue_mul _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.mulw, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp])]
-  rw [hvd₁, hvd₂]
-  bv_decide
+  revert h₁ h₂
+  veir_bv_decide
 
 theorem mul_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics mul_local h h₂ h₃ h₄ :=
@@ -669,51 +563,16 @@ theorem udiv_isRefinedBy_toInt_divu {x y xt yt : Data.LLVM.Int 64} (exact : Bool
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.udiv x y exact
       ⊒ RISCV.Reg.toInt (Data.RISCV.divu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hyne : y.getValueD ≠ 0 := by
-    rw [Data.LLVM.Int.isPoison_udiv] at hnp
-    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
-  rw [Data.LLVM.Int.getValue_udiv _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.divu, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  simp only [BitVec.setWidth_eq]
-  rw [if_neg (show ¬ y.getValueD = 0#64 from hyne)]
+  revert h₁ h₂
+  veir_bv_decide
 
 /-- Correctness of the `riscv.divuw` lowering of a 32-bit `llvm.udiv`. -/
 theorem udiv_isRefinedBy_toInt_divuw {x y xt yt : Data.LLVM.Int 32} (exact : Bool)
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.udiv x y exact
       ⊒ RISCV.Reg.toInt (Data.RISCV.divuw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_udiv] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hyne : y.getValueD ≠ 0 := by
-    rw [Data.LLVM.Int.isPoison_udiv] at hnp
-    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
-  rw [Data.LLVM.Int.getValue_udiv _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.divuw, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  bv_decide
+  revert h₁ h₂
+  veir_bv_decide
 
 theorem udiv_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics udiv_local h h₂ h₃ h₄ :=
@@ -751,49 +610,16 @@ theorem sdiv_isRefinedBy_toInt_div {x y xt yt : Data.LLVM.Int 64} (exact : Bool)
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.sdiv x y exact
       ⊒ RISCV.Reg.toInt (Data.RISCV.div (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hyne : y.getValueD ≠ 0 := by
-    rw [Data.LLVM.Int.isPoison_sdiv] at hnp
-    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
-  rw [Data.LLVM.Int.getValue_sdiv _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.div, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  simp only [BitVec.setWidth_eq]
-  rw [if_neg (show ¬ y.getValueD = 0#64 from hyne)]
+  revert h₁ h₂
+  veir_bv_decide
 
 /-- Correctness of the `riscv.divw` lowering of a 32-bit `llvm.sdiv`. -/
 theorem sdiv_isRefinedBy_toInt_divw {x y xt yt : Data.LLVM.Int 32} (exact : Bool)
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.sdiv x y exact
       ⊒ RISCV.Reg.toInt (Data.RISCV.divw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_sdiv] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hyne : y.getValueD ≠ 0 := by
-    rw [Data.LLVM.Int.isPoison_sdiv] at hnp
-    rw [Data.LLVM.Int.getValueD_eq, dif_pos hynp]; grind
-  rw [Data.LLVM.Int.getValue_sdiv _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.divw, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  bv_decide
+  revert h₁ h₂
+  veir_bv_decide
 
 theorem sdiv_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics sdiv_local h h₂ h₃ h₄ :=
@@ -828,42 +654,16 @@ theorem urem_isRefinedBy_toInt_remu {x y xt yt : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.urem x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.remu (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  rw [Data.LLVM.Int.getValue_urem _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.remu, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  simp only [BitVec.setWidth_eq]
+  revert h₁ h₂
+  veir_bv_decide
 
 /-- Correctness of the `riscv.remuw` lowering of a 32-bit `llvm.urem`. -/
 theorem urem_isRefinedBy_toInt_remuw {x y xt yt : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.urem x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.remuw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_urem] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  rw [Data.LLVM.Int.getValue_urem _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.remuw, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  bv_decide
+  revert h₁ h₂
+  veir_bv_decide
 
 theorem urem_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics urem_local h h₂ h₃ h₄ :=
@@ -898,42 +698,16 @@ theorem srem_isRefinedBy_toInt_rem {x y xt yt : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.srem x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.rem (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  rw [Data.LLVM.Int.getValue_srem _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.rem, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  simp only [BitVec.setWidth_eq]
+  revert h₁ h₂
+  veir_bv_decide
 
 /-- Correctness of the `riscv.remw` lowering of a 32-bit `llvm.srem`. -/
 theorem srem_isRefinedBy_toInt_remw {x y xt yt : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.srem x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.remw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
-  have hynp : y.isPoison = false := by rw [Data.LLVM.Int.isPoison_srem] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by grind [Data.LLVM.Int.getValueD_eq]
-  rw [Data.LLVM.Int.getValue_srem _ _ hnp, toInt_getValue]
-  simp only [Data.RISCV.remw, val_toReg,
-    dif_neg (show ¬xt.isPoison = true by simp [hp₁ hxnp]),
-    dif_neg (show ¬yt.isPoison = true by simp [hp₂ hynp]),
-    Data.LLVM.Int.getValue_eq_getValueD]
-  rw [← hvd₁, ← hvd₂]
-  bv_decide
+  revert h₁ h₂
+  veir_bv_decide
 
 theorem srem_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics srem_local h h₂ h₃ h₄ :=

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBinopNot.lean
@@ -6,6 +6,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64Sdag
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
@@ -415,17 +416,7 @@ theorem and_not_isRefinedBy_toInt_andn {x y xt yt : Data.LLVM.Int 64}
     (hx : x ⊒ xt) (hy : y ⊒ yt) :
     Data.LLVM.Int.and x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1)))
       ⊒ RISCV.Reg.toInt (Data.RISCV.andn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
-  obtain ⟨hxp, hxv⟩ := hx
-  obtain ⟨hyp, hyv⟩ := hy
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hynp : y.isPoison = false := by grind
-  have hxvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  have hyvd : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.andn]
+  revert hx hy
   veir_bv_decide
 
 /-- Correctness of the `riscv.andn` lowering of `and (not y) x` (the `not` on the left). -/
@@ -433,17 +424,7 @@ theorem not_and_isRefinedBy_toInt_andn {x y xt yt : Data.LLVM.Int 64}
     (hx : x ⊒ xt) (hy : y ⊒ yt) :
     Data.LLVM.Int.and (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x
       ⊒ RISCV.Reg.toInt (Data.RISCV.andn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
-  obtain ⟨hxp, hxv⟩ := hx
-  obtain ⟨hyp, hyv⟩ := hy
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hynp : y.isPoison = false := by grind
-  have hxvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  have hyvd : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.andn]
+  revert hx hy
   veir_bv_decide
 
 theorem andn_local_preservesSemantics :
@@ -475,8 +456,8 @@ info: 'Veir.andn_local_preservesSemantics' depends on axioms: [propext,
  ValuePtr.dominatesIp_before_WfRewriter_createOp,
  ValuePtr.dominatesIp_before_of_strictlyDominates,
  IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
- and_not_isRefinedBy_toInt_andn._native.bv_decide.ax_1_13,
- not_and_isRefinedBy_toInt_andn._native.bv_decide.ax_1_13,
+ and_not_isRefinedBy_toInt_andn._native.bv_decide.ax_1_5,
+ not_and_isRefinedBy_toInt_andn._native.bv_decide.ax_1_5,
  MemoryState.llvmLoad._native.bv_decide.ax_8]
 -/
 #guard_msgs in
@@ -490,17 +471,7 @@ theorem or_not_isRefinedBy_toInt_orn {x y xt yt : Data.LLVM.Int 64} (disjoint : 
     (hx : x ⊒ xt) (hy : y ⊒ yt) :
     Data.LLVM.Int.or x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) disjoint
       ⊒ RISCV.Reg.toInt (Data.RISCV.orn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
-  obtain ⟨hxp, hxv⟩ := hx
-  obtain ⟨hyp, hyv⟩ := hy
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hynp : y.isPoison = false := by grind
-  have hxvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  have hyvd : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.orn]
+  revert hx hy
   veir_bv_decide
 
 /-- Correctness of the `riscv.orn` lowering of `or (not y) x` (the `not` on the left). -/
@@ -508,17 +479,7 @@ theorem not_or_isRefinedBy_toInt_orn {x y xt yt : Data.LLVM.Int 64} (disjoint : 
     (hx : x ⊒ xt) (hy : y ⊒ yt) :
     Data.LLVM.Int.or (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x disjoint
       ⊒ RISCV.Reg.toInt (Data.RISCV.orn (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
-  obtain ⟨hxp, hxv⟩ := hx
-  obtain ⟨hyp, hyv⟩ := hy
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hynp : y.isPoison = false := by grind
-  have hxvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  have hyvd : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.orn]
+  revert hx hy
   veir_bv_decide
 
 theorem orn_local_preservesSemantics :
@@ -550,8 +511,8 @@ info: 'Veir.orn_local_preservesSemantics' depends on axioms: [propext,
  ValuePtr.dominatesIp_before_WfRewriter_createOp,
  ValuePtr.dominatesIp_before_of_strictlyDominates,
  IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
- not_or_isRefinedBy_toInt_orn._native.bv_decide.ax_1_15,
- or_not_isRefinedBy_toInt_orn._native.bv_decide.ax_1_15,
+ not_or_isRefinedBy_toInt_orn._native.bv_decide.ax_1_5,
+ or_not_isRefinedBy_toInt_orn._native.bv_decide.ax_1_5,
  MemoryState.llvmLoad._native.bv_decide.ax_8]
 -/
 #guard_msgs in
@@ -565,17 +526,7 @@ theorem xor_not_isRefinedBy_toInt_xnor {x y xt yt : Data.LLVM.Int 64}
     (hx : x ⊒ xt) (hy : y ⊒ yt) :
     Data.LLVM.Int.xor x (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1)))
       ⊒ RISCV.Reg.toInt (Data.RISCV.xnor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
-  obtain ⟨hxp, hxv⟩ := hx
-  obtain ⟨hyp, hyv⟩ := hy
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hynp : y.isPoison = false := by grind
-  have hxvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  have hyvd : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.xnor]
+  revert hx hy
   veir_bv_decide
 
 /-- Correctness of the `riscv.xnor` lowering of `xor (not y) x` (the `not` on the left). -/
@@ -583,17 +534,7 @@ theorem not_xor_isRefinedBy_toInt_xnor {x y xt yt : Data.LLVM.Int 64}
     (hx : x ⊒ xt) (hy : y ⊒ yt) :
     Data.LLVM.Int.xor (Data.LLVM.Int.xor y (Data.LLVM.Int.constant 64 (-1))) x
       ⊒ RISCV.Reg.toInt (Data.RISCV.xnor (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at hx hy ⊢
-  obtain ⟨hxp, hxv⟩ := hx
-  obtain ⟨hyp, hyv⟩ := hy
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hynp : y.isPoison = false := by grind
-  have hxvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  have hyvd : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.xnor]
+  revert hx hy
   veir_bv_decide
 
 theorem xnor_local_preservesSemantics :
@@ -625,8 +566,8 @@ info: 'Veir.xnor_local_preservesSemantics' depends on axioms: [propext,
  ValuePtr.dominatesIp_before_WfRewriter_createOp,
  ValuePtr.dominatesIp_before_of_strictlyDominates,
  IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
- not_xor_isRefinedBy_toInt_xnor._native.bv_decide.ax_1_13,
- xor_not_isRefinedBy_toInt_xnor._native.bv_decide.ax_1_13,
+ not_xor_isRefinedBy_toInt_xnor._native.bv_decide.ax_1_5,
+ xor_not_isRefinedBy_toInt_xnor._native.bv_decide.ax_1_5,
  MemoryState.llvmLoad._native.bv_decide.ax_8]
 -/
 #guard_msgs in

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitwiseReg.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitwiseReg.lean
@@ -6,6 +6,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
@@ -277,20 +278,9 @@ theorem and_isRefinedBy_toInt_and {bw : Nat}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.and x y
       ⊒ RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) bw := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_and] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_and] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.and]
-  rcases hbw with h | h | h | h <;> subst h <;> veir_bv_decide
+  revert h₁ h₂
+  rcases hbw with ⟨hA, hB, hC, hD⟩ | hbw | hbw | hbw
+  <;> try subst hbw; veir_bv_decide
 
 theorem and_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics and_local h h₂ h₃ h₄ :=
@@ -312,20 +302,9 @@ theorem or_isRefinedBy_toInt_or {bw : Nat}
     (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
     Data.LLVM.Int.or x y disjoint
       ⊒ RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) bw := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_or] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_or] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.or]
-  rcases hbw with h | h | h | h <;> subst h <;> veir_bv_decide
+  revert h₁ h₂
+  rcases hbw with ⟨hA, hB, hC, hD⟩ | hbw | hbw | hbw
+  <;> try subst hbw; veir_bv_decide
 
 theorem or_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics or_local h h₂ h₃ h₄ :=

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitwiseReg.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitwiseReg.lean
@@ -280,7 +280,13 @@ theorem and_isRefinedBy_toInt_and {bw : Nat}
       ⊒ RISCV.Reg.toInt (Data.RISCV.and (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) bw := by
   revert h₁ h₂
   rcases hbw with ⟨hA, hB, hC, hD⟩ | hbw | hbw | hbw
-  <;> try subst hbw; veir_bv_decide
+  · veir_bv_decide
+  · subst hbw
+    veir_bv_decide
+  · subst hbw
+    veir_bv_decide
+  · subst hbw
+    veir_bv_decide
 
 theorem and_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics and_local h h₂ h₃ h₄ :=
@@ -304,7 +310,13 @@ theorem or_isRefinedBy_toInt_or {bw : Nat}
       ⊒ RISCV.Reg.toInt (Data.RISCV.or (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) bw := by
   revert h₁ h₂
   rcases hbw with ⟨hA, hB, hC, hD⟩ | hbw | hbw | hbw
-  <;> try subst hbw; veir_bv_decide
+  · veir_bv_decide
+  · subst hbw
+    veir_bv_decide
+  · subst hbw
+    veir_bv_decide
+  · subst hbw
+    veir_bv_decide
 
 theorem or_local_preservesSemantics :
     LocalRewritePattern.PreservesSemantics or_local h h₂ h₃ h₄ :=

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBswap.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBswap.lean
@@ -6,7 +6,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
-import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
@@ -66,14 +66,7 @@ theorem interpretOp_riscv_srli_forward
     of the operand.) -/
 theorem bswap_isRefinedBy_toInt_rev8 {x xt : Data.LLVM.Int 64} (h : x ⊒ xt) :
     Data.LLVM.Int.bswap x ⊒ RISCV.Reg.toInt (Data.RISCV.rev8 (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_bswap] at hnp; exact hnp
-  have hvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.rev8]
+  revert h
   veir_bv_decide
 
 /-- Correctness of the `riscv.srli 32 (rev8 ·)` lowering of a 32-bit `llvm.intr.bswap`: `rev8`
@@ -83,14 +76,7 @@ theorem bswap_isRefinedBy_toInt_srli_rev8 {x xt : Data.LLVM.Int 32} (h : x ⊒ x
     Data.LLVM.Int.bswap x ⊒
       RISCV.Reg.toInt (Data.RISCV.srli (BitVec.ofInt 6 32) (Data.RISCV.rev8 (LLVM.Int.toReg xt)))
         32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_bswap] at hnp; exact hnp
-  have hvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.rev8, Data.RISCV.srli]
+  revert h
   veir_bv_decide
 
 set_option maxHeartbeats 1000000 in

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerExt.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerExt.lean
@@ -509,38 +509,32 @@ theorem zextLike_isRefinedBy_toInt {opW retW : Nat} (hlt : opW < retW) (hle : re
 /-- `riscv.sextb` sign-extends the low byte. -/
 theorem sextb_val (r : Data.RISCV.Reg) :
     (Data.RISCV.sextb r).val = BitVec.signExtend 64 (BitVec.setWidth 8 r.val) := by
-  simp only [Data.RISCV.val_sextb]
-  bv_decide
+  veir_bv_decide
 
 /-- `riscv.sexth` sign-extends the low halfword. -/
 theorem sexth_val (r : Data.RISCV.Reg) :
     (Data.RISCV.sexth r).val = BitVec.signExtend 64 (BitVec.setWidth 16 r.val) := by
-  simp only [Data.RISCV.val_sexth]
-  bv_decide
+  veir_bv_decide
 
 /-- `riscv.sextw` sign-extends the low word. -/
 theorem sextw_val (r : Data.RISCV.Reg) :
     (Data.RISCV.sextw r).val = BitVec.signExtend 64 (BitVec.setWidth 32 r.val) := by
-  simp only [Data.RISCV.val_sextw, Data.RISCV.addiw]
-  bv_decide
+  veir_bv_decide
 
 /-- `riscv.zextb` zero-extends the low byte. -/
 theorem zextb_val (r : Data.RISCV.Reg) :
     (Data.RISCV.zextb r).val = BitVec.setWidth 64 (BitVec.setWidth 8 r.val) := by
-  simp only [Data.RISCV.val_zextb, Data.RISCV.andi]
-  bv_decide
+  veir_bv_decide
 
 /-- `riscv.zexth` zero-extends the low halfword. -/
 theorem zexth_val (r : Data.RISCV.Reg) :
     (Data.RISCV.zexth r).val = BitVec.setWidth 64 (BitVec.setWidth 16 r.val) := by
-  simp only [Data.RISCV.val_zexth]
-  bv_decide
+  veir_bv_decide
 
 /-- `riscv.zextw` zero-extends the low word. -/
 theorem zextw_val (r : Data.RISCV.Reg) :
     (Data.RISCV.zextw r).val = BitVec.setWidth 64 (BitVec.setWidth 32 r.val) := by
-  simp only [Data.RISCV.val_zextw, Data.RISCV.adduw, Data.RISCV.li]
-  bv_decide
+  veir_bv_decide
 
 /-!
 ## RISC-V lowering of `llvm.sext`

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerRotate.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerRotate.lean
@@ -589,19 +589,7 @@ theorem fshl_isRefinedBy_toInt_rol {x c xt ct : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : c ⊒ ct) :
     Data.LLVM.Int.fshl x x c
       ⊒ RISCV.Reg.toInt (Data.RISCV.rol (LLVM.Int.toReg ct) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshl] at hnp; grind
-  have hcnp : c.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshl] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : c.getValueD = ct.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.rol]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.rolw` lowering of a 32-bit rotate-left (`fshl x x c`). -/
@@ -609,19 +597,7 @@ theorem fshl_isRefinedBy_toInt_rolw {x c xt ct : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : c ⊒ ct) :
     Data.LLVM.Int.fshl x x c
       ⊒ RISCV.Reg.toInt (Data.RISCV.rolw (LLVM.Int.toReg ct) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshl] at hnp; grind
-  have hcnp : c.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshl] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : c.getValueD = ct.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.rolw]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem fshl_local_preservesSemantics :
@@ -644,19 +620,7 @@ theorem fshr_isRefinedBy_toInt_ror {x c xt ct : Data.LLVM.Int 64}
     (h₁ : x ⊒ xt) (h₂ : c ⊒ ct) :
     Data.LLVM.Int.fshr x x c
       ⊒ RISCV.Reg.toInt (Data.RISCV.ror (LLVM.Int.toReg ct) (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshr] at hnp; grind
-  have hcnp : c.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshr] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : c.getValueD = ct.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.ror]
+  revert h₁ h₂
   veir_bv_decide
 
 /-- Correctness of the `riscv.rorw` lowering of a 32-bit rotate-right (`fshr x x c`). -/
@@ -664,19 +628,7 @@ theorem fshr_isRefinedBy_toInt_rorw {x c xt ct : Data.LLVM.Int 32}
     (h₁ : x ⊒ xt) (h₂ : c ⊒ ct) :
     Data.LLVM.Int.fshr x x c
       ⊒ RISCV.Reg.toInt (Data.RISCV.rorw (LLVM.Int.toReg ct) (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshr] at hnp; grind
-  have hcnp : c.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_fshr] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : c.getValueD = ct.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.rorw]
+  revert h₁ h₂
   veir_bv_decide
 
 theorem fshr_local_preservesSemantics :

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerSextOne.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerSextOne.lean
@@ -41,8 +41,7 @@ value characterisation below is new.
 theorem srai_slli_63_val (r : Data.RISCV.Reg) :
     (Data.RISCV.srai (BitVec.ofInt 6 63) (Data.RISCV.slli (BitVec.ofInt 6 63) r)).val
       = BitVec.signExtend 64 (BitVec.setWidth 1 r.val) := by
-  simp only [Data.RISCV.srai, Data.RISCV.slli]
-  bv_decide
+  veir_bv_decide
 
 /-- Correctness of the `srai (slli _ 63) 63` lowering of an `llvm.sext` from `i1` to `i{retW}`
     (`retW ∈ {32, 64}`): the round trip `i1 → reg → slli 63 → srai 63 → i{retW}` refines

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUaddSat.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUaddSat.lean
@@ -77,19 +77,7 @@ theorem uaddSat_isRefinedBy_toInt_add_minu {x y xt yt : Data.LLVM.Int 64}
         (Data.RISCV.add (LLVM.Int.toReg yt)
           (Data.RISCV.minu (Data.RISCV.xori (BitVec.ofInt 12 (-1)) (LLVM.Int.toReg yt))
             (LLVM.Int.toReg xt))) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_uaddSat] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_uaddSat] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.add, Data.RISCV.minu, Data.RISCV.xori]
+  revert h₁ h₂
   veir_bv_decide
 
 set_option maxHeartbeats 1000000 in

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUnaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUnaryW.lean
@@ -6,6 +6,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Verifier
 import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
 import Veir.Passes.InstructionSelection.RISCV64
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
@@ -346,30 +347,13 @@ lemmas below are `ctlz`-specific.
     of the operand.) -/
 theorem ctlz_isRefinedBy_toInt_clz {x xt : Data.LLVM.Int 64} (pf : Bool) (h : x ⊒ xt) :
     Data.LLVM.Int.ctlz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.clz (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_ctlz] at hnp; grind
-  have hvd : x.getValueD = xt.getValueD := by
-    rw [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq, dif_pos hxnp, dif_pos (hp hxnp)]
-    exact hv hxnp (hp hxnp)
-  rw [Data.LLVM.Int.getValue_ctlz _ hnp, toInt_getValue]
-  simp only [Data.RISCV.clz, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
-    dif_neg (show ¬xt.isPoison = true by simp [hp hxnp])]
-  rw [hvd]
-  bv_decide
+  revert h
+  veir_bv_decide
 
 /-- Correctness of the `riscv.clzw` lowering of a 32-bit `llvm.intr.ctlz`. -/
 theorem ctlz_isRefinedBy_toInt_clzw {x xt : Data.LLVM.Int 32} (pf : Bool) (h : x ⊒ xt) :
     Data.LLVM.Int.ctlz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.clzw (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.clzw]
+  revert h
   veir_bv_decide
 
 theorem ctlz_local_preservesSemantics :
@@ -401,30 +385,13 @@ data-level refinement lemmas below are `ctpop`-specific.
     value of the operand.) -/
 theorem ctpop_isRefinedBy_toInt_cpop {x xt : Data.LLVM.Int 64} (h : x ⊒ xt) :
     Data.LLVM.Int.ctpop x ⊒ RISCV.Reg.toInt (Data.RISCV.cpop (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_ctpop] at hnp; exact hnp
-  have hvd : x.getValueD = xt.getValueD := by
-    rw [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq, dif_pos hxnp, dif_pos (hp hxnp)]
-    exact hv hxnp (hp hxnp)
-  rw [Data.LLVM.Int.getValue_ctpop _ hnp, toInt_getValue]
-  simp only [Data.RISCV.cpop, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
-    dif_neg (show ¬xt.isPoison = true by simp [hp hxnp])]
-  rw [hvd]
-  bv_decide
+  revert h
+  veir_bv_decide
 
 /-- Correctness of the `riscv.cpopw` lowering of a 32-bit `llvm.intr.ctpop`. -/
 theorem ctpop_isRefinedBy_toInt_cpopw {x xt : Data.LLVM.Int 32} (h : x ⊒ xt) :
     Data.LLVM.Int.ctpop x ⊒ RISCV.Reg.toInt (Data.RISCV.cpopw (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.cpopw]
+  revert h
   veir_bv_decide
 
 theorem ctpop_local_preservesSemantics :
@@ -456,30 +423,13 @@ data-level refinement lemmas below are `cttz`-specific.
     of the operand.) -/
 theorem cttz_isRefinedBy_toInt_ctz {x xt : Data.LLVM.Int 64} (pf : Bool) (h : x ⊒ xt) :
     Data.LLVM.Int.cttz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.ctz (LLVM.Int.toReg xt)) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_cttz] at hnp; grind
-  have hvd : x.getValueD = xt.getValueD := by
-    rw [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq, dif_pos hxnp, dif_pos (hp hxnp)]
-    exact hv hxnp (hp hxnp)
-  rw [Data.LLVM.Int.getValue_cttz _ hnp, toInt_getValue]
-  simp only [Data.RISCV.ctz, val_toReg, Data.LLVM.Int.getValue_eq_getValueD,
-    dif_neg (show ¬xt.isPoison = true by simp [hp hxnp])]
-  rw [hvd]
-  bv_decide
+  revert h
+  veir_bv_decide
 
 /-- Correctness of the `riscv.ctzw` lowering of a 32-bit `llvm.intr.cttz`. -/
 theorem cttz_isRefinedBy_toInt_ctzw {x xt : Data.LLVM.Int 32} (pf : Bool) (h : x ⊒ xt) :
     Data.LLVM.Int.cttz x pf ⊒ RISCV.Reg.toInt (Data.RISCV.ctzw (LLVM.Int.toReg xt)) 32 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h ⊢
-  obtain ⟨hp, hv⟩ := h
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by grind
-  have hvd : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq, Data.LLVM.Int.getValueD_eq]
-  simp only [Data.RISCV.ctzw]
+  revert h
   veir_bv_decide
 
 theorem cttz_local_preservesSemantics :

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerUshlSat.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerUshlSat.lean
@@ -112,28 +112,7 @@ theorem ushlSat_isRefinedBy_toInt {x y xt yt : Data.LLVM.Int 64}
                 (Data.RISCV.srl (LLVM.Int.toReg yt)
                   (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)))
                 (LLVM.Int.toReg xt))))) 64 := by
-  rw [Data.LLVM.Int.isRefinedBy_iff] at h₁ h₂ ⊢
-  obtain ⟨hp₁, hv₁⟩ := h₁
-  obtain ⟨hp₂, hv₂⟩ := h₂
-  refine ⟨fun _ => toInt_isPoison, fun hnp _ => ?_⟩
-  have hxnp : x.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_ushlSat] at hnp; grind
-  have hynp : y.isPoison = false := by
-    rw [Data.LLVM.Int.isPoison_ushlSat] at hnp; grind
-  have hvd₁ : x.getValueD = xt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  have hvd₂ : y.getValueD = yt.getValueD := by
-    grind [Data.LLVM.Int.getValueD_eq]
-  -- The shift amount is `< 64` in the non-poison case, so the RISC-V shift-amount masking (to 6
-  -- bits) agrees with LLVM's full-width shift.
-  have hyb : ¬ (y.getValueD ≥ (64 : BitVec 64)) := by
-    have hh := hnp
-    rw [Data.LLVM.Int.isPoison_ushlSat] at hh
-    simp only [hxnp, hynp, or_self, Bool.false_eq_true, dite_false, decide_eq_false_iff_not,
-      Data.LLVM.Int.getValue_eq_getValueD] at hh
-    exact hh
-  simp only [Data.RISCV.or, Data.RISCV.sll, Data.RISCV.srl, Data.RISCV.xor, Data.RISCV.sltiu,
-    Data.RISCV.addi]
+  revert h₁ h₂
   veir_bv_decide
 
 set_option maxHeartbeats 2000000 in

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerZextOne.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerZextOne.lean
@@ -37,8 +37,7 @@ characterisation below is new.
 theorem andi_one_val (r : Data.RISCV.Reg) :
     (Data.RISCV.andi (BitVec.ofInt 12 1) r).val
       = BitVec.setWidth 64 (BitVec.setWidth 1 r.val) := by
-  simp only [Data.RISCV.andi]
-  bv_decide
+  veir_bv_decide
 
 /-- Correctness of the `riscv.andi _, 1` lowering of an `llvm.zext` from `i1` to `i64`: the round
     trip `i1 → reg → andi 1 → i64` refines `llvm.zext`. (`xt` is the possibly-more-defined


### PR DESCRIPTION
The previous proof scripts included a lot of manual reasoning, which can be uniformly replaced by veir_bv_decide, in case all the hypothesis are in the goal. 