### PR TITLE
feat: complete immediate-form shift instruction selection

### DIFF
--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerSelectBinopImm.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerSelectBinopImm.lean
@@ -33,6 +33,97 @@ verifier facts, the interpreter computation facts for the source op and the imme
 and one data-level refinement lemma.
 -/
 
+/-- Shift analogue of `matchBinaryOp_interpretOp_unfold`: for `llvm.shl`/`llvm.lshr`, whose verifier
+    (`verifyLLVMShift`) permits the shift amount (operand 1) to have a *different* integer width
+    `intType2` from operand 0 (`intType`), a *successful* interpretation forces the two widths equal.
+    The `hSemSrc` hypothesis captures the interpreter's own width guard: it takes the mismatched
+    operands `#[.int bw x, .int bw' y]` and returns the width-equality proof `h'` together with the
+    result value. -/
+theorem matchShiftOp_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCode}
+    {op : OperationPtr} {lhs rhs : ValuePtr} {props : propertiesOf (.llvm srcOp)} {intType intType2}
+    {shiftFn : ∀ {bw : Nat},
+      Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) → Data.LLVM.Int bw}
+    {state newState : InterpreterState ctx} {cf} (opInBounds : op.InBounds ctx.raw)
+    (hOpType : op.getOpType! ctx.raw = .llvm srcOp)
+    (hNumResults : op.getNumResults! ctx.raw = 1)
+    (hOperands : op.getOperands! ctx.raw = #[lhs, rhs])
+    (hProps : props = op.getProperties! ctx.raw (.llvm srcOp))
+    (hSemSrc : ∀ (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+        (props : propertiesOf (.llvm srcOp)) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+          = some (.ok res) →
+        ∃ (h' : bw' = bw), res = (#[.int bw (shiftFn x (h' ▸ y) props)], mem, none))
+    (hinterp : interpretOp op state opInBounds = some (.ok (newState, cf)))
+    (hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType)
+    (hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType2) :
+    ∃ (x : Data.LLVM.Int intType.bitwidth) (y : Data.LLVM.Int intType2.bitwidth)
+      (h' : intType2.bitwidth = intType.bitwidth),
+      state.variables.getVar? lhs = some (RuntimeValue.int intType.bitwidth x) ∧
+      state.variables.getVar? rhs = some (RuntimeValue.int intType2.bitwidth y) ∧
+      state.memory = newState.memory ∧
+      newState.variables.getVar? (op.getResult 0) =
+        some (RuntimeValue.int intType.bitwidth (shiftFn x (h' ▸ y) props)) ∧
+      cf = none := by
+  have hNumOperands : op.getNumOperands! ctx.raw = 2 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize0 : 0 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  have hsize1 : 1 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨lval, hlval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize0
+  obtain ⟨rval, hrval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 1 hsize1
+  have hlGetVar : state.variables.getVar? lhs = some lval := by
+    rw [hLhsEq, show (op.getOperands! ctx.raw)[0]! = (op.getOperands! ctx.raw)[0] from by grind]
+    exact hlval
+  have hrGetVar : state.variables.getVar? rhs = some rval := by
+    rw [hRhsEq, show (op.getOperands! ctx.raw)[1]! = (op.getOperands! ctx.raw)[1] from by grind]
+    exact hrval
+  have hlconf := VariableState.getVar?_conforms hlGetVar
+  rw [show lhs.getType! ctx.raw = ⟨.integerType intType, hLhsType ▸ (lhs.getType! ctx.raw).2⟩
+        from Subtype.ext hLhsType] at hlconf
+  obtain ⟨x, rfl⟩ := RuntimeValue.Conforms.integerType hlconf
+  have hrconf := VariableState.getVar?_conforms hrGetVar
+  rw [show rhs.getType! ctx.raw = ⟨.integerType intType2, hRhsType ▸ (rhs.getType! ctx.raw).2⟩
+        from Subtype.ext hRhsType] at hrconf
+  obtain ⟨y, rfl⟩ := RuntimeValue.Conforms.integerType hrconf
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues op
+      = some #[RuntimeValue.int intType.bitwidth x, RuntimeValue.int intType2.bitwidth y] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    match i, hi with
+    | 0, _ => simpa [hOperand0] using hlGetVar
+    | 1, _ => simpa [hOperand1] using hrGetVar
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [← hProps, interpretOp'] at hInterp'
+  obtain ⟨h', hres⟩ := hSemSrc _ _ _ _ _ _ _ _ _ hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ :
+      resValues = #[RuntimeValue.int intType.bitwidth (shiftFn x (h' ▸ y) props)] ∧
+      mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  refine ⟨x, y, h', hlGetVar, hrGetVar, rfl, ?_, rfl⟩
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
 set_option maxHeartbeats 1000000 in
 /-- Shared correctness proof for every `selectBinopImmLocal` lowering: the round trip
     `int → reg → dst(imm) → int` refines `srcFn _ (constant imm)`.
@@ -208,6 +299,191 @@ theorem selectBinopImmLocal_preservesSemantics {α : Type} {srcOp : Llvm}
   have hCastBackResTypes : castBackOp.getResultTypes! ctx₃.raw
       = #[⟨Attribute.integerType { bitwidth := width }, by grind⟩] := by grind
   -- Interpretation tail: execute `interpretOpList [xCastOp, retOp, castBackOp]` in `state'`.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+    interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+      hCastXType hCastXOperands hCastXResTypes hXVal'
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+    interpretOp_riscv_unaryReg_imm_forward (state := s₁) (inBounds := by grind)
+      (res := rFn imm.value (LLVM.Int.toReg xt))
+      (fun rt bo mem => hSemR imm.value _ rt bo mem)
+      hRetType hRetProps hRetOperands hRetResTypes hRes₁
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, -⟩ :=
+    interpretOp_castBack_forward (state := s₂) (inBounds := by grind)
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₂
+  refine ⟨s₃, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, hI₃, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int width
+        (RISCV.Reg.toInt (rFn imm.value (LLVM.Int.toReg xt)) width)], ?_, ?_⟩
+    · simp [hRes₃, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using hRefine xlv xt imm.value _ hLo hHi hxtRef⟩
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness proof for the `shl`/`lshr` `selectBinopImmLocal` lowerings. Identical in shape to
+    `selectBinopImmLocal_preservesSemantics`, but the source op verifies via `verifyLLVMShift`
+    (`IsVerifiedLLVMShift`) rather than `IsVerifiedIntegerBinop`: the shift amount's width is not
+    pinned statically, so the operand-width equality is recovered from the successful interpretation
+    (`matchShiftOp_interpretOp_unfold`) and then substituted, collapsing the proof to the binop
+    shape. -/
+theorem selectBinopImmLocal_shift_preservesSemantics {α : Type} {srcOp : Llvm}
+    {matchPair : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × α)}
+    {dst : Riscv} {hdst : Riscv.propertiesOf dst = RISCVImmediateProperties}
+    {width : Nat} {lo hi : Int}
+    {rFn : Int → Data.RISCV.Reg → Data.RISCV.Reg}
+    {srcFn : ∀ {bw : Nat}, Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) →
+      Data.LLVM.Int bw}
+    (hMatchImplies : ∀ {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs a},
+        matchPair op ctx = some (lhs, rhs, a) →
+        op.getOpType! ctx = .llvm srcOp ∧
+        op.getNumResults! ctx = 1 ∧
+        op.getOperands! ctx = #[lhs, rhs])
+    (hVerified : ∀ {ctx : WfIRContext OpCode} {op : OperationPtr}
+        {opInBounds : op.InBounds ctx.raw},
+        op.Verified ctx opInBounds → op.getOpType! ctx.raw = .llvm srcOp →
+        op.IsVerifiedLLVMShift ctx)
+    (hSemSrc : ∀ (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+        (props : propertiesOf (.llvm srcOp)) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+          = some (.ok res) →
+        ∃ (h' : bw' = bw), res = (#[.int bw (srcFn x (h' ▸ y) props)], mem, none))
+    (hSemR : ∀ (c : Int) (r : Data.RISCV.Reg) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' dst
+            (cast hdst.symm (RISCVImmediateProperties.mk (IntegerAttr.mk c (IntegerType.mk 64))))
+            resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (rFn c r)], mem, none)))
+    (hRefine : ∀ (x xt : Data.LLVM.Int width) (c : Int) (props : propertiesOf (.llvm srcOp)),
+        lo ≤ c → c ≤ hi → x ⊒ xt →
+        srcFn x (Data.LLVM.Int.constant width c) props
+          ⊒ RISCV.Reg.toInt (rFn c (LLVM.Int.toReg xt)) width)
+    {h : LocalRewritePattern.ReturnOps (selectBinopImmLocal matchPair dst hdst width lo hi)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (selectBinopImmLocal matchPair dst hdst width lo hi)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds
+      (selectBinopImmLocal matchPair dst hdst width lo hi)}
+    {h₄ : LocalRewritePattern.ReturnValues (selectBinopImmLocal matchPair dst hdst width lo hi)} :
+    LocalRewritePattern.PreservesSemantics
+      (selectBinopImmLocal matchPair dst hdst width lo hi) h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, selectBinopImmLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  have hMatchSome : (matchPair op ctx.raw).isSome := by
+    cases hM : matchPair op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs, a⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  have ⟨hOpType, hNumResults, hOperands⟩ := hMatchImplies hMatch
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hResEqOp0, intType2, hOp1Type⟩ := hVerified opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- The result type must be an integer for the pattern to fire; derive it and hence `lhs`'s type.
+  obtain ⟨intType, hResType⟩ :
+      ∃ intType, ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    cases hr : ((op.getResult 0).get! ctx.raw).type.val with
+    | integerType t => exact ⟨t, rfl⟩
+    | _ => rw [hr] at hpattern; simp at hpattern
+  have hLhsType : (lhs.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hOperand0, ← hResEqOp0, hResType]
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType2 := by
+    rw [← hOperand1, hOp1Type]
+  rw [hResType] at hpattern
+  simp only [] at hpattern
+  split at hpattern
+  case isFalse hne => simp at hpattern
+  rename_i hWidth
+  have hCstSome : (matchConstantIntVal rhs ctx.raw).isSome := by
+    cases hM : matchConstantIntVal rhs ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨imm, hCstMatch⟩ := Option.isSome_iff_exists.mp hCstSome
+  rw [hCstMatch] at hpattern
+  simp only [] at hpattern
+  split at hpattern
+  case isTrue hrange => simp at hpattern
+  rename_i hRange
+  obtain ⟨hLo, hHi⟩ : lo ≤ imm.value ∧ imm.value ≤ hi := by omega
+  -- Unfold the shift interpretation: recovers the width equality `h'` between the two operands.
+  obtain ⟨xlv, xrv, h', hlVal, hrVal, hMem, hRes, hCf⟩ :=
+    matchShiftOp_interpretOp_unfold (props := op.getProperties! ctx.raw (.llvm srcOp))
+      opInBounds hOpType hNumResults hOperands rfl hSemSrc hinterp hLhsType hRhsType
+  subst hCf
+  -- Both operand widths equal `width`; substitute so the shift collapses to the binop shape.
+  obtain ⟨bw⟩ := intType; obtain ⟨bw2⟩ := intType2
+  simp only at hWidth h' hlVal hRes ⊢
+  subst bw; subst bw2
+  have hDomLhs : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hrhsVal := matchConstantIntVal_getVar?_of_EquationLemmaAt ctxDom ctxVerif opInBounds
+    stateWf hCstMatch (by rw [hOperands]; simp) hRhsType
+  obtain rfl : xrv = Data.LLVM.Int.constant width imm.value := by
+    have := hrVal.symm.trans hrhsVal
+    simpa using this
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  have vNotOpLhs : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  peelCastToRegLocal hpattern ctx₁ xCastOp hCastX hDomLhs hDomLhs₁
+  peelOpCreation! hpattern ctx₂ retOp hRet hDomLhs₁ hDomLhs₂
+  peelReplaceWithRegLocal hpattern ctx₃ castBackOp hCastBack hDomLhs₂ hDomLhs₃
+  cleanupHpattern hpattern
+  obtain ⟨xt, hXVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hlVal
+      hDomLhs hDomLhs₃ vNotOpLhs
+  have hCastXType : xCastOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by grind
+  have hRetType : retOp.getOpType! ctx₃.raw = .riscv dst := by grind
+  have hCastBackType : castBackOp.getOpType! ctx₃.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastXOperands : xCastOp.getOperands! ctx₃.raw = #[lhs] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hCastX (operation := xCastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := xCastOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := xCastOp)]
+  have hRetOperands : retOp.getOperands! ctx₃.raw
+      = #[ValuePtr.opResult (xCastOp.getResult 0)] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+      OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₃.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+  have hRetProps : retOp.getProperties! ctx₃.raw (.riscv dst)
+      = cast hdst.symm (RISCVImmediateProperties.mk (IntegerAttr.mk imm.value (IntegerType.mk 64))) := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind)]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hRet (operation := retOp)]
+  have hCBType : ((op.getResult 0).get! ctx₂.raw).type
+      = (⟨Attribute.integerType { bitwidth := width }, by grind⟩ : TypeAttr) := by
+    have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₂.raw
+        = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+      grind [ValuePtr.getType!_WfRewriter_createOp hRet
+          (value := ValuePtr.opResult (op.getResult 0)),
+        ValuePtr.getType!_WfRewriter_createOp hCastX
+          (value := ValuePtr.opResult (op.getResult 0))]
+    rw [ValuePtr.getType!_opResult, ValuePtr.getType!_opResult] at h1
+    rw [h1]; exact Subtype.ext hResType
+  have hCastXResTypes : xCastOp.getResultTypes! ctx₃.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastX (operation := xCastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := xCastOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := xCastOp)]
+  have hRetResTypes : retOp.getResultTypes! ctx₃.raw
+      = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp),
+      OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp)]
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₃.raw
+      = #[⟨Attribute.integerType { bitwidth := width }, by grind⟩] := by grind
   obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
     interpretOp_castToReg_forward (state := state') (inBounds := by grind)
       hCastXType hCastXOperands hCastXResTypes hXVal'
@@ -476,6 +752,156 @@ theorem sraiw_local_preservesSemantics
     (fun _ _ _ _ _ => rfl)
     (fun x xt c props hlo hhi h => sraiw_isRefinedBy (exact := props.exact) c hlo hhi h)
 
+/-- Correctness of the `riscv.slli` lowering of a 64-bit `llvm.shl` by a constant `uimm6`. -/
+theorem slli_isRefinedBy {nsw nuw : Bool} {x xt : Data.LLVM.Int 64} (c : Int)
+    (_hlo : 0 ≤ c) (_hhi : c ≤ 63) (h : x ⊒ xt) :
+    Data.LLVM.Int.shl x (Data.LLVM.Int.constant 64 c) nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.slli (BitVec.ofInt 6 c) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.RISCV.slli, ← setWidth_ofInt_6_64 c]
+  simp only [Data.LLVM.Int.constant]
+  generalize BitVec.ofInt 64 c = v
+  revert h
+  veir_bv_decide
+
+/-- Correctness of the `riscv.srli` lowering of a 64-bit `llvm.lshr` by a constant `uimm6`. -/
+theorem srli_isRefinedBy {exact : Bool} {x xt : Data.LLVM.Int 64} (c : Int)
+    (_hlo : 0 ≤ c) (_hhi : c ≤ 63) (h : x ⊒ xt) :
+    Data.LLVM.Int.lshr x (Data.LLVM.Int.constant 64 c) exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.srli (BitVec.ofInt 6 c) (LLVM.Int.toReg xt)) 64 := by
+  rw [Data.RISCV.srli, ← setWidth_ofInt_6_64 c]
+  simp only [Data.LLVM.Int.constant]
+  generalize BitVec.ofInt 64 c = v
+  revert h
+  veir_bv_decide
+
+/-- Correctness of the `riscv.slliw` lowering of a 32-bit `llvm.shl` by a constant `uimm5`. -/
+theorem slliw_isRefinedBy {nsw nuw : Bool} {x xt : Data.LLVM.Int 32} (c : Int)
+    (_hlo : 0 ≤ c) (_hhi : c ≤ 31) (h : x ⊒ xt) :
+    Data.LLVM.Int.shl x (Data.LLVM.Int.constant 32 c) nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.slliw (BitVec.ofInt 5 c) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.RISCV.slliw, ← setWidth_ofInt_5_64 c]
+  simp only [Data.LLVM.Int.constant]
+  rw [← BitVec.setWidth_ofInt_32_64 c]
+  generalize BitVec.ofInt 64 c = v
+  revert h
+  veir_bv_decide
+
+/-- Correctness of the `riscv.srliw` lowering of a 32-bit `llvm.lshr` by a constant `uimm5`. -/
+theorem srliw_isRefinedBy {exact : Bool} {x xt : Data.LLVM.Int 32} (c : Int)
+    (_hlo : 0 ≤ c) (_hhi : c ≤ 31) (h : x ⊒ xt) :
+    Data.LLVM.Int.lshr x (Data.LLVM.Int.constant 32 c) exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.srliw (BitVec.ofInt 5 c) (LLVM.Int.toReg xt)) 32 := by
+  rw [Data.RISCV.srliw, ← setWidth_ofInt_5_64 c]
+  simp only [Data.LLVM.Int.constant]
+  rw [← BitVec.setWidth_ofInt_32_64 c]
+  generalize BitVec.ofInt 64 c = v
+  revert h
+  veir_bv_decide
+
+/-- Shared discharge for the shift `hSemSrc`: the interpreter's own width guard forces the shift
+    amount to have the operand's width, and the result is the shift value. -/
+private theorem shl_shiftSem (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+    (props : propertiesOf (.llvm .shl)) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState)
+    (res : Array RuntimeValue × MemoryState × Option ControlFlowAction)
+    (h : Llvm.interpretOp' .shl props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+      = some (.ok res)) :
+    ∃ (h' : bw' = bw),
+      res = (#[.int bw (Data.LLVM.Int.shl x (h' ▸ y) props.nsw props.nuw)], mem, none) := by
+  simp only [Llvm.interpretOp'] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hbw
+    obtain rfl : bw' = bw := by omega
+    refine ⟨rfl, ?_⟩
+    simp only [Data.LLVM.Int.cast_self, pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h
+    grind
+
+private theorem lshr_shiftSem (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+    (props : propertiesOf (.llvm .lshr)) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState)
+    (res : Array RuntimeValue × MemoryState × Option ControlFlowAction)
+    (h : Llvm.interpretOp' .lshr props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+      = some (.ok res)) :
+    ∃ (h' : bw' = bw),
+      res = (#[.int bw (Data.LLVM.Int.lshr x (h' ▸ y) props.exact)], mem, none) := by
+  simp only [Llvm.interpretOp'] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hbw
+    obtain rfl : bw' = bw := by omega
+    refine ⟨rfl, ?_⟩
+    simp only [Data.LLVM.Int.cast_self, pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h
+    grind
+
+theorem slli_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps (selectBinopImmLocal matchShl .slli rfl 64 0 63)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (selectBinopImmLocal matchShl .slli rfl 64 0 63)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds (selectBinopImmLocal matchShl .slli rfl 64 0 63)}
+    {h₄ : LocalRewritePattern.ReturnValues (selectBinopImmLocal matchShl .slli rfl 64 0 63)} :
+    LocalRewritePattern.PreservesSemantics
+      (selectBinopImmLocal matchShl .slli rfl 64 0 63) h h₂ h₃ h₄ :=
+  selectBinopImmLocal_shift_preservesSemantics
+    (srcOp := .shl) (dst := .slli) (hdst := rfl) (width := 64) (lo := 0) (hi := 63)
+    (srcFn := fun x y props => Data.LLVM.Int.shl x y props.nsw props.nuw)
+    (rFn := fun c r => Data.RISCV.slli (BitVec.ofInt 6 c) r)
+    (fun hm => ⟨(matchShl_implies hm).1, (matchShl_implies hm).2.1, (matchShl_implies hm).2.2.1⟩)
+    OperationPtr.Verified.llvm_shl
+    shl_shiftSem
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ c props hlo hhi h => slli_isRefinedBy (nsw := props.nsw) (nuw := props.nuw) c hlo hhi h)
+
+theorem srli_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps (selectBinopImmLocal matchLshr .srli rfl 64 0 63)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (selectBinopImmLocal matchLshr .srli rfl 64 0 63)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds (selectBinopImmLocal matchLshr .srli rfl 64 0 63)}
+    {h₄ : LocalRewritePattern.ReturnValues (selectBinopImmLocal matchLshr .srli rfl 64 0 63)} :
+    LocalRewritePattern.PreservesSemantics
+      (selectBinopImmLocal matchLshr .srli rfl 64 0 63) h h₂ h₃ h₄ :=
+  selectBinopImmLocal_shift_preservesSemantics
+    (srcOp := .lshr) (dst := .srli) (hdst := rfl) (width := 64) (lo := 0) (hi := 63)
+    (srcFn := fun x y props => Data.LLVM.Int.lshr x y props.exact)
+    (rFn := fun c r => Data.RISCV.srli (BitVec.ofInt 6 c) r)
+    (fun hm => ⟨(matchLshr_implies hm).1, (matchLshr_implies hm).2.1, (matchLshr_implies hm).2.2.1⟩)
+    OperationPtr.Verified.llvm_lshr
+    lshr_shiftSem
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ c props hlo hhi h => srli_isRefinedBy (exact := props.exact) c hlo hhi h)
+
+theorem slliw_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps (selectBinopImmLocal matchShl .slliw rfl 32 0 31)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (selectBinopImmLocal matchShl .slliw rfl 32 0 31)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds (selectBinopImmLocal matchShl .slliw rfl 32 0 31)}
+    {h₄ : LocalRewritePattern.ReturnValues (selectBinopImmLocal matchShl .slliw rfl 32 0 31)} :
+    LocalRewritePattern.PreservesSemantics
+      (selectBinopImmLocal matchShl .slliw rfl 32 0 31) h h₂ h₃ h₄ :=
+  selectBinopImmLocal_shift_preservesSemantics
+    (srcOp := .shl) (dst := .slliw) (hdst := rfl) (width := 32) (lo := 0) (hi := 31)
+    (srcFn := fun x y props => Data.LLVM.Int.shl x y props.nsw props.nuw)
+    (rFn := fun c r => Data.RISCV.slliw (BitVec.ofInt 5 c) r)
+    (fun hm => ⟨(matchShl_implies hm).1, (matchShl_implies hm).2.1, (matchShl_implies hm).2.2.1⟩)
+    OperationPtr.Verified.llvm_shl
+    shl_shiftSem
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ c props hlo hhi h => slliw_isRefinedBy (nsw := props.nsw) (nuw := props.nuw) c hlo hhi h)
+
+theorem srliw_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps (selectBinopImmLocal matchLshr .srliw rfl 32 0 31)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (selectBinopImmLocal matchLshr .srliw rfl 32 0 31)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds (selectBinopImmLocal matchLshr .srliw rfl 32 0 31)}
+    {h₄ : LocalRewritePattern.ReturnValues (selectBinopImmLocal matchLshr .srliw rfl 32 0 31)} :
+    LocalRewritePattern.PreservesSemantics
+      (selectBinopImmLocal matchLshr .srliw rfl 32 0 31) h h₂ h₃ h₄ :=
+  selectBinopImmLocal_shift_preservesSemantics
+    (srcOp := .lshr) (dst := .srliw) (hdst := rfl) (width := 32) (lo := 0) (hi := 31)
+    (srcFn := fun x y props => Data.LLVM.Int.lshr x y props.exact)
+    (rFn := fun c r => Data.RISCV.srliw (BitVec.ofInt 5 c) r)
+    (fun hm => ⟨(matchLshr_implies hm).1, (matchLshr_implies hm).2.1, (matchLshr_implies hm).2.2.1⟩)
+    OperationPtr.Verified.llvm_lshr
+    lshr_shiftSem
+    (fun _ _ _ _ _ => rfl)
+    (fun _ _ c props hlo hhi h => srliw_isRefinedBy (exact := props.exact) c hlo hhi h)
+
 /--
 info: 'Veir.selectBinopImmLocal_preservesSemantics' depends on axioms: [propext,
  Classical.choice,
@@ -513,5 +939,44 @@ info: 'Veir.addi_local_preservesSemantics' depends on axioms: [propext,
 -/
 #guard_msgs in
 #print axioms addi_local_preservesSemantics
+
+/--
+info: 'Veir.selectBinopImmLocal_shift_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms selectBinopImmLocal_shift_preservesSemantics
+
+/--
+info: 'Veir.slli_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ slli_isRefinedBy._native.bv_decide.ax_1_7,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms slli_local_preservesSemantics
 
 end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -185,10 +185,15 @@ structural proof is done **once per combinator**. Currently:
   a *single* abstract 64-bit vector `v`, and `veir_bv_decide` closes the rest (the shift lemmas need
   *no* range bound because LLVM's shift-past-width poison makes the refinement trivial there). The
   matched-property equation is *not* needed (the combinator reads `getProperties!` directly). The
-  four `shl`/`lshr` immediate instances (`slli`/`srli`/`slliw`/`srliw`) do *not* fit yet: `llvm.shl`
-  and `llvm.lshr` verify via `verifyLLVMShift` (which permits a byte or *different-width* shift
-  operand), so they yield no `IsVerifiedIntegerBinop` and the combinator's `hVerified` does not apply
-  — they need the operand-width equality derived from the successful source interpretation instead.
+  four `shl`/`lshr` immediate instances (`slli`/`srli`/`slliw`/`srliw`) need a *second* combinator
+  proof, `selectBinopImmLocal_shift_preservesSemantics`: `llvm.shl`/`llvm.lshr` verify via
+  `verifyLLVMShift` (which permits a byte or *different-width* shift operand), so they yield the
+  weaker `IsVerifiedLLVMShift` (`Verifier.lean`) rather than `IsVerifiedIntegerBinop` — it pins only
+  the result-vs-operand-0 type match and that operand 1 is *some* integer. The operand-width equality
+  is instead recovered *dynamically*: `matchShiftOp_interpretOp_unfold` reads the interpreter's own
+  width guard out of the successful source interpretation, and `subst`ing it collapses the proof to
+  the binop shape (so the same three-op tail and refinement lemmas apply). The `shl`/`lshr` `hSemSrc`
+  is discharged by `shl_shiftSem`/`lshr_shiftSem`, which case-split the interpreter's `if bw' ≠ bw`.
 - `trunc_local` (`RISCV64.lean`) — `llvm.trunc` on integer *and* byte operands: two
   `unrealized_conversion_cast`s (`operand → reg`, then `reg → result-type`) that keep only the low
   `resBw` bits. Not a combinator: a *standalone* proof (`trunc_local_preservesSemantics`,
@@ -552,7 +557,7 @@ per lowering as above.
 | `RewriteProofs/LowerAshr.lean` | `ashr_local_preservesSemantics` (standalone `i8`/`i32`/`i64` `ashr`; three width branches, `i8` adds a `sextb`), `ashr_isRefinedBy_toInt_sra`/`_sraw`/`_sra_sextb` (shift-refinement data lemmas: `ctlz`-style `getValue`→`getValueD` + `isPoison_ashr` `y<w` bound), `#guard_msgs` axiom pin | — (one-off) |
 | `RewriteProofs/LowerSextOne.lean` | `sext_1_local_preservesSemantics` (standalone `i1 → i64`/`i32` sext ⟶ `srai (slli _ 63) 63`; four-op chain, no bitwidth branch, first immediate-emitting proof), `srai_slli_63_val` + `sext1_isRefinedBy_toInt_srai_slli` (reusing `matchExtOp_interpretOp_unfold` / `sextLike_isRefinedBy_toInt` from `LowerExt.lean`), `#guard_msgs` axiom pin | — (one-off) |
 | `RewriteProofs/LowerZextOne.lean` | `zext_1_local_preservesSemantics` (standalone `i1 → i64` zext ⟶ `andi 1`; first immediate-emitting proof), `andi_one_val` + `zext1_isRefinedBy_toInt_andi` (reusing `matchExtOp_interpretOp_unfold` / `zextLike_isRefinedBy_toInt` from `LowerExt.lean`), `#guard_msgs` axiom pin | — (one-off) |
-| `RewriteProofs/LowerSelectBinopImm.lean` | `selectBinopImmLocal_preservesSemantics` (immediate-form binop combinator: cast-lhs → `dst(imm)` → cast-back, constant RHS folded into the immediate; single width, no bitwidth branch) + instantiations (`addi`/`ori`/`andi`/`xori`/`srai`/`addiw`/`sraiw`), the `signExtend_ofInt_12_64` / `setWidth_ofInt_{5,6}_64` immediate-encoding bridges, per-op `*_isRefinedBy` data lemmas, `#guard_msgs` axiom pins | one data lemma + one instantiation per immediate op that verifies as `IsVerifiedIntegerBinop` |
+| `RewriteProofs/LowerSelectBinopImm.lean` | `selectBinopImmLocal_preservesSemantics` (immediate-form binop combinator: cast-lhs → `dst(imm)` → cast-back, constant RHS folded into the immediate; single width, no bitwidth branch) + the shift variant `selectBinopImmLocal_shift_preservesSemantics` (+ `matchShiftOp_interpretOp_unfold`, `shl_shiftSem`/`lshr_shiftSem`) + instantiations (`addi`/`ori`/`andi`/`xori`/`srai`/`addiw`/`sraiw` and `slli`/`srli`/`slliw`/`srliw`), the `signExtend_ofInt_12_64` / `setWidth_ofInt_{5,6}_64` immediate-encoding bridges, per-op `*_isRefinedBy` data lemmas, `#guard_msgs` axiom pins | one data lemma + one instantiation per immediate op |
 | `RewriteProofs/CommonGraphLemmas.lean` | `matchBinaryOp_interpretOp_unfold` (shared by the binary combinator proofs) + Layer 3: `OperationPtr.Pure.llvm_*`, `constantOp_interpretOp_unfold`, `matchNot_getVar?_of_EquationLemmaAt`, `matchConstantIntVal_getVar?_of_EquationLemmaAt` | one packaged lemma per new *matcher* used on defining ops |
 | `RewriteProofs/CommonForwardInterpret.lean` | forward lemmas (casts + byte casts `interpretOp_castToReg_byte_forward`/`interpretOp_castBack_byte_forward` + generic unary/binary reg-to-reg riscv ops + `interpretOp_riscv_unaryReg_imm_forward` for immediate-form unary ops) | one lemma per new emitted-op *shape* |
 | `RewriteProofs/LowerTrunc.lean` | `trunc_local_preservesSemantics` (standalone `llvm.trunc` over integer *and* byte operands, widths `{8,16,32,64}`; two raw-`createOp!` casts, operand-value case split with symmetric int/byte branches), `trunc_isRefinedBy_toInt`/`_toByte` (concrete-width round-trip data lemmas via `revert; veir_bv_decide`), `conforms_int_type`/`conforms_byte_type`, `#guard_msgs` axiom pin | — (one-off; first byte-typed proof) |
@@ -561,7 +566,7 @@ per lowering as above.
 | `RewriteProofs/CommonMatchLemmas.lean` | ctlz-specific unfold/peel lemmas — currently unused (superseded by the generic `matchUnaryOp_interpretOp_unfold`); candidate for deletion | — |
 | `Veir/Passes/InstructionSelection/RISCV64.lean` | the GlobalISel lowering combinators (`lowerUnaryWLocal`, `lowerBinaryWLocal`, …) and their instances | one `def` (or a new combinator) |
 | `Veir/Passes/InstructionSelection/RISCV64Sdag.lean` | the SelectionDAG lowering combinators (`lowerBinopNotLocal`, `selectBinopImmLocal`, …) and their instances | one `def` (or a new combinator) |
-| `Veir/Verifier.lean` | `IsVerified*` bundles (`…IntegerUnop`/`Binop`/`Ternop`) + `Verified.llvm_*` extractors (Layer 1; incl. `Verified.llvm_mlir__constant`) | one 3-line lemma (unop/binop/ternop) |
+| `Veir/Verifier.lean` | `IsVerified*` bundles (`…IntegerUnop`/`Binop`/`Ternop`/`LLVMShift`) + `Verified.llvm_*` extractors (Layer 1; incl. `Verified.llvm_mlir__constant`, `Verified.llvm_shl`/`llvm_lshr`) | one 3-line lemma (unop/binop/ternop/shift) |
 | `Veir/Passes/Matching/Lemmas.lean` | `match*_implies` (Layer 2) | usually nothing |
 | `Veir/Interpreter/Lemmas.lean` | generic `interpretOp_forward`, `interpretOpList_cons` | nothing |
 | `Veir/Interpreter/EquationLemma.lean` | `Pure`, `EquationHolds`, `EquationLemmaAt` (the Layer-3 invariant) | nothing |

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1109,6 +1109,55 @@ private theorem OperationPtr.Verified.integerBinop {op : OperationPtr} {opInBoun
     op.IsVerifiedIntegerBinop ctx :=
   op.verifyIntegerBinop_eq_ok <| op.verifyIntegerBinop_ok_of_Verified opVerify armReduces
 
+/--
+  Structural facts guaranteed by a successful `verifyLLVMShift` check. Unlike `IsVerifiedIntegerBinop`
+  it does *not* pin the two operands to the same type: `verifyLLVMShift` only requires the shift
+  amount (operand 1) to be an integer, and the result to match operand 0 (which may be an integer or
+  a byte). The equality of the two operand widths is a *dynamic* fact recovered from a successful
+  interpretation, not a static one.
+-/
+def OperationPtr.IsVerifiedLLVMShift (op : OperationPtr) (ctx : WfIRContext OpCode) : Prop :=
+  op.getNumResults! ctx.raw = 1 ∧
+  op.getNumOperands! ctx.raw = 2 ∧
+  ((op.getResult 0).get! ctx.raw).type.val = ((op.getOperand! ctx.raw 0).getType! ctx.raw).val ∧
+  ∃ intType, ((op.getOperand! ctx.raw 1).getType! ctx.raw).val = .integerType intType
+
+private theorem OperationPtr.verifyLLVMShift_eq_ok {ctx : WfIRContext OpCode} {op : OperationPtr}
+    {opInBounds : op.InBounds ctx.raw} (h : op.verifyLLVMShift ctx opInBounds = .ok ()) :
+    op.IsVerifiedLLVMShift ctx := by
+  simp only [IsVerifiedLLVMShift] at ⊢
+  simp [verifyLLVMShift, verifyPlainOpCounts, verifyResultTypeMatches,
+    TypeAttr.verifyIntegerType, TypeAttr.verifyIntegerOrByteType, bind, Except.bind, throw,
+    throwThe, MonadExceptOf.throw, pure, Except.pure] at h
+  grind [getNumOperands!_eq_getNumOperands, getNumResults!_eq_getNumResults]
+
+private theorem OperationPtr.verifyLLVMShift_ok_of_Verified {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (armReduces : op.verifyLocalInvariants ctx opInBounds
+      = (op.verifyLLVMShift ctx opInBounds >>= fun _ => pure ())) :
+    op.verifyLLVMShift ctx opInBounds = .ok () := by
+  rw [Verified, armReduces] at opVerify
+  cases hb : op.verifyLLVMShift ctx opInBounds with
+  | ok u => rfl
+  | error e => rw [hb] at opVerify; simp [bind, Except.bind] at opVerify
+
+private theorem OperationPtr.Verified.llvmShift {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (armReduces : op.verifyLocalInvariants ctx opInBounds
+      = (op.verifyLLVMShift ctx opInBounds >>= fun _ => pure ())) :
+    op.IsVerifiedLLVMShift ctx :=
+  op.verifyLLVMShift_eq_ok <| op.verifyLLVMShift_ok_of_Verified opVerify armReduces
+
+theorem OperationPtr.Verified.llvm_shl {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .shl) :
+    op.IsVerifiedLLVMShift ctx := OperationPtr.Verified.llvmShift opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+
+theorem OperationPtr.Verified.llvm_lshr {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .lshr) :
+    op.IsVerifiedLLVMShift ctx := OperationPtr.Verified.llvmShift opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+
 theorem OperationPtr.Verified.arith_addi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .addi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by


### PR DESCRIPTION
Completes the `selectBinopImmLocal` family (11/11) by proving the four `shl`/`lshr` immediate lowerings — `slli`, `srli`, `slliw`, `srliw`. Unlike the arithmetic/bitwise immediates, `llvm.shl`/`llvm.lshr` verify via `verifyLLVMShift`, which does not pin the shift-amount width statically, so they yield a new weaker `IsVerifiedLLVMShift` bundle (+ `Verified.llvm_shl`/`llvm_lshr`) instead of `IsVerifiedIntegerBinop`. A second combinator (`selectBinopImmLocal_shift_preservesSemantics`) recovers the operand-width equality *dynamically* from the successful source interpretation (`matchShiftOp_interpretOp_unfold`) and `subst`s it, collapsing the proof to the binop shape and reusing the same three-op tail and refinement lemmas. Adds the four data lemmas plus `shl_shiftSem`/`lshr_shiftSem`; all modules build warning-clean and sorry-free with `#guard_msgs` axiom pins.