### PR TITLE
feat: proof for `same_val_zero_0`

### DIFF
--- a/Test/Passes/RISCVCombines/sub_self_to_zero.mlir
+++ b/Test/Passes/RISCVCombines/sub_self_to_zero.mlir
@@ -1,0 +1,32 @@
+// RUN: veir-opt %s -p=riscv-combine | filecheck %s
+
+// `llvm.sub x x` is always zero, so (at the i64 width the combine fires on) it folds to a constant
+// zero. If the operand is poison the result poison is refined by the concrete constant, so the
+// rewrite is sound.
+
+"builtin.module"() ({
+  // Positive case: i64 `sub x x` folds to constant 0.
+  "func.func"() <{function_type = (i64) -> i64}> ({
+  ^bb0(%x: i64):
+    %r = "llvm.sub"(%x, %x) : (i64, i64) -> i64
+    "func.return"(%r) : (i64) -> ()
+  }) : () -> ()
+
+  // Negative case: distinct operands, so the rule must not fire.
+  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  ^bb0(%x: i64, %y: i64):
+    %r = "llvm.sub"(%x, %y) : (i64, i64) -> i64
+    "func.return"(%r) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// The i64 `sub` is replaced by a constant zero; the operand is now dead.
+// CHECK:      "func.func"() <{"function_type" = (i64) -> i64}>
+// CHECK:      %[[Z:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
+// CHECK-NEXT: "func.return"(%[[Z]]) : (i64) -> ()
+
+// Distinct operands: the `sub` survives untouched.
+// CHECK:      "func.func"() <{"function_type" = (i64, i64) -> i64}>
+// CHECK:      ^{{.*}}(%[[DX:.*]] : i64, %[[DY:.*]] : i64):
+// CHECK-NEXT: %[[DR:.*]] = "llvm.sub"(%[[DX]], %[[DY]]) : (i64, i64) -> i64
+// CHECK-NEXT: "func.return"(%[[DR]]) : (i64) -> ()

--- a/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
+++ b/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
@@ -107,20 +107,30 @@ def binop_same_val_1 (rewriter: PatternRewriter OpCode) (op: OperationPtr)
   let rewriter := rewriter.replaceValue (op.getResult 0) src sorry sorry sorry
   rewriter.eraseOp op sorry sorry sorry
 
+/-- `llvm.sub x x` -> `llvm.mlir.constant 0` (64-bit only): subtracting a value from itself is
+  always zero (and if the operand is poison, the result poison is refined by the concrete constant).
+  This is the `LocalRewritePattern` restatement of the `same_val_zero_0` MIR combine, proven correct
+  in `RewriterProofs/MIRSameValZeroSub.lean`. -/
+def same_val_zero_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (x, x1, _props) := matchSub op ctx | return (ctx, none)
+  if x != x1 then return (ctx, none)
+  let type := ((op.getResult 0).get! ctx.raw).type
+  let .integerType type' := type.val | return (ctx, none)
+  if type'.bitwidth ≠ 64 then return (ctx, none)
+  let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type'))
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[type] #[]
+      #[] #[] cstProp none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
+
 def same_val_zero_0 (rewriter: PatternRewriter OpCode) (op: OperationPtr)
-    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some (x, x1, _props) := matchSub op rewriter.ctx | return rewriter
-  if x != x1 then return rewriter
-  let .integerType type := (x.getType! rewriter.ctx.raw).val | return rewriter
-  let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) type))
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[x.getType! rewriter.ctx.raw] #[]
-    #[] #[] cstProp (some $ .before op)
-  return rewriter.replaceOp! op newOp
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite same_val_zero_0_local rewriter op opInBounds
 
 /-- `llvm.xor x x` -> `llvm.mlir.constant 0` (64-bit only): xoring a value with itself is always
   zero (and if the operand is poison, the result poison is refined by the concrete constant). This
   is the `LocalRewritePattern` restatement of the `same_val_zero_1` MIR combine, proven correct in
-  `RewriterProofs/MIRSameValZero.lean`. -/
+  `RewriterProofs/MIRSameValZeroXor.lean`. -/
 def same_val_zero_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (x, x1, _props) := matchXor op ctx | return (ctx, none)

--- a/Veir/Passes/RISCVCombines/Proofs.lean
+++ b/Veir/Passes/RISCVCombines/Proofs.lean
@@ -3,6 +3,11 @@ import Veir.Data.RISCV.Reg.Lemmas
 
 import Veir.Meta.BVDecide
 
+-- `PreservesSemantics` proofs for the MIR (`llvm` → `llvm`) combines in `MIRCombinesVeir.lean`.
+-- Imported here so the `Veir.lean` → `Proofs.lean` path pulls them into the CI build.
+import Veir.Passes.RISCVCombines.RewriterProofs.MIRSameValZeroXor
+import Veir.Passes.RISCVCombines.RewriterProofs.MIRSameValZeroSub
+
 /-!
   Correctness proofs for the RISC-V combines in `Combine.lean`.
 -/

--- a/Veir/Passes/RISCVCombines/RewriterProofs/CommonConstantForward.lean
+++ b/Veir/Passes/RISCVCombines/RewriterProofs/CommonConstantForward.lean
@@ -1,0 +1,50 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Rewriter.WfRewriter
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+
+namespace Veir
+
+/-! ## Shared forward lemma for a freshly-created `llvm.mlir.constant`
+
+Used by the MIR-combine correctness proofs that emit a single `llvm.mlir.constant` (e.g. the
+`same_val_zero_*` combines). It is the `llvm.mlir.constant` analogue of `interpretOp_riscv_li_forward`
+(`LowerConst.lean`). -/
+
+/-- Nullary `llvm.mlir.constant` specialization of `interpretOp_forward`: an `llvm.mlir.constant`
+op with no operands, a single `i{bw}` result type, and integer value attribute `intAttr` binds
+that result to `.int bw (LLVM.Int.constant bw intAttr.value)`, leaving memory and every other
+value unchanged. Mirrors `interpretOp_riscv_li_forward` (`LowerConst.lean`). -/
+theorem interpretOp_llvm_constant_forward
+    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
+    {inBounds : theOp.InBounds ctx.raw} {intType : IntegerType} {hIsTy}
+    {intAttr : IntegerAttr}
+    (hType : theOp.getOpType! ctx.raw = .llvm .mlir__constant)
+    (hProps : (theOp.getProperties! ctx.raw (.llvm .mlir__constant)).value = .integer intAttr)
+    (hOperands : theOp.getOperands! ctx.raw = #[])
+    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.integerType intType, hIsTy⟩]) :
+    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
+      state'.memory = state.memory ∧
+      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
+        = some (.int intType.bitwidth
+            (Data.LLVM.Int.constant intType.bitwidth intAttr.value)) ∧
+      (∀ v', v' ∉ theOp.getResults! ctx.raw →
+        state'.variables.getVar? v' = state.variables.getVar? v') := by
+  obtain ⟨state', hI, hMem, hVal⟩ :=
+    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
+      (vals := #[])
+      (results := #[.int intType.bitwidth (Data.LLVM.Int.constant intType.bitwidth intAttr.value)])
+      (mem' := state.memory)
+      (by simp [VariableState.getOperandValues, hOperands])
+      (by simp only [OperationPtr.interpret]
+          rw [hType]
+          simp only [interpretOp', Llvm.interpretOp', hProps, hResTypes, Interp]
+          rfl)
+      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
+  have hNRes : 0 < theOp.getNumResults! ctx.raw := by
+    rw [← OperationPtr.getResultTypes!.size_eq_getNumResults!, hResTypes]; simp
+  grind
+
+end Veir

--- a/Veir/Passes/RISCVCombines/RewriterProofs/CommonMIRMatchEqns.lean
+++ b/Veir/Passes/RISCVCombines/RewriterProofs/CommonMIRMatchEqns.lean
@@ -1,0 +1,29 @@
+import Lean
+import Veir.Interpreter
+import Veir.Passes.RISCVCombines.MIRCombinesVeir
+
+/-!
+# Pre-generated match equations for the MIR (`llvm` → `llvm`) combines
+
+Same problem, and same fix, as `CommonMatchEqns.lean` (see its comment): `split`/`grind`
+realize a matcher's `match_n.eq_k` / `match_n.congr_eq_k` (and `_sparseCasesOn_*`) lemmas
+lazily, in whichever module first needs them, so two sibling proof modules that case on the
+same matcher each bake a private copy into their olean and then clash when co-imported
+(`environment already contains 'Veir.RISCV.sub_minus_one.match_3.congr_eq_1._sparseCasesOn_2'`).
+
+The MIR combines and their matchers live in `Veir.Passes.RISCVCombines.MIRCombinesVeir`, which
+`CommonMatchEqns` does *not* anchor. Pre-generating them here once — in a module every MIR-combine
+proof imports — gives them a single shared copy. The anchor pins that module (via
+`same_val_zero_1_local`).
+-/
+
+open Lean Meta in
+run_meta do
+  let env ← getEnv
+  for anchor in [``Veir.RISCV.same_val_zero_1_local] do
+    let some modIdx := env.getModuleIdxFor? anchor
+      | throwError "expected `{anchor}` to be imported"
+    for n in env.header.moduleData[modIdx.toNat]!.constNames do
+      if isMatcherCore env n then
+        discard <| Match.getEquationsFor n
+        discard <| Match.genMatchCongrEqns n

--- a/Veir/Passes/RISCVCombines/RewriterProofs/MIRSameValZeroSub.lean
+++ b/Veir/Passes/RISCVCombines/RewriterProofs/MIRSameValZeroSub.lean
@@ -13,82 +13,47 @@ import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
 import Veir.Passes.InstructionSelection.RewriteProofs.CommonGraphLemmas
+import Veir.Passes.RISCVCombines.RewriterProofs.CommonConstantForward
+import Veir.Passes.RISCVCombines.RewriterProofs.CommonMIRMatchEqns
 
 namespace Veir
 
-/-! ## Correctness of `same_val_zero_1_local` (`llvm.xor x x` → `llvm.mlir.constant 0`)
+/-! ## Correctness of `same_val_zero_0_local` (`llvm.sub x x` → `llvm.mlir.constant 0`)
 
-The MIR combine `same_val_zero_1` rewrites `llvm.xor x x` (64-bit) to a constant zero. This is the
-`LocalRewritePattern` restatement (`RISCV.same_val_zero_1_local`, `MIRCombinesVeir.lean`) and its
-`PreservesSemantics` proof. It reads the (equal) operands of the matched `xor` with the
-binary-source unfolder, then emits a single `llvm.mlir.constant 0` — so the structure is a
-binop *match* (as in `LowerBinaryW`) followed by a single constant *creation* (as in
-`LowerConst`). -/
+The sibling of `same_val_zero_1` (see `MIRSameValZeroXor.lean`), matching `llvm.sub` instead of
+`llvm.xor`. `sub x x` is `0` (the subtraction never overflows, whatever `nsw`/`nuw` say), so the
+structure — and proof — is identical to the `xor` case, only the matcher, verifier lemma, and data
+lemma change. Both share `interpretOp_llvm_constant_forward` (`CommonConstantForward.lean`). -/
 
-/-- Nullary `llvm.mlir.constant` specialization of `interpretOp_forward`: an `llvm.mlir.constant`
-op with no operands, a single `i{bw}` result type, and integer value attribute `intAttr` binds
-that result to `.int bw (LLVM.Int.constant bw intAttr.value)`, leaving memory and every other
-value unchanged. Mirrors `interpretOp_riscv_li_forward` (`LowerConst.lean`). -/
-theorem interpretOp_llvm_constant_forward
-    {ctx : WfIRContext OpCode} {theOp : OperationPtr} {state : InterpreterState ctx}
-    {inBounds : theOp.InBounds ctx.raw} {intType : IntegerType} {hIsTy}
-    {intAttr : IntegerAttr}
-    (hType : theOp.getOpType! ctx.raw = .llvm .mlir__constant)
-    (hProps : (theOp.getProperties! ctx.raw (.llvm .mlir__constant)).value = .integer intAttr)
-    (hOperands : theOp.getOperands! ctx.raw = #[])
-    (hResTypes : theOp.getResultTypes! ctx.raw = #[⟨.integerType intType, hIsTy⟩]) :
-    ∃ state', interpretOp theOp state inBounds = some (.ok (state', none)) ∧
-      state'.memory = state.memory ∧
-      state'.variables.getVar? (ValuePtr.opResult (theOp.getResult 0))
-        = some (.int intType.bitwidth
-            (Data.LLVM.Int.constant intType.bitwidth intAttr.value)) ∧
-      (∀ v', v' ∉ theOp.getResults! ctx.raw →
-        state'.variables.getVar? v' = state.variables.getVar? v') := by
-  obtain ⟨state', hI, hMem, hVal⟩ :=
-    interpretOp_forward (op := theOp) (state := state) (inBounds := inBounds)
-      (vals := #[])
-      (results := #[.int intType.bitwidth (Data.LLVM.Int.constant intType.bitwidth intAttr.value)])
-      (mem' := state.memory)
-      (by simp [VariableState.getOperandValues, hOperands])
-      (by simp only [OperationPtr.interpret]
-          rw [hType]
-          simp only [interpretOp', Llvm.interpretOp', hProps, hResTypes, Interp]
-          rfl)
-      (by simp [RuntimeValue.ArrayConforms, hResTypes, RuntimeValue.Conforms])
-  have hNRes : 0 < theOp.getNumResults! ctx.raw := by
-    rw [← OperationPtr.getResultTypes!.size_eq_getNumResults!, hResTypes]; simp
-  grind
-
-/-- The Layer-0 data refinement (at the `i64` width the combine fires on): `xor x x` (poison when
-`x` is poison, else `0`) is refined by the constant `0`. When `x` is poison the source poison is
-refined by any value; otherwise both sides are `0`. -/
-theorem xor_self_isRefinedBy_constant_zero (x : Data.LLVM.Int 64) :
-    Data.LLVM.Int.xor x x ⊒ Data.LLVM.Int.constant 64 0 := by
-  veir_bv_decide
+/-- The Layer-0 data refinement (at the `i64` width the combine fires on): `sub x x` (poison when
+`x` is poison, else `0`, for any `nsw`/`nuw`) is refined by the constant `0`. -/
+theorem sub_self_isRefinedBy_constant_zero (x : Data.LLVM.Int 64) (nsw nuw : Bool) :
+    Data.LLVM.Int.sub x x nsw nuw ⊒ Data.LLVM.Int.constant 64 0 := by
+  cases nsw <;> cases nuw <;> veir_bv_decide
 
 set_option maxHeartbeats 1000000 in
-/-- Correctness of the `same_val_zero_1_local` lowering: a 64-bit `llvm.xor x x` lowers to a single
-`llvm.mlir.constant 0` of the `i64` result type, which refines the `xor`. -/
-theorem same_val_zero_1_local_preservesSemantics :
-    LocalRewritePattern.PreservesSemantics RISCV.same_val_zero_1_local h h₂ h₃ h₄ := by
-  simp only [LocalRewritePattern.PreservesSemantics, RISCV.same_val_zero_1_local]
+/-- Correctness of the `same_val_zero_0_local` lowering: a 64-bit `llvm.sub x x` lowers to a single
+`llvm.mlir.constant 0` of the `i64` result type, which refines the `sub`. -/
+theorem same_val_zero_0_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics RISCV.same_val_zero_0_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, RISCV.same_val_zero_0_local]
   intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
     newState cf hinterp
   rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
   simp [liftM, monadLift, MonadLift.monadLift] at hinterp
   simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
   -- Peel the matcher: only the `some` branch reaches the `some (...)` RHS.
-  have hMatchSome : (matchXor op ctx.raw).isSome := by
-    cases hM : matchXor op ctx.raw with
+  have hMatchSome : (matchSub op ctx.raw).isSome := by
+    cases hM : matchSub op ctx.raw with
     | some y => rfl
     | none => rw [hM] at hpattern; simp at hpattern
   obtain ⟨⟨x, x1, xprops⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
   rw [hMatch] at hpattern
   simp only [] at hpattern
   -- Syntactic + verification facts.
-  have ⟨hOpType, hNRes, hOperands, hProps⟩ := matchXor_implies hMatch
+  have ⟨hOpType, hNRes, hOperands, hProps⟩ := matchSub_implies hMatch
   have opVerif : op.Verified ctx opInBounds := by clear hpattern; grind
-  have hVer := OperationPtr.Verified.llvm_xor opVerif hOpType
+  have hVer := OperationPtr.Verified.llvm_sub opVerif hOpType
   obtain ⟨hNResV, hNOper, hNSucc, hNReg, intType, hResTy, hOp0Ty, hOp1Ty⟩ := hVer
   -- The `x != x1` guard is false, so the two operands are equal.
   have hResTyVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
@@ -120,10 +85,10 @@ theorem same_val_zero_1_local_preservesSemantics :
     rw [← hx0, hOp0Ty]
   have hRhsType : (x1.getType! ctx.raw).val = Attribute.integerType intType := by
     rw [← hx1, hOp1Ty]
-  -- Source value: `op`'s single result is `xor xv x1v`.
+  -- Source value: `op`'s single result is `sub xv x1v props.nsw props.nuw`.
   obtain ⟨xv, x1v, hxVal, hx1Val, hMemEq, hResVal, rfl⟩ :=
-    matchBinaryOp_interpretOp_unfold (srcOp := .xor)
-      (srcFn := fun a b _ => Data.LLVM.Int.xor a b)
+    matchBinaryOp_interpretOp_unfold (srcOp := .sub)
+      (srcFn := fun a b props => Data.LLVM.Int.sub a b props.nsw props.nuw)
       (props := xprops) opInBounds hOpType hNRes hOperands hProps
       (by intro bw a b props resultTypes blockOperands mem res hI
           simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at hI
@@ -133,7 +98,7 @@ theorem same_val_zero_1_local_preservesSemantics :
   have hxvEq : xv = x1v := by
     rw [hxx1] at hxVal; rw [hxVal] at hx1Val; simpa using hx1Val
   subst hxvEq
-  -- Source values array: `op`'s single result value is `xor xv xv`.
+  -- Source values array: `op`'s single result value is `sub xv xv props.nsw props.nuw`.
   rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
     at hsourceValues
   simp at hsourceValues
@@ -171,9 +136,9 @@ theorem same_val_zero_1_local_preservesSemantics :
       revert xv
       rw [hBw64]
       intro xv
-      simpa using xor_self_isRefinedBy_constant_zero xv
+      simpa using sub_self_isRefinedBy_constant_zero xv xprops.nsw xprops.nuw
 
-/-- info: 'Veir.same_val_zero_1_local_preservesSemantics' depends on axioms: [propext,
+/-- info: 'Veir.same_val_zero_0_local_preservesSemantics' depends on axioms: [propext,
  Classical.choice,
  Quot.sound,
  floatEqOfToBitsEq,
@@ -182,6 +147,6 @@ theorem same_val_zero_1_local_preservesSemantics :
  ValuePtr.dominatesIp,
  MemoryState.llvmLoad._native.bv_decide.ax_8] -/
 #guard_msgs in
-#print axioms same_val_zero_1_local_preservesSemantics
+#print axioms same_val_zero_0_local_preservesSemantics
 
 end Veir

--- a/Veir/Passes/RISCVCombines/RewriterProofs/MIRSameValZeroXor.lean
+++ b/Veir/Passes/RISCVCombines/RewriterProofs/MIRSameValZeroXor.lean
@@ -1,0 +1,155 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.Casting
+import Veir.Passes.RISCVCombines.MIRCombinesVeir
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonGraphLemmas
+import Veir.Passes.RISCVCombines.RewriterProofs.CommonConstantForward
+import Veir.Passes.RISCVCombines.RewriterProofs.CommonMIRMatchEqns
+
+namespace Veir
+
+/-! ## Correctness of `same_val_zero_1_local` (`llvm.xor x x` → `llvm.mlir.constant 0`)
+
+The MIR combine `same_val_zero_1` rewrites `llvm.xor x x` (64-bit) to a constant zero. This is the
+`LocalRewritePattern` restatement (`RISCV.same_val_zero_1_local`, `MIRCombinesVeir.lean`) and its
+`PreservesSemantics` proof. It reads the (equal) operands of the matched `xor` with the
+binary-source unfolder, then emits a single `llvm.mlir.constant 0` — so the structure is a
+binop *match* (as in `LowerBinaryW`) followed by a single constant *creation* (as in
+`LowerConst`, via the shared `interpretOp_llvm_constant_forward`). -/
+
+/-- The Layer-0 data refinement (at the `i64` width the combine fires on): `xor x x` (poison when
+`x` is poison, else `0`) is refined by the constant `0`. When `x` is poison the source poison is
+refined by any value; otherwise both sides are `0`. -/
+theorem xor_self_isRefinedBy_constant_zero (x : Data.LLVM.Int 64) :
+    Data.LLVM.Int.xor x x ⊒ Data.LLVM.Int.constant 64 0 := by
+  veir_bv_decide
+
+set_option maxHeartbeats 1000000 in
+/-- Correctness of the `same_val_zero_1_local` lowering: a 64-bit `llvm.xor x x` lowers to a single
+`llvm.mlir.constant 0` of the `i64` result type, which refines the `xor`. -/
+theorem same_val_zero_1_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics RISCV.same_val_zero_1_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, RISCV.same_val_zero_1_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch reaches the `some (...)` RHS.
+  have hMatchSome : (matchXor op ctx.raw).isSome := by
+    cases hM : matchXor op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨x, x1, xprops⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Syntactic + verification facts.
+  have ⟨hOpType, hNRes, hOperands, hProps⟩ := matchXor_implies hMatch
+  have opVerif : op.Verified ctx opInBounds := by clear hpattern; grind
+  have hVer := OperationPtr.Verified.llvm_xor opVerif hOpType
+  obtain ⟨hNResV, hNOper, hNSucc, hNReg, intType, hResTy, hOp0Ty, hOp1Ty⟩ := hVer
+  -- The `x != x1` guard is false, so the two operands are equal.
+  have hResTyVal : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType intType := by
+    rw [hResTy]
+  have hxx1 : x = x1 := by
+    rcases Decidable.em (x = x1) with heq | hne
+    · exact heq
+    · rw [if_neg hne] at hpattern
+      exact absurd hpattern (by simp)
+  rw [if_pos hxx1] at hpattern
+  -- Resolve the result-type destructuring match: the result type is `integerType intType`.
+  rw [hResTyVal] at hpattern
+  simp only [] at hpattern
+  -- The `bitwidth ≠ 64` guard is false, so the result width is 64.
+  have hBw64 : intType.bitwidth = 64 := by
+    rcases Decidable.em (intType.bitwidth = 64) with hbw | hbw
+    · exact hbw
+    · rw [if_neg hbw] at hpattern
+      exact absurd hpattern (by simp)
+  rw [if_pos hBw64] at hpattern
+  -- The operands have integer type `intType`, feeding the source-interpretation unfolder.
+  have hx0 : op.getOperand! ctx.raw 0 = x := by
+    have : (op.getOperands! ctx.raw)[0]! = x := by rw [hOperands]; rfl
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hx1 : op.getOperand! ctx.raw 1 = x1 := by
+    have : (op.getOperands! ctx.raw)[1]! = x1 := by rw [hOperands]; rfl
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hLhsType : (x.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hx0, hOp0Ty]
+  have hRhsType : (x1.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [← hx1, hOp1Ty]
+  -- Source value: `op`'s single result is `xor xv x1v`.
+  obtain ⟨xv, x1v, hxVal, hx1Val, hMemEq, hResVal, rfl⟩ :=
+    matchBinaryOp_interpretOp_unfold (srcOp := .xor)
+      (srcFn := fun a b _ => Data.LLVM.Int.xor a b)
+      (props := xprops) opInBounds hOpType hNRes hOperands hProps
+      (by intro bw a b props resultTypes blockOperands mem res hI
+          simp only [Llvm.interpretOp', Data.LLVM.Int.cast_self, pure, Interp] at hI
+          grind)
+      hinterp hLhsType hRhsType
+  -- The two operands are the same value, so `xv = x1v`.
+  have hxvEq : xv = x1v := by
+    rw [hxx1] at hxVal; rw [hxVal] at hx1Val; simpa using hx1Val
+  subst hxvEq
+  -- Source values array: `op`'s single result value is `xor xv xv`.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hResVal] at hsourceValues
+  subst sourceValues
+  -- Peel the single created op: the `llvm.mlir.constant`.
+  peelOpCreation hpattern ctx₁ cstOp hCst
+  rw [WfRewriter.createOp!_none_eq (by clear hpattern; grind) (by clear hpattern; simp)
+    (by clear hpattern; simp)] at hCst
+  cleanupHpattern hpattern
+  -- Structural facts about the created constant op in the final context `ctx₁`.
+  have hCstType : cstOp.getOpType! ctx₁.raw = .llvm .mlir__constant := by grind
+  have hCstOperands : cstOp.getOperands! ctx₁.raw = #[] := by
+    grind [OperationPtr.getOperands!_WfRewriter_createOp hCst (operation := cstOp)]
+  have hCstProps : (cstOp.getProperties! ctx₁.raw (.llvm .mlir__constant)).value
+      = .integer (IntegerAttr.mk 0 intType) := by
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hCst (operation := cstOp)]
+  have hCstResTypes : cstOp.getResultTypes! ctx₁.raw
+      = #[⟨Attribute.integerType intType, (by grind)⟩] := by
+    have hty : ((op.getResult 0).get! ctx.raw).type = ⟨Attribute.integerType intType, by grind⟩ :=
+      Subtype.ext hResTyVal
+    grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCst (operation := cstOp)]
+  -- Interpretation tail: execute `interpretOpList [cstOp]` in `state'`.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+    interpretOp_llvm_constant_forward (state := state') (inBounds := by grind)
+      hCstType hCstProps hCstOperands hCstResTypes
+  refine ⟨s₁, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int intType.bitwidth
+        (Data.LLVM.Int.constant intType.bitwidth (IntegerAttr.mk 0 intType).value)], ?_, ?_⟩
+    · simp [hRes₁, Option.bind, Option.map]
+    · refine RuntimeValue.arrayIsRefinedBy_singleton.mpr ⟨rfl, ?_⟩
+      -- The result width is 64, so the concrete-width data lemma applies.
+      clear hxVal hx1Val hResVal
+      revert xv
+      rw [hBw64]
+      intro xv
+      simpa using xor_self_isRefinedBy_constant_zero xv
+
+/-- info: 'Veir.same_val_zero_1_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominatesIp,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ ValuePtr.dominatesIp,
+ MemoryState.llvmLoad._native.bv_decide.ax_8] -/
+#guard_msgs in
+#print axioms same_val_zero_1_local_preservesSemantics
+
+end Veir


### PR DESCRIPTION
This PR introduces the proof for `same_val_zero_0`, and refactors some of the files so that common constructors can be shared with the `same_val_zero_1` proof.