### PR TITLE
feat: Prove correctness of `icmp`, `bitreverse`, and `shl`/`lshr` instruction selection

### DIFF
--- a/Veir/Data/LLVM/Byte/Lemmas.lean
+++ b/Veir/Data/LLVM/Byte/Lemmas.lean
@@ -87,4 +87,25 @@ theorem val_xor {w : Nat} (x y : Byte w) :
     (x ^^^ y).val = (x.val ^^^ y.val) &&& ~~~(x.poison ||| y.poison) := by
   simp [xor_eq]
 
+/- # shl -/
+
+/-- `Byte.shl` as a conditional chain. Unlike `Byte.lshr`, `Byte.shl` is defined as a `do`-block,
+which `bv_decide` cannot see through; this restates it in the same shape as `Byte.lshr` so that the
+normalization set can unfold it. -/
+@[veir_bv_normalize]
+theorem shl_eq {w : Nat} (x : Byte w) (y : Int w) (nuw : Bool) :
+    x.shl y nuw =
+      if y.isPoison || y.getValueD ≥ w then allPoison
+      else if nuw ∧ (x.val <<< y.getValueD) >>> y.getValueD ≠ x.val then allPoison
+      else if nuw ∧ (x.poison <<< y.getValueD) >>> y.getValueD ≠ x.poison then allPoison
+      else ⟨x.val <<< y.getValueD, x.poison <<< y.getValueD, by
+        simp [← BitVec.shiftLeft_and_distrib, x.h]⟩ := by
+  cases y with
+  | poison => simp [Byte.shl, Id.run, Int.isPoison_of_poison]
+  | val y' =>
+    simp only [Byte.shl, Id.run, Int.isPoison_of_val, Int.getValueD_val, Bool.false_or,
+      decide_eq_true_eq]
+    repeat' split
+    all_goals first | rfl | simp_all | (exfalso; bv_omega)
+
 end Veir.Data.LLVM.Byte

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -460,7 +460,8 @@ def ashr (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite ashr_local rewriter op opInBounds
 
-/--
+/-! ### `llvm.icmp` lowering
+
     llvm.icmp eq lhs rhs  -> riscv.sltiu (riscv.xor lhs rhs) 1
     llvm.icmp ne lhs rhs  -> riscv.sltu 0 (riscv.xor lhs rhs)
     llvm.icmp slt lhs rhs -> riscv.slt lhs rhs
@@ -471,153 +472,159 @@ def ashr (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     llvm.icmp ule lhs rhs -> riscv.xori (riscv_sltu rhs lhs) 1
     llvm.icmp ugt lhs rhs -> riscv.sltu rhs lhs
     llvm.icmp uge lhs rhs -> riscv.xori (riscv_sltu lhs rhs) 1
+
+  Every arm shares the same prologue (`icmpCastExtLocal`: cast both operands into registers, and
+  sign-extend them when they are narrower than a register) and the same epilogue (cast the `i1`
+  result back). Only the comparison sequence in between differs, and the five shapes it can take are
+  the `icmpEmit*Local` combinators below, each of which is proven correct once in
+  `RewriteProofs/LowerIcmp.lean`. -/
+
+/-- The `i1` constant `1`, the immediate shared by the `sltiu`/`xori` arms. -/
+def icmpOneImm : RISCVImmediateProperties :=
+  RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
+
+/-- The immediate `0`, materialized by the `li` feeding the `sltu` of the `≠` arms. -/
+def icmpZeroImm : RISCVImmediateProperties :=
+  RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
+
+/-- A `riscv` sign-extension instruction usable as an `icmp` prologue: an opcode with no
+    properties (`riscv.sextw`, `riscv.sextb`). Bundling the opcode with the proof keeps the
+    prologue's `ext` argument non-dependent, so proofs can case on it directly. -/
+structure IcmpExtOp where
+  /-- The sign-extension opcode. -/
+  op : Riscv
+  /-- The opcode takes no properties. -/
+  hprops : Riscv.propertiesOf op = Unit
+
+/--
+  Shared prologue of every `llvm.icmp` arm: cast both operands into registers and, when `ext` is
+  `some e`, sign-extend each register with `e` (`riscv.sextw` for `i32`, `riscv.sextb` for `i8`).
+  `castToRegLocal` zero-extends into the register, so without the fixup a negative narrow operand
+  would look positive to the 64-bit signed comparison; sign-extension also preserves the unsigned
+  order, so the unsigned comparisons stay correct too.
+
+  Returns the created operations along with the two registers to compare.
 -/
+def icmpCastExtLocal (ctx : WfIRContext OpCode) (lhs rhs : ValuePtr) (ext : Option IcmpExtOp) :
+    Option (WfIRContext OpCode × Array OperationPtr × ValuePtr × ValuePtr) := do
+  let (ctx, lcastOp) ← castToRegLocal ctx lhs
+  let (ctx, rcastOp) ← castToRegLocal ctx rhs
+  match ext with
+  | none => some (ctx, #[lcastOp, rcastOp], lcastOp.getResult 0, rcastOp.getResult 0)
+  | some e =>
+    let props : Riscv.propertiesOf e.op := cast e.hprops.symm ()
+    let (ctx, lsOp) ← WfRewriter.createOp! ctx (.riscv e.op) #[RegisterType.mk]
+      #[lcastOp.getResult 0] #[] #[] props none
+    let (ctx, rsOp) ← WfRewriter.createOp! ctx (.riscv e.op) #[RegisterType.mk]
+      #[rcastOp.getResult 0] #[] #[] props none
+    some (ctx, #[lcastOp, rcastOp, lsOp, rsOp], lsOp.getResult 0, rsOp.getResult 0)
+
+/-- `icmp` arm emitting a single register-register comparison `rop` (`slt`/`sltu`), whose operands
+    are the two comparison registers, swapped when `swap` is set: `slt`/`sgt`/`ult`/`ugt`. -/
+def icmpEmitCmpLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : ValuePtr)
+    (ext : Option IcmpExtOp)
+    (rop : Riscv) (hrop : Riscv.propertiesOf rop = Unit) (swap : Bool) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let (ctx, pre, a, b) ← icmpCastExtLocal ctx lhs rhs ext
+  let (u, v) := if swap then (b, a) else (a, b)
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk] #[u, v]
+    #[] #[] (cast hrop.symm ()) none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
+  some (ctx, some (pre ++ #[cmpOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `icmp` arm emitting a register-register comparison `rop` followed by the immediate op `ropImm`
+    applied to its result with the immediate `1`: `sle`/`sge`/`ule`/`uge` (`slt`/`sltu` then
+    `xori _ 1`) and the generic `eq` (`xor` then `sltiu _ 1`). -/
+def icmpEmitCmpImmLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : ValuePtr)
+    (ext : Option IcmpExtOp)
+    (rop : Riscv) (hrop : Riscv.propertiesOf rop = Unit) (swap : Bool)
+    (ropImm : Riscv) (hropImm : Riscv.propertiesOf ropImm = RISCVImmediateProperties) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let (ctx, pre, a, b) ← icmpCastExtLocal ctx lhs rhs ext
+  let (u, v) := if swap then (b, a) else (a, b)
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk] #[u, v]
+    #[] #[] (cast hrop.symm ()) none
+  let (ctx, immOp) ← WfRewriter.createOp! ctx (.riscv ropImm) #[RegisterType.mk]
+    #[cmpOp.getResult 0] #[] #[] (cast hropImm.symm icmpOneImm) none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (immOp.getResult 0)
+  some (ctx, some (pre ++ #[cmpOp, immOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `icmp` arm emitting `sltiu a 1` (`seqz`) on the left comparison register: the `eq`-against-zero
+    peephole. -/
+def icmpEmitSeqzLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : ValuePtr)
+    (ext : Option IcmpExtOp) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let (ctx, pre, a, _) ← icmpCastExtLocal ctx lhs rhs ext
+  let (ctx, immOp) ← WfRewriter.createOp! ctx (.riscv .sltiu) #[RegisterType.mk] #[a]
+    #[] #[] icmpOneImm none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (immOp.getResult 0)
+  some (ctx, some (pre ++ #[immOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `icmp` arm emitting `sltu 0 a` (`snez`) on the left comparison register: the `ne`-against-zero
+    peephole. The `riscv.li 0` becomes `x0` under `riscv-combine` (see `li_zero_to_x0`). -/
+def icmpEmitSnezLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : ValuePtr)
+    (ext : Option IcmpExtOp) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let (ctx, pre, a, _) ← icmpCastExtLocal ctx lhs rhs ext
+  let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+    #[] #[] icmpZeroImm none
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk]
+    #[liOp.getResult 0, a] #[] #[] () none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
+  some (ctx, some (pre ++ #[liOp, cmpOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- `icmp` arm emitting `sltu 0 (xor b a)` (`snez` of the difference): the generic `ne`. -/
+def icmpEmitXorSnezLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : ValuePtr)
+    (ext : Option IcmpExtOp) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let (ctx, pre, a, b) ← icmpCastExtLocal ctx lhs rhs ext
+  let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xor) #[RegisterType.mk] #[b, a]
+    #[] #[] () none
+  let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+    #[] #[] icmpZeroImm none
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk]
+    #[liOp.getResult 0, xorOp.getResult 0] #[] #[] () none
+  let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
+  some (ctx, some (pre ++ #[xorOp, liOp, cmpOp, castBackOp], #[castBackOp.getResult 0]))
+
+/-- The sign-extension instruction needed to compare two `bw`-wide operands in a register, if any. -/
+def icmpExtOf (bw : Nat) : Option IcmpExtOp :=
+  if bw = 32 then some ⟨.sextw, rfl⟩ else if bw = 8 then some ⟨.sextb, rfl⟩ else none
+
+/-- llvm.icmp -> riscv comparison sequence (see the arms above). -/
 def icmp_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, property) := matchIcmp op ctx | return (ctx, none)
-  /- support `i64` and `i32` -/
+  /- support `i64`, `i32` and `i8` -/
   let .integerType ltype := (lhs.getType! ctx.raw).val | return (ctx, none)
   if ltype.bitwidth ≠ 64 ∧ ltype.bitwidth ≠ 32 ∧ ltype.bitwidth ≠ 8 then return (ctx, none)
   let .integerType rtype := (rhs.getType! ctx.raw).val | return (ctx, none)
   if rtype.bitwidth ≠ 64 ∧ rtype.bitwidth ≠ 32 ∧ rtype.bitwidth ≠ 8 then return (ctx, none)
-  /- Casting is necessary regardless of the predicate. -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
-      #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
-      #[] #[] () none
-  /- For i32, sign-extend operands so both signed and unsigned comparisons work correctly.
-     Zero-extended i32 negatives look positive in 64-bit signed arithmetic without this. -/
-  let (ctx, extOps, lCmpReg, rCmpReg) ←
-    if ltype.bitwidth = 32 then do
-      let (ctx, ls) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[lcastOp.getResult 0]
-          #[] #[] () none
-      let (ctx, rs) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[rcastOp.getResult 0]
-          #[] #[] () none
-      pure (ctx, #[ls, rs], ls.getResult 0, rs.getResult 0)
-    else if ltype.bitwidth = 8 then do
-      let (ctx, ls) ← WfRewriter.createOp! ctx (.riscv .sextb) #[RegisterType.mk] #[lcastOp.getResult 0]
-          #[] #[] () none
-      let (ctx, rs) ← WfRewriter.createOp! ctx (.riscv .sextb) #[RegisterType.mk] #[rcastOp.getResult 0]
-          #[] #[] () none
-      pure (ctx, #[ls, rs], ls.getResult 0, rs.getResult 0)
-    else
-      pure (ctx, #[], lcastOp.getResult 0, rcastOp.getResult 0)
-  /- Casting back result for type consistency is always necessary. -/
-  let type := ((op.getResult 0).get! ctx.raw).type
-  let .integerType _ := type.val | return (ctx, none)
-  /- Match depending on the predicate and build correct lowering. -/
-  let (ctx, predOps, retOp) ← match property.predicate with
-    | .eq =>
-      /- Peephole: when the rhs is a constant 0, `a == 0` lowers directly to
-         `riscv.sltiu a 1` (seqz) with no xor. Otherwise fall back to the generic
-         `riscv.sltiu (riscv.xor lhs rhs) 1` idiom. Canonicalization runs before
-         isel and moves the constant to the rhs, so we only check that side.
-         LLVM: `Pat<(riscv_seteq GPR:$rs1), (SLTIU GPR:$rs1, 1)>` (`selectSETEQ`
-         normalizes `a == 0` to the zero-compare form first).
-         https://github.com/llvm/llvm-project/blob/d9906882fc613471ab51e7185094efae893066de/llvm/lib/Target/RISCV/RISCVInstrInfo.td#L1649 -/
-      let zeroCmpReg :=
-        if (matchConstantZero rhs ctx).isSome then some lCmpReg
-        else none
-      match zeroCmpReg with
-      | some cmpReg =>
-        /- llvm.icmp eq a 0  -> riscv.sltiu a 1 (seqz) -/
-        let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-        let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .sltiu) #[RegisterType.mk] #[cmpReg]
-          #[] #[] c1 none
-        pure (ctx, #[retOp], retOp)
-      | none =>
-        /- llvm.icmp eq lhs rhs  -> riscv.sltiu (riscv.xor lhs rhs) 1 -/
-        let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xor) #[RegisterType.mk] #[rCmpReg, lCmpReg]
-          #[] #[] () none
-        let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-        let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .sltiu) #[RegisterType.mk] #[xorOp.getResult 0]
-          #[] #[] c1 none
-        pure (ctx, #[xorOp, retOp], retOp)
-    | .ne =>
-      /- Peephole: when the rhs is a constant 0, `a != 0` lowers directly to
-         `riscv.sltu 0 a` (snez) with no xor. Otherwise fall back to the generic
-         `riscv.sltu 0 (riscv.xor lhs rhs)` idiom. Canonicalization runs before
-         isel and moves the constant to the rhs, so we only check that side.
-         The `riscv.li 0` feeding `sltu` becomes `x0` under `riscv-combine` (see
-         `li_zero_to_x0`), matching LLVM's `SLTU X0, rs1`.
-         LLVM: `Pat<(riscv_setne GPR:$rs1), (SLTU (XLenVT X0), GPR:$rs1)>`.
-         https://github.com/llvm/llvm-project/blob/d9906882fc613471ab51e7185094efae893066de/llvm/lib/Target/RISCV/RISCVInstrInfo.td#L1650 -/
-      let zeroCmpReg :=
-        if (matchConstantZero rhs ctx).isSome then some lCmpReg
-        else none
-      let c0 := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-      match zeroCmpReg with
-      | some cmpReg =>
-        /- llvm.icmp ne a 0  -> riscv.sltu 0 a (snez) -/
-        let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
-          #[] #[] c0 none
-        let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, cmpReg]
-          #[] #[] () none
-        pure (ctx, #[liOp, retOp], retOp)
-      | none =>
-        /- llvm.icmp ne lhs rhs  -> riscv.sltu 0 (riscv.xor lhs rhs) -/
-        let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xor) #[RegisterType.mk] #[rCmpReg, lCmpReg]
-          #[] #[] () none
-        let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
-          #[] #[] c0 none
-        let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk] #[liOp.getResult 0, xorOp.getResult 0]
-          #[] #[] () none
-        pure (ctx, #[xorOp, liOp, retOp], retOp)
-    | .slt =>
-      /- llvm.icmp slt lhs rhs -> riscv.slt lhs rhs  -/
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .slt) #[RegisterType.mk] #[lCmpReg, rCmpReg]
-        #[] #[] () none
-      pure (ctx, #[retOp], retOp)
-    | .sle =>
-      /- llvm.icmp sle lhs rhs -> riscv.xori (riscv_slt rhs lhs) 1 -/
-      let (ctx, sltOp) ← WfRewriter.createOp! ctx (.riscv .slt) #[RegisterType.mk] #[rCmpReg, lCmpReg]
-        #[] #[] () none
-      let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
-        #[] #[] c1 none
-      pure (ctx, #[sltOp, retOp], retOp)
-    | .sgt =>
-      /- llvm.icmp sgt lhs rhs -> riscv.slt rhs lhs -/
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .slt) #[RegisterType.mk] #[rCmpReg, lCmpReg]
-        #[] #[] () none
-      pure (ctx, #[retOp], retOp)
-    | .sge =>
-      /- llvm.icmp sge lhs rhs -> riscv.xori (riscv_slt lhs rhs) 1 -/
-      let (ctx, sltOp) ← WfRewriter.createOp! ctx (.riscv .slt) #[RegisterType.mk] #[lCmpReg, rCmpReg]
-        #[] #[] () none
-      let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[sltOp.getResult 0]
-        #[] #[] c1 none
-      pure (ctx, #[sltOp, retOp], retOp)
-    | .ult =>
-      /- llvm.icmp ult lhs rhs -> riscv.sltu lhs rhs -/
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk] #[lCmpReg, rCmpReg]
-        #[] #[] () none
-      pure (ctx, #[retOp], retOp)
-    | .ule =>
-      /- llvm.icmp ule lhs rhs -> riscv.xori (riscv_sltu rhs lhs) 1 -/
-      let (ctx, sltuOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk] #[rCmpReg, lCmpReg]
-        #[] #[] () none
-      let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
-        #[] #[] c1 none
-      pure (ctx, #[sltuOp, retOp], retOp)
-    | .ugt =>
-      /- llvm.icmp ugt lhs rhs -> riscv.sltu rhs lhs -/
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk] #[rCmpReg, lCmpReg]
-        #[] #[] () none
-      pure (ctx, #[retOp], retOp)
-    | .uge =>
-      /- llvm.icmp uge lhs rhs -> riscv.xori (riscv_sltu lhs rhs) 1 -/
-      let (ctx, sltuOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk] #[lCmpReg, rCmpReg]
-        #[] #[] () none
-      let c1 := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-      let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[sltuOp.getResult 0]
-        #[] #[] c1 none
-      pure (ctx, #[sltuOp, retOp], retOp)
-  let (ctx, castEqOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
-        #[] #[] () none
-  some (ctx, some (#[lcastOp, rcastOp] ++ extOps ++ predOps ++ #[castEqOp], #[castEqOp.getResult 0]))
+  /- The result is cast back for type consistency, so it must be an integer type. -/
+  let .integerType _ := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
+  let ext := icmpExtOf ltype.bitwidth
+  /- Peephole for `eq`/`ne`: when the rhs is a constant `0`, the `xor` is unnecessary and the
+     comparison is against the left register directly (`seqz`/`snez`). Canonicalization runs before
+     isel and moves the constant to the rhs, so we only check that side.
+     LLVM: `Pat<(riscv_seteq GPR:$rs1), (SLTIU GPR:$rs1, 1)>` and
+     `Pat<(riscv_setne GPR:$rs1), (SLTU (XLenVT X0), GPR:$rs1)>`.
+     https://github.com/llvm/llvm-project/blob/d9906882fc613471ab51e7185094efae893066de/llvm/lib/Target/RISCV/RISCVInstrInfo.td#L1649 -/
+  let rhsIsZero := (matchConstantZero rhs ctx).isSome
+  match property.predicate with
+  | .eq =>
+    if rhsIsZero then icmpEmitSeqzLocal ctx op lhs rhs ext
+    else icmpEmitCmpImmLocal ctx op lhs rhs ext .xor rfl true .sltiu rfl
+  | .ne =>
+    if rhsIsZero then icmpEmitSnezLocal ctx op lhs rhs ext
+    else icmpEmitXorSnezLocal ctx op lhs rhs ext
+  | .slt => icmpEmitCmpLocal ctx op lhs rhs ext .slt rfl false
+  | .sgt => icmpEmitCmpLocal ctx op lhs rhs ext .slt rfl true
+  | .ult => icmpEmitCmpLocal ctx op lhs rhs ext .sltu rfl false
+  | .ugt => icmpEmitCmpLocal ctx op lhs rhs ext .sltu rfl true
+  | .sge => icmpEmitCmpImmLocal ctx op lhs rhs ext .slt rfl false .xori rfl
+  | .sle => icmpEmitCmpImmLocal ctx op lhs rhs ext .slt rfl true .xori rfl
+  | .uge => icmpEmitCmpImmLocal ctx op lhs rhs ext .sltu rfl false .xori rfl
+  | .ule => icmpEmitCmpImmLocal ctx op lhs rhs ext .sltu rfl true .xori rfl
 
 /-- llvm.icmp -> riscv comparison sequence (see `icmp_local`). -/
 def icmp (rewriter : PatternRewriter OpCode) (op : OperationPtr)

--- a/Veir/Passes/InstructionSelection/RewriteProofs.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs.lean
@@ -4,11 +4,14 @@ import Veir.Passes.InstructionSelection.RewriteProofs.LowerBexti
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryReg
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinaryW
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerBinopNot
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBitreverse
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerBswap
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerBitwiseReg
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerByteBinaryW
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerConst
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerExt
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerFshlConst
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerIcmp
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerFshrConst
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerLoad
 import Veir.Passes.InstructionSelection.RewriteProofs.LowerRoriw

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitreverse.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerBitreverse.lean
@@ -1,0 +1,720 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerUnaryW
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerBswap
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerConst
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerSaddSat
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerIcmp
+
+namespace Veir
+
+/-!
+## Correctness of `bitreverse_local`
+
+`llvm.intr.bitreverse` on a 64- or 32-bit integer is lowered to a cast to a register, three SWAR
+bit-swap stages (`((x & mask) << k) | ((x >> k) & mask)` for `(mask, k)` = (`0x5555…`, 1),
+(`0x3333…`, 2), (`0x0f0f…`, 4) — each emitted by `bitreverseStageLocal` as
+`li`/`and`/`slli`/`srli`/`and`/`or`), a byte-reversing `riscv.rev8`, for `i32` an extra
+`riscv.srli 32` (the 32-bit masks keep the SWAR result in the low word, which `rev8` sends to the
+high word), and the cast back — 21 operations for `i64`, 22 for `i32`, the longest chain proven
+so far.
+
+A monolithic (`LowerSaddSat`-style) peel of 21 creations would need hundreds of pairwise
+distinctness transports, so this proof instead factors the repeated 6-op stage the way
+`LowerIcmp` factors its prologue: `bitreverseStageLocal_extends` shows one stage's creations
+only extend the context (`CtxExtends`), and `bitreverseStageLocal_run` symbolically executes one
+stage against an *arbitrary* final context, given the extension witness. The main proof peels the
+shared prefix, applies the stage lemmas three times, and finishes with the `rev8`(/`srli`)
+cast-back tail. This is also what motivates the `properties` field of `CtxExtends`: the stage's
+`li`/`slli`/`srli` immediates must survive to the final context.
+
+The data-level core (`Data.LLVM.Int.bitreverse` = `BitVec.reverse`) is outside `bv_decide`'s
+vocabulary: `BitVec.reverse` is width-recursive. At the two concrete widths, unfolding `reverse`
+(and `concat`) by simp produces a bitblastable append/`msb` normal form, after which
+`bv_decide` closes the SWAR identity.
+-/
+
+/-- The register value computed by one SWAR stage (`bitreverseStageLocal mask shamt`) on input
+    `r`: `or` of the masked-then-shifted low part and the shifted-then-masked high part, with the
+    mask materialized by `li`. Data-level counterpart of the emitted
+    `li`/`and`/`slli`/`srli`/`and`/`or` chain (in the interpreter's `op₂ op₁` operand order). -/
+def bitreverseStageReg (mask shamt : Int) (r : Data.RISCV.Reg) : Data.RISCV.Reg :=
+  Data.RISCV.or
+    (Data.RISCV.and (Data.RISCV.srli (BitVec.ofInt 6 shamt) r)
+      (Data.RISCV.li (BitVec.ofInt 64 mask)))
+    (Data.RISCV.slli (BitVec.ofInt 6 shamt)
+      (Data.RISCV.and r (Data.RISCV.li (BitVec.ofInt 64 mask))))
+
+/-- Correctness of the three-SWAR-stage + `rev8` lowering of a 64-bit `llvm.intr.bitreverse`:
+    the stages swap adjacent bits, then bit pairs, then nibbles (so every *byte* is bit-reversed
+    in place), and `rev8` reverses the bytes, completing the full bit reversal. -/
+theorem bitreverse_isRefinedBy_toInt_rev8_swar {x xt : Data.LLVM.Int 64} (h : x ⊒ xt) :
+    Data.LLVM.Int.bitreverse x ⊒
+      RISCV.Reg.toInt
+        (Data.RISCV.rev8
+          (bitreverseStageReg 0x0f0f0f0f0f0f0f0f 4
+            (bitreverseStageReg 0x3333333333333333 2
+              (bitreverseStageReg 0x5555555555555555 1 (LLVM.Int.toReg xt))))) 64 := by
+  revert h
+  simp only [bitreverseStageReg]
+  veir_bv_normalize
+  simp only [BitVec.reverse, BitVec.concat, BitVec.truncate_eq_setWidth]
+  bv_decide
+
+/-- Correctness of the `srli 32 (rev8 ·)` tail of a 32-bit `llvm.intr.bitreverse`: with the
+    32-bit masks the SWAR stages stay in the low word, `rev8` sends its byte-reversal to the
+    high word, and `srli 32` shifts it back down before the truncating cast reads the low
+    32 bits. -/
+theorem bitreverse_isRefinedBy_toInt_srli_rev8_swar {x xt : Data.LLVM.Int 32} (h : x ⊒ xt) :
+    Data.LLVM.Int.bitreverse x ⊒
+      RISCV.Reg.toInt
+        (Data.RISCV.srli (BitVec.ofInt 6 32)
+          (Data.RISCV.rev8
+            (bitreverseStageReg 0x0f0f0f0f 4
+              (bitreverseStageReg 0x33333333 2
+                (bitreverseStageReg 0x55555555 1 (LLVM.Int.toReg xt)))))) 32 := by
+  revert h
+  simp only [bitreverseStageReg]
+  veir_bv_normalize
+  simp only [BitVec.reverse, BitVec.concat, BitVec.truncate_eq_setWidth]
+  bv_decide
+
+/-! ### The repeated 6-op SWAR stage `bitreverseStageLocal`
+
+Following the `LowerIcmp` prologue treatment: the stage is proven once against an arbitrary final
+context, and the main proof instantiates it three times. -/
+
+/-- One SWAR stage only creates fresh operations, so it extends the context. -/
+theorem bitreverseStageLocal_extends {mask shamt : Int} {ctx ctx' : WfIRContext OpCode}
+    {op : OperationPtr} {input out : ValuePtr} {ops : Array OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    (hStage : bitreverseStageLocal mask shamt ctx input = some (ctx', ops, out)) :
+    CtxExtends op ctx ctx' := by
+  simp only [bitreverseStageLocal, bind, Option.bind_eq_some_iff] at hStage
+  peelOpCreation hStage ctx₁ maskOp hMask
+  replace hMask := WfRewriter.createOp!_none_some hMask
+  obtain ⟨_, _, _, hMask⟩ := hMask
+  peelOpCreation hStage ctx₂ lowOp hLow
+  replace hLow := WfRewriter.createOp!_none_some hLow
+  obtain ⟨_, _, _, hLow⟩ := hLow
+  peelOpCreation hStage ctx₃ lowShiftOp hLowShift
+  replace hLowShift := WfRewriter.createOp!_none_some hLowShift
+  obtain ⟨_, _, _, hLowShift⟩ := hLowShift
+  peelOpCreation hStage ctx₄ highShiftOp hHighShift
+  replace hHighShift := WfRewriter.createOp!_none_some hHighShift
+  obtain ⟨_, _, _, hHighShift⟩ := hHighShift
+  peelOpCreation hStage ctx₅ highOp hHigh
+  replace hHigh := WfRewriter.createOp!_none_some hHigh
+  obtain ⟨_, _, _, hHigh⟩ := hHigh
+  peelOpCreation hStage ctx₆ orOp hOr
+  replace hOr := WfRewriter.createOp!_none_some hOr
+  obtain ⟨_, _, _, hOr⟩ := hOr
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hStage
+  have E₁ := CtxExtends.of_createOp hMask opInBounds
+  have hOpIn₁ := E₁.inBounds op opInBounds
+  have E₂ := CtxExtends.of_createOp hLow hOpIn₁
+  have hOpIn₂ := E₂.inBounds op hOpIn₁
+  have E₃ := CtxExtends.of_createOp hLowShift hOpIn₂
+  have hOpIn₃ := E₃.inBounds op hOpIn₂
+  have E₄ := CtxExtends.of_createOp hHighShift hOpIn₃
+  have hOpIn₄ := E₄.inBounds op hOpIn₃
+  have E₅ := CtxExtends.of_createOp hHigh hOpIn₄
+  have hOpIn₅ := E₅.inBounds op hOpIn₄
+  have E₆ := CtxExtends.of_createOp hOr hOpIn₅
+  exact E₁.trans (E₂.trans (E₃.trans (E₄.trans (E₅.trans E₆))))
+
+/-- One SWAR stage's emitted ops, and its output value, are in bounds in the context it
+    returns. -/
+theorem bitreverseStageLocal_inBounds {mask shamt : Int} {ctx ctx' : WfIRContext OpCode}
+    {input out : ValuePtr} {ops : Array OperationPtr}
+    (hStage : bitreverseStageLocal mask shamt ctx input = some (ctx', ops, out)) :
+    (∀ o ∈ ops.toList, o.InBounds ctx'.raw) ∧ out.InBounds ctx'.raw := by
+  simp only [bitreverseStageLocal, bind, Option.bind_eq_some_iff] at hStage
+  peelOpCreation hStage ctx₁ maskOp hMask
+  replace hMask := WfRewriter.createOp!_none_some hMask
+  obtain ⟨_, _, _, hMask⟩ := hMask
+  peelOpCreation hStage ctx₂ lowOp hLow
+  replace hLow := WfRewriter.createOp!_none_some hLow
+  obtain ⟨_, _, _, hLow⟩ := hLow
+  peelOpCreation hStage ctx₃ lowShiftOp hLowShift
+  replace hLowShift := WfRewriter.createOp!_none_some hLowShift
+  obtain ⟨_, _, _, hLowShift⟩ := hLowShift
+  peelOpCreation hStage ctx₄ highShiftOp hHighShift
+  replace hHighShift := WfRewriter.createOp!_none_some hHighShift
+  obtain ⟨_, _, _, hHighShift⟩ := hHighShift
+  peelOpCreation hStage ctx₅ highOp hHigh
+  replace hHigh := WfRewriter.createOp!_none_some hHigh
+  obtain ⟨_, _, _, hHigh⟩ := hHigh
+  peelOpCreation hStage ctx₆ orOp hOr
+  replace hOr := WfRewriter.createOp!_none_some hOr
+  obtain ⟨_, _, _, hOr⟩ := hOr
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hStage
+  have hMaskIn₁ : maskOp.InBounds ctx₁.raw := WfRewriter.createOp_new_inBounds _ hMask
+  have hLowIn₂ : lowOp.InBounds ctx₂.raw := WfRewriter.createOp_new_inBounds _ hLow
+  have hLowShiftIn₃ : lowShiftOp.InBounds ctx₃.raw :=
+    WfRewriter.createOp_new_inBounds _ hLowShift
+  have hHighShiftIn₄ : highShiftOp.InBounds ctx₄.raw :=
+    WfRewriter.createOp_new_inBounds _ hHighShift
+  have hHighIn₅ : highOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hHigh
+  have hOrIn₆ : orOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hOr
+  have E₂ := CtxExtends.of_createOp (op := maskOp) hLow hMaskIn₁
+  have E₃ := CtxExtends.of_createOp (op := maskOp) hLowShift (E₂.inBounds _ hMaskIn₁)
+  have E₄ := CtxExtends.of_createOp (op := maskOp) hHighShift
+    (E₃.inBounds _ (E₂.inBounds _ hMaskIn₁))
+  have E₅ := CtxExtends.of_createOp (op := maskOp) hHigh
+    (E₄.inBounds _ (E₃.inBounds _ (E₂.inBounds _ hMaskIn₁)))
+  have E₆ := CtxExtends.of_createOp (op := maskOp) hOr
+    (E₅.inBounds _ (E₄.inBounds _ (E₃.inBounds _ (E₂.inBounds _ hMaskIn₁))))
+  have E₂₆ := E₂.trans (E₃.trans (E₄.trans (E₅.trans E₆)))
+  have E₃₆ := E₃.trans (E₄.trans (E₅.trans E₆))
+  have E₄₆ := E₄.trans (E₅.trans E₆)
+  have E₅₆ := E₅.trans E₆
+  refine ⟨?_, ?_⟩
+  · intro o ho
+    simp only [List.mem_cons, List.not_mem_nil, or_false] at ho
+    rcases ho with rfl | rfl | rfl | rfl | rfl | rfl
+    · exact E₂₆.inBounds o hMaskIn₁
+    · exact E₃₆.inBounds o hLowIn₂
+    · exact E₄₆.inBounds o hLowShiftIn₃
+    · exact E₅₆.inBounds o hHighShiftIn₄
+    · exact E₆.inBounds o hHighIn₅
+    · exact hOrIn₆
+  · grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+
+set_option maxHeartbeats 1600000 in
+/-- Symbolic execution of one SWAR stage in the main proof's final context `F`: given the
+    extension of the stage's output context to `F` and the input register value `r`, the six ops
+    run without touching memory and leave the stage output holding
+    `bitreverseStageReg mask shamt r`. -/
+theorem bitreverseStageLocal_run {mask shamt : Int} {ctx ctx' F : WfIRContext OpCode}
+    {op : OperationPtr} {input out : ValuePtr} {ops : Array OperationPtr}
+    {r : Data.RISCV.Reg} {state' : InterpreterState F}
+    (opInBounds : op.InBounds ctx.raw)
+    (hStage : bitreverseStageLocal mask shamt ctx input = some (ctx', ops, out))
+    (hExt : CtxExtends op ctx' F)
+    (hInputIn : input.InBounds ctx.raw)
+    (hVal : state'.variables.getVar? input = some (.reg r))
+    (hin : ∀ o ∈ ops.toList, o.InBounds F.raw) :
+    ∃ s' : InterpreterState F,
+      interpretOpList ops.toList state' hin = some (.ok (s', none)) ∧
+      s'.memory = state'.memory ∧
+      s'.variables.getVar? out = some (.reg (bitreverseStageReg mask shamt r)) := by
+  simp only [bitreverseStageLocal, bind, Option.bind_eq_some_iff] at hStage
+  peelOpCreation hStage ctx₁ maskOp hMask
+  replace hMask := WfRewriter.createOp!_none_some hMask
+  obtain ⟨_, _, _, hMask⟩ := hMask
+  peelOpCreation hStage ctx₂ lowOp hLow
+  replace hLow := WfRewriter.createOp!_none_some hLow
+  obtain ⟨_, _, _, hLow⟩ := hLow
+  peelOpCreation hStage ctx₃ lowShiftOp hLowShift
+  replace hLowShift := WfRewriter.createOp!_none_some hLowShift
+  obtain ⟨_, _, _, hLowShift⟩ := hLowShift
+  peelOpCreation hStage ctx₄ highShiftOp hHighShift
+  replace hHighShift := WfRewriter.createOp!_none_some hHighShift
+  obtain ⟨_, _, _, hHighShift⟩ := hHighShift
+  peelOpCreation hStage ctx₅ highOp hHigh
+  replace hHigh := WfRewriter.createOp!_none_some hHigh
+  obtain ⟨_, _, _, hHigh⟩ := hHigh
+  peelOpCreation hStage ctx₆ orOp hOr
+  replace hOr := WfRewriter.createOp!_none_some hOr
+  obtain ⟨_, _, _, hOr⟩ := hOr
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hStage
+  -- Context extensions: one per creation, plus the suffixes reaching `F`.
+  have E₁ := CtxExtends.of_createOp hMask opInBounds
+  have hOpIn₁ := E₁.inBounds op opInBounds
+  have E₂ := CtxExtends.of_createOp hLow hOpIn₁
+  have hOpIn₂ := E₂.inBounds op hOpIn₁
+  have E₃ := CtxExtends.of_createOp hLowShift hOpIn₂
+  have hOpIn₃ := E₃.inBounds op hOpIn₂
+  have E₄ := CtxExtends.of_createOp hHighShift hOpIn₃
+  have hOpIn₄ := E₄.inBounds op hOpIn₃
+  have E₅ := CtxExtends.of_createOp hHigh hOpIn₄
+  have hOpIn₅ := E₅.inBounds op hOpIn₄
+  have E₆ := CtxExtends.of_createOp hOr hOpIn₅
+  have F₆ : CtxExtends op ctx₆ F := hExt
+  have F₅ : CtxExtends op ctx₅ F := E₆.trans F₆
+  have F₄ : CtxExtends op ctx₄ F := E₅.trans F₅
+  have F₃ : CtxExtends op ctx₃ F := E₄.trans F₄
+  have F₂ : CtxExtends op ctx₂ F := E₃.trans F₃
+  have F₁ : CtxExtends op ctx₁ F := E₂.trans F₂
+  -- Freshness and in-bounds bookkeeping for the frame conditions.
+  have hMaskIn₁ : maskOp.InBounds ctx₁.raw := WfRewriter.createOp_new_inBounds _ hMask
+  have hLowIn₂ : lowOp.InBounds ctx₂.raw := WfRewriter.createOp_new_inBounds _ hLow
+  have hLowShiftIn₃ : lowShiftOp.InBounds ctx₃.raw :=
+    WfRewriter.createOp_new_inBounds _ hLowShift
+  have hHighShiftIn₄ : highShiftOp.InBounds ctx₄.raw :=
+    WfRewriter.createOp_new_inBounds _ hHighShift
+  have hHighIn₅ : highOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hHigh
+  have hOrIn₆ : orOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hOr
+  have hMaskFresh : ¬ maskOp.InBounds ctx.raw := WfRewriter.createOp_new_not_inBounds _ hMask
+  have hLowFresh : ¬ lowOp.InBounds ctx₁.raw := WfRewriter.createOp_new_not_inBounds _ hLow
+  have hLowShiftFresh : ¬ lowShiftOp.InBounds ctx₂.raw :=
+    WfRewriter.createOp_new_not_inBounds _ hLowShift
+  have hHighShiftFresh : ¬ highShiftOp.InBounds ctx₃.raw :=
+    WfRewriter.createOp_new_not_inBounds _ hHighShift
+  have hHighFresh : ¬ highOp.InBounds ctx₄.raw := WfRewriter.createOp_new_not_inBounds _ hHigh
+  have hInputIn₁ : input.InBounds ctx₁.raw := E₁.valueInBounds input hInputIn
+  have hInputIn₂ : input.InBounds ctx₂.raw := E₂.valueInBounds input hInputIn₁
+  have hMaskResIn₁ : (ValuePtr.opResult (maskOp.getResult 0)).InBounds ctx₁.raw := by
+    grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  have hMaskResIn₂ : (ValuePtr.opResult (maskOp.getResult 0)).InBounds ctx₂.raw :=
+    E₂.valueInBounds _ hMaskResIn₁
+  have hMaskResIn₃ : (ValuePtr.opResult (maskOp.getResult 0)).InBounds ctx₃.raw :=
+    E₃.valueInBounds _ hMaskResIn₂
+  have hLowShiftResIn₃ : (ValuePtr.opResult (lowShiftOp.getResult 0)).InBounds ctx₃.raw := by
+    grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  have hLowShiftResIn₄ : (ValuePtr.opResult (lowShiftOp.getResult 0)).InBounds ctx₄.raw :=
+    E₄.valueInBounds _ hLowShiftResIn₃
+  -- Structural facts about the six ops, in `F`.
+  have hMaskType : maskOp.getOpType! F.raw = .riscv .li := by
+    rw [F₁.opType maskOp hMaskIn₁]; grind
+  have hMaskOperands : maskOp.getOperands! F.raw = #[] := by
+    rw [F₁.operands maskOp hMaskIn₁]; grind
+  have hMaskResTypes : maskOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [F₁.resultTypes maskOp hMaskIn₁]; grind
+  have hMaskProps : maskOp.getProperties! F.raw (.riscv .li)
+      = RISCVImmediateProperties.mk (IntegerAttr.mk mask (IntegerType.mk 64)) := by
+    rw [F₁.properties maskOp hMaskIn₁]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hMask (operation := maskOp)]
+  have hLowType : lowOp.getOpType! F.raw = .riscv .and := by
+    rw [F₂.opType lowOp hLowIn₂]; grind
+  have hLowOperands :
+      lowOp.getOperands! F.raw = #[ValuePtr.opResult (maskOp.getResult 0), input] := by
+    rw [F₂.operands lowOp hLowIn₂]; grind
+  have hLowResTypes : lowOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [F₂.resultTypes lowOp hLowIn₂]; grind
+  have hLowShiftType : lowShiftOp.getOpType! F.raw = .riscv .slli := by
+    rw [F₃.opType lowShiftOp hLowShiftIn₃]; grind
+  have hLowShiftOperands :
+      lowShiftOp.getOperands! F.raw = #[ValuePtr.opResult (lowOp.getResult 0)] := by
+    rw [F₃.operands lowShiftOp hLowShiftIn₃]; grind
+  have hLowShiftResTypes :
+      lowShiftOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [F₃.resultTypes lowShiftOp hLowShiftIn₃]; grind
+  have hLowShiftProps : lowShiftOp.getProperties! F.raw (.riscv .slli)
+      = RISCVImmediateProperties.mk (IntegerAttr.mk shamt (IntegerType.mk 64)) := by
+    rw [F₃.properties lowShiftOp hLowShiftIn₃]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hLowShift (operation := lowShiftOp)]
+  have hLowShiftImm : BitVec.ofInt 6 (lowShiftOp.getProperties! F.raw (.riscv .slli)).value.value
+      = BitVec.ofInt 6 shamt := by rw [hLowShiftProps]
+  have hHighShiftType : highShiftOp.getOpType! F.raw = .riscv .srli := by
+    rw [F₄.opType highShiftOp hHighShiftIn₄]; grind
+  have hHighShiftOperands : highShiftOp.getOperands! F.raw = #[input] := by
+    rw [F₄.operands highShiftOp hHighShiftIn₄]; grind
+  have hHighShiftResTypes :
+      highShiftOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [F₄.resultTypes highShiftOp hHighShiftIn₄]; grind
+  have hHighShiftProps : highShiftOp.getProperties! F.raw (.riscv .srli)
+      = RISCVImmediateProperties.mk (IntegerAttr.mk shamt (IntegerType.mk 64)) := by
+    rw [F₄.properties highShiftOp hHighShiftIn₄]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hHighShift (operation := highShiftOp)]
+  have hHighShiftImm : BitVec.ofInt 6 (highShiftOp.getProperties! F.raw (.riscv .srli)).value.value
+      = BitVec.ofInt 6 shamt := by rw [hHighShiftProps]
+  have hHighType : highOp.getOpType! F.raw = .riscv .and := by
+    rw [F₅.opType highOp hHighIn₅]; grind
+  have hHighOperands : highOp.getOperands! F.raw
+      = #[ValuePtr.opResult (maskOp.getResult 0), ValuePtr.opResult (highShiftOp.getResult 0)] := by
+    rw [F₅.operands highOp hHighIn₅]; grind
+  have hHighResTypes : highOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [F₅.resultTypes highOp hHighIn₅]; grind
+  have hOrType : orOp.getOpType! F.raw = .riscv .or := by
+    rw [F₆.opType orOp hOrIn₆]; grind
+  have hOrOperands : orOp.getOperands! F.raw
+      = #[ValuePtr.opResult (lowShiftOp.getResult 0), ValuePtr.opResult (highOp.getResult 0)] := by
+    rw [F₆.operands orOp hOrIn₆]; grind
+  have hOrResTypes : orOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [F₆.resultTypes orOp hOrIn₆]; grind
+  -- Execute the six ops.
+  obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+    interpretOp_riscv_li_forward (state := state') (inBounds := hin maskOp (by simp))
+      (props := RISCVImmediateProperties.mk (IntegerAttr.mk mask (IntegerType.mk 64)))
+      hMaskType hMaskProps hMaskOperands hMaskResTypes
+  replace hRes₁ : s₁.variables.getVar? (ValuePtr.opResult (maskOp.getResult 0))
+      = some (.reg (Data.RISCV.li (BitVec.ofInt 64 mask))) := hRes₁
+  have hInputVal₁ : s₁.variables.getVar? input = some (.reg r) := by
+    rw [hFrame₁ input
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hInputIn hMaskFresh)]
+    exact hVal
+  obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₁) (inBounds := hin lowOp (by simp))
+      (f := fun r₁ r₂ => Data.RISCV.and r₂ r₁) (fun _ _ _ _ => rfl)
+      hLowType hLowOperands hLowResTypes hRes₁ hInputVal₁
+  obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+    interpretOp_riscv_slli_forward (state := s₂) (inBounds := hin lowShiftOp (by simp))
+      (k := BitVec.ofInt 6 shamt)
+      hLowShiftType hLowShiftImm hLowShiftOperands hLowShiftResTypes hRes₂
+  have hInputVal₂ : s₂.variables.getVar? input = some (.reg r) := by
+    rw [hFrame₂ input
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hInputIn₁ hLowFresh)]
+    exact hInputVal₁
+  have hInputVal₃ : s₃.variables.getVar? input = some (.reg r) := by
+    rw [hFrame₃ input
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hInputIn₂ hLowShiftFresh)]
+    exact hInputVal₂
+  obtain ⟨s₄, hI₄, hMem₄, hRes₄, hFrame₄⟩ :=
+    interpretOp_riscv_srli_forward (state := s₃) (inBounds := hin highShiftOp (by simp))
+      (k := BitVec.ofInt 6 shamt)
+      hHighShiftType hHighShiftImm hHighShiftOperands hHighShiftResTypes hInputVal₃
+  have hMaskVal₂ : s₂.variables.getVar? (ValuePtr.opResult (maskOp.getResult 0))
+      = some (.reg (Data.RISCV.li (BitVec.ofInt 64 mask))) := by
+    rw [hFrame₂ _
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hMaskResIn₁ hLowFresh)]
+    exact hRes₁
+  have hMaskVal₃ : s₃.variables.getVar? (ValuePtr.opResult (maskOp.getResult 0))
+      = some (.reg (Data.RISCV.li (BitVec.ofInt 64 mask))) := by
+    rw [hFrame₃ _
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hMaskResIn₂ hLowShiftFresh)]
+    exact hMaskVal₂
+  have hMaskVal₄ : s₄.variables.getVar? (ValuePtr.opResult (maskOp.getResult 0))
+      = some (.reg (Data.RISCV.li (BitVec.ofInt 64 mask))) := by
+    rw [hFrame₄ _
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hMaskResIn₃ hHighShiftFresh)]
+    exact hMaskVal₃
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, hFrame₅⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₄) (inBounds := hin highOp (by simp))
+      (f := fun r₁ r₂ => Data.RISCV.and r₂ r₁) (fun _ _ _ _ => rfl)
+      hHighType hHighOperands hHighResTypes hMaskVal₄ hRes₄
+  have hLowShiftVal₄ : s₄.variables.getVar? (ValuePtr.opResult (lowShiftOp.getResult 0))
+      = some (.reg (Data.RISCV.slli (BitVec.ofInt 6 shamt)
+          (Data.RISCV.and r (Data.RISCV.li (BitVec.ofInt 64 mask))))) := by
+    rw [hFrame₄ _
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hLowShiftResIn₃ hHighShiftFresh)]
+    exact hRes₃
+  have hLowShiftVal₅ : s₅.variables.getVar? (ValuePtr.opResult (lowShiftOp.getResult 0))
+      = some (.reg (Data.RISCV.slli (BitVec.ofInt 6 shamt)
+          (Data.RISCV.and r (Data.RISCV.li (BitVec.ofInt 64 mask))))) := by
+    rw [hFrame₅ _
+      (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hLowShiftResIn₄ hHighFresh)]
+    exact hLowShiftVal₄
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, hFrame₆⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₅) (inBounds := hin orOp (by simp))
+      (f := fun r₁ r₂ => Data.RISCV.or r₂ r₁) (fun _ _ _ _ => rfl)
+      hOrType hOrOperands hOrResTypes hLowShiftVal₅ hRes₅
+  refine ⟨s₆, ?_, by grind, ?_⟩
+  · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, hI₅, hI₆, Interp]
+  · exact hRes₆
+
+set_option maxHeartbeats 4000000 in
+/-- Correctness of the `bitreverse_local` lowering: the
+    `castToReg → 3 × SWAR stage → rev8 (→ srli 32 for i32) → castBack` round trip refines
+    `llvm.intr.bitreverse`. -/
+theorem bitreverse_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics bitreverse_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, bitreverse_local]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (matchBitreverse op ctx.raw).isSome := by
+    cases hM : matchBitreverse op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨operand, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Gather the syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands⟩ := matchBitreverse_implies hMatch
+  have hOperandEq : operand = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, hResOperType, intType, isT, hResType⟩ :=
+    OperationPtr.Verified.llvm_intr__bitreverse opVerif hOpType
+  -- The operand type is the integer type `intType`; resolve the type-destructuring match.
+  have hOperandType : (operand.getType! ctx.raw).val = Attribute.integerType intType := by
+    rw [show operand.getType! ctx.raw = ⟨.integerType intType, isT⟩ from by grind]
+  rw [hOperandType] at hpattern
+  simp only [] at hpattern
+  -- Unfold the interpretation of the matched op: exposes the operand's value and `bitreverse`.
+  obtain ⟨xVal, hxVal, hMem, hRes, hCf⟩ :=
+    matchUnaryOp_interpretOp_unfold (srcFn := fun {_} x _ => Data.LLVM.Int.bitreverse x)
+      opInBounds hOpType hNumResults hOperands rfl (fun _ _ _ _ _ _ => rfl) hinterp hOperandType
+  subst hCf
+  -- The matched operand dominates the rewrite point in the source context.
+  have hDomCtx : operand.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- The bitwidth guard must be false (otherwise the RHS would be `some (ctx, none)`).
+  peelSplittableCondition [hBw] hpattern
+  -- Source value: `op`'s single result is `bitreverse` of its operand.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  -- `operand` is not one of `op`'s results, and `op`'s result is in bounds.
+  have vNotOp : ¬ operand ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw := by
+    grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  have hOperandIn : operand.InBounds ctx.raw := by rw [hOperandEq]; grind
+  -- Peel the shared `castToReg`.
+  simp only [Option.bind_eq_some_iff] at hpattern
+  obtain ⟨⟨ctx₁, castOp⟩, hCast, hpattern⟩ := hpattern
+  simp only [castToRegLocal] at hCast
+  replace hCast := WfRewriter.createOp!_none_some hCast
+  obtain ⟨_, _, _, hCast⟩ := hCast
+  have Ecast := CtxExtends.of_createOp hCast opInBounds
+  have hOpIn₁ := Ecast.inBounds op opInBounds
+  have hCastIn₁ : castOp.InBounds ctx₁.raw := WfRewriter.createOp_new_inBounds _ hCast
+  have hCastResIn₁ : (ValuePtr.opResult (castOp.getResult 0)).InBounds ctx₁.raw := by
+    grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  have hBwCases : intType.bitwidth = 64 ∨ intType.bitwidth = 32 := by omega
+  rcases hBwCases with hbw | hbw
+  · -- ===== 64-bit: `castToReg → 3 stages (64-bit masks) → rev8 → castBack` =====
+    rw [if_neg (show ¬intType.bitwidth = 32 by omega)] at hpattern
+    simp only [Option.bind_eq_some_iff] at hpattern
+    obtain ⟨⟨ctx₂, ops1, x1⟩, hSt1, hpattern⟩ := hpattern
+    obtain ⟨⟨ctx₃, ops2, x2⟩, hSt2, hpattern⟩ := hpattern
+    obtain ⟨⟨ctx₄, ops3, x3⟩, hSt3, hpattern⟩ := hpattern
+    obtain ⟨⟨ctx₅, rev8Op⟩, hRev8, hpattern⟩ := hpattern
+    replace hRev8 := WfRewriter.createOp!_none_some hRev8
+    obtain ⟨_, _, _, hRev8⟩ := hRev8
+    obtain ⟨⟨ctx₆, castBackOp⟩, hCastBack, hpattern⟩ := hpattern
+    simp only [replaceWithRegLocal] at hCastBack
+    replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+    obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+    obtain ⟨rfl, rfl, rfl⟩ := by simpa using hpattern
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    -- Context extensions and their composites reaching the final context.
+    have E₁ := bitreverseStageLocal_extends hOpIn₁ hSt1
+    have hOpIn₂ := E₁.inBounds op hOpIn₁
+    have E₂ := bitreverseStageLocal_extends hOpIn₂ hSt2
+    have hOpIn₃ := E₂.inBounds op hOpIn₂
+    have E₃ := bitreverseStageLocal_extends hOpIn₃ hSt3
+    have hOpIn₄ := E₃.inBounds op hOpIn₃
+    have Erev8 := CtxExtends.of_createOp hRev8 hOpIn₄
+    have hOpIn₅ := Erev8.inBounds op hOpIn₄
+    have Ecb := CtxExtends.of_createOp hCastBack hOpIn₅
+    have FS5 : CtxExtends op ctx₅ ctx₆ := Ecb
+    have FS4 : CtxExtends op ctx₄ ctx₆ := Erev8.trans FS5
+    have FS3 : CtxExtends op ctx₃ ctx₆ := E₃.trans FS4
+    have FS2 : CtxExtends op ctx₂ ctx₆ := E₂.trans FS3
+    have FS1 : CtxExtends op ctx₁ ctx₆ := E₁.trans FS2
+    have Ectx : CtxExtends op ctx ctx₆ := Ecast.trans FS1
+    -- Read the refined operand in the target state.
+    obtain ⟨xt, hOpVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hOperandIn hxVal
+        hDomCtx (Ectx.dominates operand hDomCtx) vNotOp
+    -- In-bounds of the emitted ops in the final context.
+    obtain ⟨hOps1In₂, hX1In₂⟩ := bitreverseStageLocal_inBounds hSt1
+    obtain ⟨hOps2In₃, hX2In₃⟩ := bitreverseStageLocal_inBounds hSt2
+    obtain ⟨hOps3In₄, hX3In₄⟩ := bitreverseStageLocal_inBounds hSt3
+    have hOps1F : ∀ o ∈ ops1.toList, o.InBounds ctx₆.raw :=
+      fun o ho => FS2.inBounds o (hOps1In₂ o ho)
+    have hOps2F : ∀ o ∈ ops2.toList, o.InBounds ctx₆.raw :=
+      fun o ho => FS3.inBounds o (hOps2In₃ o ho)
+    have hOps3F : ∀ o ∈ ops3.toList, o.InBounds ctx₆.raw :=
+      fun o ho => FS4.inBounds o (hOps3In₄ o ho)
+    have hRev8In₅ : rev8Op.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hRev8
+    have hCBIn₆ : castBackOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hCastBack
+    -- Structural facts about the cast, `rev8`, and cast-back, in the final context.
+    have hCastType : castOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast := by
+      rw [FS1.opType castOp hCastIn₁]; grind
+    have hCastOperands : castOp.getOperands! ctx₆.raw = #[operand] := by
+      rw [FS1.operands castOp hCastIn₁]; grind
+    have hCastResTypes : castOp.getResultTypes! ctx₆.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [FS1.resultTypes castOp hCastIn₁]; grind
+    have hRev8Type : rev8Op.getOpType! ctx₆.raw = .riscv .rev8 := by
+      rw [FS5.opType rev8Op hRev8In₅]; grind
+    have hRev8Operands : rev8Op.getOperands! ctx₆.raw = #[x3] := by
+      rw [FS5.operands rev8Op hRev8In₅]; grind
+    have hRev8ResTypes : rev8Op.getResultTypes! ctx₆.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [FS5.resultTypes rev8Op hRev8In₅]; grind
+    have hCBType : ((op.getResult 0).get! ctx₅.raw).type
+        = (⟨Attribute.integerType { bitwidth := 64 }, isT⟩ : TypeAttr) := by
+      have h1 := (Ecast.trans (E₁.trans (E₂.trans (E₃.trans Erev8)))).valueType
+        (ValuePtr.opResult (op.getResult 0)) hResIn
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastBackType : castBackOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast :=
+      by grind
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₆.raw = #[ValuePtr.opResult (rev8Op.getResult 0)] := by grind
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₆.raw
+        = #[⟨Attribute.integerType { bitwidth := 64 }, isT⟩] := by grind
+    -- Execute the chain.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := FS1.inBounds castOp hCastIn₁)
+        hCastType hCastOperands hCastResTypes hOpVal'
+    obtain ⟨sA, hRun1, hMemA, hX1Val⟩ :=
+      bitreverseStageLocal_run hOpIn₁ hSt1 FS2 hCastResIn₁ hRes₁ hOps1F
+    obtain ⟨sB, hRun2, hMemB, hX2Val⟩ :=
+      bitreverseStageLocal_run hOpIn₂ hSt2 FS3 hX1In₂ hX1Val hOps2F
+    obtain ⟨sC, hRun3, hMemC, hX3Val⟩ :=
+      bitreverseStageLocal_run hOpIn₃ hSt3 FS4 hX2In₃ hX2Val hOps3F
+    obtain ⟨sD, hIRev8, hMemD, hRev8Res, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := sC) (inBounds := FS5.inBounds rev8Op hRev8In₅)
+        (f := Data.RISCV.rev8) (fun _ _ _ _ => rfl) hRev8Type hRev8Operands hRev8ResTypes hX3Val
+    obtain ⟨sE, hICB, hMemE, hCBRes, -⟩ :=
+      interpretOp_castBack_forward (state := sD) (inBounds := hCBIn₆)
+        hCastBackType hCastBackOperands hCastBackResTypes hRev8Res
+    refine ⟨sE, ?_, by grind, ?_⟩
+    · simp [Array.toList_append, interpretOpList_append, interpretOpList_cons, hI₁, hRun1,
+        hRun2, hRun3, hIRev8, hICB, liftM, monadLift, MonadLift.monadLift, Interp]
+    · refine ⟨#[RuntimeValue.int 64 (RISCV.Reg.toInt
+          (Data.RISCV.rev8
+            (bitreverseStageReg 0x0f0f0f0f0f0f0f0f 4
+              (bitreverseStageReg 0x3333333333333333 2
+                (bitreverseStageReg 0x5555555555555555 1 (LLVM.Int.toReg xt))))) 64)], ?_, ?_⟩
+      · simp [hCBRes, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using bitreverse_isRefinedBy_toInt_rev8_swar hxtRef⟩
+  · -- ===== 32-bit: `castToReg → 3 stages (32-bit masks) → rev8 → srli 32 → castBack` =====
+    rw [if_pos hbw] at hpattern
+    simp only [Option.bind_eq_some_iff] at hpattern
+    obtain ⟨⟨ctx₂, ops1, x1⟩, hSt1, hpattern⟩ := hpattern
+    obtain ⟨⟨ctx₃, ops2, x2⟩, hSt2, hpattern⟩ := hpattern
+    obtain ⟨⟨ctx₄, ops3, x3⟩, hSt3, hpattern⟩ := hpattern
+    obtain ⟨⟨ctx₅, rev8Op⟩, hRev8, hpattern⟩ := hpattern
+    replace hRev8 := WfRewriter.createOp!_none_some hRev8
+    obtain ⟨_, _, _, hRev8⟩ := hRev8
+    obtain ⟨⟨ctx₆, srliOp⟩, hSrli, hpattern⟩ := hpattern
+    replace hSrli := WfRewriter.createOp!_none_some hSrli
+    obtain ⟨_, _, _, hSrli⟩ := hSrli
+    obtain ⟨⟨ctx₇, castBackOp⟩, hCastBack, hpattern⟩ := hpattern
+    simp only [replaceWithRegLocal] at hCastBack
+    replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+    obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+    obtain ⟨rfl, rfl, rfl⟩ := by simpa using hpattern
+    obtain ⟨bw⟩ := intType; simp only at hbw; subst hbw
+    -- Context extensions and their composites reaching the final context.
+    have E₁ := bitreverseStageLocal_extends hOpIn₁ hSt1
+    have hOpIn₂ := E₁.inBounds op hOpIn₁
+    have E₂ := bitreverseStageLocal_extends hOpIn₂ hSt2
+    have hOpIn₃ := E₂.inBounds op hOpIn₂
+    have E₃ := bitreverseStageLocal_extends hOpIn₃ hSt3
+    have hOpIn₄ := E₃.inBounds op hOpIn₃
+    have Erev8 := CtxExtends.of_createOp hRev8 hOpIn₄
+    have hOpIn₅ := Erev8.inBounds op hOpIn₄
+    have Esrli := CtxExtends.of_createOp hSrli hOpIn₅
+    have hOpIn₆ := Esrli.inBounds op hOpIn₅
+    have Ecb := CtxExtends.of_createOp hCastBack hOpIn₆
+    have FS6 : CtxExtends op ctx₆ ctx₇ := Ecb
+    have FS5 : CtxExtends op ctx₅ ctx₇ := Esrli.trans FS6
+    have FS4 : CtxExtends op ctx₄ ctx₇ := Erev8.trans FS5
+    have FS3 : CtxExtends op ctx₃ ctx₇ := E₃.trans FS4
+    have FS2 : CtxExtends op ctx₂ ctx₇ := E₂.trans FS3
+    have FS1 : CtxExtends op ctx₁ ctx₇ := E₁.trans FS2
+    have Ectx : CtxExtends op ctx ctx₇ := Ecast.trans FS1
+    -- Read the refined operand in the target state.
+    obtain ⟨xt, hOpVal', hxtRef⟩ :=
+      LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hOperandIn hxVal
+        hDomCtx (Ectx.dominates operand hDomCtx) vNotOp
+    -- In-bounds of the emitted ops in the final context.
+    obtain ⟨hOps1In₂, hX1In₂⟩ := bitreverseStageLocal_inBounds hSt1
+    obtain ⟨hOps2In₃, hX2In₃⟩ := bitreverseStageLocal_inBounds hSt2
+    obtain ⟨hOps3In₄, hX3In₄⟩ := bitreverseStageLocal_inBounds hSt3
+    have hOps1F : ∀ o ∈ ops1.toList, o.InBounds ctx₇.raw :=
+      fun o ho => FS2.inBounds o (hOps1In₂ o ho)
+    have hOps2F : ∀ o ∈ ops2.toList, o.InBounds ctx₇.raw :=
+      fun o ho => FS3.inBounds o (hOps2In₃ o ho)
+    have hOps3F : ∀ o ∈ ops3.toList, o.InBounds ctx₇.raw :=
+      fun o ho => FS4.inBounds o (hOps3In₄ o ho)
+    have hRev8In₅ : rev8Op.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hRev8
+    have hSrliIn₆ : srliOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hSrli
+    have hCBIn₇ : castBackOp.InBounds ctx₇.raw := WfRewriter.createOp_new_inBounds _ hCastBack
+    -- Structural facts about the cast, `rev8`, `srli`, and cast-back, in the final context.
+    have hCastType : castOp.getOpType! ctx₇.raw = .builtin .unrealized_conversion_cast := by
+      rw [FS1.opType castOp hCastIn₁]; grind
+    have hCastOperands : castOp.getOperands! ctx₇.raw = #[operand] := by
+      rw [FS1.operands castOp hCastIn₁]; grind
+    have hCastResTypes : castOp.getResultTypes! ctx₇.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [FS1.resultTypes castOp hCastIn₁]; grind
+    have hRev8Type : rev8Op.getOpType! ctx₇.raw = .riscv .rev8 := by
+      rw [FS5.opType rev8Op hRev8In₅]; grind
+    have hRev8Operands : rev8Op.getOperands! ctx₇.raw = #[x3] := by
+      rw [FS5.operands rev8Op hRev8In₅]; grind
+    have hRev8ResTypes : rev8Op.getResultTypes! ctx₇.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [FS5.resultTypes rev8Op hRev8In₅]; grind
+    have hSrliType : srliOp.getOpType! ctx₇.raw = .riscv .srli := by
+      rw [FS6.opType srliOp hSrliIn₆]; grind
+    have hSrliOperands :
+        srliOp.getOperands! ctx₇.raw = #[ValuePtr.opResult (rev8Op.getResult 0)] := by
+      rw [FS6.operands srliOp hSrliIn₆]; grind
+    have hSrliResTypes : srliOp.getResultTypes! ctx₇.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [FS6.resultTypes srliOp hSrliIn₆]; grind
+    have hSrliProps : srliOp.getProperties! ctx₇.raw (.riscv .srli)
+        = RISCVImmediateProperties.mk (IntegerAttr.mk 32 (IntegerType.mk 64)) := by
+      rw [FS6.properties srliOp hSrliIn₆]
+      grind [OperationPtr.getProperties!_WfRewriter_createOp hSrli (operation := srliOp)]
+    have hSrliImm : BitVec.ofInt 6 (srliOp.getProperties! ctx₇.raw (.riscv .srli)).value.value
+        = BitVec.ofInt 6 32 := by rw [hSrliProps]
+    have hCBType : ((op.getResult 0).get! ctx₆.raw).type
+        = (⟨Attribute.integerType { bitwidth := 32 }, isT⟩ : TypeAttr) := by
+      have h1 := (Ecast.trans (E₁.trans (E₂.trans (E₃.trans (Erev8.trans Esrli))))).valueType
+        (ValuePtr.opResult (op.getResult 0)) hResIn
+      simpa only [ValuePtr.getType!_opResult, hResType] using h1
+    have hCastBackType : castBackOp.getOpType! ctx₇.raw = .builtin .unrealized_conversion_cast :=
+      by grind
+    have hCastBackOperands :
+        castBackOp.getOperands! ctx₇.raw = #[ValuePtr.opResult (srliOp.getResult 0)] := by grind
+    have hCastBackResTypes : castBackOp.getResultTypes! ctx₇.raw
+        = #[⟨Attribute.integerType { bitwidth := 32 }, isT⟩] := by grind
+    -- Execute the chain.
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := FS1.inBounds castOp hCastIn₁)
+        hCastType hCastOperands hCastResTypes hOpVal'
+    obtain ⟨sA, hRun1, hMemA, hX1Val⟩ :=
+      bitreverseStageLocal_run hOpIn₁ hSt1 FS2 hCastResIn₁ hRes₁ hOps1F
+    obtain ⟨sB, hRun2, hMemB, hX2Val⟩ :=
+      bitreverseStageLocal_run hOpIn₂ hSt2 FS3 hX1In₂ hX1Val hOps2F
+    obtain ⟨sC, hRun3, hMemC, hX3Val⟩ :=
+      bitreverseStageLocal_run hOpIn₃ hSt3 FS4 hX2In₃ hX2Val hOps3F
+    obtain ⟨sD, hIRev8, hMemD, hRev8Res, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := sC) (inBounds := FS5.inBounds rev8Op hRev8In₅)
+        (f := Data.RISCV.rev8) (fun _ _ _ _ => rfl) hRev8Type hRev8Operands hRev8ResTypes hX3Val
+    obtain ⟨sE, hISrli, hMemE, hSrliRes, -⟩ :=
+      interpretOp_riscv_srli_forward (state := sD) (inBounds := FS6.inBounds srliOp hSrliIn₆)
+        (k := BitVec.ofInt 6 32) hSrliType hSrliImm hSrliOperands hSrliResTypes hRev8Res
+    obtain ⟨sF, hICB, hMemF, hCBRes, -⟩ :=
+      interpretOp_castBack_forward (state := sE) (inBounds := hCBIn₇)
+        hCastBackType hCastBackOperands hCastBackResTypes hSrliRes
+    refine ⟨sF, ?_, by grind, ?_⟩
+    · simp [Array.toList_append, interpretOpList_append, interpretOpList_cons, hI₁, hRun1,
+        hRun2, hRun3, hIRev8, hISrli, hICB, liftM, monadLift, MonadLift.monadLift, Interp]
+    · refine ⟨#[RuntimeValue.int 32 (RISCV.Reg.toInt
+          (Data.RISCV.srli (BitVec.ofInt 6 32)
+            (Data.RISCV.rev8
+              (bitreverseStageReg 0x0f0f0f0f 4
+                (bitreverseStageReg 0x33333333 2
+                  (bitreverseStageReg 0x55555555 1 (LLVM.Int.toReg xt)))))) 32)], ?_, ?_⟩
+      · simp [hCBRes, Option.bind, Option.map]
+      · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+          ⟨rfl, by simpa using bitreverse_isRefinedBy_toInt_srli_rev8_swar hxtRef⟩
+
+/--
+info: 'Veir.bitreverse_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ bitreverse_isRefinedBy_toInt_rev8_swar._native.bv_decide.ax_1_6,
+ bitreverse_isRefinedBy_toInt_srli_rev8_swar._native.bv_decide.ax_1_6,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms bitreverse_local_preservesSemantics
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerByteBinaryW.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerByteBinaryW.lean
@@ -1,0 +1,969 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.LLVM.Byte.Lemmas
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Data.Casting
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonGraphLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerSelectBinopImm
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerTrunc
+
+namespace Veir
+
+/-!
+## Generic correctness of `lowerByteBinaryWLocal`
+
+`lowerByteBinaryWLocal match? op64 op32` lowers the two-operand LLVM shifts (`llvm.shl`,
+`llvm.lshr`) to `unrealized_conversion_cast` (each operand to a register) → `riscv` op (`op64`, or
+its `W` variant `op32` when the shifted value is 32 bits wide) → `unrealized_conversion_cast` (back
+to the source type).
+
+It differs from `lowerBinaryWLocal` in two ways, both stemming from `llvm.shl`/`llvm.lshr` being
+verified by `verifyLLVMShift` rather than `verifyIntegerBinop`:
+
+* the shifted operand (operand 0) may have *integer* **or** *byte* type — hence the two symmetric
+  branches below, and the two families of data-level refinement lemmas;
+* the shift amount (operand 1) is only known to be *some* integer; that its width agrees with
+  operand 0's is a *dynamic* fact, recovered from the successful source interpretation by
+  `matchShiftOp_interpretOp_unfold` (integer case) and `matchShiftOp_byteLhs_interpretOp_unfold`
+  (byte case), then `subst`ed.
+
+The RISC-V shift ops mask the shift amount to its low 5/6 bits while LLVM's shifts are poison for
+shift amounts `≥ w`, so the data-level refinement lemmas are trivial exactly on the branch where
+the source is poison.
+-/
+
+/-- The byte-operand analogue of `matchShiftOp_interpretOp_unfold`: unfold the interpretation of a
+    shift whose shifted operand (operand 0) has *byte* type and whose shift amount (operand 1) has
+    integer type. As in the integer case, the equality of the two operand widths is read out of the
+    successful interpretation via `hSemSrc` rather than assumed. -/
+theorem matchShiftOp_byteLhs_interpretOp_unfold {srcOp : Llvm} {ctx : WfIRContext OpCode}
+    {op : OperationPtr} {lhs rhs : ValuePtr} {props : propertiesOf (.llvm srcOp)}
+    {byteTy : LLVM.ByteType} {intType2 : IntegerType}
+    {shiftFn : ∀ {bw : Nat},
+      Data.LLVM.Byte bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) → Data.LLVM.Byte bw}
+    {state newState : InterpreterState ctx} {cf} (opInBounds : op.InBounds ctx.raw)
+    (hOpType : op.getOpType! ctx.raw = .llvm srcOp)
+    (hNumResults : op.getNumResults! ctx.raw = 1)
+    (hOperands : op.getOperands! ctx.raw = #[lhs, rhs])
+    (hProps : props = op.getProperties! ctx.raw (.llvm srcOp))
+    (hSemSrc : ∀ (bw bw' : Nat) (x : Data.LLVM.Byte bw) (y : Data.LLVM.Int bw')
+        (props : propertiesOf (.llvm srcOp)) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
+        Llvm.interpretOp' srcOp props resultTypes #[.byte bw x, .int bw' y] blockOperands mem
+          = some (.ok res) →
+        ∃ (h' : bw' = bw), res = (#[.byte bw (shiftFn x (h' ▸ y) props)], mem, none))
+    (hinterp : interpretOp op state opInBounds = some (.ok (newState, cf)))
+    (hLhsType : (lhs.getType! ctx.raw).val = Attribute.byteType byteTy)
+    (hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType2) :
+    ∃ (x : Data.LLVM.Byte byteTy.bitwidth) (y : Data.LLVM.Int intType2.bitwidth)
+      (h' : intType2.bitwidth = byteTy.bitwidth),
+      state.variables.getVar? lhs = some (RuntimeValue.byte byteTy.bitwidth x) ∧
+      state.variables.getVar? rhs = some (RuntimeValue.int intType2.bitwidth y) ∧
+      state.memory = newState.memory ∧
+      newState.variables.getVar? (op.getResult 0) =
+        some (RuntimeValue.byte byteTy.bitwidth (shiftFn x (h' ▸ y) props)) ∧
+      cf = none := by
+  have hNumOperands : op.getNumOperands! ctx.raw = 2 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize0 : 0 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  have hsize1 : 1 < (op.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨lval, hlval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize0
+  obtain ⟨rval, hrval⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 1 hsize1
+  have hlGetVar : state.variables.getVar? lhs = some lval := by
+    rw [hLhsEq, show (op.getOperands! ctx.raw)[0]! = (op.getOperands! ctx.raw)[0] from by grind]
+    exact hlval
+  have hrGetVar : state.variables.getVar? rhs = some rval := by
+    rw [hRhsEq, show (op.getOperands! ctx.raw)[1]! = (op.getOperands! ctx.raw)[1] from by grind]
+    exact hrval
+  have hlconf := VariableState.getVar?_conforms hlGetVar
+  rw [show lhs.getType! ctx.raw = ⟨.byteType byteTy, hLhsType ▸ (lhs.getType! ctx.raw).2⟩
+        from Subtype.ext hLhsType] at hlconf
+  obtain ⟨x, rfl⟩ := RuntimeValue.Conforms.byteType hlconf
+  have hrconf := VariableState.getVar?_conforms hrGetVar
+  rw [show rhs.getType! ctx.raw = ⟨.integerType intType2, hRhsType ▸ (rhs.getType! ctx.raw).2⟩
+        from Subtype.ext hRhsType] at hrconf
+  obtain ⟨y, rfl⟩ := RuntimeValue.Conforms.integerType hrconf
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues op
+      = some #[RuntimeValue.byte byteTy.bitwidth x, RuntimeValue.int intType2.bitwidth y] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    match i, hi with
+    | 0, _ => simpa [hOperand0] using hlGetVar
+    | 1, _ => simpa [hOperand1] using hrGetVar
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType] at hInterp'
+  simp only [← hProps, interpretOp'] at hInterp'
+  obtain ⟨h', hres⟩ := hSemSrc _ _ _ _ _ _ _ _ _ hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ :
+      resValues = #[RuntimeValue.byte byteTy.bitwidth (shiftFn x (h' ▸ y) props)] ∧
+      mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  refine ⟨x, y, h', hlGetVar, hrGetVar, rfl, ?_, rfl⟩
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
+set_option maxHeartbeats 4000000 in
+/-- Shared correctness proof for every `lowerByteBinaryWLocal` lowering.
+
+    Per-lowering inputs: the matcher's syntactic facts (`hMatchImplies`), the verifier fact
+    (`hVerified`, yielding the weak `IsVerifiedLLVMShift`), the interpreter computation facts for
+    the source op on integer and byte operands (`hSemSrcInt`/`hSemSrcByte`) and for the two riscv
+    ops (`hSemR64`/`hSemR32`), and the four data-level refinement lemmas. -/
+theorem lowerByteBinaryWLocal_preservesSemantics {srcOp : Llvm}
+    {match? : OperationPtr → IRContext OpCode →
+      Option (ValuePtr × ValuePtr × propertiesOf (.llvm srcOp))}
+    {op64 op32 : Riscv}
+    {props64 : propertiesOf (.riscv op64)} {props32 : propertiesOf (.riscv op32)}
+    {f64 f32 : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg}
+    {srcIntFn : ∀ {bw : Nat}, Data.LLVM.Int bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) →
+      Data.LLVM.Int bw}
+    {srcByteFn : ∀ {bw : Nat}, Data.LLVM.Byte bw → Data.LLVM.Int bw → propertiesOf (.llvm srcOp) →
+      Data.LLVM.Byte bw}
+    (hMatchImplies : ∀ {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs props},
+        match? op ctx = some (lhs, rhs, props) →
+        op.getOpType! ctx = .llvm srcOp ∧
+        op.getNumResults! ctx = 1 ∧
+        op.getOperands! ctx = #[lhs, rhs] ∧
+        props = op.getProperties! ctx (.llvm srcOp))
+    (hVerified : ∀ {ctx : WfIRContext OpCode} {op : OperationPtr}
+        {opInBounds : op.InBounds ctx.raw},
+        op.Verified ctx opInBounds → op.getOpType! ctx.raw = .llvm srcOp →
+        op.IsVerifiedLLVMShift ctx)
+    (hSemSrcInt : ∀ (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+        (props : propertiesOf (.llvm srcOp)) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
+        Llvm.interpretOp' srcOp props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+          = some (.ok res) →
+        ∃ (h' : bw' = bw), res = (#[.int bw (srcIntFn x (h' ▸ y) props)], mem, none))
+    (hSemSrcByte : ∀ (bw bw' : Nat) (x : Data.LLVM.Byte bw) (y : Data.LLVM.Int bw')
+        (props : propertiesOf (.llvm srcOp)) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (res : Array RuntimeValue × MemoryState × Option ControlFlowAction),
+        Llvm.interpretOp' srcOp props resultTypes #[.byte bw x, .int bw' y] blockOperands mem
+          = some (.ok res) →
+        ∃ (h' : bw' = bw), res = (#[.byte bw (srcByteFn x (h' ▸ y) props)], mem, none))
+    (hSemR64 : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op64)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' op64 props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f64 r₁ r₂)], mem, none)))
+    (hSemR32 : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf op32)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' op32 props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f32 r₁ r₂)], mem, none)))
+    (hRefineInt64 : ∀ (x y xt yt : Data.LLVM.Int 64) (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcIntFn x y props ⊒ RISCV.Reg.toInt (f64 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)
+    (hRefineInt32 : ∀ (x y xt yt : Data.LLVM.Int 32) (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcIntFn x y props ⊒ RISCV.Reg.toInt (f32 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 32)
+    (hRefineByte64 : ∀ (x xt : Data.LLVM.Byte 64) (y yt : Data.LLVM.Int 64)
+        (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcByteFn x y props ⊒ RISCV.Reg.toByte (f64 (LLVM.Byte.toReg xt) (LLVM.Int.toReg yt)) 64)
+    (hRefineByte32 : ∀ (x xt : Data.LLVM.Byte 32) (y yt : Data.LLVM.Int 32)
+        (props : propertiesOf (.llvm srcOp)),
+        x ⊒ xt → y ⊒ yt →
+        srcByteFn x y props ⊒ RISCV.Reg.toByte (f32 (LLVM.Byte.toReg xt) (LLVM.Int.toReg yt)) 32)
+    {h : LocalRewritePattern.ReturnOps (lowerByteBinaryWLocal match? op64 op32 props64 props32)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges
+      (lowerByteBinaryWLocal match? op64 op32 props64 props32)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds
+      (lowerByteBinaryWLocal match? op64 op32 props64 props32)}
+    {h₄ : LocalRewritePattern.ReturnValues
+      (lowerByteBinaryWLocal match? op64 op32 props64 props32)} :
+    LocalRewritePattern.PreservesSemantics
+      (lowerByteBinaryWLocal match? op64 op32 props64 props32) h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, lowerByteBinaryWLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [Option.bind_eq_bind, pure, Option.bind_eq_bind] at hpattern
+  -- Peel the matcher: only the `some` branch can reach the `some (...)` RHS.
+  have hMatchSome : (match? op ctx.raw).isSome := by
+    cases hM : match? op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨⟨lhs, rhs, props⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Syntactic and verification facts about the matched op.
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := hMatchImplies hMatch
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have opVerif : op.Verified ctx opInBounds := by grind
+  obtain ⟨hNRes, hNOper, hResEqOp0, intType2, hOp1Type⟩ := hVerified opVerif hOpType
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]; grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]; grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  -- The shift amount is *some* integer; its width is not yet pinned to `lhs`'s.
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType intType2 := by
+    rw [← hOperand1, hOp1Type]
+  -- The lowering only fires when `lhs` has integer or byte type; extract its width `bw`.
+  obtain ⟨bw, hbwEq⟩ : ∃ bw, getIntByteTypeBitwidth (lhs.getType! ctx.raw) = some bw := by
+    cases hg : getIntByteTypeBitwidth (lhs.getType! ctx.raw) with
+    | some b => exact ⟨b, rfl⟩
+    | none => rw [hg] at hpattern; simp at hpattern
+  rw [hbwEq] at hpattern
+  simp only [] at hpattern
+  -- The width guard must be false: `bw ∈ {64, 32}`.
+  peelSplittableCondition [hBw] hpattern
+  have hBwCases : bw = 64 ∨ bw = 32 := by omega
+  -- The matched operands dominate the rewrite point, and are not `op`'s results.
+  have hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have lNotOp : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have rNotOp : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  -- `lhs`'s declared type is either `i{bw}` or `byte{bw}`.
+  have hLhsTypeCases : (lhs.getType! ctx.raw).val = Attribute.integerType ⟨bw⟩ ∨
+      (lhs.getType! ctx.raw).val = Attribute.byteType ⟨bw⟩ := by
+    unfold getIntByteTypeBitwidth at hbwEq
+    split at hbwEq
+    · rename_i it hit; left; grind
+    · rename_i bt hbt; right; grind
+    · simp at hbwEq
+  rcases hLhsTypeCases with hLhsType | hLhsType
+  · -- Integer-typed shifted operand.
+    have hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨bw⟩ := by
+      rw [hResEqOp0, hOperand0, hLhsType]
+    obtain ⟨xVal, yVal, hWEq, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+      matchShiftOp_interpretOp_unfold (shiftFn := srcIntFn) opInBounds hOpType hNumResults hOperands
+        hProps hSemSrcInt hinterp hLhsType hRhsType
+    subst hCf
+    -- The shift amount's width equals `bw`: normalise it away.
+    obtain ⟨w2⟩ := intType2
+    simp only at hWEq hyVal hRhsType
+    subst hWEq
+    rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+      at hsourceValues
+    simp at hsourceValues
+    simp [hRes] at hsourceValues
+    subst sourceValues
+    peelCastToRegLocal₂ hpattern ctx₁ lcastOp hLCast hDomCtxL hDomL₁ hDomCtxR hDomR₁
+    peelCastToRegLocal₂ hpattern ctx₂ rcastOp hRCast hDomL₁ hDomL₂ hDomR₁ hDomR₂
+    have hLCastFresh : ¬ lcastOp.InBounds ctx.raw :=
+      WfRewriter.createOp_new_not_inBounds lcastOp hLCast
+    have hRhsIn : rhs.InBounds ctx.raw := by clear hpattern; grind
+    have hRhsNeLCastRes : ∀ i, rhs ≠ ValuePtr.opResult (lcastOp.getResult i) := by
+      intro i heq
+      rw [heq] at hRhsIn
+      rw [ValuePtr.inBounds_opResult] at hRhsIn
+      obtain ⟨hIn, -⟩ := hRhsIn
+      exact hLCastFresh hIn
+    have hLCastNeRCast : lcastOp ≠ rcastOp := by clear hpattern; grind
+    rcases hBwCases with hbw | hbw
+    · -- `i64`, lowered to `op64`.
+      rw [if_neg (show ¬w2 = 32 by omega)] at hpattern
+      simp only [] at hpattern
+      peelOpCreation!₂ hpattern ctx₃ retOp hRet hDomL₂ hDomL₃ hDomR₂ hDomR₃
+      peelReplaceWithRegLocal₂ hpattern ctx₄ castBackOp hCastBack hDomL₃ hDomL₄ hDomR₃ hDomR₄
+      cleanupHpattern hpattern
+      obtain ⟨xt, hLVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+          hDomCtxL hDomL₄ lNotOp
+      obtain ⟨yt, hRVal', hytRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+          hDomCtxR hDomR₄ rNotOp
+      subst hbw
+      have hLCastType : lcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRCastType : rcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRetType : retOp.getOpType! ctx₄.raw = .riscv op64 := by grind
+      have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hLCastOperands : lcastOp.getOperands! ctx₄.raw = #[lhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastOperands : rcastOp.getOperands! ctx₄.raw = #[rhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetOperands : retOp.getOperands! ctx₄.raw
+          = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+      have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+          = (⟨Attribute.integerType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+        have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+            = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+          grind [ValuePtr.getType!_WfRewriter_createOp hRet
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hRCast
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hLCast
+              (value := ValuePtr.opResult (op.getResult 0))]
+        rw [ValuePtr.getType!_opResult, ValuePtr.getType!_opResult] at h1
+        rw [h1]; exact Subtype.ext hResType
+      have hLCastResTypes : lcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastResTypes : rcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.integerType { bitwidth := 64 }, by grind⟩] := by grind
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+        interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+          hLCastType hLCastOperands hLCastResTypes hLVal'
+      have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw rhs lcastOp
+          with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (hRhsNeLCastRes i)
+      have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 64 yt) := by
+        rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+        interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+          hRCastType hRCastOperands hRCastResTypes hRVal₁
+      have hLCastNotRCastRes :
+          ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+            (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (by grind [OperationPtr.getResult])
+      have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+          = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+        rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+      obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+        interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+          (f := f64) (hSemR64 _ _) hRetType hRetOperands hRetResTypes hLRes₂ hRes₂
+      obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+        interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+      refine ⟨s₄, ?_, by grind, ?_⟩
+      · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+          Interp]
+      · refine ⟨#[RuntimeValue.int 64
+            (RISCV.Reg.toInt (f64 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 64)], ?_, ?_⟩
+        · simp [hRes₄, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+            ⟨rfl, by simpa using hRefineInt64 xVal yVal xt yt props hxtRef hytRef⟩
+    · -- `i32`, lowered to `op32`.
+      rw [if_pos hbw] at hpattern
+      simp only [] at hpattern
+      peelOpCreation!₂ hpattern ctx₃ retOp hRet hDomL₂ hDomL₃ hDomR₂ hDomR₃
+      peelReplaceWithRegLocal₂ hpattern ctx₄ castBackOp hCastBack hDomL₃ hDomL₄ hDomR₃ hDomR₄
+      cleanupHpattern hpattern
+      obtain ⟨xt, hLVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hxVal
+          hDomCtxL hDomL₄ lNotOp
+      obtain ⟨yt, hRVal', hytRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+          hDomCtxR hDomR₄ rNotOp
+      subst hbw
+      have hLCastType : lcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRCastType : rcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRetType : retOp.getOpType! ctx₄.raw = .riscv op32 := by grind
+      have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hLCastOperands : lcastOp.getOperands! ctx₄.raw = #[lhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastOperands : rcastOp.getOperands! ctx₄.raw = #[rhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetOperands : retOp.getOperands! ctx₄.raw
+          = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+      have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+          = (⟨Attribute.integerType { bitwidth := 32 }, by grind⟩ : TypeAttr) := by
+        have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+            = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+          grind [ValuePtr.getType!_WfRewriter_createOp hRet
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hRCast
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hLCast
+              (value := ValuePtr.opResult (op.getResult 0))]
+        rw [ValuePtr.getType!_opResult, ValuePtr.getType!_opResult] at h1
+        rw [h1]; exact Subtype.ext hResType
+      have hLCastResTypes : lcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastResTypes : rcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.integerType { bitwidth := 32 }, by grind⟩] := by grind
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+        interpretOp_castToReg_forward (state := state') (inBounds := by grind)
+          hLCastType hLCastOperands hLCastResTypes hLVal'
+      have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw rhs lcastOp
+          with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (hRhsNeLCastRes i)
+      have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 32 yt) := by
+        rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+        interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+          hRCastType hRCastOperands hRCastResTypes hRVal₁
+      have hLCastNotRCastRes :
+          ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+            (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (by grind [OperationPtr.getResult])
+      have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+          = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+        rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+      obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+        interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+          (f := f32) (hSemR32 _ _) hRetType hRetOperands hRetResTypes hLRes₂ hRes₂
+      obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+        interpretOp_castBack_forward (state := s₃) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+      refine ⟨s₄, ?_, by grind, ?_⟩
+      · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+          Interp]
+      · refine ⟨#[RuntimeValue.int 32
+            (RISCV.Reg.toInt (f32 (LLVM.Int.toReg xt) (LLVM.Int.toReg yt)) 32)], ?_, ?_⟩
+        · simp [hRes₄, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+            ⟨rfl, by simpa using hRefineInt32 xVal yVal xt yt props hxtRef hytRef⟩
+  · -- Byte-typed shifted operand: same chain, but the outer casts go through `Byte.toReg` /
+    -- `Reg.toByte`, and the cast-back's result type is a `byteType`.
+    have hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.byteType ⟨bw⟩ := by
+      rw [hResEqOp0, hOperand0, hLhsType]
+    obtain ⟨xVal, yVal, hWEq, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+      matchShiftOp_byteLhs_interpretOp_unfold (shiftFn := srcByteFn) opInBounds hOpType hNumResults
+        hOperands hProps hSemSrcByte hinterp hLhsType hRhsType
+    subst hCf
+    obtain ⟨w2⟩ := intType2
+    simp only at hWEq hyVal hRhsType
+    subst hWEq
+    rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+      at hsourceValues
+    simp at hsourceValues
+    simp [hRes] at hsourceValues
+    subst sourceValues
+    peelCastToRegLocal₂ hpattern ctx₁ lcastOp hLCast hDomCtxL hDomL₁ hDomCtxR hDomR₁
+    peelCastToRegLocal₂ hpattern ctx₂ rcastOp hRCast hDomL₁ hDomL₂ hDomR₁ hDomR₂
+    have hLCastFresh : ¬ lcastOp.InBounds ctx.raw :=
+      WfRewriter.createOp_new_not_inBounds lcastOp hLCast
+    have hRhsIn : rhs.InBounds ctx.raw := by clear hpattern; grind
+    have hRhsNeLCastRes : ∀ i, rhs ≠ ValuePtr.opResult (lcastOp.getResult i) := by
+      intro i heq
+      rw [heq] at hRhsIn
+      rw [ValuePtr.inBounds_opResult] at hRhsIn
+      obtain ⟨hIn, -⟩ := hRhsIn
+      exact hLCastFresh hIn
+    have hLCastNeRCast : lcastOp ≠ rcastOp := by clear hpattern; grind
+    rcases hBwCases with hbw | hbw
+    · -- `byte 64`, lowered to `op64`.
+      rw [if_neg (show ¬w2 = 32 by omega)] at hpattern
+      simp only [] at hpattern
+      peelOpCreation!₂ hpattern ctx₃ retOp hRet hDomL₂ hDomL₃ hDomR₂ hDomR₃
+      peelReplaceWithRegLocal₂ hpattern ctx₄ castBackOp hCastBack hDomL₃ hDomL₄ hDomR₃ hDomR₄
+      cleanupHpattern hpattern
+      obtain ⟨xt, hLVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_byte_getVar? valueRefinement state'Dom (by grind) hxVal
+          hDomCtxL hDomL₄ lNotOp
+      obtain ⟨yt, hRVal', hytRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+          hDomCtxR hDomR₄ rNotOp
+      subst hbw
+      have hLCastType : lcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRCastType : rcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRetType : retOp.getOpType! ctx₄.raw = .riscv op64 := by grind
+      have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hLCastOperands : lcastOp.getOperands! ctx₄.raw = #[lhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastOperands : rcastOp.getOperands! ctx₄.raw = #[rhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetOperands : retOp.getOperands! ctx₄.raw
+          = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+      have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+          = (⟨Attribute.byteType { bitwidth := 64 }, by grind⟩ : TypeAttr) := by
+        have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+            = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+          grind [ValuePtr.getType!_WfRewriter_createOp hRet
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hRCast
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hLCast
+              (value := ValuePtr.opResult (op.getResult 0))]
+        rw [ValuePtr.getType!_opResult, ValuePtr.getType!_opResult] at h1
+        rw [h1]; exact Subtype.ext hResType
+      have hLCastResTypes : lcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastResTypes : rcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.byteType { bitwidth := 64 }, by grind⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack
+          (operation := castBackOp)]
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+        interpretOp_castToReg_byte_forward (state := state') (inBounds := by grind)
+          hLCastType hLCastOperands hLCastResTypes hLVal'
+      have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw rhs lcastOp
+          with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (hRhsNeLCastRes i)
+      have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 64 yt) := by
+        rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+        interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+          hRCastType hRCastOperands hRCastResTypes hRVal₁
+      have hLCastNotRCastRes :
+          ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+            (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (by grind [OperationPtr.getResult])
+      have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+          = some (RuntimeValue.reg (LLVM.Byte.toReg xt)) := by
+        rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+      obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+        interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+          (f := f64) (hSemR64 _ _) hRetType hRetOperands hRetResTypes hLRes₂ hRes₂
+      obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+        interpretOp_castBack_byte_forward (state := s₃) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+      refine ⟨s₄, ?_, by grind, ?_⟩
+      · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+          Interp]
+      · refine ⟨#[RuntimeValue.byte 64
+            (RISCV.Reg.toByte (f64 (LLVM.Byte.toReg xt) (LLVM.Int.toReg yt)) 64)], ?_, ?_⟩
+        · simp [hRes₄, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+            ⟨rfl, by simpa using hRefineByte64 xVal xt yVal yt props hxtRef hytRef⟩
+    · -- `byte 32`, lowered to `op32`.
+      rw [if_pos hbw] at hpattern
+      simp only [] at hpattern
+      peelOpCreation!₂ hpattern ctx₃ retOp hRet hDomL₂ hDomL₃ hDomR₂ hDomR₃
+      peelReplaceWithRegLocal₂ hpattern ctx₄ castBackOp hCastBack hDomL₃ hDomL₄ hDomR₃ hDomR₄
+      cleanupHpattern hpattern
+      obtain ⟨xt, hLVal', hxtRef⟩ :=
+        LocalRewritePattern.exists_refined_byte_getVar? valueRefinement state'Dom (by grind) hxVal
+          hDomCtxL hDomL₄ lNotOp
+      obtain ⟨yt, hRVal', hytRef⟩ :=
+        LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom (by grind) hyVal
+          hDomCtxR hDomR₄ rNotOp
+      subst hbw
+      have hLCastType : lcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRCastType : rcastOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hRetType : retOp.getOpType! ctx₄.raw = .riscv op32 := by grind
+      have hCastBackType : castBackOp.getOpType! ctx₄.raw = .builtin .unrealized_conversion_cast := by
+        grind
+      have hLCastOperands : lcastOp.getOperands! ctx₄.raw = #[lhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastOperands : rcastOp.getOperands! ctx₄.raw = #[rhs] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetOperands : retOp.getOperands! ctx₄.raw
+          = #[ValuePtr.opResult (lcastOp.getResult 0), ValuePtr.opResult (rcastOp.getResult 0)] := by
+        grind [OperationPtr.getOperands!_WfRewriter_createOp hRet (operation := retOp),
+          OperationPtr.getOperands!_WfRewriter_createOp hCastBack (operation := retOp)]
+      have hCastBackOperands :
+          castBackOp.getOperands! ctx₄.raw = #[ValuePtr.opResult (retOp.getResult 0)] := by grind
+      have hCBType : ((op.getResult 0).get! ctx₃.raw).type
+          = (⟨Attribute.byteType { bitwidth := 32 }, by grind⟩ : TypeAttr) := by
+        have h1 : (ValuePtr.opResult (op.getResult 0)).getType! ctx₃.raw
+            = (ValuePtr.opResult (op.getResult 0)).getType! ctx.raw := by
+          grind [ValuePtr.getType!_WfRewriter_createOp hRet
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hRCast
+              (value := ValuePtr.opResult (op.getResult 0)),
+            ValuePtr.getType!_WfRewriter_createOp hLCast
+              (value := ValuePtr.opResult (op.getResult 0))]
+        rw [ValuePtr.getType!_opResult, ValuePtr.getType!_opResult] at h1
+        rw [h1]; exact Subtype.ext hResType
+      have hLCastResTypes : lcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hLCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := lcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := lcastOp)]
+      have hRCastResTypes : rcastOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hRCast (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := rcastOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := rcastOp)]
+      have hRetResTypes : retOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack (operation := retOp),
+          OperationPtr.getResultTypes!_WfRewriter_createOp hRet (operation := retOp)]
+      have hCastBackResTypes : castBackOp.getResultTypes! ctx₄.raw
+          = #[⟨Attribute.byteType { bitwidth := 32 }, by grind⟩] := by
+        grind [OperationPtr.getResultTypes!_WfRewriter_createOp hCastBack
+          (operation := castBackOp)]
+      obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+        interpretOp_castToReg_byte_forward (state := state') (inBounds := by grind)
+          hLCastType hLCastOperands hLCastResTypes hLVal'
+      have hRhsNotLCastRes : rhs ∉ lcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw rhs lcastOp
+          with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (hRhsNeLCastRes i)
+      have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int 32 yt) := by
+        rw [hFrame₁ rhs hRhsNotLCastRes]; exact hRVal'
+      obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+        interpretOp_castToReg_forward (state := s₁) (inBounds := by grind)
+          hRCastType hRCastOperands hRCastResTypes hRVal₁
+      have hLCastNotRCastRes :
+          ValuePtr.opResult (lcastOp.getResult 0) ∉ rcastOp.getResults! ctx₄.raw := by
+        rcases OperationPtr.getResults!_not_mem_or_eq_getResult ctx₄.raw
+            (ValuePtr.opResult (lcastOp.getResult 0)) rcastOp with hres | ⟨i, hi, heq⟩
+        · exact hres
+        · exact absurd heq (by grind [OperationPtr.getResult])
+      have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+          = some (RuntimeValue.reg (LLVM.Byte.toReg xt)) := by
+        rw [hFrame₂ _ hLCastNotRCastRes]; exact hRes₁
+      obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+        interpretOp_riscv_binaryReg_forward (state := s₂) (inBounds := by grind)
+          (f := f32) (hSemR32 _ _) hRetType hRetOperands hRetResTypes hLRes₂ hRes₂
+      obtain ⟨s₄, hI₄, hMem₄, hRes₄, -⟩ :=
+        interpretOp_castBack_byte_forward (state := s₃) (inBounds := by grind)
+          hCastBackType hCastBackOperands hCastBackResTypes hRes₃
+      refine ⟨s₄, ?_, by grind, ?_⟩
+      · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, liftM, monadLift, MonadLift.monadLift,
+          Interp]
+      · refine ⟨#[RuntimeValue.byte 32
+            (RISCV.Reg.toByte (f32 (LLVM.Byte.toReg xt) (LLVM.Int.toReg yt)) 32)], ?_, ?_⟩
+        · simp [hRes₄, Option.bind, Option.map]
+        · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+            ⟨rfl, by simpa using hRefineByte32 xVal xt yVal yt props hxtRef hytRef⟩
+
+/-!
+## RISC-V lowering of `llvm.shl`
+
+`llvm.shl` on 64- or 32-bit integers *or bytes* is lowered to `riscv.sll`/`riscv.sllw`. The RISC-V
+shift masks the shift amount to its low 6 (resp. 5) bits while `llvm.shl` is poison as soon as the
+shift amount reaches the bitwidth, so the two agree exactly on the branch where the source is not
+poison. The byte lowering additionally *drops* the operand's per-bit poison mask when the byte is
+moved into a register; this is sound because the source's own result mask only ever marks bits the
+refinement ignores, and the value bits agree wherever the source is not poison.
+-/
+
+/-- The `shl` source-interpretation fact on *integer* operands: a successful interpretation forces
+    the two operand widths to agree, and computes `Int.shl`. -/
+private theorem shl_shiftSemInt (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+    (props : propertiesOf (.llvm .shl)) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState)
+    (res : Array RuntimeValue × MemoryState × Option ControlFlowAction)
+    (h : Llvm.interpretOp' .shl props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+      = some (.ok res)) :
+    ∃ (h' : bw' = bw),
+      res = (#[.int bw (Data.LLVM.Int.shl x (h' ▸ y) props.nsw props.nuw)], mem, none) := by
+  simp only [Llvm.interpretOp'] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hbw
+    obtain rfl : bw' = bw := by omega
+    refine ⟨rfl, ?_⟩
+    simp only [Data.LLVM.Int.cast_self, pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h
+    grind
+
+/-- The `shl` source-interpretation fact on *byte* operands. Besides the width guard, the byte arm of
+    the interpreter refuses to run when `nsw` is set, which makes the hypothesis vacuous there. -/
+private theorem shl_shiftSemByte (bw bw' : Nat) (x : Data.LLVM.Byte bw) (y : Data.LLVM.Int bw')
+    (props : propertiesOf (.llvm .shl)) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState)
+    (res : Array RuntimeValue × MemoryState × Option ControlFlowAction)
+    (h : Llvm.interpretOp' .shl props resultTypes #[.byte bw x, .int bw' y] blockOperands mem
+      = some (.ok res)) :
+    ∃ (h' : bw' = bw),
+      res = (#[.byte bw (Data.LLVM.Byte.shl x (h' ▸ y) props.nuw)], mem, none) := by
+  simp only [Llvm.interpretOp'] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hbw
+    obtain rfl : bw' = bw := by omega
+    split at h
+    · exact absurd h (by simp)
+    refine ⟨rfl, ?_⟩
+    simp only [Data.LLVM.Int.cast_self, pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h
+    grind
+
+/-- Correctness of the `riscv.sll` lowering of a 64-bit integer `llvm.shl`. -/
+theorem shl_isRefinedBy_toInt_sll {x y xt yt : Data.LLVM.Int 64} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.shl x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  revert h₁ h₂
+  veir_bv_decide
+
+/-- Correctness of the `riscv.sllw` lowering of a 32-bit integer `llvm.shl`. -/
+theorem shl_isRefinedBy_toInt_sllw {x y xt yt : Data.LLVM.Int 32} (nsw nuw : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.shl x y nsw nuw
+      ⊒ RISCV.Reg.toInt (Data.RISCV.sllw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  revert h₁ h₂
+  veir_bv_decide
+
+/-- Correctness of the `riscv.sll` lowering of a 64-bit byte `llvm.shl`. -/
+theorem shl_isRefinedBy_toByte_sll {x xt : Data.LLVM.Byte 64} {y yt : Data.LLVM.Int 64}
+    (nuw : Bool) (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Byte.shl x y nuw
+      ⊒ RISCV.Reg.toByte (Data.RISCV.sll (LLVM.Int.toReg yt) (LLVM.Byte.toReg xt)) 64 := by
+  revert h₁ h₂
+  simp only [RISCV.Reg.toByte, LLVM.Byte.toReg]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.sllw` lowering of a 32-bit byte `llvm.shl`. -/
+theorem shl_isRefinedBy_toByte_sllw {x xt : Data.LLVM.Byte 32} {y yt : Data.LLVM.Int 32}
+    (nuw : Bool) (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Byte.shl x y nuw
+      ⊒ RISCV.Reg.toByte (Data.RISCV.sllw (LLVM.Int.toReg yt) (LLVM.Byte.toReg xt)) 32 := by
+  revert h₁ h₂
+  simp only [RISCV.Reg.toByte, LLVM.Byte.toReg]
+  veir_bv_decide
+
+theorem shl_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics shl_local h h₂ h₃ h₄ :=
+  lowerByteBinaryWLocal_preservesSemantics
+    (srcOp := .shl)
+    (srcIntFn := fun x y props => Data.LLVM.Int.shl x y props.nsw props.nuw)
+    (srcByteFn := fun x y props => Data.LLVM.Byte.shl x y props.nuw)
+    (f64 := fun r₁ r₂ => Data.RISCV.sll r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.sllw r₂ r₁)
+    matchShl_implies
+    OperationPtr.Verified.llvm_shl
+    shl_shiftSemInt
+    shl_shiftSemByte
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => shl_isRefinedBy_toInt_sll props.nsw props.nuw h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => shl_isRefinedBy_toInt_sllw props.nsw props.nuw h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => shl_isRefinedBy_toByte_sll props.nuw h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => shl_isRefinedBy_toByte_sllw props.nuw h₁ h₂)
+
+/-!
+## RISC-V lowering of `llvm.lshr`
+
+`llvm.lshr` lowers to `riscv.srl`/`riscv.srlw`. `castToRegLocal` holds the operand *zero*-extended
+in the 64-bit register, so the low bits already carry the value and the word variant `srlw` reads
+exactly those in the 32-bit case.
+-/
+
+/-- The `lshr` source-interpretation fact on *integer* operands. -/
+private theorem lshr_shiftSemInt (bw bw' : Nat) (x : Data.LLVM.Int bw) (y : Data.LLVM.Int bw')
+    (props : propertiesOf (.llvm .lshr)) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState)
+    (res : Array RuntimeValue × MemoryState × Option ControlFlowAction)
+    (h : Llvm.interpretOp' .lshr props resultTypes #[.int bw x, .int bw' y] blockOperands mem
+      = some (.ok res)) :
+    ∃ (h' : bw' = bw),
+      res = (#[.int bw (Data.LLVM.Int.lshr x (h' ▸ y) props.exact)], mem, none) := by
+  simp only [Llvm.interpretOp'] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hbw
+    obtain rfl : bw' = bw := by omega
+    refine ⟨rfl, ?_⟩
+    simp only [Data.LLVM.Int.cast_self, pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h
+    grind
+
+/-- The `lshr` source-interpretation fact on *byte* operands. -/
+private theorem lshr_shiftSemByte (bw bw' : Nat) (x : Data.LLVM.Byte bw) (y : Data.LLVM.Int bw')
+    (props : propertiesOf (.llvm .lshr)) (resultTypes : Array TypeAttr)
+    (blockOperands : Array BlockPtr) (mem : MemoryState)
+    (res : Array RuntimeValue × MemoryState × Option ControlFlowAction)
+    (h : Llvm.interpretOp' .lshr props resultTypes #[.byte bw x, .int bw' y] blockOperands mem
+      = some (.ok res)) :
+    ∃ (h' : bw' = bw),
+      res = (#[.byte bw (Data.LLVM.Byte.lshr x (h' ▸ y) props.exact)], mem, none) := by
+  simp only [Llvm.interpretOp'] at h
+  split at h
+  · exact absurd h (by simp)
+  · rename_i hbw
+    obtain rfl : bw' = bw := by omega
+    refine ⟨rfl, ?_⟩
+    simp only [Data.LLVM.Int.cast_self, pure, Interp, Option.some.injEq, UBOr.ok.injEq] at h
+    grind
+
+/-- Correctness of the `riscv.srl` lowering of a 64-bit integer `llvm.lshr`. -/
+theorem lshr_isRefinedBy_toInt_srl {x y xt yt : Data.LLVM.Int 64} (exact : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.lshr x y exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.srl (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 64 := by
+  revert h₁ h₂
+  veir_bv_decide
+
+/-- Correctness of the `riscv.srlw` lowering of a 32-bit integer `llvm.lshr`. -/
+theorem lshr_isRefinedBy_toInt_srlw {x y xt yt : Data.LLVM.Int 32} (exact : Bool)
+    (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Int.lshr x y exact
+      ⊒ RISCV.Reg.toInt (Data.RISCV.srlw (LLVM.Int.toReg yt) (LLVM.Int.toReg xt)) 32 := by
+  revert h₁ h₂
+  veir_bv_decide
+
+/-- Correctness of the `riscv.srl` lowering of a 64-bit byte `llvm.lshr`. -/
+theorem lshr_isRefinedBy_toByte_srl {x xt : Data.LLVM.Byte 64} {y yt : Data.LLVM.Int 64}
+    (exact : Bool) (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Byte.lshr x y exact
+      ⊒ RISCV.Reg.toByte (Data.RISCV.srl (LLVM.Int.toReg yt) (LLVM.Byte.toReg xt)) 64 := by
+  revert h₁ h₂
+  simp only [RISCV.Reg.toByte, LLVM.Byte.toReg]
+  veir_bv_decide
+
+/-- Correctness of the `riscv.srlw` lowering of a 32-bit byte `llvm.lshr`. -/
+theorem lshr_isRefinedBy_toByte_srlw {x xt : Data.LLVM.Byte 32} {y yt : Data.LLVM.Int 32}
+    (exact : Bool) (h₁ : x ⊒ xt) (h₂ : y ⊒ yt) :
+    Data.LLVM.Byte.lshr x y exact
+      ⊒ RISCV.Reg.toByte (Data.RISCV.srlw (LLVM.Int.toReg yt) (LLVM.Byte.toReg xt)) 32 := by
+  revert h₁ h₂
+  simp only [RISCV.Reg.toByte, LLVM.Byte.toReg]
+  veir_bv_decide
+
+theorem lshr_local_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics lshr_local h h₂ h₃ h₄ :=
+  lowerByteBinaryWLocal_preservesSemantics
+    (srcOp := .lshr)
+    (srcIntFn := fun x y props => Data.LLVM.Int.lshr x y props.exact)
+    (srcByteFn := fun x y props => Data.LLVM.Byte.lshr x y props.exact)
+    (f64 := fun r₁ r₂ => Data.RISCV.srl r₂ r₁)
+    (f32 := fun r₁ r₂ => Data.RISCV.srlw r₂ r₁)
+    matchLshr_implies
+    OperationPtr.Verified.llvm_lshr
+    lshr_shiftSemInt
+    lshr_shiftSemByte
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ _ _ => rfl)
+    (fun _ _ _ _ props h₁ h₂ => lshr_isRefinedBy_toInt_srl props.exact h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => lshr_isRefinedBy_toInt_srlw props.exact h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => lshr_isRefinedBy_toByte_srl props.exact h₁ h₂)
+    (fun _ _ _ _ props h₁ h₂ => lshr_isRefinedBy_toByte_srlw props.exact h₁ h₂)
+
+/--
+info: 'Veir.shl_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ shl_isRefinedBy_toByte_sll._native.bv_decide.ax_1_5,
+ shl_isRefinedBy_toByte_sllw._native.bv_decide.ax_1_5,
+ shl_isRefinedBy_toInt_sll._native.bv_decide.ax_1_5,
+ shl_isRefinedBy_toInt_sllw._native.bv_decide.ax_1_5,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms shl_local_preservesSemantics
+
+/--
+info: 'Veir.lshr_local_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominates_refl,
+ OperationPtr.satisfyInvariants_of_IRContext_satisfyOpInvariants,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ lshr_isRefinedBy_toByte_srl._native.bv_decide.ax_1_5,
+ lshr_isRefinedBy_toByte_srlw._native.bv_decide.ax_1_5,
+ lshr_isRefinedBy_toInt_srl._native.bv_decide.ax_1_5,
+ lshr_isRefinedBy_toInt_srlw._native.bv_decide.ax_1_5,
+ MemoryState.llvmLoad._native.bv_decide.ax_8]
+-/
+#guard_msgs in
+#print axioms lshr_local_preservesSemantics
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/LowerIcmp.lean
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/LowerIcmp.lean
@@ -1,0 +1,1584 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.LLVM.Int.Lemmas
+import Veir.Data.LLVM.Int.Bitblast
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Data.Refinement
+import Veir.Passes.InstructionSelection.Proofs
+import Veir.Passes.InstructionSelection.RISCV64
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonGraphLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerConst
+import Veir.Passes.InstructionSelection.RewriteProofs.LowerSlti
+
+namespace Veir
+
+/-!
+## Correctness of `icmp_local`
+
+`icmp_local` lowers `llvm.icmp` on `i64`/`i32`/`i8` operands to a RISC-V comparison sequence. Every
+arm shares the prologue `icmpCastExtLocal` (cast both operands into registers, sign-extending them
+for the narrow widths) and the epilogue `replaceWithRegLocal` (cast the `i1` result back); the five
+possible comparison sequences in between are the `icmpEmit*Local` combinators.
+
+The proof mirrors that factoring:
+
+* `icmpCastExtLocal_mono` transports in-bounds, type and dominance facts across the prologue's
+  creations, and `icmpCastExtLocal_run` symbolically executes the prologue, producing the two
+  comparison registers `e (toReg xt)` / `e (toReg yt)` for refinements `xt`/`yt` of the source
+  operands. Both are stated against an arbitrary *final* context `F` reached from the prologue's
+  context by further creations, which the caller supplies as generic transport hypotheses
+  (`hTransOp`/`hTransDom`) — this is what lets the prologue be proven once instead of once per arm.
+* One `icmpEmit*Local_sound` lemma per comparison sequence peels its own creations, discharges the
+  transport hypotheses from them, replays the prologue through `interpretOpList_append`, and then
+  executes its own ops.
+* `icmp_local_preservesSemantics` peels the matcher and the width guards and dispatches the twelve
+  predicate arms onto those five lemmas, each with its data-level refinement lemma.
+-/
+
+
+/-! ### Context extension
+
+Every arm creates its operations on top of the prologue's context `ctxP`, so the prologue's
+structural facts have to be transported into the arm's final context. `CtxExtends op ctx ctx'`
+bundles exactly what a chain of `WfRewriter.createOp`s preserves, and is closed under composition;
+this is what lets the prologue be proven once, against an arbitrary final context, instead of once
+per arm. -/
+
+/-- The facts preserved when `ctx'` is reached from `ctx` by creating fresh (detached) operations:
+    everything already in bounds keeps its in-bounds status, opcode, operands, result types, value
+    types, and its dominance of the program point before `op`. -/
+structure CtxExtends (op : OperationPtr) (ctx ctx' : WfIRContext OpCode) : Prop where
+  /-- Pre-existing operations stay in bounds. -/
+  inBounds : ∀ o : OperationPtr, o.InBounds ctx.raw → o.InBounds ctx'.raw
+  /-- Pre-existing operations keep their opcode. -/
+  opType : ∀ o : OperationPtr, o.InBounds ctx.raw → o.getOpType! ctx'.raw = o.getOpType! ctx.raw
+  /-- Pre-existing operations keep their operands. -/
+  operands : ∀ o : OperationPtr, o.InBounds ctx.raw →
+    o.getOperands! ctx'.raw = o.getOperands! ctx.raw
+  /-- Pre-existing operations keep their result types. -/
+  resultTypes : ∀ o : OperationPtr, o.InBounds ctx.raw →
+    o.getResultTypes! ctx'.raw = o.getResultTypes! ctx.raw
+  /-- Pre-existing operations keep their properties (at every opcode). -/
+  properties : ∀ o : OperationPtr, o.InBounds ctx.raw → ∀ oc : OpCode,
+    o.getProperties! ctx'.raw oc = o.getProperties! ctx.raw oc
+  /-- Pre-existing values stay in bounds. -/
+  valueInBounds : ∀ v : ValuePtr, v.InBounds ctx.raw → v.InBounds ctx'.raw
+  /-- Pre-existing values keep their type. -/
+  valueType : ∀ v : ValuePtr, v.InBounds ctx.raw → v.getType! ctx'.raw = v.getType! ctx.raw
+  /-- Dominance of the rewrite point is preserved. -/
+  dominates : ∀ v : ValuePtr, v.dominatesIp (InsertPoint.before op) ctx →
+    v.dominatesIp (InsertPoint.before op) ctx'
+
+theorem CtxExtends.refl {op : OperationPtr} {ctx : WfIRContext OpCode} : CtxExtends op ctx ctx :=
+  ⟨fun _ h => h, fun _ _ => rfl, fun _ _ => rfl, fun _ _ => rfl, fun _ _ _ => rfl, fun _ h => h,
+    fun _ _ => rfl, fun _ h => h⟩
+
+theorem CtxExtends.trans {op : OperationPtr} {ctx ctx' ctx'' : WfIRContext OpCode}
+    (h₁ : CtxExtends op ctx ctx') (h₂ : CtxExtends op ctx' ctx'') : CtxExtends op ctx ctx'' where
+  inBounds o ho := h₂.inBounds o (h₁.inBounds o ho)
+  opType o ho := by rw [h₂.opType o (h₁.inBounds o ho), h₁.opType o ho]
+  operands o ho := by rw [h₂.operands o (h₁.inBounds o ho), h₁.operands o ho]
+  resultTypes o ho := by rw [h₂.resultTypes o (h₁.inBounds o ho), h₁.resultTypes o ho]
+  properties o ho oc := by rw [h₂.properties o (h₁.inBounds o ho) oc, h₁.properties o ho oc]
+  valueInBounds v hv := h₂.valueInBounds v (h₁.valueInBounds v hv)
+  valueType v hv := by rw [h₂.valueType v (h₁.valueInBounds v hv), h₁.valueType v hv]
+  dominates v hd := h₂.dominates v (h₁.dominates v hd)
+
+/-- Creating one fresh operation extends the context. -/
+theorem CtxExtends.of_createOp {ctx ctx' : WfIRContext OpCode} {op newOp : OperationPtr}
+    {opType : OpCode} {resultTypes operands blockOperands regions}
+    {properties : HasOpInfo.propertiesOf opType} {hoper hblock hreg hins}
+    (h : WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties none
+      hoper hblock hreg hins = some (ctx', newOp))
+    (hop : op.InBounds ctx.raw) : CtxExtends op ctx ctx' := by
+  have hFresh : ¬ newOp.InBounds ctx.raw := WfRewriter.createOp_new_not_inBounds newOp h
+  have hne : ∀ o : OperationPtr, o.InBounds ctx.raw → o ≠ newOp := by grind
+  refine ⟨fun o ho => WfRewriter.createOp_inBounds_mono (ptr := .operation o) h ho, ?_, ?_, ?_, ?_,
+    fun v hv => WfRewriter.createOp_inBounds_mono (ptr := .value v) h hv, ?_,
+    fun v hd => (ValuePtr.dominatesIp_before_WfRewriter_createOp h hop (hne op hop)).mpr hd⟩
+  · intro o ho
+    rw [OperationPtr.getOpType!_WfRewriter_createOp h, if_neg (hne o ho)]
+  · intro o ho
+    rw [OperationPtr.getOperands!_WfRewriter_createOp h, if_neg (hne o ho)]
+  · intro o ho
+    rw [OperationPtr.getResultTypes!_WfRewriter_createOp h, if_neg (hne o ho)]
+  · intro o ho oc
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne h (hne o ho)]
+  · intro v hv
+    cases v with
+    | blockArgument ba => rw [ValuePtr.getType!_WfRewriter_createOp h]
+    | opResult opRes =>
+      have hnd : ¬ (opRes.op = newOp ∧ opRes.index < resultTypes.size) := by
+        rintro ⟨rfl, -⟩
+        exact hFresh (by grind [ValuePtr.InBounds, OpResultPtr.InBounds])
+      rw [ValuePtr.getType!_WfRewriter_createOp h]
+      simp only [hnd, dif_neg, not_false_eq_true]
+
+
+/-! ### The shared prologue `icmpCastExtLocal` -/
+
+/-- The prologue only creates fresh operations, so it extends the context. -/
+theorem icmpCastExtLocal_extends {ctx ctxP : WfIRContext OpCode} {op : OperationPtr}
+    {lhs rhs a b : ValuePtr} {ext : Option IcmpExtOp} {pre : Array OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    (hCE : icmpCastExtLocal ctx lhs rhs ext = some (ctxP, pre, a, b)) :
+    CtxExtends op ctx ctxP := by
+  simp only [icmpCastExtLocal, bind] at hCE
+  peelOpCreation hCE ctx₁ lcastOp hLCast
+  simp only [castToRegLocal] at hLCast
+  replace hLCast := WfRewriter.createOp!_none_some hLCast
+  obtain ⟨_, _, _, hLCast⟩ := hLCast
+  peelOpCreation hCE ctx₂ rcastOp hRCast
+  simp only [castToRegLocal] at hRCast
+  replace hRCast := WfRewriter.createOp!_none_some hRCast
+  obtain ⟨_, _, _, hRCast⟩ := hRCast
+  have E₁ := CtxExtends.of_createOp hLCast opInBounds
+  have E₂ := CtxExtends.of_createOp hRCast (E₁.inBounds op opInBounds)
+  have E₁₂ := E₁.trans E₂
+  split at hCE
+  · obtain ⟨rfl, -, -, -⟩ := by simpa using hCE
+    exact E₁₂
+  · peelOpCreation hCE ctx₃ lsOp hLs
+    replace hLs := WfRewriter.createOp!_none_some hLs
+    obtain ⟨_, _, _, hLs⟩ := hLs
+    peelOpCreation hCE ctx₄ rsOp hRs
+    replace hRs := WfRewriter.createOp!_none_some hRs
+    obtain ⟨_, _, _, hRs⟩ := hRs
+    obtain ⟨rfl, -, -, -⟩ := by simpa using hCE
+    have E₃ := CtxExtends.of_createOp hLs (E₁₂.inBounds op opInBounds)
+    have E₄ := CtxExtends.of_createOp hRs (E₃.inBounds op (E₁₂.inBounds op opInBounds))
+    exact E₁₂.trans (E₃.trans E₄)
+
+/-- The prologue's two comparison registers are in bounds in the context it returns. -/
+theorem icmpCastExtLocal_regs_inBounds {ctx ctxP : WfIRContext OpCode}
+    {lhs rhs a b : ValuePtr} {ext : Option IcmpExtOp} {pre : Array OperationPtr}
+    (hCE : icmpCastExtLocal ctx lhs rhs ext = some (ctxP, pre, a, b)) :
+    a.InBounds ctxP.raw ∧ b.InBounds ctxP.raw := by
+  rcases ext with _ | eo
+  all_goals
+    simp only [icmpCastExtLocal, bind] at hCE
+    peelOpCreation hCE ctx₁ lcastOp hLCast
+    simp only [castToRegLocal] at hLCast
+    replace hLCast := WfRewriter.createOp!_none_some hLCast
+    obtain ⟨_, _, _, hLCast⟩ := hLCast
+    peelOpCreation hCE ctx₂ rcastOp hRCast
+    simp only [castToRegLocal] at hRCast
+    replace hRCast := WfRewriter.createOp!_none_some hRCast
+    obtain ⟨_, _, _, hRCast⟩ := hRCast
+  · obtain ⟨rfl, rfl, rfl, rfl⟩ := by simpa using hCE
+    have E₂ := CtxExtends.of_createOp (op := lcastOp) hRCast
+      (WfRewriter.createOp_new_inBounds _ hLCast)
+    exact ⟨E₂.valueInBounds _ (by grind [ValuePtr.InBounds, OpResultPtr.InBounds,
+        OperationPtr.getResult]),
+      by grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]⟩
+  · peelOpCreation hCE ctx₃ lsOp hLs
+    replace hLs := WfRewriter.createOp!_none_some hLs
+    obtain ⟨_, _, _, hLs⟩ := hLs
+    peelOpCreation hCE ctx₄ rsOp hRs
+    replace hRs := WfRewriter.createOp!_none_some hRs
+    obtain ⟨_, _, _, hRs⟩ := hRs
+    obtain ⟨rfl, rfl, rfl, rfl⟩ := by simpa using hCE
+    have E₄ := CtxExtends.of_createOp (op := lsOp) hRs (WfRewriter.createOp_new_inBounds _ hLs)
+    exact ⟨E₄.valueInBounds _ (by grind [ValuePtr.InBounds, OpResultPtr.InBounds,
+        OperationPtr.getResult]),
+      by grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]⟩
+
+/-- Symbolic execution of the prologue in the arm's final context `F`: the two casts (and, when
+    `ext` fires, the two sign-extensions) run without touching memory and leave the comparison
+    registers holding `e (toReg xt)` and `e (toReg yt)`, where `e` is the extension's semantics
+    (the identity when there is none).
+
+    The arm supplies `hExt`, the extension of `ctxP` to its own final context, which is how this
+    single lemma serves every arm. -/
+theorem icmpCastExtLocal_run {ctx ctxP F : WfIRContext OpCode} {op : OperationPtr}
+    {lhs rhs a b : ValuePtr} {ext : Option IcmpExtOp} {pre : Array OperationPtr}
+    {e : Data.RISCV.Reg → Data.RISCV.Reg} {bw : Nat} {xt yt : Data.LLVM.Int bw}
+    {state' : InterpreterState F}
+    (opInBounds : op.InBounds ctx.raw)
+    (hCE : icmpCastExtLocal ctx lhs rhs ext = some (ctxP, pre, a, b))
+    (hExt : CtxExtends op ctxP F)
+    (hExtId : ext = none → ∀ r, e r = r)
+    (hExtSem : ∀ eo, ext = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none)))
+    (hRhsIn : rhs.InBounds ctx.raw)
+    (hLVal : state'.variables.getVar? lhs = some (RuntimeValue.int bw xt))
+    (hRVal : state'.variables.getVar? rhs = some (RuntimeValue.int bw yt))
+    (hin : ∀ o ∈ pre.toList, o.InBounds F.raw) :
+    ∃ sPre : InterpreterState F,
+      interpretOpList pre.toList state' hin = some (.ok (sPre, none)) ∧
+      sPre.memory = state'.memory ∧
+      sPre.variables.getVar? a = some (.reg (e (LLVM.Int.toReg xt))) ∧
+      sPre.variables.getVar? b = some (.reg (e (LLVM.Int.toReg yt))) := by
+  -- The two casts are peeled the same way in both branches.
+  rcases ext with _ | eo
+  all_goals
+    simp only [icmpCastExtLocal, bind] at hCE
+    peelOpCreation hCE ctx₁ lcastOp hLCast
+    simp only [castToRegLocal] at hLCast
+    replace hLCast := WfRewriter.createOp!_none_some hLCast
+    obtain ⟨_, _, _, hLCast⟩ := hLCast
+    peelOpCreation hCE ctx₂ rcastOp hRCast
+    simp only [castToRegLocal] at hRCast
+    replace hRCast := WfRewriter.createOp!_none_some hRCast
+    obtain ⟨_, _, _, hRCast⟩ := hRCast
+    have E₁ := CtxExtends.of_createOp hLCast opInBounds
+    have E₂ := CtxExtends.of_createOp hRCast (E₁.inBounds op opInBounds)
+    have hLCastIn₁ : lcastOp.InBounds ctx₁.raw := WfRewriter.createOp_new_inBounds _ hLCast
+    have hRCastIn₂ : rcastOp.InBounds ctx₂.raw := WfRewriter.createOp_new_inBounds _ hRCast
+    have hLCastFresh : ¬ lcastOp.InBounds ctx.raw := WfRewriter.createOp_new_not_inBounds _ hLCast
+    have hRCastFresh₁ : ¬ rcastOp.InBounds ctx₁.raw :=
+      WfRewriter.createOp_new_not_inBounds _ hRCast
+    have hLResIn₁ : (ValuePtr.opResult (lcastOp.getResult 0)).InBounds ctx₁.raw := by
+      grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  · -- ===== no sign-extension (`i64`): the two casts are the whole prologue =====
+    obtain ⟨rfl, rfl, rfl, rfl⟩ := by simpa using hCE
+    have F₂ : CtxExtends op ctx₂ F := hExt
+    have F₁ : CtxExtends op ctx₁ F := E₂.trans hExt
+    have hLCastType : lcastOp.getOpType! F.raw = .builtin .unrealized_conversion_cast := by
+      rw [F₁.opType lcastOp hLCastIn₁]; grind
+    have hLCastOperands : lcastOp.getOperands! F.raw = #[lhs] := by
+      rw [F₁.operands lcastOp hLCastIn₁]; grind
+    have hLCastResTypes :
+        lcastOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [F₁.resultTypes lcastOp hLCastIn₁]; grind
+    have hRCastType : rcastOp.getOpType! F.raw = .builtin .unrealized_conversion_cast := by
+      rw [F₂.opType rcastOp hRCastIn₂]; grind
+    have hRCastOperands : rcastOp.getOperands! F.raw = #[rhs] := by
+      rw [F₂.operands rcastOp hRCastIn₂]; grind
+    have hRCastResTypes :
+        rcastOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [F₂.resultTypes rcastOp hRCastIn₂]; grind
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := hin lcastOp (by simp))
+        hLCastType hLCastOperands hLCastResTypes hLVal
+    have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int bw yt) := by
+      rw [hFrame₁ rhs (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hRhsIn hLCastFresh)]
+      exact hRVal
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+      interpretOp_castToReg_forward (state := s₁) (inBounds := hin rcastOp (by simp))
+        hRCastType hRCastOperands hRCastResTypes hRVal₁
+    refine ⟨s₂, ?_, by grind, ?_, ?_⟩
+    · simp [interpretOpList_cons, hI₁, hI₂, Interp]
+    · rw [hFrame₂ _
+        (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hLResIn₁ hRCastFresh₁), hRes₁,
+        hExtId rfl]
+    · rw [hRes₂, hExtId rfl]
+  · -- ===== sign-extended prologue (`i32`/`i8`) =====
+    peelOpCreation hCE ctx₃ lsOp hLs
+    replace hLs := WfRewriter.createOp!_none_some hLs
+    obtain ⟨_, _, _, hLs⟩ := hLs
+    peelOpCreation hCE ctx₄ rsOp hRs
+    replace hRs := WfRewriter.createOp!_none_some hRs
+    obtain ⟨_, _, _, hRs⟩ := hRs
+    obtain ⟨rfl, rfl, rfl, rfl⟩ := by simpa using hCE
+    have E₃ := CtxExtends.of_createOp hLs (E₂.inBounds op (E₁.inBounds op opInBounds))
+    have E₄ := CtxExtends.of_createOp hRs
+      (E₃.inBounds op (E₂.inBounds op (E₁.inBounds op opInBounds)))
+    have F₄ : CtxExtends op ctx₄ F := hExt
+    have F₃ : CtxExtends op ctx₃ F := E₄.trans hExt
+    have F₂ : CtxExtends op ctx₂ F := E₃.trans F₃
+    have F₁ : CtxExtends op ctx₁ F := E₂.trans F₂
+    have hLsIn₃ : lsOp.InBounds ctx₃.raw := WfRewriter.createOp_new_inBounds _ hLs
+    have hRsIn₄ : rsOp.InBounds ctx₄.raw := WfRewriter.createOp_new_inBounds _ hRs
+    have hLsFresh₂ : ¬ lsOp.InBounds ctx₂.raw := WfRewriter.createOp_new_not_inBounds _ hLs
+    have hRsFresh₃ : ¬ rsOp.InBounds ctx₃.raw := WfRewriter.createOp_new_not_inBounds _ hRs
+    have hRResIn₂ : (ValuePtr.opResult (rcastOp.getResult 0)).InBounds ctx₂.raw := by
+      grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+    have hLsResIn₃ : (ValuePtr.opResult (lsOp.getResult 0)).InBounds ctx₃.raw := by
+      grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+    have hLCastType : lcastOp.getOpType! F.raw = .builtin .unrealized_conversion_cast := by
+      rw [F₁.opType lcastOp hLCastIn₁]; grind
+    have hLCastOperands : lcastOp.getOperands! F.raw = #[lhs] := by
+      rw [F₁.operands lcastOp hLCastIn₁]; grind
+    have hLCastResTypes :
+        lcastOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [F₁.resultTypes lcastOp hLCastIn₁]; grind
+    have hRCastType : rcastOp.getOpType! F.raw = .builtin .unrealized_conversion_cast := by
+      rw [F₂.opType rcastOp hRCastIn₂]; grind
+    have hRCastOperands : rcastOp.getOperands! F.raw = #[rhs] := by
+      rw [F₂.operands rcastOp hRCastIn₂]; grind
+    have hRCastResTypes :
+        rcastOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [F₂.resultTypes rcastOp hRCastIn₂]; grind
+    have hLsType : lsOp.getOpType! F.raw = .riscv eo.op := by
+      rw [F₃.opType lsOp hLsIn₃]; grind
+    have hLsOperands : lsOp.getOperands! F.raw = #[ValuePtr.opResult (lcastOp.getResult 0)] := by
+      rw [F₃.operands lsOp hLsIn₃]; grind
+    have hLsResTypes : lsOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [F₃.resultTypes lsOp hLsIn₃]; grind
+    have hRsType : rsOp.getOpType! F.raw = .riscv eo.op := by
+      rw [F₄.opType rsOp hRsIn₄]; grind
+    have hRsOperands : rsOp.getOperands! F.raw = #[ValuePtr.opResult (rcastOp.getResult 0)] := by
+      rw [F₄.operands rsOp hRsIn₄]; grind
+    have hRsResTypes : rsOp.getResultTypes! F.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      rw [F₄.resultTypes rsOp hRsIn₄]; grind
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, hFrame₁⟩ :=
+      interpretOp_castToReg_forward (state := state') (inBounds := hin lcastOp (by simp))
+        hLCastType hLCastOperands hLCastResTypes hLVal
+    have hRVal₁ : s₁.variables.getVar? rhs = some (RuntimeValue.int bw yt) := by
+      rw [hFrame₁ rhs (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hRhsIn hLCastFresh)]
+      exact hRVal
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, hFrame₂⟩ :=
+      interpretOp_castToReg_forward (state := s₁) (inBounds := hin rcastOp (by simp))
+        hRCastType hRCastOperands hRCastResTypes hRVal₁
+    have hLRes₂ : s₂.variables.getVar? (ValuePtr.opResult (lcastOp.getResult 0))
+        = some (RuntimeValue.reg (LLVM.Int.toReg xt)) := by
+      rw [hFrame₂ _ (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hLResIn₁ hRCastFresh₁)]
+      exact hRes₁
+    obtain ⟨s₃, hI₃, hMem₃, hRes₃, hFrame₃⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := s₂) (inBounds := hin lsOp (by simp)) (f := e)
+        (fun props rt bo mem => hExtSem eo rfl props rt bo mem _)
+        hLsType hLsOperands hLsResTypes hLRes₂
+    have hRRes₃ : s₃.variables.getVar? (ValuePtr.opResult (rcastOp.getResult 0))
+        = some (RuntimeValue.reg (LLVM.Int.toReg yt)) := by
+      rw [hFrame₃ _ (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hRResIn₂ hLsFresh₂)]
+      exact hRes₂
+    obtain ⟨s₄, hI₄, hMem₄, hRes₄, hFrame₄⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := s₃) (inBounds := hin rsOp (by simp)) (f := e)
+        (fun props rt bo mem => hExtSem eo rfl props rt bo mem _)
+        hRsType hRsOperands hRsResTypes hRRes₃
+    refine ⟨s₄, ?_, by grind, ?_, hRes₄⟩
+    · simp [interpretOpList_cons, hI₁, hI₂, hI₃, hI₄, Interp]
+    · rw [hFrame₄ _ (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hLsResIn₃ hRsFresh₃)]
+      exact hRes₃
+
+
+/-! ### The comparison arms
+
+Each arm peels its own creations, builds the `CtxExtends ctxP newCtx` witness they justify, replays
+the prologue with `icmpCastExtLocal_run` through `interpretOpList_append`, and then executes its own
+operations. The per-predicate content is entirely in `hData`. -/
+
+set_option maxHeartbeats 1600000 in
+/-- Correctness of the single-comparison arm (`slt`/`sgt`/`ult`/`ugt`). -/
+theorem icmpEmitCmpLocal_sound {ctx : WfIRContext OpCode} {op : OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    {lhs rhs : ValuePtr} {ext : Option IcmpExtOp} {rop : Riscv}
+    {hrop : Riscv.propertiesOf rop = Unit} {swap : Bool}
+    {e : Data.RISCV.Reg → Data.RISCV.Reg} {f : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg}
+    {pattern : LocalRewritePattern OpCode}
+    {hReturnOps : pattern.ReturnOps} {hReturnCtx : pattern.ReturnCtxChanges}
+    {hReturnVIB : pattern.ReturnValuesInBounds} {hReturnV : pattern.ReturnValues}
+    {newCtx : WfIRContext OpCode} {newOps : Array OperationPtr} {newValues : Array ValuePtr}
+    {state newState : InterpreterState ctx} {state' : InterpreterState newCtx}
+    {bw : Nat} {xVal yVal : Data.LLVM.Int bw} {srcVal : Data.LLVM.Int 1}
+    {ipIn : (InsertPoint.before op).InBounds ctx.raw}
+    {ipIn' : (InsertPoint.before op).InBounds newCtx.raw}
+    (hpatternOrig : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    (hEmit : icmpEmitCmpLocal ctx op lhs rhs ext rop hrop swap
+      = some (newCtx, some (newOps, newValues)))
+    (hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨1⟩)
+    (hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw)
+    (hLhsIn : lhs.InBounds ctx.raw) (hRhsIn : rhs.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? lhs = some (RuntimeValue.int bw xVal))
+    (hyVal : state.variables.getVar? rhs = some (RuntimeValue.int bw yVal))
+    (hMem : state.memory = newState.memory)
+    (memoryRefinement : state.memory = state'.memory)
+    (hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx)
+    (hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx)
+    (lNotOp : lhs ∉ op.getResults! ctx.raw) (rNotOp : rhs ∉ op.getResults! ctx.raw)
+    (state'Dom : state'.DefinesDominating (InsertPoint.before op) ipIn')
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpatternOrig hReturnVIB hReturnV hReturnCtx)
+      (.at (.before op)) (.at (.before op)) ipIn ipIn')
+    (hExtId : ext = none → ∀ r, e r = r)
+    (hExtSem : ∀ eo, ext = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none)))
+    (hSemR : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf rop)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' rop props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f r₁ r₂)], mem, none)))
+    (hData : ∀ xt yt : Data.LLVM.Int bw, xVal ⊒ xt → yVal ⊒ yt →
+      srcVal ⊒ RISCV.Reg.toInt
+        (f (if swap then e (LLVM.Int.toReg yt) else e (LLVM.Int.toReg xt))
+           (if swap then e (LLVM.Int.toReg xt) else e (LLVM.Int.toReg yt))) 1) :
+    ∃ newState', interpretOpList newOps.toList state'
+        (by grind [LocalRewritePattern.ReturnOps]) = some (newState', none) ∧
+      newState.memory = newState'.memory ∧
+      ∃ targetValues, newValues.mapM (newState'.variables.getVar? ·) = some targetValues ∧
+        (#[RuntimeValue.int 1 srcVal] : Array RuntimeValue) ⊒ targetValues := by
+  -- Peel the prologue (opaquely) and this arm's two creations.
+  simp only [icmpEmitCmpLocal, bind, Option.bind_eq_some_iff] at hEmit
+  obtain ⟨⟨ctxP, pre, a, b⟩, hCE, hEmit⟩ := hEmit
+  obtain ⟨u, v, huv⟩ : ∃ u v, (if swap then (b, a) else (a, b)) = (u, v) := ⟨_, _, rfl⟩
+  rw [huv] at hEmit
+  obtain ⟨⟨ctx₅, cmpOp⟩, hCmp, hEmit⟩ := hEmit
+  replace hCmp := WfRewriter.createOp!_none_some hCmp
+  obtain ⟨_, _, _, hCmp⟩ := hCmp
+  obtain ⟨⟨ctx₆, castBackOp⟩, hCastBack, hEmit⟩ := hEmit
+  simp only [replaceWithRegLocal] at hCastBack
+  replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+  obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hEmit
+  -- Context extensions: prologue, then this arm's two creations.
+  have Ep := icmpCastExtLocal_extends opInBounds hCE
+  have hOpInP : op.InBounds ctxP.raw := Ep.inBounds op opInBounds
+  have E₅ := CtxExtends.of_createOp hCmp hOpInP
+  have E₆ := CtxExtends.of_createOp hCastBack (E₅.inBounds op hOpInP)
+  have hExtP : CtxExtends op ctxP ctx₆ := E₅.trans E₆
+  have Ectx : CtxExtends op ctx ctx₆ := Ep.trans hExtP
+  -- All emitted ops are in bounds in the final context.
+  have hOpsIn : ∀ o ∈ (pre ++ #[cmpOp, castBackOp]).toList, o.InBounds ctx₆.raw := by
+    grind [LocalRewritePattern.ReturnOps]
+  have hPreIn : ∀ o ∈ pre.toList, o.InBounds ctx₆.raw := by
+    intro o ho
+    exact hOpsIn o (by simp only [Array.toList_append, List.mem_append]; exact Or.inl ho)
+  -- Read the refined operands in the target state.
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hLhsIn hxVal
+      hDomCtxL (Ectx.dominates lhs hDomCtxL) lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hRhsIn hyVal
+      hDomCtxR (Ectx.dominates rhs hDomCtxR) rNotOp
+  -- Replay the prologue.
+  obtain ⟨sPre, hPre, hPreMem, hAVal, hBVal⟩ :=
+    icmpCastExtLocal_run opInBounds hCE hExtP hExtId hExtSem hRhsIn hLVal' hRVal' hPreIn
+  -- The two comparison operands, in the order this arm feeds them to `rop`.
+  have hUVal : sPre.variables.getVar? u
+      = some (.reg (if swap then e (LLVM.Int.toReg yt) else e (LLVM.Int.toReg xt))) := by
+    cases swap <;> (simp only [Bool.false_eq_true, reduceIte, Prod.mk.injEq] at huv ⊢
+                    obtain ⟨rfl, rfl⟩ := huv) <;> assumption
+  have hVVal : sPre.variables.getVar? v
+      = some (.reg (if swap then e (LLVM.Int.toReg xt) else e (LLVM.Int.toReg yt))) := by
+    cases swap <;> (simp only [Bool.false_eq_true, reduceIte, Prod.mk.injEq] at huv ⊢
+                    obtain ⟨rfl, rfl⟩ := huv) <;> assumption
+  -- Structural facts about this arm's two ops.
+  have hCmpIn₅ : cmpOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hCmp
+  have hCmpType : cmpOp.getOpType! ctx₆.raw = .riscv rop := by
+    rw [E₆.opType cmpOp hCmpIn₅]; grind
+  have hCmpOperands : cmpOp.getOperands! ctx₆.raw = #[u, v] := by
+    rw [E₆.operands cmpOp hCmpIn₅]; grind
+  have hCmpResTypes : cmpOp.getResultTypes! ctx₆.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [E₆.resultTypes cmpOp hCmpIn₅]; grind
+  have hCastBackType : castBackOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₆.raw = #[ValuePtr.opResult (cmpOp.getResult 0)] := by grind
+  have isT : Attribute.isType (Attribute.integerType (⟨1⟩ : IntegerType)) := by grind
+  have hCBType : ((op.getResult 0).get! ctx₅.raw).type
+      = (⟨Attribute.integerType ⟨1⟩, isT⟩ : TypeAttr) := by
+    have h1 := (Ep.trans E₅).valueType (ValuePtr.opResult (op.getResult 0)) hResIn
+    simp only [ValuePtr.getType!_opResult] at h1
+    apply Subtype.ext
+    rw [show ((op.getResult 0).get! ctx₅.raw).type = ((op.getResult 0).get! ctx.raw).type from h1]
+    exact hResType
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.integerType ⟨1⟩, isT⟩] := by grind
+  -- Execute this arm's two ops on top of the prologue's state.
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, -⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := sPre) (inBounds := hOpsIn cmpOp (by simp))
+      (f := f) (hSemR _ _) hCmpType hCmpOperands hCmpResTypes hUVal hVVal
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, -⟩ :=
+    interpretOp_castBack_forward (state := s₅) (inBounds := hOpsIn castBackOp (by simp))
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₅
+  refine ⟨s₆, ?_, by grind, ?_⟩
+  · simp only [Array.toList_append]
+    rw [interpretOpList_append, hPre]
+    simp [interpretOpList_cons, hI₅, hI₆, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 1 (RISCV.Reg.toInt (f
+        (if swap then e (LLVM.Int.toReg yt) else e (LLVM.Int.toReg xt))
+        (if swap then e (LLVM.Int.toReg xt) else e (LLVM.Int.toReg yt))) 1)], ?_, ?_⟩
+    · simp [hRes₆, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using hData xt yt hxtRef hytRef⟩
+
+set_option maxHeartbeats 1600000 in
+/-- Correctness of the comparison-then-immediate arm (`sle`/`sge`/`ule`/`uge` and the generic
+    `eq`). -/
+theorem icmpEmitCmpImmLocal_sound {ctx : WfIRContext OpCode} {op : OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    {lhs rhs : ValuePtr} {ext : Option IcmpExtOp}
+    {e : Data.RISCV.Reg → Data.RISCV.Reg}
+    {pattern : LocalRewritePattern OpCode}
+    {hReturnOps : pattern.ReturnOps} {hReturnCtx : pattern.ReturnCtxChanges}
+    {hReturnVIB : pattern.ReturnValuesInBounds} {hReturnV : pattern.ReturnValues}
+    {newCtx : WfIRContext OpCode} {newOps : Array OperationPtr} {newValues : Array ValuePtr}
+    {state newState : InterpreterState ctx} {state' : InterpreterState newCtx}
+    {bw : Nat} {xVal yVal : Data.LLVM.Int bw} {srcVal : Data.LLVM.Int 1}
+    {ipIn : (InsertPoint.before op).InBounds ctx.raw}
+    {ipIn' : (InsertPoint.before op).InBounds newCtx.raw}
+    (hpatternOrig : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    {rop : Riscv} {hrop : Riscv.propertiesOf rop = Unit} {swap : Bool}
+    {ropImm : Riscv} {hropImm : Riscv.propertiesOf ropImm = RISCVImmediateProperties}
+    {f : Data.RISCV.Reg → Data.RISCV.Reg → Data.RISCV.Reg} {g : Data.RISCV.Reg → Data.RISCV.Reg}
+    (hEmit : icmpEmitCmpImmLocal ctx op lhs rhs ext rop hrop swap ropImm hropImm
+      = some (newCtx, some (newOps, newValues)))
+    (hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨1⟩)
+    (hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw)
+    (hLhsIn : lhs.InBounds ctx.raw) (hRhsIn : rhs.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? lhs = some (RuntimeValue.int bw xVal))
+    (hyVal : state.variables.getVar? rhs = some (RuntimeValue.int bw yVal))
+    (hMem : state.memory = newState.memory)
+    (memoryRefinement : state.memory = state'.memory)
+    (hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx)
+    (hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx)
+    (lNotOp : lhs ∉ op.getResults! ctx.raw) (rNotOp : rhs ∉ op.getResults! ctx.raw)
+    (state'Dom : state'.DefinesDominating (InsertPoint.before op) ipIn')
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpatternOrig hReturnVIB hReturnV hReturnCtx)
+      (.at (.before op)) (.at (.before op)) ipIn ipIn')
+    (hExtId : ext = none → ∀ r, e r = r)
+    (hExtSem : ∀ eo, ext = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none)))
+    (hSemR : ∀ (r₁ r₂ : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf rop)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' rop props resultTypes #[.reg r₁, .reg r₂] blockOperands mem
+          = some (.ok (#[.reg (f r₁ r₂)], mem, none)))
+    (hSemImm : ∀ (r : Data.RISCV.Reg) (resultTypes : Array TypeAttr)
+        (blockOperands : Array BlockPtr) (mem : MemoryState),
+        Riscv.interpretOp' ropImm (cast hropImm.symm icmpOneImm) resultTypes #[.reg r]
+            blockOperands mem
+          = some (.ok (#[.reg (g r)], mem, none)))
+    (hData : ∀ xt yt : Data.LLVM.Int bw, xVal ⊒ xt → yVal ⊒ yt →
+      srcVal ⊒ RISCV.Reg.toInt (g
+        (f (if swap then e (LLVM.Int.toReg yt) else e (LLVM.Int.toReg xt))
+           (if swap then e (LLVM.Int.toReg xt) else e (LLVM.Int.toReg yt)))) 1) :
+    ∃ newState', interpretOpList newOps.toList state'
+        (by grind [LocalRewritePattern.ReturnOps]) = some (newState', none) ∧
+      newState.memory = newState'.memory ∧
+      ∃ targetValues, newValues.mapM (newState'.variables.getVar? ·) = some targetValues ∧
+        (#[RuntimeValue.int 1 srcVal] : Array RuntimeValue) ⊒ targetValues := by
+  simp only [icmpEmitCmpImmLocal, bind, Option.bind_eq_some_iff] at hEmit
+  obtain ⟨⟨ctxP, pre, a, b⟩, hCE, hEmit⟩ := hEmit
+  obtain ⟨u, v, huv⟩ : ∃ u v, (if swap then (b, a) else (a, b)) = (u, v) := ⟨_, _, rfl⟩
+  rw [huv] at hEmit
+  obtain ⟨⟨ctx₅, cmpOp⟩, hCmp, hEmit⟩ := hEmit
+  replace hCmp := WfRewriter.createOp!_none_some hCmp
+  obtain ⟨_, _, _, hCmp⟩ := hCmp
+  obtain ⟨⟨ctx₆, immOp⟩, hImm, hEmit⟩ := hEmit
+  replace hImm := WfRewriter.createOp!_none_some hImm
+  obtain ⟨_, _, _, hImm⟩ := hImm
+  obtain ⟨⟨ctx₇, castBackOp⟩, hCastBack, hEmit⟩ := hEmit
+  simp only [replaceWithRegLocal] at hCastBack
+  replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+  obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hEmit
+  -- Context extensions: prologue, then this arm's creations.
+  have Ep := icmpCastExtLocal_extends opInBounds hCE
+  have hOpInP : op.InBounds ctxP.raw := Ep.inBounds op opInBounds
+  have E₅ := CtxExtends.of_createOp hCmp hOpInP
+  have E₆ := CtxExtends.of_createOp hImm (E₅.inBounds op hOpInP)
+  have E₇ := CtxExtends.of_createOp hCastBack (E₆.inBounds op (E₅.inBounds op hOpInP))
+  have hExtP : CtxExtends op ctxP ctx₇ := E₅.trans (E₆.trans E₇)
+  have Ectx : CtxExtends op ctx ctx₇ := Ep.trans hExtP
+  have hOpsIn : ∀ o ∈ (pre ++ #[cmpOp, immOp, castBackOp]).toList, o.InBounds ctx₇.raw := by
+    grind [LocalRewritePattern.ReturnOps]
+  have hPreIn : ∀ o ∈ pre.toList, o.InBounds ctx₇.raw := by
+    intro o ho
+    exact hOpsIn o (by simp only [Array.toList_append, List.mem_append]; exact Or.inl ho)
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hLhsIn hxVal
+      hDomCtxL (Ectx.dominates lhs hDomCtxL) lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hRhsIn hyVal
+      hDomCtxR (Ectx.dominates rhs hDomCtxR) rNotOp
+  obtain ⟨sPre, hPre, hPreMem, hAVal, hBVal⟩ :=
+    icmpCastExtLocal_run opInBounds hCE hExtP hExtId hExtSem hRhsIn hLVal' hRVal' hPreIn
+  have hUVal : sPre.variables.getVar? u
+      = some (.reg (if swap then e (LLVM.Int.toReg yt) else e (LLVM.Int.toReg xt))) := by
+    cases swap <;> (simp only [Bool.false_eq_true, reduceIte, Prod.mk.injEq] at huv ⊢
+                    obtain ⟨rfl, rfl⟩ := huv) <;> assumption
+  have hVVal : sPre.variables.getVar? v
+      = some (.reg (if swap then e (LLVM.Int.toReg xt) else e (LLVM.Int.toReg yt))) := by
+    cases swap <;> (simp only [Bool.false_eq_true, reduceIte, Prod.mk.injEq] at huv ⊢
+                    obtain ⟨rfl, rfl⟩ := huv) <;> assumption
+  have hCmpIn₅ : cmpOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hCmp
+  have hImmIn₆ : immOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hImm
+  have hCmpType : cmpOp.getOpType! ctx₇.raw = .riscv rop := by
+    rw [(E₆.trans E₇).opType cmpOp hCmpIn₅]; grind
+  have hCmpOperands : cmpOp.getOperands! ctx₇.raw = #[u, v] := by
+    rw [(E₆.trans E₇).operands cmpOp hCmpIn₅]; grind
+  have hCmpResTypes : cmpOp.getResultTypes! ctx₇.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [(E₆.trans E₇).resultTypes cmpOp hCmpIn₅]; grind
+  have hImmType : immOp.getOpType! ctx₇.raw = .riscv ropImm := by
+    rw [E₇.opType immOp hImmIn₆]; grind
+  have hImmOperands : immOp.getOperands! ctx₇.raw = #[ValuePtr.opResult (cmpOp.getResult 0)] := by
+    rw [E₇.operands immOp hImmIn₆]; grind
+  have hImmResTypes : immOp.getResultTypes! ctx₇.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [E₇.resultTypes immOp hImmIn₆]; grind
+  have hImmProps : immOp.getProperties! ctx₇.raw (.riscv ropImm)
+      = cast hropImm.symm icmpOneImm := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind)]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hImm (operation := immOp)]
+  have hCastBackType : castBackOp.getOpType! ctx₇.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₇.raw = #[ValuePtr.opResult (immOp.getResult 0)] := by grind
+  have isT : Attribute.isType (Attribute.integerType (⟨1⟩ : IntegerType)) := by grind
+  have hCBType : ((op.getResult 0).get! ctx₆.raw).type
+      = (⟨Attribute.integerType ⟨1⟩, isT⟩ : TypeAttr) := by
+    have h1 := (Ep.trans (E₅.trans E₆)).valueType (ValuePtr.opResult (op.getResult 0)) hResIn
+    simp only [ValuePtr.getType!_opResult] at h1
+    apply Subtype.ext
+    rw [show ((op.getResult 0).get! ctx₆.raw).type = ((op.getResult 0).get! ctx.raw).type from h1]
+    exact hResType
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₇.raw
+      = #[⟨Attribute.integerType ⟨1⟩, isT⟩] := by grind
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, -⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := sPre) (inBounds := hOpsIn cmpOp (by simp))
+      (f := f) (hSemR _ _) hCmpType hCmpOperands hCmpResTypes hUVal hVVal
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, -⟩ :=
+    interpretOp_riscv_unaryReg_imm_forward (state := s₅) (inBounds := hOpsIn immOp (by simp))
+      (res := g _) (props := cast hropImm.symm icmpOneImm) (hSemImm _)
+      hImmType hImmProps hImmOperands hImmResTypes hRes₅
+  obtain ⟨s₇, hI₇, hMem₇, hRes₇, -⟩ :=
+    interpretOp_castBack_forward (state := s₆) (inBounds := hOpsIn castBackOp (by simp))
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₆
+  refine ⟨s₇, ?_, by grind, ?_⟩
+  · simp only [Array.toList_append]
+    rw [interpretOpList_append, hPre]
+    simp [interpretOpList_cons, hI₅, hI₆, hI₇, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 1 (RISCV.Reg.toInt (g (f
+        (if swap then e (LLVM.Int.toReg yt) else e (LLVM.Int.toReg xt))
+        (if swap then e (LLVM.Int.toReg xt) else e (LLVM.Int.toReg yt)))) 1)], ?_, ?_⟩
+    · simp [hRes₇, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa using hData xt yt hxtRef hytRef⟩
+
+set_option maxHeartbeats 1600000 in
+/-- Correctness of the `seqz` arm: `eq` against a zero constant lowers to `sltiu a 1`. -/
+theorem icmpEmitSeqzLocal_sound {ctx : WfIRContext OpCode} {op : OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    {lhs rhs : ValuePtr} {ext : Option IcmpExtOp}
+    {e : Data.RISCV.Reg → Data.RISCV.Reg}
+    {pattern : LocalRewritePattern OpCode}
+    {hReturnOps : pattern.ReturnOps} {hReturnCtx : pattern.ReturnCtxChanges}
+    {hReturnVIB : pattern.ReturnValuesInBounds} {hReturnV : pattern.ReturnValues}
+    {newCtx : WfIRContext OpCode} {newOps : Array OperationPtr} {newValues : Array ValuePtr}
+    {state newState : InterpreterState ctx} {state' : InterpreterState newCtx}
+    {bw : Nat} {xVal yVal : Data.LLVM.Int bw} {srcVal : Data.LLVM.Int 1}
+    {ipIn : (InsertPoint.before op).InBounds ctx.raw}
+    {ipIn' : (InsertPoint.before op).InBounds newCtx.raw}
+    (hpatternOrig : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    (hEmit : icmpEmitSeqzLocal ctx op lhs rhs ext = some (newCtx, some (newOps, newValues)))
+    (hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨1⟩)
+    (hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw)
+    (hLhsIn : lhs.InBounds ctx.raw) (hRhsIn : rhs.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? lhs = some (RuntimeValue.int bw xVal))
+    (hyVal : state.variables.getVar? rhs = some (RuntimeValue.int bw yVal))
+    (hMem : state.memory = newState.memory)
+    (memoryRefinement : state.memory = state'.memory)
+    (hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx)
+    (hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx)
+    (lNotOp : lhs ∉ op.getResults! ctx.raw) (rNotOp : rhs ∉ op.getResults! ctx.raw)
+    (state'Dom : state'.DefinesDominating (InsertPoint.before op) ipIn')
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpatternOrig hReturnVIB hReturnV hReturnCtx)
+      (.at (.before op)) (.at (.before op)) ipIn ipIn')
+    (hExtId : ext = none → ∀ r, e r = r)
+    (hExtSem : ∀ eo, ext = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none)))
+    (hData : ∀ xt : Data.LLVM.Int bw, xVal ⊒ xt →
+      srcVal ⊒ RISCV.Reg.toInt (Data.RISCV.sltiu (BitVec.ofInt 12 1) (e (LLVM.Int.toReg xt))) 1) :
+    ∃ newState', interpretOpList newOps.toList state'
+        (by grind [LocalRewritePattern.ReturnOps]) = some (newState', none) ∧
+      newState.memory = newState'.memory ∧
+      ∃ targetValues, newValues.mapM (newState'.variables.getVar? ·) = some targetValues ∧
+        (#[RuntimeValue.int 1 srcVal] : Array RuntimeValue) ⊒ targetValues := by
+  simp only [icmpEmitSeqzLocal, bind, Option.bind_eq_some_iff] at hEmit
+  obtain ⟨⟨ctxP, pre, a, b⟩, hCE, hEmit⟩ := hEmit
+  obtain ⟨⟨ctx₅, immOp⟩, hImm, hEmit⟩ := hEmit
+  replace hImm := WfRewriter.createOp!_none_some hImm
+  obtain ⟨_, _, _, hImm⟩ := hImm
+  obtain ⟨⟨ctx₆, castBackOp⟩, hCastBack, hEmit⟩ := hEmit
+  simp only [replaceWithRegLocal] at hCastBack
+  replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+  obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hEmit
+  -- Context extensions: prologue, then this arm's creations.
+  have Ep := icmpCastExtLocal_extends opInBounds hCE
+  have hOpInP : op.InBounds ctxP.raw := Ep.inBounds op opInBounds
+  have E₅ := CtxExtends.of_createOp hImm hOpInP
+  have E₆ := CtxExtends.of_createOp hCastBack (E₅.inBounds op hOpInP)
+  have hExtP : CtxExtends op ctxP ctx₆ := E₅.trans E₆
+  have Ectx : CtxExtends op ctx ctx₆ := Ep.trans hExtP
+  have hOpsIn : ∀ o ∈ (pre ++ #[immOp, castBackOp]).toList, o.InBounds ctx₆.raw := by
+    grind [LocalRewritePattern.ReturnOps]
+  have hPreIn : ∀ o ∈ pre.toList, o.InBounds ctx₆.raw := by
+    intro o ho
+    exact hOpsIn o (by simp only [Array.toList_append, List.mem_append]; exact Or.inl ho)
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hLhsIn hxVal
+      hDomCtxL (Ectx.dominates lhs hDomCtxL) lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hRhsIn hyVal
+      hDomCtxR (Ectx.dominates rhs hDomCtxR) rNotOp
+  obtain ⟨sPre, hPre, hPreMem, hAVal, hBVal⟩ :=
+    icmpCastExtLocal_run opInBounds hCE hExtP hExtId hExtSem hRhsIn hLVal' hRVal' hPreIn
+  have hImmIn₅ : immOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hImm
+  have hImmType : immOp.getOpType! ctx₆.raw = .riscv .sltiu := by
+    rw [E₆.opType immOp hImmIn₅]; grind
+  have hImmOperands : immOp.getOperands! ctx₆.raw = #[a] := by
+    rw [E₆.operands immOp hImmIn₅]; grind
+  have hImmResTypes : immOp.getResultTypes! ctx₆.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [E₆.resultTypes immOp hImmIn₅]; grind
+  have hImmProps : immOp.getProperties! ctx₆.raw (.riscv .sltiu) = icmpOneImm := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind)]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hImm (operation := immOp)]
+  have hCastBackType : castBackOp.getOpType! ctx₆.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₆.raw = #[ValuePtr.opResult (immOp.getResult 0)] := by grind
+  have isT : Attribute.isType (Attribute.integerType (⟨1⟩ : IntegerType)) := by grind
+  have hCBType : ((op.getResult 0).get! ctx₅.raw).type
+      = (⟨Attribute.integerType ⟨1⟩, isT⟩ : TypeAttr) := by
+    have h1 := (Ep.trans E₅).valueType (ValuePtr.opResult (op.getResult 0)) hResIn
+    simp only [ValuePtr.getType!_opResult] at h1
+    apply Subtype.ext
+    rw [show ((op.getResult 0).get! ctx₅.raw).type = ((op.getResult 0).get! ctx.raw).type from h1]
+    exact hResType
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₆.raw
+      = #[⟨Attribute.integerType ⟨1⟩, isT⟩] := by grind
+  have hSemImm : ∀ (r : Data.RISCV.Reg) (resultTypes : Array TypeAttr)
+      (blockOperands : Array BlockPtr) (mem : MemoryState),
+      Riscv.interpretOp' .sltiu icmpOneImm resultTypes #[.reg r] blockOperands mem
+        = some (.ok (#[.reg (Data.RISCV.sltiu (BitVec.ofInt 12 1) r)], mem, none)) := by
+    intro r rt bo mem; simp [Riscv.interpretOp', icmpOneImm, pure, Interp]
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, -⟩ :=
+    interpretOp_riscv_unaryReg_imm_forward (state := sPre) (inBounds := hOpsIn immOp (by simp))
+      (rop := Riscv.sltiu) (res := Data.RISCV.sltiu (BitVec.ofInt 12 1) (e (LLVM.Int.toReg xt)))
+      (props := icmpOneImm) (hSemImm _) hImmType hImmProps hImmOperands hImmResTypes hAVal
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, -⟩ :=
+    interpretOp_castBack_forward (state := s₅) (inBounds := hOpsIn castBackOp (by simp))
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₅
+  refine ⟨s₆, ?_, by grind, ?_⟩
+  · simp only [Array.toList_append]
+    rw [interpretOpList_append, hPre]
+    simp [interpretOpList_cons, hI₅, hI₆, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 1 (RISCV.Reg.toInt
+        (Data.RISCV.sltiu (BitVec.ofInt 12 1) (e (LLVM.Int.toReg xt))) 1)], ?_, ?_⟩
+    · simp [hRes₆, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr ⟨rfl, by simpa using hData xt hxtRef⟩
+
+set_option maxHeartbeats 1600000 in
+/-- Correctness of the `snez` arm: `ne` against a zero constant lowers to `sltu 0 a`. -/
+theorem icmpEmitSnezLocal_sound {ctx : WfIRContext OpCode} {op : OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    {lhs rhs : ValuePtr} {ext : Option IcmpExtOp}
+    {e : Data.RISCV.Reg → Data.RISCV.Reg}
+    {pattern : LocalRewritePattern OpCode}
+    {hReturnOps : pattern.ReturnOps} {hReturnCtx : pattern.ReturnCtxChanges}
+    {hReturnVIB : pattern.ReturnValuesInBounds} {hReturnV : pattern.ReturnValues}
+    {newCtx : WfIRContext OpCode} {newOps : Array OperationPtr} {newValues : Array ValuePtr}
+    {state newState : InterpreterState ctx} {state' : InterpreterState newCtx}
+    {bw : Nat} {xVal yVal : Data.LLVM.Int bw} {srcVal : Data.LLVM.Int 1}
+    {ipIn : (InsertPoint.before op).InBounds ctx.raw}
+    {ipIn' : (InsertPoint.before op).InBounds newCtx.raw}
+    (hpatternOrig : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    (hEmit : icmpEmitSnezLocal ctx op lhs rhs ext = some (newCtx, some (newOps, newValues)))
+    (hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨1⟩)
+    (hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw)
+    (hLhsIn : lhs.InBounds ctx.raw) (hRhsIn : rhs.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? lhs = some (RuntimeValue.int bw xVal))
+    (hyVal : state.variables.getVar? rhs = some (RuntimeValue.int bw yVal))
+    (hMem : state.memory = newState.memory)
+    (memoryRefinement : state.memory = state'.memory)
+    (hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx)
+    (hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx)
+    (lNotOp : lhs ∉ op.getResults! ctx.raw) (rNotOp : rhs ∉ op.getResults! ctx.raw)
+    (state'Dom : state'.DefinesDominating (InsertPoint.before op) ipIn')
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpatternOrig hReturnVIB hReturnV hReturnCtx)
+      (.at (.before op)) (.at (.before op)) ipIn ipIn')
+    (hExtId : ext = none → ∀ r, e r = r)
+    (hExtSem : ∀ eo, ext = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none)))
+    (hData : ∀ xt : Data.LLVM.Int bw, xVal ⊒ xt →
+      srcVal ⊒ RISCV.Reg.toInt
+        (Data.RISCV.sltu (e (LLVM.Int.toReg xt)) (Data.RISCV.li (BitVec.ofInt 64 0))) 1) :
+    ∃ newState', interpretOpList newOps.toList state'
+        (by grind [LocalRewritePattern.ReturnOps]) = some (newState', none) ∧
+      newState.memory = newState'.memory ∧
+      ∃ targetValues, newValues.mapM (newState'.variables.getVar? ·) = some targetValues ∧
+        (#[RuntimeValue.int 1 srcVal] : Array RuntimeValue) ⊒ targetValues := by
+  simp only [icmpEmitSnezLocal, bind, Option.bind_eq_some_iff] at hEmit
+  obtain ⟨⟨ctxP, pre, a, b⟩, hCE, hEmit⟩ := hEmit
+  obtain ⟨⟨ctx₅, liOp⟩, hLi, hEmit⟩ := hEmit
+  replace hLi := WfRewriter.createOp!_none_some hLi
+  obtain ⟨_, _, _, hLi⟩ := hLi
+  obtain ⟨⟨ctx₆, cmpOp⟩, hCmp, hEmit⟩ := hEmit
+  replace hCmp := WfRewriter.createOp!_none_some hCmp
+  obtain ⟨_, _, _, hCmp⟩ := hCmp
+  obtain ⟨⟨ctx₇, castBackOp⟩, hCastBack, hEmit⟩ := hEmit
+  simp only [replaceWithRegLocal] at hCastBack
+  replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+  obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hEmit
+  -- Context extensions: prologue, then this arm's creations.
+  have Ep := icmpCastExtLocal_extends opInBounds hCE
+  have hOpInP : op.InBounds ctxP.raw := Ep.inBounds op opInBounds
+  have E₅ := CtxExtends.of_createOp hLi hOpInP
+  have E₆ := CtxExtends.of_createOp hCmp (E₅.inBounds op hOpInP)
+  have E₇ := CtxExtends.of_createOp hCastBack (E₆.inBounds op (E₅.inBounds op hOpInP))
+  have hExtP : CtxExtends op ctxP ctx₇ := E₅.trans (E₆.trans E₇)
+  have Ectx : CtxExtends op ctx ctx₇ := Ep.trans hExtP
+  have hOpsIn : ∀ o ∈ (pre ++ #[liOp, cmpOp, castBackOp]).toList, o.InBounds ctx₇.raw := by
+    grind [LocalRewritePattern.ReturnOps]
+  have hPreIn : ∀ o ∈ pre.toList, o.InBounds ctx₇.raw := by
+    intro o ho
+    exact hOpsIn o (by simp only [Array.toList_append, List.mem_append]; exact Or.inl ho)
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hLhsIn hxVal
+      hDomCtxL (Ectx.dominates lhs hDomCtxL) lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hRhsIn hyVal
+      hDomCtxR (Ectx.dominates rhs hDomCtxR) rNotOp
+  obtain ⟨sPre, hPre, hPreMem, hAVal, hBVal⟩ :=
+    icmpCastExtLocal_run opInBounds hCE hExtP hExtId hExtSem hRhsIn hLVal' hRVal' hPreIn
+  have hLiIn₅ : liOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hLi
+  have hLiFresh : ¬ liOp.InBounds ctxP.raw := WfRewriter.createOp_new_not_inBounds _ hLi
+  have hCmpIn₆ : cmpOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hCmp
+  have hAInP : a.InBounds ctxP.raw := (icmpCastExtLocal_regs_inBounds hCE).1
+  have hLiType : liOp.getOpType! ctx₇.raw = .riscv .li := by
+    rw [(E₆.trans E₇).opType liOp hLiIn₅]; grind
+  have hLiOperands : liOp.getOperands! ctx₇.raw = #[] := by
+    rw [(E₆.trans E₇).operands liOp hLiIn₅]; grind
+  have hLiResTypes : liOp.getResultTypes! ctx₇.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [(E₆.trans E₇).resultTypes liOp hLiIn₅]; grind
+  have hLiProps : liOp.getProperties! ctx₇.raw (.riscv .li) = icmpZeroImm := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hCmp (by grind)]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hLi (operation := liOp)]
+  have hCmpType : cmpOp.getOpType! ctx₇.raw = .riscv .sltu := by
+    rw [E₇.opType cmpOp hCmpIn₆]; grind
+  have hCmpOperands : cmpOp.getOperands! ctx₇.raw = #[ValuePtr.opResult (liOp.getResult 0), a] := by
+    rw [E₇.operands cmpOp hCmpIn₆]; grind
+  have hCmpResTypes : cmpOp.getResultTypes! ctx₇.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [E₇.resultTypes cmpOp hCmpIn₆]; grind
+  have hCastBackType : castBackOp.getOpType! ctx₇.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₇.raw = #[ValuePtr.opResult (cmpOp.getResult 0)] := by grind
+  have isT : Attribute.isType (Attribute.integerType (⟨1⟩ : IntegerType)) := by grind
+  have hCBType : ((op.getResult 0).get! ctx₆.raw).type
+      = (⟨Attribute.integerType ⟨1⟩, isT⟩ : TypeAttr) := by
+    have h1 := (Ep.trans (E₅.trans E₆)).valueType (ValuePtr.opResult (op.getResult 0)) hResIn
+    simp only [ValuePtr.getType!_opResult] at h1
+    apply Subtype.ext
+    rw [show ((op.getResult 0).get! ctx₆.raw).type = ((op.getResult 0).get! ctx.raw).type from h1]
+    exact hResType
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₇.raw
+      = #[⟨Attribute.integerType ⟨1⟩, isT⟩] := by grind
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, hFrame₅⟩ :=
+    interpretOp_riscv_li_forward (state := sPre) (inBounds := hOpsIn liOp (by simp))
+      (props := icmpZeroImm) hLiType hLiProps hLiOperands hLiResTypes
+  have hAVal₅ : s₅.variables.getVar? a = some (.reg (e (LLVM.Int.toReg xt))) := by
+    rw [hFrame₅ a (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hAInP hLiFresh)]
+    exact hAVal
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, -⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₅) (inBounds := hOpsIn cmpOp (by simp))
+      (f := fun r₁ r₂ => Data.RISCV.sltu r₂ r₁) (fun _ _ _ _ => rfl)
+      hCmpType hCmpOperands hCmpResTypes hRes₅ hAVal₅
+  obtain ⟨s₇, hI₇, hMem₇, hRes₇, -⟩ :=
+    interpretOp_castBack_forward (state := s₆) (inBounds := hOpsIn castBackOp (by simp))
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₆
+  refine ⟨s₇, ?_, by grind, ?_⟩
+  · simp only [Array.toList_append]
+    rw [interpretOpList_append, hPre]
+    simp [interpretOpList_cons, hI₅, hI₆, hI₇, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 1 (RISCV.Reg.toInt (Data.RISCV.sltu (e (LLVM.Int.toReg xt))
+        (Data.RISCV.li (BitVec.ofInt 64 icmpZeroImm.value.value))) 1)], ?_, ?_⟩
+    · simp [hRes₇, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa [icmpZeroImm] using hData xt hxtRef⟩
+
+set_option maxHeartbeats 1600000 in
+/-- Correctness of the generic `ne` arm: `sltu 0 (xor b a)`. -/
+theorem icmpEmitXorSnezLocal_sound {ctx : WfIRContext OpCode} {op : OperationPtr}
+    (opInBounds : op.InBounds ctx.raw)
+    {lhs rhs : ValuePtr} {ext : Option IcmpExtOp}
+    {e : Data.RISCV.Reg → Data.RISCV.Reg}
+    {pattern : LocalRewritePattern OpCode}
+    {hReturnOps : pattern.ReturnOps} {hReturnCtx : pattern.ReturnCtxChanges}
+    {hReturnVIB : pattern.ReturnValuesInBounds} {hReturnV : pattern.ReturnValues}
+    {newCtx : WfIRContext OpCode} {newOps : Array OperationPtr} {newValues : Array ValuePtr}
+    {state newState : InterpreterState ctx} {state' : InterpreterState newCtx}
+    {bw : Nat} {xVal yVal : Data.LLVM.Int bw} {srcVal : Data.LLVM.Int 1}
+    {ipIn : (InsertPoint.before op).InBounds ctx.raw}
+    {ipIn' : (InsertPoint.before op).InBounds newCtx.raw}
+    (hpatternOrig : pattern ctx op = some (newCtx, some (newOps, newValues)))
+    (hEmit : icmpEmitXorSnezLocal ctx op lhs rhs ext = some (newCtx, some (newOps, newValues)))
+    (hResType : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨1⟩)
+    (hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw)
+    (hLhsIn : lhs.InBounds ctx.raw) (hRhsIn : rhs.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? lhs = some (RuntimeValue.int bw xVal))
+    (hyVal : state.variables.getVar? rhs = some (RuntimeValue.int bw yVal))
+    (hMem : state.memory = newState.memory)
+    (memoryRefinement : state.memory = state'.memory)
+    (hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx)
+    (hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx)
+    (lNotOp : lhs ∉ op.getResults! ctx.raw) (rNotOp : rhs ∉ op.getResults! ctx.raw)
+    (state'Dom : state'.DefinesDominating (InsertPoint.before op) ipIn')
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpatternOrig hReturnVIB hReturnV hReturnCtx)
+      (.at (.before op)) (.at (.before op)) ipIn ipIn')
+    (hExtId : ext = none → ∀ r, e r = r)
+    (hExtSem : ∀ eo, ext = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none)))
+    (hData : ∀ xt yt : Data.LLVM.Int bw, xVal ⊒ xt → yVal ⊒ yt →
+      srcVal ⊒ RISCV.Reg.toInt
+        (Data.RISCV.sltu (Data.RISCV.xor (e (LLVM.Int.toReg xt)) (e (LLVM.Int.toReg yt)))
+          (Data.RISCV.li (BitVec.ofInt 64 0))) 1) :
+    ∃ newState', interpretOpList newOps.toList state'
+        (by grind [LocalRewritePattern.ReturnOps]) = some (newState', none) ∧
+      newState.memory = newState'.memory ∧
+      ∃ targetValues, newValues.mapM (newState'.variables.getVar? ·) = some targetValues ∧
+        (#[RuntimeValue.int 1 srcVal] : Array RuntimeValue) ⊒ targetValues := by
+  simp only [icmpEmitXorSnezLocal, bind, Option.bind_eq_some_iff] at hEmit
+  obtain ⟨⟨ctxP, pre, a, b⟩, hCE, hEmit⟩ := hEmit
+  obtain ⟨⟨ctx₅, xorOp⟩, hXor, hEmit⟩ := hEmit
+  replace hXor := WfRewriter.createOp!_none_some hXor
+  obtain ⟨_, _, _, hXor⟩ := hXor
+  obtain ⟨⟨ctx₆, liOp⟩, hLi, hEmit⟩ := hEmit
+  replace hLi := WfRewriter.createOp!_none_some hLi
+  obtain ⟨_, _, _, hLi⟩ := hLi
+  obtain ⟨⟨ctx₇, cmpOp⟩, hCmp, hEmit⟩ := hEmit
+  replace hCmp := WfRewriter.createOp!_none_some hCmp
+  obtain ⟨_, _, _, hCmp⟩ := hCmp
+  obtain ⟨⟨ctx₈, castBackOp⟩, hCastBack, hEmit⟩ := hEmit
+  simp only [replaceWithRegLocal] at hCastBack
+  replace hCastBack := WfRewriter.createOp!_none_some hCastBack
+  obtain ⟨_, _, _, hCastBack⟩ := hCastBack
+  obtain ⟨rfl, rfl, rfl⟩ := by simpa using hEmit
+  -- Context extensions: prologue, then this arm's creations.
+  have Ep := icmpCastExtLocal_extends opInBounds hCE
+  have hOpInP : op.InBounds ctxP.raw := Ep.inBounds op opInBounds
+  have E₅ := CtxExtends.of_createOp hXor hOpInP
+  have E₆ := CtxExtends.of_createOp hLi (E₅.inBounds op hOpInP)
+  have E₇ := CtxExtends.of_createOp hCmp (E₆.inBounds op (E₅.inBounds op hOpInP))
+  have E₈ := CtxExtends.of_createOp hCastBack
+    (E₇.inBounds op (E₆.inBounds op (E₅.inBounds op hOpInP)))
+  have hExtP : CtxExtends op ctxP ctx₈ := E₅.trans (E₆.trans (E₇.trans E₈))
+  have Ectx : CtxExtends op ctx ctx₈ := Ep.trans hExtP
+  have hOpsIn : ∀ o ∈ (pre ++ #[xorOp, liOp, cmpOp, castBackOp]).toList, o.InBounds ctx₈.raw := by
+    grind [LocalRewritePattern.ReturnOps]
+  have hPreIn : ∀ o ∈ pre.toList, o.InBounds ctx₈.raw := by
+    intro o ho
+    exact hOpsIn o (by simp only [Array.toList_append, List.mem_append]; exact Or.inl ho)
+  obtain ⟨xt, hLVal', hxtRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hLhsIn hxVal
+      hDomCtxL (Ectx.dominates lhs hDomCtxL) lNotOp
+  obtain ⟨yt, hRVal', hytRef⟩ :=
+    LocalRewritePattern.exists_refined_int_getVar? valueRefinement state'Dom hRhsIn hyVal
+      hDomCtxR (Ectx.dominates rhs hDomCtxR) rNotOp
+  obtain ⟨sPre, hPre, hPreMem, hAVal, hBVal⟩ :=
+    icmpCastExtLocal_run opInBounds hCE hExtP hExtId hExtSem hRhsIn hLVal' hRVal' hPreIn
+  have hXorIn₅ : xorOp.InBounds ctx₅.raw := WfRewriter.createOp_new_inBounds _ hXor
+  have hLiIn₆ : liOp.InBounds ctx₆.raw := WfRewriter.createOp_new_inBounds _ hLi
+  have hLiFresh₅ : ¬ liOp.InBounds ctx₅.raw := WfRewriter.createOp_new_not_inBounds _ hLi
+  have hCmpIn₇ : cmpOp.InBounds ctx₇.raw := WfRewriter.createOp_new_inBounds _ hCmp
+  have hXorResIn₅ : (ValuePtr.opResult (xorOp.getResult 0)).InBounds ctx₅.raw := by
+    grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  have hXorType : xorOp.getOpType! ctx₈.raw = .riscv .xor := by
+    rw [(E₆.trans (E₇.trans E₈)).opType xorOp hXorIn₅]; grind
+  have hXorOperands : xorOp.getOperands! ctx₈.raw = #[b, a] := by
+    rw [(E₆.trans (E₇.trans E₈)).operands xorOp hXorIn₅]; grind
+  have hXorResTypes : xorOp.getResultTypes! ctx₈.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [(E₆.trans (E₇.trans E₈)).resultTypes xorOp hXorIn₅]; grind
+  have hLiType : liOp.getOpType! ctx₈.raw = .riscv .li := by
+    rw [(E₇.trans E₈).opType liOp hLiIn₆]; grind
+  have hLiOperands : liOp.getOperands! ctx₈.raw = #[] := by
+    rw [(E₇.trans E₈).operands liOp hLiIn₆]; grind
+  have hLiResTypes : liOp.getResultTypes! ctx₈.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [(E₇.trans E₈).resultTypes liOp hLiIn₆]; grind
+  have hLiProps : liOp.getProperties! ctx₈.raw (.riscv .li) = icmpZeroImm := by
+    rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hCastBack (by grind),
+      OperationPtr.getProperties!_WfRewriter_createOp_ne hCmp (by grind)]
+    grind [OperationPtr.getProperties!_WfRewriter_createOp hLi (operation := liOp)]
+  have hCmpType : cmpOp.getOpType! ctx₈.raw = .riscv .sltu := by
+    rw [E₈.opType cmpOp hCmpIn₇]; grind
+  have hCmpOperands : cmpOp.getOperands! ctx₈.raw
+      = #[ValuePtr.opResult (liOp.getResult 0), ValuePtr.opResult (xorOp.getResult 0)] := by
+    rw [E₈.operands cmpOp hCmpIn₇]; grind
+  have hCmpResTypes : cmpOp.getResultTypes! ctx₈.raw = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+    rw [E₈.resultTypes cmpOp hCmpIn₇]; grind
+  have hCastBackType : castBackOp.getOpType! ctx₈.raw = .builtin .unrealized_conversion_cast := by
+    grind
+  have hCastBackOperands :
+      castBackOp.getOperands! ctx₈.raw = #[ValuePtr.opResult (cmpOp.getResult 0)] := by grind
+  have isT : Attribute.isType (Attribute.integerType (⟨1⟩ : IntegerType)) := by grind
+  have hCBType : ((op.getResult 0).get! ctx₇.raw).type
+      = (⟨Attribute.integerType ⟨1⟩, isT⟩ : TypeAttr) := by
+    have h1 := (Ep.trans (E₅.trans (E₆.trans E₇))).valueType
+      (ValuePtr.opResult (op.getResult 0)) hResIn
+    simp only [ValuePtr.getType!_opResult] at h1
+    apply Subtype.ext
+    rw [show ((op.getResult 0).get! ctx₇.raw).type = ((op.getResult 0).get! ctx.raw).type from h1]
+    exact hResType
+  have hCastBackResTypes : castBackOp.getResultTypes! ctx₈.raw
+      = #[⟨Attribute.integerType ⟨1⟩, isT⟩] := by grind
+  obtain ⟨s₅, hI₅, hMem₅, hRes₅, -⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := sPre) (inBounds := hOpsIn xorOp (by simp))
+      (f := fun r₁ r₂ => Data.RISCV.xor r₂ r₁) (fun _ _ _ _ => rfl)
+      hXorType hXorOperands hXorResTypes hBVal hAVal
+  obtain ⟨s₆, hI₆, hMem₆, hRes₆, hFrame₆⟩ :=
+    interpretOp_riscv_li_forward (state := s₅) (inBounds := hOpsIn liOp (by simp))
+      (props := icmpZeroImm) hLiType hLiProps hLiOperands hLiResTypes
+  have hXorRes₆ : s₆.variables.getVar? (ValuePtr.opResult (xorOp.getResult 0))
+      = some (.reg (Data.RISCV.xor (e (LLVM.Int.toReg xt)) (e (LLVM.Int.toReg yt)))) := by
+    rw [hFrame₆ _ (ValuePtr.not_mem_getResults!_of_inBounds_of_not_inBounds hXorResIn₅ hLiFresh₅)]
+    exact hRes₅
+  obtain ⟨s₇, hI₇, hMem₇, hRes₇, -⟩ :=
+    interpretOp_riscv_binaryReg_forward (state := s₆) (inBounds := hOpsIn cmpOp (by simp))
+      (f := fun r₁ r₂ => Data.RISCV.sltu r₂ r₁) (fun _ _ _ _ => rfl)
+      hCmpType hCmpOperands hCmpResTypes hRes₆ hXorRes₆
+  obtain ⟨s₈, hI₈, hMem₈, hRes₈, -⟩ :=
+    interpretOp_castBack_forward (state := s₇) (inBounds := hOpsIn castBackOp (by simp))
+      hCastBackType hCastBackOperands hCastBackResTypes hRes₇
+  refine ⟨s₈, ?_, by grind, ?_⟩
+  · simp only [Array.toList_append]
+    rw [interpretOpList_append, hPre]
+    simp [interpretOpList_cons, hI₅, hI₆, hI₇, hI₈, liftM, monadLift, MonadLift.monadLift, Interp]
+  · refine ⟨#[RuntimeValue.int 1 (RISCV.Reg.toInt (Data.RISCV.sltu
+        (Data.RISCV.xor (e (LLVM.Int.toReg xt)) (e (LLVM.Int.toReg yt)))
+        (Data.RISCV.li (BitVec.ofInt 64 icmpZeroImm.value.value))) 1)], ?_, ?_⟩
+    · simp [hRes₈, Option.bind, Option.map]
+    · exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+        ⟨rfl, by simpa [icmpZeroImm] using hData xt yt hxtRef hytRef⟩
+
+/-! ### Data-level refinement lemmas
+
+Each arm's data obligation has the shape `icmp x y pred ⊒ RISCV.Reg.toInt (…) 1`, where the source
+operands `x`/`y` are replaced by refinements `xt`/`yt` (via `icmp_mono`) and each register holds the
+sign-extension `e (toReg ·)` of its operand: `sextw` at `i32`, `sextb` at `i8`, and the identity at
+`i64` (`toReg` already zero-extends into the full register).
+
+Sign-extending both operands preserves *both* comparison orders: for the signed comparisons it is
+required (`toReg` zero-extends, so a negative narrow operand would look positive), and it is
+harmless for the unsigned ones because sign-extension is monotone for the unsigned order (it maps
+the two halves of the narrow range to two intervals of the wide range in the same relative order).
+-/
+
+/-- `icmp eq` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_eq_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.eq ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltiu 1#12
+        (Data.RISCV.xor (Data.RISCV.sextw (LLVM.Int.toReg y))
+          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp ne` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ne_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ne ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu
+        (Data.RISCV.xor (Data.RISCV.sextw (LLVM.Int.toReg y)) (Data.RISCV.sextw (LLVM.Int.toReg x)))
+        (Data.RISCV.li 0#64)) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp slt` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_slt_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.slt ⊒
+      RISCV.Reg.toInt (Data.RISCV.slt (Data.RISCV.sextw (LLVM.Int.toReg y))
+        (Data.RISCV.sextw (LLVM.Int.toReg x))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp sle` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_sle_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sle ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.slt (Data.RISCV.sextw (LLVM.Int.toReg x))
+          (Data.RISCV.sextw (LLVM.Int.toReg y)))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp sgt` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_sgt_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sgt ⊒
+      RISCV.Reg.toInt (Data.RISCV.slt (Data.RISCV.sextw (LLVM.Int.toReg x))
+        (Data.RISCV.sextw (LLVM.Int.toReg y))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp sge` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_sge_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sge ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.slt (Data.RISCV.sextw (LLVM.Int.toReg y))
+          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp ult` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ult_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ult ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.sextw (LLVM.Int.toReg y))
+        (Data.RISCV.sextw (LLVM.Int.toReg x))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp ule` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ule_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ule ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.sltu (Data.RISCV.sextw (LLVM.Int.toReg x))
+          (Data.RISCV.sextw (LLVM.Int.toReg y)))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp ugt` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ugt_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ugt ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.sextw (LLVM.Int.toReg x))
+        (Data.RISCV.sextw (LLVM.Int.toReg y))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp uge` on `i32` operands, sign-extended into their registers. -/
+theorem icmp_refinement_uge_32 {x y : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.uge ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.sltu (Data.RISCV.sextw (LLVM.Int.toReg y))
+          (Data.RISCV.sextw (LLVM.Int.toReg x)))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp eq x 0` on `i32`: the zero-compare peephole. -/
+theorem icmp_refinement_eq_zero_rhs_32 {x : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x (Data.LLVM.Int.constant 32 0) Data.LLVM.IntPred.eq ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltiu 1#12 (Data.RISCV.sextw (LLVM.Int.toReg x))) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp ne x 0` on `i32`: the zero-compare peephole. -/
+theorem icmp_refinement_ne_zero_rhs_32 {x : Data.LLVM.Int 32} :
+    Data.LLVM.Int.icmp x (Data.LLVM.Int.constant 32 0) Data.LLVM.IntPred.ne ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.sextw (LLVM.Int.toReg x))
+        (Data.RISCV.li 0#64)) 1 := by
+  simp only [Data.RISCV.sextw, Data.RISCV.addiw]
+  veir_bv_decide
+
+/-- `icmp eq` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_eq_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.eq ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltiu 1#12
+        (Data.RISCV.xor (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp ne` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ne_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ne ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu
+        (Data.RISCV.xor (Data.RISCV.sextb (LLVM.Int.toReg y)) (Data.RISCV.sextb (LLVM.Int.toReg x)))
+        (Data.RISCV.li 0#64)) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp slt` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_slt_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.slt ⊒
+      RISCV.Reg.toInt (Data.RISCV.slt (Data.RISCV.sextb (LLVM.Int.toReg y))
+        (Data.RISCV.sextb (LLVM.Int.toReg x))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp sle` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_sle_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sle ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.slt (Data.RISCV.sextb (LLVM.Int.toReg x))
+          (Data.RISCV.sextb (LLVM.Int.toReg y)))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp sgt` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_sgt_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sgt ⊒
+      RISCV.Reg.toInt (Data.RISCV.slt (Data.RISCV.sextb (LLVM.Int.toReg x))
+        (Data.RISCV.sextb (LLVM.Int.toReg y))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp sge` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_sge_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sge ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.slt (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp ult` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ult_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ult ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.sextb (LLVM.Int.toReg y))
+        (Data.RISCV.sextb (LLVM.Int.toReg x))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp ule` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ule_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ule ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.sltu (Data.RISCV.sextb (LLVM.Int.toReg x))
+          (Data.RISCV.sextb (LLVM.Int.toReg y)))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp ugt` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_ugt_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ugt ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.sextb (LLVM.Int.toReg x))
+        (Data.RISCV.sextb (LLVM.Int.toReg y))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp uge` on `i8` operands, sign-extended into their registers. -/
+theorem icmp_refinement_uge_8 {x y : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x y Data.LLVM.IntPred.uge ⊒
+      RISCV.Reg.toInt (Data.RISCV.xori 1#12
+        (Data.RISCV.sltu (Data.RISCV.sextb (LLVM.Int.toReg y))
+          (Data.RISCV.sextb (LLVM.Int.toReg x)))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp eq x 0` on `i8`: the zero-compare peephole. -/
+theorem icmp_refinement_eq_zero_rhs_8 {x : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x (Data.LLVM.Int.constant 8 0) Data.LLVM.IntPred.eq ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltiu 1#12 (Data.RISCV.sextb (LLVM.Int.toReg x))) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-- `icmp ne x 0` on `i8`: the zero-compare peephole. -/
+theorem icmp_refinement_ne_zero_rhs_8 {x : Data.LLVM.Int 8} :
+    Data.LLVM.Int.icmp x (Data.LLVM.Int.constant 8 0) Data.LLVM.IntPred.ne ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (Data.RISCV.sextb (LLVM.Int.toReg x))
+        (Data.RISCV.li 0#64)) 1 := by
+  simp only [Data.RISCV.sextb]
+  veir_bv_decide
+
+/-! ### Bundling the data facts per width
+
+The twelve arms of `icmp_local` need twelve data-level refinements, all at the source operands'
+width and all mentioning the same extension `e`. `icmpData_of_bitwidth` produces, for each legal
+width, the extension semantics together with all twelve, so the dispatch below can quote them
+uniformly. -/
+
+/-- The data-level refinements the `icmp` arms need at operand width `bw`, when each operand
+    register holds `e` of the operand. `eqZero`/`neZero` are the zero-compare peepholes. -/
+structure IcmpData (bw : Nat) (e : Data.RISCV.Reg → Data.RISCV.Reg) : Prop where
+  slt : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.slt ⊒
+    RISCV.Reg.toInt (Data.RISCV.slt (e (LLVM.Int.toReg y)) (e (LLVM.Int.toReg x))) 1
+  sgt : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sgt ⊒
+    RISCV.Reg.toInt (Data.RISCV.slt (e (LLVM.Int.toReg x)) (e (LLVM.Int.toReg y))) 1
+  ult : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ult ⊒
+    RISCV.Reg.toInt (Data.RISCV.sltu (e (LLVM.Int.toReg y)) (e (LLVM.Int.toReg x))) 1
+  ugt : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ugt ⊒
+    RISCV.Reg.toInt (Data.RISCV.sltu (e (LLVM.Int.toReg x)) (e (LLVM.Int.toReg y))) 1
+  sge : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sge ⊒
+    RISCV.Reg.toInt (Data.RISCV.xori (BitVec.ofInt 12 1)
+      (Data.RISCV.slt (e (LLVM.Int.toReg y)) (e (LLVM.Int.toReg x)))) 1
+  sle : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.sle ⊒
+    RISCV.Reg.toInt (Data.RISCV.xori (BitVec.ofInt 12 1)
+      (Data.RISCV.slt (e (LLVM.Int.toReg x)) (e (LLVM.Int.toReg y)))) 1
+  uge : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.uge ⊒
+    RISCV.Reg.toInt (Data.RISCV.xori (BitVec.ofInt 12 1)
+      (Data.RISCV.sltu (e (LLVM.Int.toReg y)) (e (LLVM.Int.toReg x)))) 1
+  ule : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ule ⊒
+    RISCV.Reg.toInt (Data.RISCV.xori (BitVec.ofInt 12 1)
+      (Data.RISCV.sltu (e (LLVM.Int.toReg x)) (e (LLVM.Int.toReg y)))) 1
+  eq : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.eq ⊒
+    RISCV.Reg.toInt (Data.RISCV.sltiu (BitVec.ofInt 12 1)
+      (Data.RISCV.xor (e (LLVM.Int.toReg x)) (e (LLVM.Int.toReg y)))) 1
+  ne : ∀ x y : Data.LLVM.Int bw, Data.LLVM.Int.icmp x y Data.LLVM.IntPred.ne ⊒
+    RISCV.Reg.toInt (Data.RISCV.sltu
+      (Data.RISCV.xor (e (LLVM.Int.toReg x)) (e (LLVM.Int.toReg y)))
+      (Data.RISCV.li (BitVec.ofInt 64 0))) 1
+  eqZero : ∀ x : Data.LLVM.Int bw,
+    Data.LLVM.Int.icmp x (Data.LLVM.Int.constant bw 0) Data.LLVM.IntPred.eq ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltiu (BitVec.ofInt 12 1) (e (LLVM.Int.toReg x))) 1
+  neZero : ∀ x : Data.LLVM.Int bw,
+    Data.LLVM.Int.icmp x (Data.LLVM.Int.constant bw 0) Data.LLVM.IntPred.ne ⊒
+      RISCV.Reg.toInt (Data.RISCV.sltu (e (LLVM.Int.toReg x)) (Data.RISCV.li (BitVec.ofInt 64 0))) 1
+
+/-- `riscv.xor` is commutative; the `eq`/`ne` arms feed it its operands in the opposite order from
+    the one the data lemmas are stated in. -/
+private theorem riscv_xor_comm (r₁ r₂ : Data.RISCV.Reg) :
+    Data.RISCV.xor r₁ r₂ = Data.RISCV.xor r₂ r₁ := by
+  simp only [Data.RISCV.xor, BitVec.xor_comm]
+
+/-- At each legal operand width, the sign-extension chosen by `icmpExtOf` has semantics `e`, and all
+    twelve data-level refinements hold for it. -/
+theorem icmpData_of_bitwidth {bw : Nat} (hBw : bw = 64 ∨ bw = 32 ∨ bw = 8) :
+    ∃ e : Data.RISCV.Reg → Data.RISCV.Reg,
+      (icmpExtOf bw = none → ∀ r, e r = r) ∧
+      (∀ eo, icmpExtOf bw = some eo → ∀ (props : HasDialectOpInfo.propertiesOf eo.op)
+        (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState)
+        (r : Data.RISCV.Reg),
+        Riscv.interpretOp' eo.op props resultTypes #[.reg r] blockOperands mem
+          = some (.ok (#[.reg (e r)], mem, none))) ∧
+      IcmpData bw e := by
+  rcases hBw with rfl | rfl | rfl
+  · refine ⟨id, fun _ _ => rfl, by simp [icmpExtOf], ?_⟩
+    exact ⟨fun x y => by simpa using Data.RISCV.icmp_refinement_slt (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_sgt (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_ult (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_ugt (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_sge (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_sle (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_uge (x := x) (y := y),
+      fun x y => by simpa using Data.RISCV.icmp_refinement_ule (x := x) (y := y),
+      fun x y => by rw [riscv_xor_comm]; simpa using Data.RISCV.icmp_refinement_eq (x := x) (y := y),
+      fun x y => by rw [riscv_xor_comm]; simpa using Data.RISCV.icmp_refinement_ne (x := x) (y := y),
+      fun x => by simpa using Data.RISCV.icmp_refinement_eq_zero_rhs (x := x),
+      fun x => by simpa using Data.RISCV.icmp_refinement_ne_zero_rhs (x := x)⟩
+  · refine ⟨Data.RISCV.sextw, by simp [icmpExtOf], ?_, ?_⟩
+    · rintro eo heq
+      obtain rfl : eo = ⟨.sextw, rfl⟩ := by simpa [icmpExtOf] using heq.symm
+      intro props rt bo mem r
+      rfl
+    · exact ⟨fun x y => icmp_refinement_slt_32, fun x y => icmp_refinement_sgt_32,
+        fun x y => icmp_refinement_ult_32, fun x y => icmp_refinement_ugt_32,
+        fun x y => icmp_refinement_sge_32, fun x y => icmp_refinement_sle_32,
+        fun x y => icmp_refinement_uge_32, fun x y => icmp_refinement_ule_32,
+        fun x y => by rw [riscv_xor_comm]; exact icmp_refinement_eq_32,
+        fun x y => by rw [riscv_xor_comm]; exact icmp_refinement_ne_32,
+        fun x => icmp_refinement_eq_zero_rhs_32, fun x => icmp_refinement_ne_zero_rhs_32⟩
+  · refine ⟨Data.RISCV.sextb, by simp [icmpExtOf], ?_, ?_⟩
+    · rintro eo heq
+      obtain rfl : eo = ⟨.sextb, rfl⟩ := by simpa [icmpExtOf] using heq.symm
+      intro props rt bo mem r
+      rfl
+    · exact ⟨fun x y => icmp_refinement_slt_8, fun x y => icmp_refinement_sgt_8,
+        fun x y => icmp_refinement_ult_8, fun x y => icmp_refinement_ugt_8,
+        fun x y => icmp_refinement_sge_8, fun x y => icmp_refinement_sle_8,
+        fun x y => icmp_refinement_uge_8, fun x y => icmp_refinement_ule_8,
+        fun x y => by rw [riscv_xor_comm]; exact icmp_refinement_eq_8,
+        fun x y => by rw [riscv_xor_comm]; exact icmp_refinement_ne_8,
+        fun x => icmp_refinement_eq_zero_rhs_8, fun x => icmp_refinement_ne_zero_rhs_8⟩
+
+/-! ### Correctness of `icmp_local` -/
+
+set_option maxHeartbeats 1600000 in
+theorem icmp_local_preservesSemantics
+    {h : LocalRewritePattern.ReturnOps icmp_local}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges icmp_local}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds icmp_local}
+    {h₄ : LocalRewritePattern.ReturnValues icmp_local} :
+    LocalRewritePattern.PreservesSemantics icmp_local h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  -- `hEmitPat` is unfolded so the matcher and the guards can be peeled; `hpattern` stays in
+  -- `icmp_local ctx op = …` form for the `mapping` in `valueRefinement`.
+  have hEmitPat := hpattern
+  simp only [icmp_local] at hEmitPat
+  simp [pure] at hEmitPat
+  -- Peel the matcher.
+  have hMatchSome : (matchIcmp op ctx.raw).isSome := by
+    cases hM : matchIcmp op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hEmitPat; simp at hEmitPat
+  obtain ⟨⟨lhs, rhs, prop⟩, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hEmitPat
+  simp only [] at hEmitPat
+  have ⟨hOpType, hNumResults, hOperands, hProps⟩ := matchIcmp_implies hMatch
+  have opVerif : op.Verified ctx opInBounds := by grind
+  have ⟨hNRes, hNOper, hNSucc, hNReg, ⟨i1ty, hResTypeV, hResBw⟩, hOpEqType⟩ :=
+    OperationPtr.Verified.llvm_icmp opVerif hOpType
+  have hLhsEq : lhs = (op.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  have hRhsEq : rhs = (op.getOperands! ctx.raw)[1]! := by rw [hOperands]; rfl
+  have hOperand0 : op.getOperand! ctx.raw 0 = lhs := by
+    rw [hLhsEq]; grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOperand1 : op.getOperand! ctx.raw 1 = rhs := by
+    rw [hRhsEq]; grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  rw [hOperand0, hOperand1] at hOpEqType
+  -- Peel the `.integerType` match on the operands' type and the two bitwidth guards.
+  have hLhsTySome : ∃ lt, (lhs.getType! ctx.raw).val = Attribute.integerType lt := by
+    cases hlt : (lhs.getType! ctx.raw).val with
+    | integerType lt => exact ⟨lt, rfl⟩
+    | _ => rw [hlt] at hEmitPat; simp at hEmitPat
+  obtain ⟨lt, hLhsType⟩ := hLhsTySome
+  have hRhsType : (rhs.getType! ctx.raw).val = Attribute.integerType lt := by
+    rw [← hOpEqType, hLhsType]
+  simp only [hLhsType] at hEmitPat
+  peelSplittableCondition [hBw] hEmitPat
+  simp only [hRhsType] at hEmitPat
+  peelSplittableCondition [hBwR] hEmitPat
+  -- Peel the `.integerType` match on the result type.
+  simp only [hResTypeV] at hEmitPat
+  -- Unfold the interpretation of the source `icmp`: exposes both operand values.
+  obtain ⟨xVal, yVal, hxVal, hyVal, hMem, hRes, hCf⟩ :=
+    matchIcmp_interpretOp_unfold opInBounds hOpType hNumResults hOperands hProps hinterp
+      hLhsType hRhsType
+  subst hCf
+  have hDomCtxL : lhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  have hDomCtxR : rhs.dominatesIp (InsertPoint.before op) ctx := by
+    grind [WfIRContext.Dom.operand_dominates_op]
+  -- Source value: `op`'s single result is `icmp x y pred`.
+  rw [show op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] from by grind]
+    at hsourceValues
+  simp at hsourceValues
+  simp [hRes] at hsourceValues
+  subst sourceValues
+  have lNotOp : ¬ lhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  have rNotOp : ¬ rhs ∈ op.getResults! ctx.raw := by
+    grind [IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom (op₁ := op)]
+  obtain ⟨bw⟩ := lt
+  obtain ⟨w⟩ := i1ty
+  simp only at hResBw
+  subst hResBw
+  have hResType1 : ((op.getResult 0).get! ctx.raw).type.val = Attribute.integerType ⟨1⟩ := hResTypeV
+  have hResIn : (ValuePtr.opResult (op.getResult 0)).InBounds ctx.raw := by
+    grind [ValuePtr.InBounds, OpResultPtr.InBounds, OperationPtr.getResult]
+  have hLhsIn : lhs.InBounds ctx.raw := by rw [← hOperand0]; grind
+  have hRhsIn : rhs.InBounds ctx.raw := by rw [← hOperand1]; grind
+  -- The extension semantics and the twelve data-level refinements at this width.
+  obtain ⟨e, hExtId, hExtSem, hD⟩ := icmpData_of_bitwidth (bw := bw) (by grind)
+  -- The `eq`/`ne` peephole guard: pin the rhs to the constant `0` when it fires.
+  have hZero : (matchConstantZero rhs ctx).isSome = true → yVal = Data.LLVM.Int.constant bw 0 := by
+    intro hIsSome
+    obtain ⟨_, hCZ⟩ := Option.isSome_iff_exists.mp hIsSome
+    obtain ⟨-, attr, hCstVal, hAttrZero⟩ := matchConstantZero_implies hCZ
+    have hyConst := matchConstantIntVal_getVar?_of_EquationLemmaAt ctxDom ctxVerif opInBounds
+      stateWf hCstVal (by rw [hOperands]; simp) hRhsType
+    rw [hAttrZero] at hyConst
+    have := hyVal.symm.trans hyConst
+    simpa using this
+  -- Dispatch on the predicate; every arm delegates to its `icmpEmit*Local_sound` lemma.
+  split at hEmitPat
+  · -- eq
+    rw [show prop.predicate = Data.LLVM.IntPred.eq from by assumption] at hRes ⊢
+    split at hEmitPat
+    · rename_i hIsZero
+      obtain rfl := hZero hIsZero
+      exact icmpEmitSeqzLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+        hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+        hExtId hExtSem
+        (fun xt hxt => isRefinedBy_trans (Data.LLVM.Int.icmp_mono _ _ xt _ _ hxt
+          (isRefinedBy_refl _)) (hD.eqZero xt))
+        (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+    · exact icmpEmitCmpImmLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+        hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+        hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.xor r₂ r₁)
+        (g := fun r => Data.RISCV.sltiu (BitVec.ofInt 12 1) r) (fun _ _ _ _ _ _ => rfl)
+        (fun _ _ _ _ => rfl)
+        (fun xt yt hxt hyt => isRefinedBy_trans
+          (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.eq xt yt))
+        (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- ne
+    rw [show prop.predicate = Data.LLVM.IntPred.ne from by assumption] at hRes ⊢
+    split at hEmitPat
+    · rename_i hIsZero
+      obtain rfl := hZero hIsZero
+      exact icmpEmitSnezLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+        hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+        hExtId hExtSem
+        (fun xt hxt => isRefinedBy_trans (Data.LLVM.Int.icmp_mono _ _ xt _ _ hxt
+          (isRefinedBy_refl _)) (hD.neZero xt))
+        (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+    · exact icmpEmitXorSnezLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+        hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+        hExtId hExtSem
+        (fun xt yt hxt hyt => isRefinedBy_trans
+          (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (hD.ne xt yt))
+        (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- slt
+    rw [show prop.predicate = Data.LLVM.IntPred.slt from by assumption] at hRes ⊢
+    exact icmpEmitCmpLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.slt r₂ r₁) (fun _ _ _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.slt xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- sgt
+    rw [show prop.predicate = Data.LLVM.IntPred.sgt from by assumption] at hRes ⊢
+    exact icmpEmitCmpLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.slt r₂ r₁) (fun _ _ _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.sgt xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- ult
+    rw [show prop.predicate = Data.LLVM.IntPred.ult from by assumption] at hRes ⊢
+    exact icmpEmitCmpLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.sltu r₂ r₁) (fun _ _ _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.ult xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- ugt
+    rw [show prop.predicate = Data.LLVM.IntPred.ugt from by assumption] at hRes ⊢
+    exact icmpEmitCmpLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.sltu r₂ r₁) (fun _ _ _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.ugt xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- sge
+    rw [show prop.predicate = Data.LLVM.IntPred.sge from by assumption] at hRes ⊢
+    exact icmpEmitCmpImmLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.slt r₂ r₁)
+      (g := fun r => Data.RISCV.xori (BitVec.ofInt 12 1) r) (fun _ _ _ _ _ _ => rfl)
+      (fun _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.sge xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- sle
+    rw [show prop.predicate = Data.LLVM.IntPred.sle from by assumption] at hRes ⊢
+    exact icmpEmitCmpImmLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.slt r₂ r₁)
+      (g := fun r => Data.RISCV.xori (BitVec.ofInt 12 1) r) (fun _ _ _ _ _ _ => rfl)
+      (fun _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.sle xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- uge
+    rw [show prop.predicate = Data.LLVM.IntPred.uge from by assumption] at hRes ⊢
+    exact icmpEmitCmpImmLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.sltu r₂ r₁)
+      (g := fun r => Data.RISCV.xori (BitVec.ofInt 12 1) r) (fun _ _ _ _ _ _ => rfl)
+      (fun _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.uge xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+  · -- ule
+    rw [show prop.predicate = Data.LLVM.IntPred.ule from by assumption] at hRes ⊢
+    exact icmpEmitCmpImmLocal_sound opInBounds hpattern hEmitPat hResType1 hResIn hLhsIn hRhsIn
+      hxVal hyVal hMem memoryRefinement hDomCtxL hDomCtxR lNotOp rNotOp state'Dom valueRefinement
+      hExtId hExtSem (f := fun r₁ r₂ => Data.RISCV.sltu r₂ r₁)
+      (g := fun r => Data.RISCV.xori (BitVec.ofInt 12 1) r) (fun _ _ _ _ _ _ => rfl)
+      (fun _ _ _ _ => rfl)
+      (fun xt yt hxt hyt => isRefinedBy_trans
+        (Data.LLVM.Int.icmp_mono _ _ xt yt _ hxt hyt) (by simpa using hD.ule xt yt))
+      (hReturnOps := h) (hReturnCtx := h₂) (hReturnVIB := h₃) (hReturnV := h₄)
+
+end Veir

--- a/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
+++ b/Veir/Passes/InstructionSelection/RewriteProofs/ProofStrategy.md
@@ -38,12 +38,37 @@ structural proof is done **once per combinator**. Currently:
 - `lowerBinaryWLocal match? op64 op32 props64 props32` — the two-operand analogue: match a
   binary LLVM integer op on `i64`/`i32`, emit `castToRegLocal` for each operand → `op64`/`op32`
   applied to the two cast results (in `#[lhs, rhs]` order) → `replaceWithRegLocal`. Instances:
-  `add`, `sub`, `mul`, `sdiv`, `udiv`, `srem`, `urem`, `xor`, `shl`, `lshr` (ops without a `W`
+  `add`, `sub`, `mul`, `sdiv`, `udiv`, `srem`, `urem`, `xor` (ops without a `W`
   variant, like `xor`, pass the same opcode twice). Its shared correctness proof is
-  `lowerBinaryWLocal_preservesSemantics` (`RewriteProofs/LowerBinaryW.lean`), instantiated so
-  far for `add`, `sub`, `mul`, `xor`. The div/rem instances cannot use the current proof: their
-  LLVM interpretation has UB branches (division by zero, `intMin / -1`), so they do not satisfy
-  the total-success `hSemSrc` hypothesis and need a combinator proof variant that propagates UB.
+  `lowerBinaryWLocal_preservesSemantics` (`RewriteProofs/LowerBinaryW.lean`), instantiated for all
+  of them. The div/rem instances need the *conditional* (UB-aware) form of `hSemSrc`: their LLVM
+  interpretation has UB branches (division by zero, `intMin / -1`), so a successful source
+  interpretation is what rules those branches out.
+- `lowerByteBinaryWLocal match? op64 op32 props64 props32` — the *shift* cousin of
+  `lowerBinaryWLocal`, whose shifted operand (operand 0) may have integer **or** byte type.
+  Instances: `shl` (`sll`/`sllw`), `lshr` (`srl`/`srlw`). Its shared correctness proof is
+  `lowerByteBinaryWLocal_preservesSemantics` (`RewriteProofs/LowerByteBinaryW.lean`). The emitted
+  4-op chain is identical to `lowerBinaryWLocal`'s; the two differences both come from `llvm.shl`/
+  `llvm.lshr` verifying via `verifyLLVMShift` rather than `verifyIntegerBinop`, which yields only
+  the weak `IsVerifiedLLVMShift` (`Verifier.lean`):
+  * the width guard reads `getIntByteTypeBitwidth` of operand 0, so the proof branches on whether
+    that type is an `integerType` or a `byteType` (four branches in all, with the width branch).
+    The byte branches run through the `LowerTrunc` byte layer (`interpretOp_castToReg_byte_forward`
+    / `interpretOp_castBack_byte_forward`, `exists_refined_byte_getVar?`).
+  * the *shift amount* (operand 1) is only pinned to be *some* integer. Its width agreeing with
+    operand 0's is a **dynamic** fact, read out of the successful source interpretation by
+    `matchShiftOp_interpretOp_unfold` (integer operand 0, from `LowerSelectBinopImm.lean`) or the
+    new `matchShiftOp_byteLhs_interpretOp_unfold` (byte operand 0), then `subst`ed. Note `subst`
+    eliminates the *pattern's* width variable in favour of the verifier's, not the other way round.
+
+  The eight data lemmas are the shift-refinement core: the RISC-V op masks the shift amount to its
+  low 5/6 bits while the LLVM shift is poison for `y ≥ w`, so refinement is trivial exactly where
+  the source is poison and `veir_bv_decide` closes the rest. The byte lemmas need
+  `Data.LLVM.Byte.shl_eq` (`Data/LLVM/Byte/Lemmas.lean`): unlike `Byte.lshr`, `Byte.shl` is defined
+  as an `Id.run do` block, which `bv_decide` cannot see through, so it is restated as a
+  `@[veir_bv_normalize]` conditional chain. Dropping the byte's per-bit poison mask on the way into
+  a register is sound: `Byte.toReg` keeps `b.val`, whose poisoned bits are zero by the `Byte`
+  invariant, and the target's result mask is `0`, which refines any source mask.
 - `lowerBinaryRegLocal match? rop props` — the width-agnostic cousin of `lowerBinaryWLocal`: match
   a binary LLVM integer op whose *result* type is `i64`/`i32`, emit `castToRegLocal` for each
   operand → a *single* `riscv` op `rop` (the same instruction at both bitwidths — no `W` variant,
@@ -109,6 +134,45 @@ structural proof is done **once per combinator**. Currently:
   `createOp_new_not_inBounds`), `clear` the in-bounds hypotheses (they break `grind` by
   non-monotonicity), and pass the in-bounds witnesses explicitly to the forward lemmas — after which
   bare `grind` closes each structural fact by e-matching without touching `hpattern`.
+- `icmpCastExtLocal` + the five `icmpEmit*Local` arms (`RISCV64.lean`) — `llvm.icmp` on
+  `i64`/`i32`/`i8`. Every arm shares a prologue (cast both operands into registers, plus a
+  `riscv.sextw`/`sextb` on each for the narrow widths) and an epilogue (cast the `i1` result back);
+  only the comparison sequence differs, and there are five of them: a single reg-reg compare
+  (`slt`/`sgt`/`ult`/`ugt`), a compare followed by an immediate op (`sle`/`sge`/`ule`/`uge`, and
+  the generic `eq` as `xor` then `sltiu _ 1`), `seqz` and `snez` (the compare-against-zero
+  peepholes), and `xor` then `snez` (the generic `ne`). Proven in `RewriteProofs/LowerIcmp.lean`.
+
+  This is the first proof to factor a *prologue* rather than a whole pattern, which needs one new
+  idea. The forward-interpretation lemmas need the prologue's ops' structural facts in the arm's
+  *final* context, which is only reachable through the arm's own creations — so the prologue cannot
+  simply be proven against its own context. `CtxExtends op ctx ctx'` bundles everything a chain of
+  `WfRewriter.createOp`s preserves (in-bounds, opcode, operands, result types, value types, and
+  dominance of `before op`), is closed under composition (`CtxExtends.trans`) and is produced by one
+  creation (`CtxExtends.of_createOp`). `icmpCastExtLocal_run` then takes the extension `ctxP → F` as
+  a *hypothesis*, so each arm discharges it from its own creations and replays the shared prologue
+  through `interpretOpList_append`. Without this the twelve predicate arms × three widths would be
+  36 separate op-chain proofs.
+
+  Two smaller notes. The operand swap (`slt lhs rhs` vs `slt rhs lhs`) is kept symbolic rather than
+  split on: obtain `⟨u, v, huv⟩ : ∃ u v, (if swap then (b, a) else (a, b)) = (u, v)` before peeling,
+  and recover the two registers' values with a `cases swap` inside a single `have`. And the `ext`
+  argument is an `Option IcmpExtOp` (opcode bundled with its `propertiesOf … = Unit` proof) rather
+  than an `Option Riscv` plus a separate dependent proof argument, so `rcases ext` is clean.
+- `bitreverse_local` (`RISCV64.lean`) — `llvm.intr.bitreverse` on `i64`/`i32`: `castToRegLocal` →
+  three SWAR bit-swap stages (`bitreverseStageLocal`, each emitting `li`/`and`/`slli`/`srli`/
+  `and`/`or`) → `riscv.rev8` (→ `riscv.srli 32` for `i32`) → `replaceWithRegLocal` — 21/22 ops,
+  the longest chain proven. Proven bespoke (`RewriteProofs/LowerBitreverse.lean`) but *factored*:
+  instead of a monolithic 21-creation peel (hundreds of pairwise distinctness transports), the
+  repeated 6-op stage is proven once against an arbitrary final context à la the `LowerIcmp`
+  prologue — `bitreverseStageLocal_extends` (its creations only extend the context) and
+  `bitreverseStageLocal_run` (symbolic execution given the `CtxExtends` witness to the final
+  context), which the main proof instantiates three times and composes through
+  `interpretOpList_append`. This motivated adding the `properties` field to `CtxExtends` (the
+  stage's `li`/`slli`/`srli` immediates must survive to the final context). The data lemmas'
+  `BitVec.reverse` is outside `bv_decide`'s vocabulary (width-recursive); at the concrete widths
+  `simp only [BitVec.reverse, BitVec.concat, BitVec.truncate_eq_setWidth]` unfolds it (simp's
+  Nat-literal offset matching peels `64 = 63+1` all the way down) into a bitblastable form, after
+  which `bv_decide` closes the three-stage SWAR identity.
 - `lowerBinopNotLocal match? dst props` (`RISCV64Sdag.lean`) — match a two-operand LLVM integer
   op on `i64` one of whose operands is a `not` (`xor _, -1`, via `matchNot`, on either side),
   then emit `castToRegLocal` ×2 → binary reg-reg `dst` → `replaceWithRegLocal`. Its shared
@@ -123,7 +187,7 @@ structural proof is done **once per combinator**. Currently:
   *zero*-extended). Standalone proof `ashr_local_preservesSemantics`
   (`RewriteProofs/LowerAshr.lean`); it verifies via `verifyIntegerBinop` (so `Verified.llvm_ashr`
   gives `IsVerifiedIntegerBinop` — both operands and the result share `intType`, no width-derivation
-  needed) and its interpreter arm is `.int`-only, so — unlike `shl`/`lshr`, which moved to the
+  needed) and its interpreter arm is `.int`-only, so — unlike `shl`/`lshr`, which use the
   byte-aware `lowerByteBinaryWLocal` — there is no byte case. Three width branches: `i32`/`i64` are
   4-op chains (like `LowerBinaryW`), `i8` is a 5-op chain threading an extra
   `interpretOp_riscv_unaryReg_forward` step for the `sextb` (like `LowerSignedMinMax`'s `sextw`), with
@@ -550,12 +614,15 @@ per lowering as above.
 | `RewriteProofs/LowerUnaryW.lean` | `matchUnaryOp_interpretOp_unfold`, `lowerUnaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations | two data lemmas + one instantiation (unary); new file per new *shape* |
 | `RewriteProofs/LowerBinaryW.lean` | `lowerBinaryWLocal_preservesSemantics`, and per-lowering Layer-0 lemmas + instantiations (`add`, `sub`, `mul`, `xor`) | two data lemmas + one instantiation (binary) |
 | `RewriteProofs/LowerBinaryReg.lean` | `lowerBinaryRegLocal_preservesSemantics` (width-agnostic single-op binary) + per-lowering Layer-0 lemmas + instantiations (`umax`, `umin`) | two data lemmas + one instantiation (binary, single op) |
+| `RewriteProofs/LowerByteBinaryW.lean` | `matchShiftOp_byteLhs_interpretOp_unfold` (byte-operand shift source unfold) + `lowerByteBinaryWLocal_preservesSemantics` (shift combinator: integer-or-byte operand 0, shift-amount width recovered dynamically, `W`-variant bitwidth branch) + four int/byte × 64/32 data lemmas per op + instantiations (`shl`, `lshr`) + `#guard_msgs` axiom pins | four data lemmas + two `hSemSrc` lemmas + one instantiation |
 | `RewriteProofs/LowerBitwiseReg.lean` | `lowerBitwiseRegLocal_preservesSemantics` (bitwise single-op binary over `i64`/`i32`/`i8`/`i1`; one width-generic refinement lemma, no bitwidth branch) + instantiations (`and`, `or`) | one width-generic data lemma + one instantiation |
 | `RewriteProofs/LowerSignedMinMax.lean` | `lowerSignedMinMaxLocal_preservesSemantics` (signed min/max; `i64` = 4 ops, `i32` = 6 ops with two extra `riscv.sextw`) + `_64`/`_32` data lemmas + instantiations (`smax`, `smin`) | two data lemmas + one instantiation |
+| `RewriteProofs/LowerIcmp.lean` | `CtxExtends` (context-extension bundle) + `icmpCastExtLocal_extends`/`_run` (shared prologue, proven once against an arbitrary final context) + one `icmpEmit*Local_sound` per comparison sequence (5) + `IcmpData` (the twelve data-level refinements at one width) + `icmpData_of_bitwidth` + `icmp_local_preservesSemantics` (twelve-arm dispatch) | twelve data lemmas per new width |
 | `RewriteProofs/LowerRotate.lean` | `matchTernaryOp_interpretOp_unfold` (ternary source unfold) + `lowerRotateLocal_preservesSemantics` (rotate; ternary source with `a = b`, result-type guard, `W`-variant bitwidth branch) + `_64`/`_32` data lemmas + instantiations (`fshl`, `fshr`) | two data lemmas + one instantiation |
 | `RewriteProofs/LowerRoriw.lean` | `roriwLike_preservesSemantics` (constant word-rotate combinator: `fshl`/`fshr a a (const)` on `i32` → `riscv.roriw` with the normalized/negated 5-bit amount; ternary source with `a = b`, immediate-emit single-cast tail, constant amount pinned via the graph lemma) + instantiations (`roriw`/`roliw`), the `ofInt_5_rotr_mod`/`ofInt_5_rotl_mod` mod-32 immediate bridges + `roriw`/`roliw_isRefinedBy` data lemmas + `#guard_msgs` axiom pins | — (one-off pair) |
 | `RewriteProofs/LowerFshConst.lean` | `fshConstLike_preservesSemantics` (GlobalISel constant word-rotate combinator: `fshl`/`fshr a a (const)` on `i64`/`i32` → `riscv.rori`/`roriw` with the normalized/negated 5-/6-bit amount; ternary `a = b`, constant amount pinned via the graph lemma, immediate-emit single-cast head with a bitwidth branch over the emitted rotate op) + instantiations (`fshrConst`/`fshlConst`), `ofInt_{5,6}_rot{r,l}` mod bridges + `fsh{r,l}_{roriw_32,rori_64}` data lemmas + `#guard_msgs` axiom pins | — (one-off pair) |
 | `RewriteProofs/LowerBinopNot.lean` | `lowerBinopNotLocal_preservesSemantics` (the DAG-matching template proof), per-lowering Layer-0 lemmas + instantiations (`andn`/`orn`/`xnor`), `#guard_msgs` axiom pins | two data lemmas + one instantiation (binop-with-not) |
+| `RewriteProofs/LowerBitreverse.lean` | `bitreverse_local_preservesSemantics` (standalone `i64`/`i32` bitreverse; 21/22-op chain factored through the reusable stage lemmas `bitreverseStageLocal_extends`/`_inBounds`/`_run`), `bitreverseStageReg` + the two SWAR data lemmas (concrete-width `BitVec.reverse` unfolding), `#guard_msgs` axiom pin | — (one-off; template for factoring any repeated emitted segment) |
 | `RewriteProofs/LowerSlliuw.lean` | `slliuw_local_preservesSemantics` (`shl (zext i32→i64 x) const` → `riscv.slliuw x const`; a two-level DAG match, outer `shl` via `matchShiftOp`, inner `zext` via a graph lemma) + `zext_getVar?_of_EquationLemmaAt` (the `zext`-defining-op graph lemma, unary/width-crossing, via `matchExtOp_interpretOp_unfold`) + `Pure.llvm_zext` + `slliuw_isRefinedBy` data lemma + `#guard_msgs` axiom pin | — (one-off) |
 | `RewriteProofs/LowerBexti.lean` | `bexti_local_preservesSemantics` (`and (lshr x n) 1` → `riscv.bexti x n`, single-bit extract; a two-level DAG match) + `lshrConst_getVar?_of_EquationLemmaAt` (the `lshr`-defining-op graph lemma, `matchNot`-style but the inner op verifies as `LLVMShift` so the width equality is recovered dynamically via `matchShiftOp_interpretOp_unfold`) + `Pure.llvm_lshr` + `bexti_isRefinedBy` data lemma + `#guard_msgs` axiom pin | — (one-off; the graph lemma also serves `slliuw`) |
 | `RewriteProofs/LowerSelectCzero.lean` | `selectCzeroeqz_local_preservesSemantics` / `selectCzeronez_local_preservesSemantics` (branchless `llvm.select c t 0`/`select c 0 f` → `riscv.czeroeqz`/`czeronez`: `i1` cond + value cast, constant-zero operand dropped via `matchConstantZero`; width-generic, no bitwidth branch) + `matchSelectOp_interpretOp_unfold` (mixed-width ternary unfold, `i1` cond) + `czeroeqz`/`czeronez_isRefinedBy` data lemmas + `#guard_msgs` axiom pins | — (one-off pair) |

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1456,6 +1456,16 @@ private theorem OperationPtr.verifyIntegerUnop_ok_of_Verified {op : OperationPtr
   | ok ty => exact ⟨ty, rfl⟩
   | error e => rw [hb] at opVerify; simp [bind, Except.bind] at opVerify
 
+/-- Structural facts from the verifier for a verified `llvm.intr.bitreverse`. Its verifier arm is
+    the shared `verifyIntegerUnop >>= pure` shape, so it reduces like `ctlz`/`cttz`/`ctpop`. -/
+theorem OperationPtr.Verified.llvm_intr__bitreverse {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds)
+    (opType : op.getOpType! ctx.raw = .llvm .intr__bitreverse) :
+    op.IsVerifiedIntegerUnop ctx := by
+  obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
+    simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  exact op.verifyIntegerUnop_eq_ok hty
+
 /-- Structural facts from the verifier for a verified `llvm.intr.ctlz`. -/
 theorem OperationPtr.Verified.llvm_intr__ctlz {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__ctlz) :


### PR DESCRIPTION
Adds correctness proofs for the `icmp_local`, `bitreverse_local`, and `shl`/`lshr` lowerings. The `shl` and `lshr` lowerings are merged into a new shared `lowerByteBinaryWLocal` combinator covering both integer and byte operands at widths 64 and 32, and `icmp_local` is refactored into a shared prologue plus five predicate arms so the common context extension is proven once. Also adds the `llvm.intr.bitreverse` verifier lemma and a few `Byte` lemmas needed by the new proofs.