### PR TITLE
feat: prove correctness of llvm.trunc instruction selection

### DIFF
--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -758,6 +758,10 @@ def trunc_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some opBw := getIntByteTypeBitwidth opType | return (ctx, none)
   let some resBw := getIntByteTypeBitwidth resType | return (ctx, none)
   if opBw ≤ resBw then return (ctx, none)
+  /- Restrict to the register-representable widths: the operand is held in a 64-bit register, so an
+     operand wider than 64 bits (or a result wider than 64 bits) would lose bits in the round trip.
+     Limiting to `{8, 16, 32, 64}` keeps the lowering sound and makes the widths concrete. -/
+  if opBw ∉ [8, 16, 32, 64] ∨ resBw ∉ [8, 16, 32, 64] then return (ctx, none)
   /- First, cast the operand to registers -/
   let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
       #[] #[] () none

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonBaseLemmas.lean
@@ -45,6 +45,30 @@ theorem LocalRewritePattern.exists_refined_int_getVar?
     grind [LocalRewritePattern.mapping, valueRefinement v]
   grind [RuntimeValue.int_of_isRefinedBy hRef]
 
+/-- Byte analogue of `exists_refined_int_getVar?`: read the target-side value of a `byte`-typed
+operand that refines the source-side one. -/
+theorem LocalRewritePattern.exists_refined_byte_getVar?
+    {ctx : WfIRContext OpCode}
+    {ipIn : ip.InBounds ctx.raw}
+    {pattern : LocalRewritePattern OpCode}
+    {hpattern : pattern ctx op = some (newCtx, some (newOps, newValues))}
+    {hreturn : pattern.ReturnValuesInBounds} {hreturn₂ : pattern.ReturnValues}
+    {hreturn₃ : pattern.ReturnCtxChanges}
+    {state : InterpreterState ctx} {state' : InterpreterState newCtx}
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpattern hreturn hreturn₂ hreturn₃) (.at ip) (.at ip) ipIn ipIn')
+    (state'Dom : state'.DefinesDominating ip ipIn')
+    (vIn : v.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? v = some (RuntimeValue.byte bw x))
+    (hDomCtx : v.dominatesIp ip ctx) (hDom' : v.dominatesIp ip newCtx)
+    (hNotRes : v ∉ op.getResults! ctx.raw) :
+    ∃ xt, state'.variables.getVar? v = some (RuntimeValue.byte bw xt) ∧ x ⊒ xt := by
+  have ⟨tv, hTv⟩ := InterpreterState.DefinesDominating.exists_getVar_of_dominatesIp state'Dom
+      (hreturn₃.valuePtr_inBounds hpattern vIn) hDom'
+  have hRef : RuntimeValue.byte bw x ⊒ tv := by
+    grind [LocalRewritePattern.mapping, valueRefinement v]
+  grind [RuntimeValue.byte_of_isRefinedBy hRef]
+
 /-- A value that exists in a context `ctx` is never a result of an operation that is *not* in
 bounds of `ctx` (e.g. a freshly created op), in any context `ctx'`: result membership pins the
 value's operation pointer, and an in-bounds `opResult` value forces its operation in bounds.

--- a/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/CommonForwardInterpret.lean
@@ -186,3 +186,57 @@ theorem interpretOp_riscv_unaryReg_imm_forward
           simp [interpretOp', hSem, Interp])
       (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
   grind
+
+/-- Byte cast-to-register specialization of `interpretOp_forward`: like `interpretOp_castToReg_forward`
+but the operand holds an `i{bw}` *byte* value, cast to `.reg (LLVM.Byte.toReg x)`. -/
+theorem interpretOp_castToReg_byte_forward
+    {ctx : WfIRContext OpCode} {castOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : castOp.InBounds ctx.raw} {v : ValuePtr} {rt : RegisterType} {hIsTy}
+    {bw : Nat} {x : Data.LLVM.Byte bw}
+    (hType : castOp.getOpType! ctx.raw = .builtin .unrealized_conversion_cast)
+    (hOperands : castOp.getOperands! ctx.raw = #[v])
+    (hResTypes : castOp.getResultTypes! ctx.raw = #[⟨.registerType rt, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.byte bw x)) :
+    ∃ state', interpretOp castOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (castOp.getResult 0))
+        = some (.reg (LLVM.Byte.toReg x)) ∧
+      (∀ v', v' ∉ castOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVar⟩ :=
+    interpretOp_forward (op := castOp) (state := state) (inBounds := inBounds)
+      (vals := #[.byte bw x]) (results := #[.reg (LLVM.Byte.toReg x)]) (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [hResTypes, interpretOp', pure, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind
+
+/-- Byte cast-back specialization of `interpretOp_forward`: like `interpretOp_castBack_forward` but
+the result has *byte* type, so the register `r` is cast to `.byte bw (RISCV.Reg.toByte r bw)`. -/
+theorem interpretOp_castBack_byte_forward
+    {ctx : WfIRContext OpCode} {castOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : castOp.InBounds ctx.raw} {v : ValuePtr} {byteTy : LLVM.ByteType} {hIsTy}
+    {r : Data.RISCV.Reg}
+    (hType : castOp.getOpType! ctx.raw = .builtin .unrealized_conversion_cast)
+    (hOperands : castOp.getOperands! ctx.raw = #[v])
+    (hResTypes : castOp.getResultTypes! ctx.raw = #[⟨.byteType byteTy, hIsTy⟩])
+    (hVal : state.variables.getVar? v = some (.reg r)) :
+    ∃ state', interpretOp castOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (castOp.getResult 0))
+        = some (.byte byteTy.bitwidth (RISCV.Reg.toByte r byteTy.bitwidth)) ∧
+      (∀ v', v' ∉ castOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVar⟩ :=
+    interpretOp_forward (op := castOp) (state := state) (inBounds := inBounds)
+      (vals := #[.reg r])
+      (results := #[.byte byteTy.bitwidth (RISCV.Reg.toByte r byteTy.bitwidth)])
+      (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands, hVal])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp [hResTypes, interpretOp', pure, Interp])
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  grind

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerTrunc.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerTrunc.lean
@@ -1,0 +1,334 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.LLVM.Byte.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Data.Casting
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+
+namespace Veir
+
+/-!
+## Correctness of `trunc_local`
+
+`llvm.trunc` narrows an `i{opBw}` / `byte{opBw}` value to a strictly smaller width (both widths in
+`{8, 16, 32, 64}`), lowering to `unrealized_conversion_cast` (operand → register) →
+`unrealized_conversion_cast` (register → the narrower result type). Truncation is free on the
+register side: the operand is held zero-extended in the 64-bit register, so casting the register back
+to the narrower type reads its low bits.
+
+The two data-level refinement lemmas below (integer and byte) close by `veir_bv_decide` after
+`fin_cases` fixes the concrete operand/result widths and the refinement hypothesis is reverted into
+the goal.
+-/
+
+/-- Correctness of the integer `llvm.trunc` round trip: `i{opBw} → reg → i{resBw}` refines
+    `Int.trunc`, for widths in `{8, 16, 32, 64}`. -/
+theorem trunc_isRefinedBy_toInt {opBw resBw : Nat}
+    (hop : opBw ∈ [8, 16, 32, 64]) (hres : resBw ∈ [8, 16, 32, 64]) (hlt : opBw > resBw)
+    (nsw nuw : Bool) {x xt : Data.LLVM.Int opBw} (h : x ⊒ xt) :
+    Data.LLVM.Int.trunc x resBw nsw nuw hlt ⊒ RISCV.Reg.toInt (LLVM.Int.toReg xt) resBw := by
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hop hres
+  rcases hop with rfl | rfl | rfl | rfl <;> rcases hres with rfl | rfl | rfl | rfl <;>
+    first | omega | (revert h; veir_bv_decide)
+
+/-- Correctness of the byte `llvm.trunc` round trip: `byte{opBw} → reg → byte{resBw}` refines
+    `Byte.trunc`, for widths in `{8, 16, 32, 64}`. -/
+theorem trunc_isRefinedBy_toByte {opBw resBw : Nat}
+    (hop : opBw ∈ [8, 16, 32, 64]) (hres : resBw ∈ [8, 16, 32, 64])
+    {x xt : Data.LLVM.Byte opBw} (h : x ⊒ xt) :
+    Data.LLVM.Byte.trunc x resBw ⊒ RISCV.Reg.toByte (LLVM.Byte.toReg xt) resBw := by
+  simp only [List.mem_cons, List.not_mem_nil, or_false] at hop hres
+  rcases hop with rfl | rfl | rfl | rfl <;> rcases hres with rfl | rfl | rfl | rfl <;>
+    (revert h; simp only [RISCV.Reg.toByte, LLVM.Byte.toReg]; veir_bv_decide)
+
+/-- An `.int` runtime value pins its declared type to a matching `integerType`. -/
+theorem conforms_int_type {bw : Nat} {x : Data.LLVM.Int bw} {ty : TypeAttr}
+    (h : RuntimeValue.Conforms (.int bw x) ty) : ty.val = Attribute.integerType ⟨bw⟩ := by
+  rcases ty with ⟨tyval, hIsTy⟩
+  cases tyval with
+  | integerType it => cases it; simp_all [RuntimeValue.Conforms]
+  | _ => simp_all [RuntimeValue.Conforms]
+
+/-- A `.byte` runtime value pins its declared type to a matching `byteType`. -/
+theorem conforms_byte_type {bw : Nat} {x : Data.LLVM.Byte bw} {ty : TypeAttr}
+    (h : RuntimeValue.Conforms (.byte bw x) ty) : ty.val = Attribute.byteType ⟨bw⟩ := by
+  rcases ty with ⟨tyval, hIsTy⟩
+  cases tyval with
+  | byteType it => cases it; simp_all [RuntimeValue.Conforms]
+  | _ => simp_all [RuntimeValue.Conforms]
+
+set_option maxHeartbeats 1000000 in
+theorem trunc_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps trunc_local}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges trunc_local}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds trunc_local}
+    {h₄ : LocalRewritePattern.ReturnValues trunc_local} :
+    LocalRewritePattern.PreservesSemantics trunc_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, trunc_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher.
+  have hMatchSome : (matchTrunc op ctx.raw).isSome := by
+    cases hM : matchTrunc op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨operand, props⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := matchTrunc_implies hMatch
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hNumOperands : op.getNumOperands! ctx.raw = 1 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  -- The op's single result type, as read by the interpreter.
+  have hResTypes : op.getResultTypes! ctx.raw
+      = #[((op.getResult 0).get! ctx.raw).type] := by
+    apply Array.ext
+    · simp [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNumResults]
+    · intro i h1 h2
+      simp only [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNumResults] at h1
+      obtain rfl : i = 0 := by omega
+      have := OperationPtr.getResultTypes!.getElem!_eq (op := op) (ctx := ctx.raw) (index := 0)
+        (by omega)
+      grind
+  -- Read the operand value from the interpretation.
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize : 0 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨val, hval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize
+  have hgetVar : state.variables.getVar? operand = some val := by
+    rw [hOperandEq, show (op.getOperands! ctx.raw)[0]! = (op.getOperands! ctx.raw)[0] from by grind]
+    exact hval
+  have hOperand0 : op.getOperand! ctx.raw 0 = operand := by
+    rw [hOperandEq]; grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues op = some #[val] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    obtain rfl : i = 0 := by omega
+    simpa [hOperand0] using hgetVar
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [interpretOp', Llvm.interpretOp', hResTypes] at hInterp'
+  -- `operand` dominates and is not a result of `op`.
+  have hDomCtx : operand.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have vNotOp : ¬ operand ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- Case on the operand runtime value: integer or byte (other kinds make the interpreter `none`).
+  match val with
+  | .int opBw x =>
+    -- The operand's declared type is `i{opBw}`.
+    have hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType ⟨opBw⟩ :=
+      conforms_int_type (VariableState.getVar?_conforms hgetVar)
+    -- Reduce the interpreter's array index and the integer-value match.
+    rw [show (#[((op.getResult 0).get! ctx.raw).type] : Array TypeAttr)[0]?
+        = some ((op.getResult 0).get! ctx.raw).type from rfl] at hInterp'
+    simp only [] at hInterp'
+    -- The result type must be an integer type; case on it.
+    split at hInterp'
+    case _ resInt hResInt =>
+      -- The width guard: `resInt.bitwidth < opBw`.
+      split at hInterp'
+      · exact absurd hInterp' (by simp)
+      rename_i hle
+      obtain ⟨rfl, rfl, rfl⟩ :
+          resValues = #[RuntimeValue.int resInt.bitwidth
+            (Data.LLVM.Int.trunc x resInt.bitwidth props.nsw props.nuw (by omega))] ∧
+          mem' = state.memory ∧ cf = none := by
+        simp only [pure, Interp, Option.some.injEq, UBOr.ok.injEq] at hInterp'; grind
+      -- Source value: `op`'s result is `Int.trunc`.
+      have hResVal : newState.variables.getVar? (op.getResult 0)
+          = some (RuntimeValue.int resInt.bitwidth
+            (Data.LLVM.Int.trunc x resInt.bitwidth props.nsw props.nuw (by omega))) := by
+        rw [hNew]
+        rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+        simp
+      rw [show op.getResults ctx.raw (by grind)
+          = #[ValuePtr.opResult (op.getResult 0)] from by grind] at hsourceValues
+      simp [hResVal] at hsourceValues
+      subst sourceValues
+      -- Resolve the lowering's type/width guards.
+      simp only [getIntByteTypeBitwidth, hOperandType, hResInt] at hpattern
+      split at hpattern
+      · exact absurd hpattern (by simp)
+      rename_i hBwGuard
+      split at hpattern
+      · exact absurd hpattern (by simp)
+      rename_i hMem
+      -- Peel the two casts (raw `createOp!`).
+      peelOpCreation! hpattern ctx₁ opCastOp hCast hDomCtx hDom₁
+      peelOpCreation! hpattern ctx₂ castBackOp hCastBack hDom₁ hDom₂
+      cleanupHpattern hpattern
+      obtain ⟨xt, hOpVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hgetVar
+          hDomCtx hDom₂ vNotOp
+      -- Structural facts.
+      have hCastType : opCastOp.getOpType! ctx₂.raw = .builtin .unrealized_conversion_cast := by grind
+      have hCastBackType : castBackOp.getOpType! ctx₂.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hCastOperands : opCastOp.getOperands! ctx₂.raw = #[operand] := by grind
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₂.raw = #[ValuePtr.opResult (opCastOp.getResult 0)] := by grind
+      have hCastResTypes : opCastOp.getResultTypes! ctx₂.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := opCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := opCastOp)]
+      have hResTypeAttr : ((op.getResult 0).get! ctx.raw).type = ⟨Attribute.integerType resInt, by grind⟩ :=
+        by apply Subtype.ext; exact hResInt
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₂.raw
+          = #[⟨Attribute.integerType resInt, by grind⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castBackOp)]
+      -- Interpretation tail: `castToReg → castBack`.
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+        interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+          hCastType hCastOperands hCastResTypes hOpVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+        interpretOp_castBack_forward (state := s₁) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₁
+      have hmemOp : opBw ∈ [8, 16, 32, 64] := by
+        simp only [List.mem_cons, List.not_mem_nil, or_false] at hMem ⊢; grind
+      have hmemRes : resInt.bitwidth ∈ [8, 16, 32, 64] := by
+        simp only [List.mem_cons, List.not_mem_nil, or_false] at hMem ⊢; grind
+      have hrefine := trunc_isRefinedBy_toInt hmemOp hmemRes (by omega) props.nsw props.nuw hxtRef
+      refine ⟨s₂, ?_, by grind, ?_⟩
+      · simp [interpretOpList_cons, hI₁, hI₂, liftM, monadLift, MonadLift.monadLift, Interp]
+      · refine ⟨#[RuntimeValue.int resInt.bitwidth
+            (RISCV.Reg.toInt (LLVM.Int.toReg xt) resInt.bitwidth)], ?_, ?_⟩
+        · simp [hRes₂, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr ⟨rfl, by simpa using hrefine⟩
+    all_goals simp at hInterp'
+  | .byte opBw x =>
+    -- The operand's declared type is a `byte` of width `opBw`.
+    have hOperandType : (operand.getType! ctx.raw).val = Attribute.byteType ⟨opBw⟩ :=
+      conforms_byte_type (VariableState.getVar?_conforms hgetVar)
+    -- Reduce the interpreter's array index and the byte-value match.
+    rw [show (#[((op.getResult 0).get! ctx.raw).type] : Array TypeAttr)[0]?
+        = some ((op.getResult 0).get! ctx.raw).type from rfl] at hInterp'
+    simp only [] at hInterp'
+    -- The result type must be a byte type; case on it.
+    split at hInterp'
+    case _ resByte hResByte =>
+      -- The width guard: `resByte.bitwidth < opBw`.
+      split at hInterp'
+      · exact absurd hInterp' (by simp)
+      rename_i hle
+      obtain ⟨rfl, rfl, rfl⟩ :
+          resValues = #[RuntimeValue.byte resByte.bitwidth
+            (Data.LLVM.Byte.trunc x resByte.bitwidth)] ∧
+          mem' = state.memory ∧ cf = none := by
+        simp only [pure, Interp, Option.some.injEq, UBOr.ok.injEq] at hInterp'; grind
+      -- Source value: `op`'s result is `Byte.trunc`.
+      have hResVal : newState.variables.getVar? (op.getResult 0)
+          = some (RuntimeValue.byte resByte.bitwidth
+            (Data.LLVM.Byte.trunc x resByte.bitwidth)) := by
+        rw [hNew]
+        rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+        simp
+      rw [show op.getResults ctx.raw (by grind)
+          = #[ValuePtr.opResult (op.getResult 0)] from by grind] at hsourceValues
+      simp [hResVal] at hsourceValues
+      subst sourceValues
+      -- Resolve the lowering's type/width guards.
+      simp only [getIntByteTypeBitwidth, hOperandType, hResByte] at hpattern
+      split at hpattern
+      · exact absurd hpattern (by simp)
+      rename_i hBwGuard
+      split at hpattern
+      · exact absurd hpattern (by simp)
+      rename_i hMem
+      -- Peel the two casts (raw `createOp!`).
+      peelOpCreation! hpattern ctx₁ opCastOp hCast hDomCtx hDom₁
+      peelOpCreation! hpattern ctx₂ castBackOp hCastBack hDom₁ hDom₂
+      cleanupHpattern hpattern
+      obtain ⟨xt, hOpVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_byte_getVar? valueRefinement state'Dom (by grind) hgetVar
+          hDomCtx hDom₂ vNotOp
+      -- Structural facts.
+      have hCastType : opCastOp.getOpType! ctx₂.raw = .builtin .unrealized_conversion_cast := by grind
+      have hCastBackType : castBackOp.getOpType! ctx₂.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hCastOperands : opCastOp.getOperands! ctx₂.raw = #[operand] := by grind
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₂.raw = #[ValuePtr.opResult (opCastOp.getResult 0)] := by grind
+      have hCastResTypes : opCastOp.getResultTypes! ctx₂.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCast (operation := opCastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := opCastOp)]
+      have hResTypeAttr : ((op.getResult 0).get! ctx.raw).type = ⟨Attribute.byteType resByte, by grind⟩ :=
+        by apply Subtype.ext; exact hResByte
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₂.raw
+          = #[⟨Attribute.byteType resByte, by grind⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := castBackOp)]
+      -- Interpretation tail: `castToReg → castBack`.
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+        interpretOp_castToReg_byte_forward (state := state') (inBounds := by grind)
+          hCastType hCastOperands hCastResTypes hOpVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+        interpretOp_castBack_byte_forward (state := s₁) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₁
+      have hmemOp : opBw ∈ [8, 16, 32, 64] := by
+        simp only [List.mem_cons, List.not_mem_nil, or_false] at hMem ⊢; grind
+      have hmemRes : resByte.bitwidth ∈ [8, 16, 32, 64] := by
+        simp only [List.mem_cons, List.not_mem_nil, or_false] at hMem ⊢; grind
+      have hrefine := trunc_isRefinedBy_toByte hmemOp hmemRes hxtRef
+      refine ⟨s₂, ?_, by grind, ?_⟩
+      · simp [interpretOpList_cons, hI₁, hI₂, liftM, monadLift, MonadLift.monadLift, Interp]
+      · refine ⟨#[RuntimeValue.byte resByte.bitwidth
+            (RISCV.Reg.toByte (LLVM.Byte.toReg xt) resByte.bitwidth)], ?_, ?_⟩
+        · simp [hRes₂, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr ⟨rfl, by simpa using hrefine⟩
+    all_goals simp at hInterp'
+  | .float _ _ | .addr _ | .reg _ => simp at hInterp'
+
+/--
+info: 'Veir.trunc_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominates_refl,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_14,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_19,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_24,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_29,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_34,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_39,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_44,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_49,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_54,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_59,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_64,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_69,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_74,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_79,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_84,
+ trunc_isRefinedBy_toByte._native.bv_decide.ax_1_9,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms trunc_local_preservesSemantics
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -164,6 +164,28 @@ structural proof is done **once per combinator**. Currently:
   the immediate-op forward lemma `interpretOp_riscv_unaryReg_imm_forward`. It is the first proof of a
   lowering that emits an immediate-form riscv op — the template for the `selectBinopImmLocal` family
   (which additionally needs a `matchConstantIntVal` DAG-matching Layer-3 lemma).
+- `trunc_local` (`RISCV64.lean`) — `llvm.trunc` on integer *and* byte operands: two
+  `unrealized_conversion_cast`s (`operand → reg`, then `reg → result-type`) that keep only the low
+  `resBw` bits. Not a combinator: a *standalone* proof (`trunc_local_preservesSemantics`,
+  `RewriteProofs/LowerTrunc.lean`). It is the first proof to cover `llvm.byte`-typed values, so it
+  adds a whole byte layer paralleling the integer one: the forward lemmas
+  `interpretOp_castToReg_byte_forward` / `interpretOp_castBack_byte_forward`
+  (`CommonForwardInterpret.lean`) and the refined-operand reader
+  `LocalRewritePattern.exists_refined_byte_getVar?` (`CommonBaseLemmas.lean`), plus the
+  `conforms_int_type` / `conforms_byte_type` helpers that pin a runtime value's declared type. The
+  proof matches on the operand runtime value (`.int` vs `.byte`) and runs the two branches
+  symmetrically, each ending in the round-trip refinement data lemma (`trunc_isRefinedBy_toInt` /
+  `trunc_isRefinedBy_toByte`). Two notable points: (a) `trunc_local` was *width-limited* to
+  `{8, 16, 32, 64}` — the round trip through a 64-bit register is only sound for register-representable
+  widths (the width-generic version is genuinely unsound for a result wider than 64 bits), and the
+  restriction also makes the widths *concrete* so the data lemmas discharge by `rcases`-ing on the four
+  widths and `revert h; veir_bv_decide` at each (the byte lemma additionally `simp only [RISCV.Reg.toByte,
+  LLVM.Byte.toReg]` first, since those projections aren't `@[veir_bv_normalize]`); (b) `trunc_local`
+  emits the two casts with *raw* `WfRewriter.createOp!` (not the `castToRegLocal`/`replaceWithRegLocal`
+  helpers), so the casts peel with `peelOpCreation!` and the type/width guards are resolved by folding
+  the type-equality rewrites *into* the `getIntByteTypeBitwidth` unfold
+  (`simp only [getIntByteTypeBitwidth, hOperandType, hResInt]`) so both the operand- and result-side
+  bitwidth matches reduce before the manual guard splits.
 
 The generic theorem is parameterized over everything opcode-specific:
 
@@ -505,10 +527,11 @@ per lowering as above.
 | `RewriteProofs/LowerAshr.lean` | `ashr_local_preservesSemantics` (standalone `i8`/`i32`/`i64` `ashr`; three width branches, `i8` adds a `sextb`), `ashr_isRefinedBy_toInt_sra`/`_sraw`/`_sra_sextb` (shift-refinement data lemmas: `ctlz`-style `getValue`→`getValueD` + `isPoison_ashr` `y<w` bound), `#guard_msgs` axiom pin | — (one-off) |
 | `RewriteProofs/LowerSextOne.lean` | `sext_1_local_preservesSemantics` (standalone `i1 → i64`/`i32` sext ⟶ `srai (slli _ 63) 63`; four-op chain, no bitwidth branch, first immediate-emitting proof), `srai_slli_63_val` + `sext1_isRefinedBy_toInt_srai_slli` (reusing `matchExtOp_interpretOp_unfold` / `sextLike_isRefinedBy_toInt` from `LowerExt.lean`), `#guard_msgs` axiom pin | — (one-off) |
 | `RewriteProofs/LowerZextOne.lean` | `zext_1_local_preservesSemantics` (standalone `i1 → i64` zext ⟶ `andi 1`; first immediate-emitting proof), `andi_one_val` + `zext1_isRefinedBy_toInt_andi` (reusing `matchExtOp_interpretOp_unfold` / `zextLike_isRefinedBy_toInt` from `LowerExt.lean`), `#guard_msgs` axiom pin | — (one-off) |
+| `RewriteProofs/LowerTrunc.lean` | `trunc_local_preservesSemantics` (standalone `llvm.trunc` over integer *and* byte operands, widths `{8,16,32,64}`; two raw-`createOp!` casts, operand-value case split with symmetric int/byte branches), `trunc_isRefinedBy_toInt`/`_toByte` (concrete-width round-trip data lemmas via `revert; veir_bv_decide`), `conforms_int_type`/`conforms_byte_type`, `#guard_msgs` axiom pin | — (one-off; first byte-typed proof) |
 | `RewriteProofs/CommonGraphLemmas.lean` | `matchBinaryOp_interpretOp_unfold` (shared by the binary combinator proofs) + Layer 3: `OperationPtr.Pure.llvm_*`, `constantOp_interpretOp_unfold`, `matchNot_getVar?_of_EquationLemmaAt` | one packaged lemma per new *matcher* used on defining ops |
-| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + generic unary/binary reg-to-reg riscv ops + `interpretOp_riscv_unaryReg_imm_forward` for immediate-form unary ops) | one lemma per new emitted-op *shape* |
+| `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + byte casts `interpretOp_castToReg_byte_forward`/`interpretOp_castBack_byte_forward` + generic unary/binary reg-to-reg riscv ops + `interpretOp_riscv_unaryReg_imm_forward` for immediate-form unary ops) | one lemma per new emitted-op *shape* |
 | `RewriteProofs/CommonTactics.lean` | `peel*` macros (incl. the two-dominance `peel*₂` variants), `cleanupHpattern` | rarely |
-| `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `not_mem_getResults!_of_inBounds_of_not_inBounds`, `createOp!` reduction, properties/dominance transport | rarely |
+| `RewriteProofs/CommonBaseLemmas.lean` | `exists_refined_int_getVar?`, `exists_refined_byte_getVar?`, `not_mem_getResults!_of_inBounds_of_not_inBounds`, `createOp!` reduction, properties/dominance transport | rarely |
 | `RewriteProofs/CommonMatchLemmas.lean` | ctlz-specific unfold/peel lemmas — currently unused (superseded by the generic `matchUnaryOp_interpretOp_unfold`); candidate for deletion | — |
 | `Veir/Passes/InstructionSelection/RISCV64.lean` | the GlobalISel lowering combinators (`lowerUnaryWLocal`, `lowerBinaryWLocal`, …) and their instances | one `def` (or a new combinator) |
 | `Veir/Passes/InstructionSelection/RISCV64Sdag.lean` | the SelectionDAG lowering combinators (`lowerBinopNotLocal`, `selectBinopImmLocal`, …) and their instances | one `def` (or a new combinator) |


### PR DESCRIPTION
Prove `trunc_local_preservesSemantics`, the first rewrite proof covering `llvm.byte` values alongside integers. Restricts `trunc_local` to the register-representable widths {8,16,32,64}, where the round trip through a 64-bit register is sound, and adds a byte proof layer (cast forward-interpret lemmas + byte refined-operand reader). Round-trip refinement lemmas discharge at concrete widths via `veir_bv_decide`.