### PR TITLE
feat: Prove correctness of the `reconcile-cast` pass

### DIFF
--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -12,11 +12,13 @@
   ^1():
     "func.func"()  <{function_type = (i64) -> ()}> ({
       ^1(%0 : i64):
+        // A lone `iX -> iX` cast is not a round trip, so nothing reconciles it away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i64
         "test.test"(%1) : (i64) -> ()
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
         // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   "test.test"([[C]]) : (i64) -> ()
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i64) -> i64
+        // CHECK-NEXT:   "test.test"([[I]]) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -54,8 +56,8 @@
         %3 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i64
         "test.test"(%2, %3) : (!riscv.reg, i64) -> ()
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
         // CHECK-NEXT:   [[T:%.*]] = "test.test"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
         // CHECK-NEXT:   "test.test"([[T]], [[I]]) : (!riscv.reg, i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
@@ -63,13 +65,15 @@
   ^5():
     "func.func"()  <{function_type = (i64) -> ()}> ({
       ^1(%0 : i64):
-        // identity cast and pairs of casts
+        // The `reg -> reg` cast in the middle breaks the `reg -> i64 -> reg` round trip: no
+        // pair of adjacent casts returns to its own input type, so nothing reconciles.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> !riscv.reg
         %3 = "builtin.unrealized_conversion_cast"(%2) : (!riscv.reg) -> i64
         "test.test"(%3) : (i64) -> ()
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[I]]) : (!riscv.reg) -> i64
         // CHECK-NEXT:   "test.test"([[C]]) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
@@ -83,20 +87,24 @@
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i64
         %4 = "builtin.unrealized_conversion_cast"(%3) : (!riscv.reg) -> i64
         "test.test"(%2, %4) : (i64, i64) -> ()
+        // Each `i64 -> reg` cast folds to the register argument, leaving the two `reg -> i64`
+        // casts behind as separate (identical) operations.
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   "test.test"([[C]], [[C]]) : (i64, i64) -> ()
+        // CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:   [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:   "test.test"([[C1]], [[C2]]) : (i64, i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
   ^7():
     "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
       ^1(%0 : !riscv.reg):
-        // identity cast on block argument
+        // identity cast on block argument: not a round trip, so it survives the pass
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> !riscv.reg
         "test.test"(%1) : (!riscv.reg) -> ()
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   "test.test"([[ARG]]) : (!riscv.reg) -> ()
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"([[I]]) : (!riscv.reg) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -105,14 +113,17 @@
       ^1(%0 : i8):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> i8
         "test.test"(%1) : (i8) -> ()
-        // CHECK:        "test.test"(%{{.*}}) : (i8) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i8):
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i8) -> i8
+        // CHECK-NEXT:   "test.test"([[I]]) : (i8) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
   ^9():
     "func.func"()  <{function_type = (i64) -> ()}> ({
       ^1(%0 : i64):
-        // pairs of casts
+        // `iX -> iY -> iX` round trips are not reconciled: the interpreter gives an
+        // integer-to-integer cast no semantics, so the pass leaves these alone.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i256
         %3 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i128
         %2 = "builtin.unrealized_conversion_cast"(%1) : (i256) -> i64
@@ -120,7 +131,11 @@
         "test.test"(%2, %4) : (i64, i64) -> ()
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
         // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   "test.test"([[C]], [[C]]) : (i64, i64) -> ()
+        // CHECK-NEXT:   [[W1:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i64) -> i256
+        // CHECK-NEXT:   [[W2:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i64) -> i128
+        // CHECK-NEXT:   [[N1:%.*]] = "builtin.unrealized_conversion_cast"([[W1]]) : (i256) -> i64
+        // CHECK-NEXT:   [[N2:%.*]] = "builtin.unrealized_conversion_cast"([[W2]]) : (i128) -> i64
+        // CHECK-NEXT:   "test.test"([[N1]], [[N2]]) : (i64, i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -131,10 +146,12 @@
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !riscv.reg
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
         "test.test"(%2) : (i32) -> ()
-        // The `i32 -> reg -> i32` round trip reconciles regardless of which `i32` feeds
-        // it, so this collapses to a single boundary `reg -> i32` cast.
+        // The `i32 -> reg -> i32` round trip is not itself reconciled (it freezes poison), but
+        // the boundary's `reg -> i32` cast forms a `reg -> i32 -> reg` round trip with the body's
+        // first cast, which lowers to `zextw`. The body's second cast remains.
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:   [[Z:%.*]] = "riscv.zextw"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[Z]]) : (!riscv.reg) -> i32
         // CHECK-NEXT:   "test.test"([[C]]) : (i32) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
@@ -187,16 +204,14 @@
         %2 = "test.test"(%1) : (!riscv.reg) -> (!riscv.reg)
         %3 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
         "test.test"(%2, %3) : (!riscv.reg, i32) -> ()
-        // The boundary's `reg -> i32` cast (`[[NEW]]`) feeds the body's `i32 -> reg` cast;
-        // that `i32 -> reg -> i32` round trip reconciles away, so `[[NEW]]` directly
-        // replaces the body's second cast. The remaining `reg -> i32 -> reg` round trip
-        // (`[[ARG]]` through `[[NEW]]` into the body's first cast) is then reconciled into
-        // an explicit `zextw`, since that cast is used elsewhere.
+        // The boundary's `reg -> i32` cast feeds the body's `i32 -> reg` cast, and that
+        // `reg -> i32 -> reg` round trip lowers to an explicit `zextw`. The body's second
+        // cast then reads the `zextw` result directly.
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[NEW:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i32
         // CHECK-NEXT:   [[Z:%.*]] = "riscv.zextw"([[ARG]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:   [[C2:%.*]] = "test.test"([[Z]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:   "test.test"([[C2]], [[NEW]]) : (!riscv.reg, i32) -> ()
+        // CHECK-NEXT:   [[T:%.*]] = "test.test"([[Z]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[Z]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:   "test.test"([[T]], [[C]]) : (!riscv.reg, i32) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -236,6 +251,22 @@
         // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
         // CHECK-NEXT:   %[[C1:.*]] = "riscv.slli"([[ARG]]) <{"value" = 50 : i64}> : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:   %[[C2:.*]] = "riscv.srli"(%[[C1]]) <{"value" = 50 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"(%[[C2]]) : (!riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+  ^18():
+    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+      ^1(%0 : !riscv.reg):
+        // reg -> i0 -> reg : the round trip is the constant zero, which the `slli`/`srli`
+        // pair cannot compute (its 6-bit shift amount `64 - 0` wraps back to `0`).
+        // The casts must be left alone.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i0
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i0) -> !riscv.reg
+        "test.test"(%2) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
+        // CHECK-NEXT:   %[[C1:.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i0
+        // CHECK-NEXT:   %[[C2:.*]] = "builtin.unrealized_conversion_cast"(%[[C1]]) : (i0) -> !riscv.reg
         // CHECK-NEXT:   "test.test"(%[[C2]]) : (!riscv.reg) -> ()
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Veir.lean
+++ b/Veir.lean
@@ -17,3 +17,4 @@ import Veir.Dominance
 import Veir.Passes.InstructionSelection.Proofs
 import Veir.Passes.CastsReconciliation.Reconciliation
 import Veir.Passes.InstructionSelection.RewriteProofs
+import Veir.Passes.CastsReconciliation.RewriteProofs

--- a/Veir/Data/Casting.lean
+++ b/Veir/Data/Casting.lean
@@ -54,6 +54,11 @@ theorem val_toReg {w : Nat} {i : Veir.Data.LLVM.Int w} :
   · simp [Veir.Data.LLVM.Int.isPoison]
   · simp [veir_bv_normalize]
 
+@[simp, grind =]
+theorem toReg_toInt_64 {r : Veir.Data.RISCV.Reg} :
+    LLVM.Int.toReg (RISCV.Reg.toInt r 64) = r := by
+  simp [LLVM.Int.toReg, RISCV.Reg.toInt]
+
 /--
   Cast `LLVM.Byte` to `RISCV.Reg`.
 -/

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -7,21 +7,14 @@ import Veir.Properties
 
 namespace Veir
 
-/-!
-  We reconcile casts in `builtin.unrealized_conversion_cast` operations for `!riscv.reg` and `i64` types.
+/--
+  We reconcile casts in `builtin.unrealized_conversion_cast` operations for `!riscv.reg` and `i64`
+  types, in the `reg -> i64 -> reg` direction. `Reg.toInt` is never poison and `Int.toReg` inverts
+  it at width 64, so the round trip is the identity.
 -/
-def isRiscvRegToI64Cast (inputType interType : TypeAttr): Bool :=
+def isRegToI64RoundTrip (inputType interType : TypeAttr): Bool :=
  match inputType.val, interType.val with
   | .registerType _, .integerType x => x.bitwidth = 64
-  | .integerType x, .registerType _ => x.bitwidth = 64
-  | _, _ => false
-
-/-!
-    We reconcile casts in `builtin.unrealized_conversion_cast` operations for `!riscv.reg` and `i32` types, however only for the `i32 -> reg -> i32` direction.
--/
-def isRiscvRegToI32Cast (inputType interType : TypeAttr): Bool :=
- match inputType.val, interType.val with
-  | .integerType x, .registerType _ => x.bitwidth = 32
   | _, _ => false
 
 /-!
@@ -34,106 +27,74 @@ def isRiscvRegToPtrCast (inputType interType : TypeAttr): Bool :=
   | .registerType _, .llvmPointerType _  => true
   | _, _ => false
 
-/-!
-  We reconcile casts in `builtin.unrealized_conversion_cast` operations for `iX` and `iY` types,
-  of the form:
-  ```
-  %x = "builtin.unrealized_conversion_cast"(%s) : (iX) -> iY
-  %y = "builtin.unrealized_conversion_cast"(%x) : (iY) -> iX
-  ```
-  where `X ≤ Y`, to ensure no information is loss and correctness is preserved.
--/
-def isPreservingIntegerTypeRoundTrip (inputType interType : TypeAttr) : Bool :=
-  match inputType.val, interType.val with
-  | .integerType x, .integerType y => x.bitwidth ≤ y.bitwidth
-  | _, _ => false
+/-- Reconciles round-trip casts of the form X->Y->X if allowed for these types by `legal X Y`.
 
-/- Reconciles round-trip casts of the form X->Y->X if allowed for these types by `legal X Y` -/
-set_option warn.sorry false in
-def reconcilePairingCast (legal : TypeAttr → TypeAttr → Bool) (rewriter : PatternRewriter OpCode)
-    (op : OperationPtr) (opInBounds : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some cast := matchCastOp op rewriter.ctx.raw | return rewriter
-  let input := op.getOperand! rewriter.ctx.raw 0
+  The parent cast is left in place: it is now dead, and DCE (run at the end of the pass) removes
+  it. A `LocalRewritePattern` may only erase the matched operation. -/
+def reconcilePairingCastLocal (legal : TypeAttr → TypeAttr → Bool) (ctx : WfIRContext OpCode)
+    (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some input := matchCastOp op ctx.raw | return (ctx, none)
   /- Note that reconciliation matches on the second casting operation, so the input type of this op would be the intermediate type -/
-  let interType := input.getType! rewriter.ctx.raw
-  let resultType := ((op.getResult 0).get! rewriter.ctx.raw).type
+  let interType := input.getType! ctx.raw
+  let resultType := ((op.getResult 0).get! ctx.raw).type
   /- If the operand's parent is a cast operation -/
-  let .opResult op' := input | return rewriter
-  let some cast := matchCastOp op'.op rewriter.ctx.raw | return rewriter
-  let parentInput := (op'.op.getOperand! rewriter.ctx.raw 0)
+  let .opResult op' := input | return (ctx, none)
+  let some parentInput := matchCastOp op'.op ctx.raw | return (ctx, none)
   /- And the result's type coincides with the parent operation operand's type -/
-  let inputType := parentInput.getType! rewriter.ctx.raw
-  if resultType ≠ inputType then return rewriter
+  let inputType := parentInput.getType! ctx.raw
+  if resultType ≠ inputType then return (ctx, none)
   /- And the reconciliation is legal -/
-  if ¬ legal inputType interType then return rewriter
-  /- Replace the initial operation's output with the parent operations input -/
-  let rewriter := rewriter.replaceValue (op.getResult 0) parentInput sorry sorry sorry
-  /- Erase the redundant cast operation -/
-  let rewriter ← rewriter.eraseOp op sorry sorry sorry
-  /- If unused and side-effect-free, erase the parent cast operation as well.
-    These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ op'.op.hasSideEffects rewriter.ctx.raw then
-    rewriter.eraseOp op'.op sorry sorry sorry
-  else
-    return rewriter
+  if ¬ legal inputType interType then return (ctx, none)
+  /- Replace the initial operation's output with the parent operation's input -/
+  return (ctx, some (#[], #[parentInput]))
 
-set_option warn.sorry false in
-def reconcileIdentityCast (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-  (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
-  let some cast := matchCastOp op rewriter.ctx.raw | return rewriter
-  /- get the input and output types -/
-  let input := op.getOperand! rewriter.ctx.raw 0
-  let inputType := input.getType! rewriter.ctx.raw
-  let resultType := ((op.getResult 0).get! rewriter.ctx.raw).type
-  if inputType ≠ resultType then return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) input sorry sorry sorry
-  rewriter.eraseOp op sorry sorry sorry
+/-- Reconciles round-trip casts of the form !riscv.reg->iX->!riscv.reg
+   using zext.b/w/h for 8/16/32-bit values, or slli+slri for other bitwidths.
 
-/- Reconciles round-trip casts of the form !riscv.reg->iX->!riscv.reg
-   using zext.b/w/h for 8/16/32-bit values, or slli+slri for other bitwidths. -/
-set_option warn.sorry false in
-def reconcileRegIntCast (rewriter : PatternRewriter OpCode)
-    (op : OperationPtr) (opInBounds : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some cast := matchCastOp op rewriter.ctx.raw | return rewriter
-  let input := op.getOperand! rewriter.ctx.raw 0
+  As in `reconcilePairingCastLocal`, the now-dead parent cast is left to DCE. -/
+def reconcileRegIntCastLocal (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some input := matchCastOp op ctx.raw | return (ctx, none)
   /- Note that reconciliation matches on the second casting operation, so the input type of this op would be the intermediate type -/
-  let interType := input.getType! rewriter.ctx.raw
-  let resultType := ((op.getResult 0).get! rewriter.ctx.raw).type
+  let interType := input.getType! ctx.raw
+  let resultType := ((op.getResult 0).get! ctx.raw).type
   /- If the operand's parent is a cast operation -/
-  let .opResult op' := input | return rewriter
-  let some cast := matchCastOp op'.op rewriter.ctx.raw | return rewriter
-  let parentInput := (op'.op.getOperand! rewriter.ctx.raw 0)
+  let .opResult op' := input | return (ctx, none)
+  let some parentInput := matchCastOp op'.op ctx.raw | return (ctx, none)
   /- And the result's type coincides with the parent operation operand's type -/
-  let inputType := parentInput.getType! rewriter.ctx.raw
-  if resultType ≠ inputType then return rewriter
+  let inputType := parentInput.getType! ctx.raw
+  if resultType ≠ inputType then return (ctx, none)
   /- And the reconciliation involves the right types -/
-  if inputType ≠ RegisterType.mk then return rewriter
-  let .integerType ⟨ interBw ⟩ := interType.val | rewriter
+  if inputType ≠ RegisterType.mk then return (ctx, none)
+  let .integerType ⟨ interBw ⟩ := interType.val | return (ctx, none)
   /- Replace the initial operation's output with a zero-extension of the parent's input -/
-  let (rewriter, newOp) ← match interBw with
+  match interBw with
   | 8 =>
-      rewriter.createOp! (.riscv .zextb) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+      let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .zextb) #[RegisterType.mk] #[parentInput]
+        #[] #[] () none
+      return (ctx, some (#[newOp], #[newOp.getResult 0]))
   | 16 =>
-      rewriter.createOp! (.riscv .zexth) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+      let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .zexth) #[RegisterType.mk] #[parentInput]
+        #[] #[] () none
+      return (ctx, some (#[newOp], #[newOp.getResult 0]))
   | 32 =>
-      rewriter.createOp! (.riscv .zextw) #[RegisterType.mk] #[parentInput] #[] #[] () (some $ .before op)
+      let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .zextw) #[RegisterType.mk] #[parentInput]
+        #[] #[] () none
+      return (ctx, some (#[newOp], #[newOp.getResult 0]))
   | bw =>
+      /- `i0` has no bits to preserve: the round trip is the constant zero, which neither
+         `slli`/`srli` (whose 6-bit shift amount would wrap `64 - 0` to `0`) nor any other
+         two-shift sequence computes. Leave such casts alone. -/
+      if bw = 0 then return (ctx, none)
       /- for bitwidths with no dedicated instruction, shift left then right -/
       if bw >= 64 then none else
       let imm := IntegerAttr.mk (64-bw) (.mk 64)
-      let (rewriter, shlOp) ← rewriter.createOp! (.riscv .slli) #[RegisterType.mk] #[parentInput] #[] #[] ⟨imm⟩ (some $ .before op)
-      rewriter.createOp! (.riscv .srli) #[RegisterType.mk] #[shlOp.getResult 0] #[] #[] ⟨imm⟩ (some $ .before op)
-  let rewriter := rewriter.replaceValue (op.getResult 0) (newOp.getResult 0) sorry sorry sorry
-  /- Erase the redundant cast operation -/
-  let rewriter ← rewriter.eraseOp op sorry sorry sorry
-  /- If unused and side-effect-free, erase the parent cast operation as well.
-    These need to be erased in this order, otherwise the parent operation will always be used. -/
-  if ¬ op'.op.hasUses! rewriter.ctx.raw && ¬ op'.op.hasSideEffects rewriter.ctx.raw then
-    rewriter.eraseOp op'.op sorry sorry sorry
-  else
-    return rewriter
+      let (ctx, shlOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[parentInput]
+        #[] #[] ⟨imm⟩ none
+      let (ctx, srlOp) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk]
+        #[shlOp.getResult 0] #[] #[] ⟨imm⟩ none
+      return (ctx, some (#[shlOp, srlOp], #[srlOp.getResult 0]))
 
 /-! ## Coercing function boundaries to `!riscv.reg`
 
@@ -245,14 +206,20 @@ def coerceFunctionBoundaries (ctx : WfIRContext OpCode) :
 def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
   let ctx ← coerceFunctionBoundaries ctx
-  let pattern := RewritePattern.GreedyRewritePattern #[reconcilePairingCast isRiscvRegToI64Cast,
-    reconcilePairingCast isRiscvRegToI32Cast, reconcilePairingCast isRiscvRegToPtrCast,
-    reconcilePairingCast isPreservingIntegerTypeRoundTrip, reconcileIdentityCast, reconcileRegIntCast]
+  let pattern := RewritePattern.GreedyRewritePattern #[
+    .fromLocalRewrite (reconcilePairingCastLocal isRegToI64RoundTrip),
+    .fromLocalRewrite (reconcilePairingCastLocal isRiscvRegToPtrCast),
+    .fromLocalRewrite reconcileRegIntCastLocal]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying cast reconciliation"
-  | some ctx => pure ctx
+  -- The patterns leave the (now dead) parent casts behind: `LocalRewritePattern` can only erase
+  -- the matched operation. Clean them up here so the pass is self-contained.
+  | some ctx =>
+    match RewritePattern.applyInContext (RewritePattern.GreedyRewritePattern #[eliminateDeadOp]) ctx with
+    | none => throw "Error while applying DCE after cast reconciliation"
+    | some ctx => pure ctx
 
 public def CastReconcilePass : Pass OpCode :=
   { name := "reconcile-cast"
-    description := "Reconcile casts where the input and output types are the same."
+    description := "Reconcile round trips of casts that return to their own input type."
     run := CastReconcilePass.impl }

--- a/Veir/Passes/CastsReconciliation/RewriteProofs.lean
+++ b/Veir/Passes/CastsReconciliation/RewriteProofs.lean
@@ -1,0 +1,3 @@
+import Veir.Passes.CastsReconciliation.RewriteProofs.CommonCast
+import Veir.Passes.CastsReconciliation.RewriteProofs.ReconcilePairingCast
+import Veir.Passes.CastsReconciliation.RewriteProofs.ReconcileRegIntCast

--- a/Veir/Passes/CastsReconciliation/RewriteProofs/CommonCast.lean
+++ b/Veir/Passes/CastsReconciliation/RewriteProofs/CommonCast.lean
@@ -1,0 +1,239 @@
+import Lean
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.Casting
+import Veir.Passes.CastsReconciliation.Reconciliation
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+
+/-! ## Pre-generated match equations for the reconciliation patterns
+
+`split`/`grind` realize a matcher's `match_n.eq_k` / `match_n.congr_eq_k` lemmas on demand, in
+whichever module first needs them, so two sibling proof modules that both case on the patterns of
+`Reconciliation.lean` would each bake a private copy into their olean and clash on import.
+Generating them once here — in the module every reconciliation proof imports — gives them a single
+shared copy. See `InstructionSelection.RewriteProofs.CommonMatchEqns` for the same trick. -/
+
+open Lean Meta in
+run_meta do
+  let env ← getEnv
+  for anchor in [``Veir.reconcilePairingCastLocal] do
+    let some modIdx := env.getModuleIdxFor? anchor
+      | throwError "expected `{anchor}` to be imported"
+    for n in env.header.moduleData[modIdx.toNat]!.constNames do
+      if isMatcherCore env n then
+        discard <| Match.getEquationsFor n
+        discard <| Match.genMatchCongrEqns n
+
+namespace Veir
+
+/-!
+# Shared machinery for the `reconcile-cast` correctness proofs
+
+`builtin.unrealized_conversion_cast` is the only operation the `reconcile-cast` patterns match, and
+every pattern reasons about *composing* two of them. This file factors that out:
+
+- `castRuntimeValue` is the interpreter's cast arm as a standalone function on runtime values, and
+  `interpretOp'_cast_eq` shows the interpreter agrees with it.
+- `castOp_interpretOp_unfold` unfolds one successful interpretation of a cast op into
+  `castRuntimeValue` applied to its operand's value.
+- `castOp_getVar?_of_EquationLemmaAt` is the graph lemma for the *inner* cast of a round trip: at a
+  program point dominated by the inner cast, the state already holds its computed value.
+-/
+
+/-- The interpreter's semantics of `builtin.unrealized_conversion_cast` at result type `resType`,
+as a function on runtime values. `none` means the cast is not defined for this type/value pair.
+Mirrors the `.builtin .unrealized_conversion_cast` arm of `interpretOp'`. -/
+def castRuntimeValue (resType : TypeAttr) (v : RuntimeValue) : Option RuntimeValue :=
+  match resType.val, v with
+  | .registerType _, .int _bw val => some (.reg (LLVM.Int.toReg val))
+  | .registerType _, .byte _bw val => some (.reg (LLVM.Byte.toReg val))
+  | .registerType _, .addr val => some (.reg ⟨val.toNat⟩)
+  | .integerType resBw, .reg val => some (.int resBw.bitwidth (RISCV.Reg.toInt val resBw.bitwidth))
+  | .byteType resBw, .reg val => some (.byte resBw.bitwidth (RISCV.Reg.toByte val resBw.bitwidth))
+  | .llvmPointerType _, .reg val => some (.addr ⟨val.val⟩)
+  | _, _ => none
+
+/-- The interpreter's cast arm computes `castRuntimeValue` at the (single) declared result type. -/
+theorem interpretOp'_cast_eq {props : HasOpInfo.propertiesOf (OpCode.builtin .unrealized_conversion_cast)}
+    {resType : TypeAttr} {resultTypes : Array TypeAttr} {v : RuntimeValue}
+    {blockOperands : Array BlockPtr} {mem : MemoryState}
+    (hRes : resultTypes[0]? = some resType) :
+    interpretOp' (.builtin .unrealized_conversion_cast) props resultTypes #[v] blockOperands mem
+      = match castRuntimeValue resType v with
+        | some r => some (.ok (#[r], mem, none))
+        | none => none := by
+  obtain ⟨a, ha⟩ := resType
+  simp only [interpretOp', hRes, castRuntimeValue]
+  cases a <;> cases v <;> simp_all [pure, Interp]
+
+/-- `builtin.unrealized_conversion_cast` is pure: its interpretation neither reads nor writes
+memory. -/
+theorem OperationPtr.Pure.builtin_cast {op : OperationPtr} {ctx : IRContext OpCode}
+    (hType : op.getOpType! ctx = .builtin .unrealized_conversion_cast) : op.Pure ctx := by
+  unfold OperationPtr.Pure
+  rw [hType]
+  intro operands memory₁ memory₂
+  simp only [interpretOp']
+  repeat' split
+  all_goals first
+    | rfl
+    | simp [Interp.map, Option.map, UBOr.map, pure, bind, Option.bind]
+
+/-- Untyped analogue of `LocalRewritePattern.exists_refined_int_getVar?`: a value `v` that is not
+one of the matched op's results maps to itself through `LocalRewritePattern.mapping`, so its
+source-state value is refined by its target-state value, whatever their common shape. -/
+theorem LocalRewritePattern.exists_refined_getVar?
+    {ctx : WfIRContext OpCode}
+    {ipIn : ip.InBounds ctx.raw}
+    {pattern : LocalRewritePattern OpCode}
+    {hpattern : pattern ctx op = some (newCtx, some (newOps, newValues))}
+    {hreturn : pattern.ReturnValuesInBounds} {hreturn₂ : pattern.ReturnValues}
+    {hreturn₃ : pattern.ReturnCtxChanges}
+    {state : InterpreterState ctx} {state' : InterpreterState newCtx}
+    (valueRefinement : state.variables.isRefinedByAt state'.variables
+      (LocalRewritePattern.mapping hpattern hreturn hreturn₂ hreturn₃) (.at ip) (.at ip) ipIn ipIn')
+    (state'Dom : state'.DefinesDominating ip ipIn')
+    (vIn : v.InBounds ctx.raw)
+    (hxVal : state.variables.getVar? v = some sv)
+    (hDomCtx : v.dominatesIp ip ctx) (hDom' : v.dominatesIp ip newCtx)
+    (hNotRes : v ∉ op.getResults! ctx.raw) :
+    ∃ tv, state'.variables.getVar? v = some tv ∧ sv ⊒ tv := by
+  have ⟨tv, hTv⟩ := InterpreterState.DefinesDominating.exists_getVar_of_dominatesIp state'Dom
+      (hreturn₃.valuePtr_inBounds hpattern vIn) hDom'
+  refine ⟨tv, hTv, ?_⟩
+  grind [LocalRewritePattern.mapping, valueRefinement v]
+
+/-- Unfold one successful interpretation of a `builtin.unrealized_conversion_cast`: it reads its
+operand's runtime value `v`, binds its result to `castRuntimeValue resType v` (which therefore
+must be defined), and touches neither memory nor control flow. Applied at `newState := state` this
+also unfolds the `EquationHolds` fact of a cast that dominates the match point. -/
+theorem castOp_interpretOp_unfold {ctx : WfIRContext OpCode} {castOp : OperationPtr}
+    {operand : ValuePtr} {resType : TypeAttr} {state newState : InterpreterState ctx} {cf}
+    (inBounds : castOp.InBounds ctx.raw)
+    (hOpType : castOp.getOpType! ctx.raw = .builtin .unrealized_conversion_cast)
+    (hNumResults : castOp.getNumResults! ctx.raw = 1)
+    (hOperands : castOp.getOperands! ctx.raw = #[operand])
+    (hResType : ((castOp.getResult 0).get! ctx.raw).type = resType)
+    (hinterp : interpretOp castOp state inBounds = some (.ok (newState, cf))) :
+    ∃ v r, state.variables.getVar? operand = some v ∧
+      castRuntimeValue resType v = some r ∧
+      state.memory = newState.memory ∧
+      newState.variables.getVar? (castOp.getResult 0) = some r ∧
+      cf = none := by
+  have hNumOperands : castOp.getNumOperands! ctx.raw = 1 := by
+    simp [← OperationPtr.getOperands!.size_eq_getNumOperands!, hOperands]
+  have hOperandEq : operand = (castOp.getOperands! ctx.raw)[0]! := by rw [hOperands]; rfl
+  -- The (single) declared result type is `resType`.
+  have hResTypes0 : (castOp.getResultTypes! ctx.raw)[0]? = some resType := by
+    have hsz : (castOp.getResultTypes! ctx.raw).size = 1 := by
+      rw [OperationPtr.getResultTypes!.size_eq_getNumResults!, hNumResults]
+    have helem := OperationPtr.getResultTypes!.getElem!_eq (op := castOp) (ctx := ctx.raw)
+      (index := 0) (by omega)
+    rw [Array.getElem?_eq_getElem (by omega),
+      show (castOp.getResultTypes! ctx.raw)[0] = (castOp.getResultTypes! ctx.raw)[0]! from by grind,
+      helem, hResType]
+  -- Read the operand's value out of the successful interpretation.
+  obtain ⟨operandValues, _, _, _, hOperandValues, _⟩ := interpretOp_some_iff.mp hinterp
+  simp only [VariableState.getOperandValues] at hOperandValues
+  have hsize : 0 < (castOp.getOperands! ctx.raw).size := by
+    rw [OperationPtr.getOperands!.size_eq_getNumOperands!]; omega
+  obtain ⟨v, hv⟩ :=
+    Array.exists_mapM_option_eq_some_iff.mp ⟨operandValues, hOperandValues⟩ 0 hsize
+  have hgetVar : state.variables.getVar? operand = some v := by
+    rw [hOperandEq,
+      show (castOp.getOperands! ctx.raw)[0]! = (castOp.getOperands! ctx.raw)[0] from by grind]
+    exact hv
+  have hOperand0 : castOp.getOperand! ctx.raw 0 = operand := by
+    rw [hOperandEq]
+    grind [OperationPtr.getOperand!, OperationPtr.getOperands!]
+  have hOpVals : state.variables.getOperandValues castOp = some #[v] := by
+    rw [VariableState.getOperandValues_eq_some_iff]
+    refine ⟨by simp [hNumOperands], fun i hi => ?_⟩
+    rw [hNumOperands] at hi
+    obtain rfl : i = 0 := by omega
+    simpa [hOperand0] using hgetVar
+  -- With the value in hand, unfold the cast's interpretation into `castRuntimeValue`.
+  rw [interpretOp_some_iff] at hinterp
+  obtain ⟨operandValues', resValues, mem', varState', hOV, hInterp', hSet, hNew⟩ := hinterp
+  rw [hOpVals, Option.some.injEq] at hOV
+  subst hOV
+  simp only [OperationPtr.interpret] at hInterp'
+  rw [hOpType, interpretOp'_cast_eq hResTypes0] at hInterp'
+  obtain ⟨r, hCast⟩ : ∃ r, castRuntimeValue resType v = some r := by
+    cases hc : castRuntimeValue resType v with
+    | none => rw [hc] at hInterp'; simp at hInterp'
+    | some r => exact ⟨r, rfl⟩
+  rw [hCast] at hInterp'
+  obtain ⟨rfl, rfl, rfl⟩ : resValues = #[r] ∧ mem' = state.memory ∧ cf = none := by grind
+  subst hNew
+  refine ⟨v, r, hgetVar, hCast, rfl, ?_, rfl⟩
+  rw [VariableState.getVar?_getResult_of_setResultValues? (by rw [hNumResults]; omega) hSet]
+  simp
+
+/-! ## The packaged graph lemma for the inner cast of a round trip -/
+
+set_option maxHeartbeats 1000000 in
+/-- Semantic content of the *inner* cast of a round trip: `input` is an operand of `op` and is
+defined by a cast operation `castPtr.op` with operand `parentInput`. In any source state
+satisfying `EquationLemmaAt` before `op`, that inner cast has already been interpreted, so
+`input`'s runtime value is `castRuntimeValue` (at `input`'s type) of `parentInput`'s value. The
+accompanying structural facts are what a `PreservesSemantics` proof needs to read `parentInput`'s
+refined value in the target state. -/
+theorem castOp_getVar?_of_EquationLemmaAt {ctx : WfIRContext OpCode}
+    (ctxDom : ctx.Dom)
+    {op : OperationPtr} (opInBounds : op.InBounds ctx.raw)
+    {state : InterpreterState ctx}
+    (stateWf : state.EquationLemmaAt (InsertPoint.before op) (by grind))
+    {castPtr : OpResultPtr} {parentInput : ValuePtr}
+    (hMatch : matchCastOp castPtr.op ctx.raw = some parentInput)
+    (hOperand : ValuePtr.opResult castPtr ∈ op.getOperands! ctx.raw) :
+    ∃ v r, state.variables.getVar? parentInput = some v ∧
+      castRuntimeValue ((ValuePtr.opResult castPtr).getType! ctx.raw) v = some r ∧
+      state.variables.getVar? (ValuePtr.opResult castPtr) = some r ∧
+      parentInput.dominatesIp (InsertPoint.before op) ctx ∧
+      parentInput.InBounds ctx.raw ∧
+      parentInput ∉ op.getResults! ctx.raw := by
+  obtain ⟨hCastType, hCastNumResults, hCastOperands⟩ := matchCastOp_implies hMatch
+  have hParentMem : parentInput ∈ castPtr.op.getOperands! ctx.raw := by rw [hCastOperands]; simp
+  -- The inner cast is in bounds and `input` is its unique result.
+  have hInputIn : (ValuePtr.opResult castPtr).InBounds ctx.raw := by
+    grind [OperationPtr.getOperands!]
+  have hCastOpIn : castPtr.op.InBounds ctx.raw := by grind [OpResultPtr.InBounds]
+  have hCastIdx : castPtr.index < castPtr.op.getNumResults! ctx.raw := by
+    grind [OpResultPtr.inBounds_OperationPtr_getNumResults!]
+  have hCastEq : castPtr = castPtr.op.getResult 0 := by
+    have hidx : castPtr.index = 0 := by omega
+    cases castPtr
+    simp only [OperationPtr.getResult, OpResultPtr.mk.injEq]
+    exact ⟨trivial, hidx⟩
+  have hResType : ((castPtr.op.getResult 0).get! ctx.raw).type
+      = (ValuePtr.opResult castPtr).getType! ctx.raw := by
+    rw [hCastEq]; rfl
+  -- Dominance: the inner cast strictly dominates `op`, so it has been interpreted into `state`.
+  have hCastDefines : (ValuePtr.opResult castPtr).getDefiningOp! ctx.raw = some castPtr.op := by
+    have hOwner := (ctx.wellFormed.operations castPtr.op hCastOpIn).result_owner 0 (by grind)
+    grind [ValuePtr.getDefiningOp!]
+  have hCastSDom : castPtr.op.strictlyDominates op ctx :=
+    OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands! ctxDom
+      hCastDefines hOperand
+  have hCastDomIp : castPtr.op.dominatesIp (InsertPoint.before op) ctx := by grind
+  have hCastPure : castPtr.op.Pure ctx.raw := OperationPtr.Pure.builtin_cast hCastType
+  obtain ⟨cfC, hInterpCast⟩ := stateWf castPtr.op hCastOpIn hCastPure hCastDomIp
+  -- Unfold the inner cast's interpretation (`newState := state`).
+  obtain ⟨v, r, hParentVal, hCast, -, hCastResVal, -⟩ :=
+    castOp_interpretOp_unfold hCastOpIn hCastType hCastNumResults hCastOperands hResType hInterpCast
+  refine ⟨v, r, hParentVal, hCast, by rw [hCastEq]; exact hCastResVal, ?_, ?_, ?_⟩
+  · -- `parentInput` dominates the inner cast, hence `op`.
+    exact ValuePtr.dominatesIp_before_of_strictlyDominates
+      (ctxDom.operand_dominates_op hCastOpIn hParentMem) hCastSDom
+  · grind [OperationPtr.getOperands!]
+  · exact IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates ctxDom
+      (OperationPtr.dominates_of_strictlyDominates hCastSDom) parentInput hParentMem
+
+end Veir

--- a/Veir/Passes/CastsReconciliation/RewriteProofs/ReconcilePairingCast.lean
+++ b/Veir/Passes/CastsReconciliation/RewriteProofs/ReconcilePairingCast.lean
@@ -1,0 +1,228 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.Casting
+import Veir.Passes.CastsReconciliation.Reconciliation
+import Veir.Passes.CastsReconciliation.RewriteProofs.CommonCast
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+
+namespace Veir
+
+/-! ## Correctness of `reconcilePairingCastLocal`
+
+`reconcilePairingCastLocal legal` erases a cast whose operand is itself a cast back from the
+original type (`X → Y → X`, legal per `legal X Y`). It is correct exactly when that round trip is
+the identity on runtime values, which is the single hypothesis `hRoundTrip` of the shared theorem
+below. Two of the four `legal` predicates satisfy it:
+
+* `isRegToI64RoundTrip` — `Int.toReg (Reg.toInt r 64) = r`;
+* `isRiscvRegToPtrCast` — pointer/register values carry no poison and the round trip is the
+  identity in both directions.
+
+The other two, `isI64ToRegRoundTrip` and `isRiscvRegToI32Cast`, are **not** provable and have no
+theorem here. Both start from an integer: `Int.toReg` maps `poison` to the concrete `0#64`, so the
+round trip *freezes* poison. In a state where the source value is `poison`, the source program
+(with the casts) produces `0` while the rewritten program produces `poison`, and `0 ⊒ poison` is
+false — the refinement `sourceValues ⊒ targetValues` fails. This is the same obstruction as the
+`freeze` lowering under the deterministic-zero poison model. Unblocking either rewrite needs a
+different cast semantics: an `Int.toReg` that raises UB on poison, or a nondeterministic freeze
+model in which the rewritten program's `poison` may take the value `0`. -/
+
+set_option maxHeartbeats 1000000 in
+/-- Shared correctness proof for every `reconcilePairingCastLocal legal` instance: given that the
+`legal` round trip is the identity on conforming runtime values, erasing it preserves semantics. -/
+theorem reconcilePairingCastLocal_preservesSemantics {legal : TypeAttr → TypeAttr → Bool}
+    (hRoundTrip : ∀ (tin tinter : TypeAttr) (v w u : RuntimeValue), legal tin tinter = true →
+      v.Conforms tin → castRuntimeValue tinter v = some w → castRuntimeValue tin w = some u →
+      u = v)
+    {h : LocalRewritePattern.ReturnOps (reconcilePairingCastLocal legal)}
+    {h₂ : LocalRewritePattern.ReturnCtxChanges (reconcilePairingCastLocal legal)}
+    {h₃ : LocalRewritePattern.ReturnValuesInBounds (reconcilePairingCastLocal legal)}
+    {h₄ : LocalRewritePattern.ReturnValues (reconcilePairingCastLocal legal)} :
+    LocalRewritePattern.PreservesSemantics (reconcilePairingCastLocal legal) h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, reconcilePairingCastLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [pure] at hpattern
+  -- Peel the outer matcher.
+  have hMatchSome : (matchCastOp op ctx.raw).isSome := by
+    cases hM : matchCastOp op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨input, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- Peel the `.opResult` destructuring: the operand must be defined by an operation.
+  obtain ⟨castPtr, rfl⟩ : ∃ castPtr, input = ValuePtr.opResult castPtr := by
+    cases input with
+    | opResult castPtr => exact ⟨castPtr, rfl⟩
+    | blockArgument _ => simp at hpattern
+  simp only [] at hpattern
+  -- Peel the inner matcher.
+  have hMatchSome' : (matchCastOp castPtr.op ctx.raw).isSome := by
+    cases hM : matchCastOp castPtr.op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨parentInput, hMatch'⟩ := Option.isSome_iff_exists.mp hMatchSome'
+  rw [hMatch'] at hpattern
+  simp only [] at hpattern
+  -- Peel the two guards: the result type is the parent's input type, and the pair is legal.
+  have hTyEq : ((op.getResult 0).get! ctx.raw).type = parentInput.getType! ctx.raw := by
+    rcases Decidable.em (((op.getResult 0).get! ctx.raw).type = parentInput.getType! ctx.raw)
+      with hty | hty
+    · exact hty
+    · rw [if_neg hty] at hpattern
+      exact absurd hpattern (by simp)
+  rw [if_pos hTyEq] at hpattern
+  have hLegal : legal (parentInput.getType! ctx.raw)
+      ((ValuePtr.opResult castPtr).getType! ctx.raw) = true := by
+    rcases Decidable.em (legal (parentInput.getType! ctx.raw)
+        ((ValuePtr.opResult castPtr).getType! ctx.raw) = true) with hl | hl
+    · exact hl
+    · rw [if_pos (by simpa using hl)] at hpattern
+      exact absurd hpattern (by simp)
+  rw [if_neg (by rw [hLegal]; simp)] at hpattern
+  -- Read off the pattern's outputs.
+  obtain ⟨rfl, rfl, rfl⟩ : ctx = newCtx ∧ newOps = #[] ∧ newValues = #[parentInput] := by
+    simp at hpattern; grind
+  -- Syntactic facts from the outer match.
+  obtain ⟨hOpType, hNRes, hOperands⟩ := matchCastOp_implies hMatch
+  have hOperandMem : ValuePtr.opResult castPtr ∈ op.getOperands! ctx.raw := by
+    rw [hOperands]; simp
+  -- `op` has a single result; pin the source-value array's shape now, while the context is small
+  -- enough for `grind` (the round-trip hypothesis makes it wander later).
+  have hResults : op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] := by
+    clear hRoundTrip hpattern; grind
+  -- Source side, outer cast: its result is `castRuntimeValue` (at the result type) of `input`.
+  obtain ⟨w, u, hInputVal, hCastOuter, hMemEq, hResVal, rfl⟩ :=
+    castOp_interpretOp_unfold opInBounds hOpType hNRes hOperands rfl hinterp
+  -- Source side, inner cast: `input` holds `castRuntimeValue` (at its type) of `parentInput`.
+  obtain ⟨v, w', hParentVal, hCastInner, hInputVal', hParentDom, hParentIn, hParentNotRes⟩ :=
+    castOp_getVar?_of_EquationLemmaAt ctxDom opInBounds stateWf hMatch' hOperandMem
+  have hww : w' = w := by rw [hInputVal'] at hInputVal; simpa using hInputVal
+  rw [hww] at hCastInner
+  -- The round trip is the identity, so the outer cast's result is `parentInput`'s value.
+  have hConf : v.Conforms (parentInput.getType! ctx.raw) := VariableState.getVar?_conforms hParentVal
+  obtain rfl : u = v :=
+    hRoundTrip _ _ v w u hLegal hConf hCastInner (by rwa [hTyEq] at hCastOuter)
+  -- Source values: `op`'s single result holds `v`.
+  rw [hResults] at hsourceValues
+  simp at hsourceValues
+  simp [hResVal] at hsourceValues
+  subst sourceValues
+  -- Target side: no operation is interpreted, so the target state is `state'`.
+  refine ⟨state', by simp [interpretOpList, liftM, monadLift, MonadLift.monadLift, pure, Interp],
+    by grind, ?_⟩
+  obtain ⟨tv, hTvVal, hTvRef⟩ :=
+    LocalRewritePattern.exists_refined_getVar? valueRefinement state'Dom hParentIn hParentVal
+      hParentDom hParentDom hParentNotRes
+  exact ⟨#[tv], by simp [hTvVal], RuntimeValue.arrayIsRefinedBy_singleton.mpr hTvRef⟩
+
+/-! ### The three provable instantiations -/
+
+/-- What `isRegToI64RoundTrip` says about the two types. -/
+theorem isRegToI64RoundTrip_implies {tin tinter : TypeAttr}
+    (h : isRegToI64RoundTrip tin tinter = true) :
+    (∃ rt, tin.val = .registerType rt) ∧ ∃ it, tinter.val = .integerType it ∧ it.bitwidth = 64 := by
+  unfold isRegToI64RoundTrip at h
+  split at h <;> simp_all
+
+/-- `reg -> i64 -> reg` is the identity: `Reg.toInt r 64` is the never-poison value of `r`, which
+`Int.toReg` maps back to `r`. -/
+theorem isRegToI64RoundTrip_roundTrip (tin tinter : TypeAttr) (v w u : RuntimeValue)
+    (hLegal : isRegToI64RoundTrip tin tinter = true) (hConf : v.Conforms tin)
+    (hInner : castRuntimeValue tinter v = some w) (hOuter : castRuntimeValue tin w = some u) :
+    u = v := by
+  obtain ⟨⟨rt, htin⟩, it, htinter, hbw⟩ := isRegToI64RoundTrip_implies hLegal
+  obtain ⟨a, ha⟩ := tin; obtain ⟨b, hb⟩ := tinter
+  simp only at htin htinter; subst htin; subst htinter
+  obtain ⟨r, rfl⟩ := RuntimeValue.Conforms.registerType hConf
+  simp only [castRuntimeValue, Option.some.injEq] at hInner
+  subst hInner
+  simp only [castRuntimeValue, Option.some.injEq] at hOuter
+  subst hOuter
+  rw [hbw, toReg_toInt_64]
+
+theorem reconcilePairingCastLocal_isRegToI64RoundTrip_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics
+      (reconcilePairingCastLocal isRegToI64RoundTrip) h h₂ h₃ h₄ :=
+  reconcilePairingCastLocal_preservesSemantics isRegToI64RoundTrip_roundTrip
+
+/-- What `isRiscvRegToPtrCast` says about the two types: one of them is a pointer and the other a
+register, in either order. -/
+theorem isRiscvRegToPtrCast_implies {tin tinter : TypeAttr}
+    (h : isRiscvRegToPtrCast tin tinter = true) :
+    (∃ pt rt, tin.val = .llvmPointerType pt ∧ tinter.val = .registerType rt) ∨
+    (∃ rt pt, tin.val = .registerType rt ∧ tinter.val = .llvmPointerType pt) := by
+  unfold isRiscvRegToPtrCast at h
+  split at h <;> simp_all
+
+/-- `ptr -> reg -> ptr` and `reg -> ptr -> reg` are both the identity: address and register values
+carry no poison, and the two conversions are inverse bit-preserving reinterpretations. -/
+theorem isRiscvRegToPtrCast_roundTrip (tin tinter : TypeAttr) (v w u : RuntimeValue)
+    (hLegal : isRiscvRegToPtrCast tin tinter = true) (hConf : v.Conforms tin)
+    (hInner : castRuntimeValue tinter v = some w) (hOuter : castRuntimeValue tin w = some u) :
+    u = v := by
+  obtain ⟨a, ha⟩ := tin; obtain ⟨b, hb⟩ := tinter
+  rcases isRiscvRegToPtrCast_implies hLegal with ⟨pt, rt, htin, htinter⟩ | ⟨rt, pt, htin, htinter⟩
+  · -- `ptr -> reg -> ptr`
+    simp only at htin htinter; subst htin; subst htinter
+    obtain ⟨addr, rfl⟩ := RuntimeValue.Conforms.llvmPointerType hConf
+    simp only [castRuntimeValue, Option.some.injEq] at hInner
+    subst hInner
+    simp only [castRuntimeValue, Option.some.injEq] at hOuter
+    subst hOuter
+    simp
+  · -- `reg -> ptr -> reg`
+    simp only at htin htinter; subst htin; subst htinter
+    obtain ⟨r, rfl⟩ := RuntimeValue.Conforms.registerType hConf
+    simp only [castRuntimeValue, Option.some.injEq] at hInner
+    subst hInner
+    simp only [castRuntimeValue, Option.some.injEq] at hOuter
+    subst hOuter
+    simp
+
+theorem reconcilePairingCastLocal_isRiscvRegToPtrCast_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics
+      (reconcilePairingCastLocal isRiscvRegToPtrCast) h h₂ h₃ h₄ :=
+  reconcilePairingCastLocal_preservesSemantics isRiscvRegToPtrCast_roundTrip
+
+/-- info: 'Veir.reconcilePairingCastLocal_isRegToI64RoundTrip_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_of_strictlyDominates,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ MemoryState.llvmLoad._native.bv_decide.ax_8] -/
+#guard_msgs in
+#print axioms reconcilePairingCastLocal_isRegToI64RoundTrip_preservesSemantics
+
+/-- info: 'Veir.reconcilePairingCastLocal_isRiscvRegToPtrCast_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_of_strictlyDominates,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ MemoryState.llvmLoad._native.bv_decide.ax_8] -/
+#guard_msgs in
+#print axioms reconcilePairingCastLocal_isRiscvRegToPtrCast_preservesSemantics
+
+end Veir

--- a/Veir/Passes/CastsReconciliation/RewriteProofs/ReconcileRegIntCast.lean
+++ b/Veir/Passes/CastsReconciliation/RewriteProofs/ReconcileRegIntCast.lean
@@ -1,0 +1,324 @@
+import Veir.PatternRewriter.Basic
+import Veir.Interpreter
+import Veir.IR.WellFormed
+import Veir.Passes.Matching
+import Veir.Rewriter.WfRewriter
+import Veir.PatternRewriter.Semantics
+import Veir.Verifier
+import Veir.Data.Casting
+import Veir.Data.RISCV.Reg.Lemmas
+import Veir.Passes.CastsReconciliation.Reconciliation
+import Veir.Passes.CastsReconciliation.RewriteProofs.CommonCast
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonMatchEqns
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonTactics
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonBaseLemmas
+import Veir.Passes.InstructionSelection.RewriteProofs.CommonForwardInterpret
+
+namespace Veir
+
+/-! ## Correctness of `reconcileRegIntCastLocal`
+
+`reg -> iX -> reg` keeps only the low `X` bits of the register: `Reg.toInt` truncates and
+`Int.toReg` zero-extends back, and no poison is ever involved (`Reg.toInt` is never poison). The
+rewrite replaces the round trip by the RISC-V instruction that computes that zero-extension:
+`zext.b`/`zext.h`/`zext.w` at `X = 8/16/32`, and an `slli`/`srli` pair by `64 - X` otherwise.
+
+`X = 0` is excluded by the pattern: the round trip is then the constant zero, while the shift pair
+would wrap its 6-bit shift amount `64 - 0` back to `0` and return the register unchanged. -/
+
+/-! ### Data lemmas: the round trip is the zero-extension of the low word -/
+
+theorem toReg_toInt_zextb {r : Data.RISCV.Reg} :
+    LLVM.Int.toReg (RISCV.Reg.toInt r 8) = Data.RISCV.zextb r := by
+  simp [LLVM.Int.toReg, RISCV.Reg.toInt, Data.RISCV.zextb, Data.RISCV.andi]
+  bv_decide
+
+theorem toReg_toInt_zexth {r : Data.RISCV.Reg} :
+    LLVM.Int.toReg (RISCV.Reg.toInt r 16) = Data.RISCV.zexth r := by
+  simp [LLVM.Int.toReg, RISCV.Reg.toInt, Data.RISCV.zexth]
+  bv_decide
+
+theorem toReg_toInt_zextw {r : Data.RISCV.Reg} :
+    LLVM.Int.toReg (RISCV.Reg.toInt r 32) = Data.RISCV.zextw r := by
+  simp [LLVM.Int.toReg, RISCV.Reg.toInt, Data.RISCV.zextw, Data.RISCV.adduw, Data.RISCV.li]
+  bv_decide
+
+/-- Shifting a 64-bit word left by `64 - bw` and back right (logically) keeps exactly its low `bw`
+bits. `bw` is symbolic, so this is a bitwise argument rather than a `bv_decide`. -/
+theorem BitVec.shiftLeft_ushiftRight_eq_setWidth {bw : Nat} (h0 : 0 < bw) (h : bw < 64)
+    (x : BitVec 64) :
+    (x <<< (BitVec.ofNat 6 (64 - bw))) >>> (BitVec.ofNat 6 (64 - bw))
+      = (x.setWidth bw).setWidth 64 := by
+  have hk : (BitVec.ofNat 6 (64 - bw)).toNat = 64 - bw := by
+    simp [BitVec.toNat_ofNat]; omega
+  apply BitVec.eq_of_getLsbD_eq
+  intro i hi
+  by_cases hib : i < bw
+  · simp [hib, hi, hk]; omega
+  · simp [hib, hi, hk]; omega
+
+/-- The `slli`/`srli` form of the `reg -> iX -> reg` round trip, for `0 < X < 64`. The shift amount
+is the immediate as the interpreter reads it (`BitVec.ofInt 6`). -/
+theorem toReg_toInt_slli_srli {bw : Nat} (h0 : 0 < bw) (h : bw < 64) {r : Data.RISCV.Reg} :
+    LLVM.Int.toReg (RISCV.Reg.toInt r bw)
+      = Data.RISCV.srli (BitVec.ofInt 6 (64 - (bw : Int)))
+          (Data.RISCV.slli (BitVec.ofInt 6 (64 - (bw : Int))) r) := by
+  have himm : BitVec.ofInt 6 (64 - (bw : Int)) = BitVec.ofNat 6 (64 - bw) := by
+    rw [show ((64 : Int) - (bw : Int)) = ((64 - bw : Nat) : Int) by omega]
+    simp [BitVec.ofInt_natCast]
+  simp only [himm, LLVM.Int.toReg, RISCV.Reg.toInt, Data.RISCV.srli, Data.RISCV.slli,
+    BitVec.truncate_eq_setWidth]
+  rw [BitVec.shiftLeft_ushiftRight_eq_setWidth h0 h]
+
+/-! ### Interpreter computation facts for the emitted ops -/
+
+theorem zextb_interpretOp' (r : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf Riscv.zextb)
+    (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState) :
+    Riscv.interpretOp' .zextb props resultTypes #[.reg r] blockOperands mem
+      = some (.ok (#[.reg (Data.RISCV.zextb r)], mem, none)) := rfl
+
+theorem zexth_interpretOp' (r : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf Riscv.zexth)
+    (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState) :
+    Riscv.interpretOp' .zexth props resultTypes #[.reg r] blockOperands mem
+      = some (.ok (#[.reg (Data.RISCV.zexth r)], mem, none)) := rfl
+
+theorem zextw_interpretOp' (r : Data.RISCV.Reg) (props : HasDialectOpInfo.propertiesOf Riscv.zextw)
+    (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState) :
+    Riscv.interpretOp' .zextw props resultTypes #[.reg r] blockOperands mem
+      = some (.ok (#[.reg (Data.RISCV.zextw r)], mem, none)) := rfl
+
+theorem slli_interpretOp' (r : Data.RISCV.Reg) (imm : IntegerAttr)
+    (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState) :
+    Riscv.interpretOp' .slli (RISCVImmediateProperties.mk imm) resultTypes #[.reg r]
+        blockOperands mem
+      = some (.ok (#[.reg (Data.RISCV.slli (BitVec.ofInt 6 imm.value) r)], mem, none)) := rfl
+
+theorem srli_interpretOp' (r : Data.RISCV.Reg) (imm : IntegerAttr)
+    (resultTypes : Array TypeAttr) (blockOperands : Array BlockPtr) (mem : MemoryState) :
+    Riscv.interpretOp' .srli (RISCVImmediateProperties.mk imm) resultTypes #[.reg r]
+        blockOperands mem
+      = some (.ok (#[.reg (Data.RISCV.srli (BitVec.ofInt 6 imm.value) r)], mem, none)) := rfl
+
+set_option maxHeartbeats 4000000 in
+theorem reconcileRegIntCastLocal_preservesSemantics :
+    LocalRewritePattern.PreservesSemantics reconcileRegIntCastLocal h h₂ h₃ h₄ := by
+  simp only [LocalRewritePattern.PreservesSemantics, reconcileRegIntCastLocal]
+  intro ctx ctxDom ctxVerif op opInBounds newCtx newOps newValues hpattern state stateWf
+    newState cf hinterp
+  rintro sourceValues hsourceValues state' state'Wf state'Dom ⟨memoryRefinement, valueRefinement⟩
+  simp [liftM, monadLift, MonadLift.monadLift] at hinterp
+  simp [pure] at hpattern
+  -- Peel the outer matcher.
+  have hMatchSome : (matchCastOp op ctx.raw).isSome := by
+    cases hM : matchCastOp op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨input, hMatch⟩ := Option.isSome_iff_exists.mp hMatchSome
+  rw [hMatch] at hpattern
+  simp only [] at hpattern
+  -- The operand must be defined by an operation.
+  obtain ⟨castPtr, rfl⟩ : ∃ castPtr, input = ValuePtr.opResult castPtr := by
+    cases input with
+    | opResult castPtr => exact ⟨castPtr, rfl⟩
+    | blockArgument _ => simp at hpattern
+  simp only [] at hpattern
+  -- Peel the inner matcher.
+  have hMatchSome' : (matchCastOp castPtr.op ctx.raw).isSome := by
+    cases hM : matchCastOp castPtr.op ctx.raw with
+    | some y => rfl
+    | none => rw [hM] at hpattern; simp at hpattern
+  obtain ⟨parentInput, hMatch'⟩ := Option.isSome_iff_exists.mp hMatchSome'
+  rw [hMatch'] at hpattern
+  simp only [] at hpattern
+  -- Peel the two type guards.
+  have hTyEq : ((op.getResult 0).get! ctx.raw).type = parentInput.getType! ctx.raw := by
+    rcases Decidable.em (((op.getResult 0).get! ctx.raw).type = parentInput.getType! ctx.raw)
+      with hty | hty
+    · exact hty
+    · rw [if_neg hty] at hpattern
+      exact absurd hpattern (by simp)
+  rw [if_pos hTyEq] at hpattern
+  have hRegTy : parentInput.getType! ctx.raw = (RegisterType.mk : TypeAttr) := by
+    rcases Decidable.em (parentInput.getType! ctx.raw = (RegisterType.mk : TypeAttr)) with hty | hty
+    · exact hty
+    · rw [if_neg hty] at hpattern
+      exact absurd hpattern (by simp)
+  rw [if_pos hRegTy] at hpattern
+  -- The intermediate type must be an integer type.
+  obtain ⟨bw, hbw⟩ :
+      ∃ bw, ((ValuePtr.opResult castPtr).getType! ctx.raw).val = .integerType ⟨bw⟩ := by
+    cases hty : ((ValuePtr.opResult castPtr).getType! ctx.raw).val
+    case integerType it => cases it; exact ⟨_, rfl⟩
+    all_goals (rw [hty] at hpattern; simp at hpattern)
+  rw [hbw] at hpattern
+  simp only [] at hpattern
+  -- Syntactic facts from the outer match.
+  obtain ⟨hOpType, hNRes, hOperands⟩ := matchCastOp_implies hMatch
+  have hOperandMem : ValuePtr.opResult castPtr ∈ op.getOperands! ctx.raw := by
+    rw [hOperands]; simp
+  have hResults : op.getResults ctx.raw (by grind) = #[ValuePtr.opResult (op.getResult 0)] := by
+    clear hpattern; grind
+  -- Source side: the outer cast reads the inner cast's value and casts it back to a register.
+  obtain ⟨w, u, hInputVal, hCastOuter, hMemEq, hResVal, rfl⟩ :=
+    castOp_interpretOp_unfold opInBounds hOpType hNRes hOperands rfl hinterp
+  obtain ⟨v, w', hParentVal, hCastInner, hInputVal', hParentDom, hParentIn, hParentNotRes⟩ :=
+    castOp_getVar?_of_EquationLemmaAt ctxDom opInBounds stateWf hMatch' hOperandMem
+  have hww : w' = w := by rw [hInputVal'] at hInputVal; simpa using hInputVal
+  rw [hww] at hCastInner
+  -- The parent's value is a register `r`.
+  have hConf : v.Conforms (parentInput.getType! ctx.raw) := VariableState.getVar?_conforms hParentVal
+  rw [hRegTy] at hConf
+  obtain ⟨r, rfl⟩ := RuntimeValue.Conforms.registerType hConf
+  -- The inner cast truncates it to `i{bw}`, the outer one zero-extends it back.
+  rw [show (ValuePtr.opResult castPtr).getType! ctx.raw
+      = ⟨.integerType ⟨bw⟩, hbw ▸ ((ValuePtr.opResult castPtr).getType! ctx.raw).2⟩
+      from Subtype.ext hbw] at hCastInner
+  simp only [castRuntimeValue, Option.some.injEq] at hCastInner
+  subst hCastInner
+  rw [hTyEq, hRegTy] at hCastOuter
+  simp only [castRuntimeValue, Option.some.injEq] at hCastOuter
+  subst hCastOuter
+  -- Source values: `op`'s single result holds the round trip's value.
+  rw [hResults] at hsourceValues
+  simp at hsourceValues
+  simp [hResVal] at hsourceValues
+  subst sourceValues
+  -- Split on the intermediate bitwidth: `8`/`16`/`32` emit one op, the rest emit `slli`+`srli`.
+  split at hpattern
+  · -- `bw = 8`: `zext.b`
+    peelOpCreation! hpattern ctx₁ zextOp hZext hParentDom hDom₁
+    cleanupHpattern hpattern
+    have hZextType : zextOp.getOpType! ctx₁.raw = .riscv .zextb := by grind
+    have hZextOperands : zextOp.getOperands! ctx₁.raw = #[parentInput] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hZext (operation := zextOp)]
+    have hZextResTypes : zextOp.getResultTypes! ctx₁.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hZext (operation := zextOp)]
+    obtain ⟨tv, hTvVal, hTvRef⟩ :=
+      LocalRewritePattern.exists_refined_getVar? valueRefinement state'Dom hParentIn hParentVal
+        hParentDom hDom₁ hParentNotRes
+    obtain rfl := RuntimeValue.reg_of_isRefinedBy hTvRef
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := state') (inBounds := by grind)
+        (f := Data.RISCV.zextb) (fun props rt bo mem => zextb_interpretOp' _ props rt bo mem)
+        hZextType hZextOperands hZextResTypes hTvVal
+    refine ⟨s₁, by simp [interpretOpList_cons, hI₁, liftM, monadLift, MonadLift.monadLift, Interp],
+      by grind, ?_⟩
+    refine ⟨#[RuntimeValue.reg (Data.RISCV.zextb r)], by simp [hRes₁, Option.bind, Option.map], ?_⟩
+    exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+      (by simp [RuntimeValue.isRefinedBy, toReg_toInt_zextb])
+  · -- `bw = 16`: `zext.h`
+    peelOpCreation! hpattern ctx₁ zextOp hZext hParentDom hDom₁
+    cleanupHpattern hpattern
+    have hZextType : zextOp.getOpType! ctx₁.raw = .riscv .zexth := by grind
+    have hZextOperands : zextOp.getOperands! ctx₁.raw = #[parentInput] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hZext (operation := zextOp)]
+    have hZextResTypes : zextOp.getResultTypes! ctx₁.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hZext (operation := zextOp)]
+    obtain ⟨tv, hTvVal, hTvRef⟩ :=
+      LocalRewritePattern.exists_refined_getVar? valueRefinement state'Dom hParentIn hParentVal
+        hParentDom hDom₁ hParentNotRes
+    obtain rfl := RuntimeValue.reg_of_isRefinedBy hTvRef
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := state') (inBounds := by grind)
+        (f := Data.RISCV.zexth) (fun props rt bo mem => zexth_interpretOp' _ props rt bo mem)
+        hZextType hZextOperands hZextResTypes hTvVal
+    refine ⟨s₁, by simp [interpretOpList_cons, hI₁, liftM, monadLift, MonadLift.monadLift, Interp],
+      by grind, ?_⟩
+    refine ⟨#[RuntimeValue.reg (Data.RISCV.zexth r)], by simp [hRes₁, Option.bind, Option.map], ?_⟩
+    exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+      (by simp [RuntimeValue.isRefinedBy, toReg_toInt_zexth])
+  · -- `bw = 32`: `zext.w`
+    peelOpCreation! hpattern ctx₁ zextOp hZext hParentDom hDom₁
+    cleanupHpattern hpattern
+    have hZextType : zextOp.getOpType! ctx₁.raw = .riscv .zextw := by grind
+    have hZextOperands : zextOp.getOperands! ctx₁.raw = #[parentInput] := by
+      grind [OperationPtr.getOperands!_WfRewriter_createOp hZext (operation := zextOp)]
+    have hZextResTypes : zextOp.getResultTypes! ctx₁.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hZext (operation := zextOp)]
+    obtain ⟨tv, hTvVal, hTvRef⟩ :=
+      LocalRewritePattern.exists_refined_getVar? valueRefinement state'Dom hParentIn hParentVal
+        hParentDom hDom₁ hParentNotRes
+    obtain rfl := RuntimeValue.reg_of_isRefinedBy hTvRef
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_riscv_unaryReg_forward (state := state') (inBounds := by grind)
+        (f := Data.RISCV.zextw) (fun props rt bo mem => zextw_interpretOp' _ props rt bo mem)
+        hZextType hZextOperands hZextResTypes hTvVal
+    refine ⟨s₁, by simp [interpretOpList_cons, hI₁, liftM, monadLift, MonadLift.monadLift, Interp],
+      by grind, ?_⟩
+    refine ⟨#[RuntimeValue.reg (Data.RISCV.zextw r)], by simp [hRes₁, Option.bind, Option.map], ?_⟩
+    exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+      (by simp [RuntimeValue.isRefinedBy, toReg_toInt_zextw])
+  · -- otherwise: `slli` then `srli` by `64 - bw`, for `0 < bw < 64`.
+    have hbw0 : bw ≠ 0 := by
+      intro hz; rw [hz] at hpattern; simp at hpattern
+    rw [if_neg hbw0] at hpattern
+    have hbwlt : ¬ (64 ≤ bw) := by
+      intro hge; rw [if_pos hge] at hpattern; simp at hpattern
+    rw [if_neg hbwlt] at hpattern
+    peelOpCreation! hpattern ctx₁ shlOp hShl hParentDom hDom₁
+    peelOpCreation! hpattern ctx₂ srlOp hSrl hDom₁ hDom₂
+    cleanupHpattern hpattern
+    have hShlType : shlOp.getOpType! ctx₂.raw = .riscv .slli := by grind
+    have hSrlType : srlOp.getOpType! ctx₂.raw = .riscv .srli := by grind
+    have hShlOperands : shlOp.getOperands! ctx₂.raw = #[parentInput] := by grind
+    have hSrlOperands : srlOp.getOperands! ctx₂.raw
+        = #[ValuePtr.opResult (shlOp.getResult 0)] := by grind
+    have hShlProps : shlOp.getProperties! ctx₂.raw (.riscv .slli)
+        = RISCVImmediateProperties.mk (IntegerAttr.mk (64 - (bw : Int)) (IntegerType.mk 64)) := by
+      rw [OperationPtr.getProperties!_WfRewriter_createOp_ne hSrl (by grind)]
+      grind [OperationPtr.getProperties!_WfRewriter_createOp hShl (operation := shlOp)]
+    have hSrlProps : srlOp.getProperties! ctx₂.raw (.riscv .srli)
+        = RISCVImmediateProperties.mk (IntegerAttr.mk (64 - (bw : Int)) (IntegerType.mk 64)) := by
+      grind [OperationPtr.getProperties!_WfRewriter_createOp hSrl (operation := srlOp)]
+    have hShlResTypes : shlOp.getResultTypes! ctx₂.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hShl (operation := shlOp),
+        OperationPtr.getResultTypes!_WfRewriter_createOp hSrl (operation := shlOp)]
+    have hSrlResTypes : srlOp.getResultTypes! ctx₂.raw
+        = #[⟨Attribute.registerType ⟨none⟩, rfl⟩] := by
+      grind [OperationPtr.getResultTypes!_WfRewriter_createOp hSrl (operation := srlOp)]
+    obtain ⟨tv, hTvVal, hTvRef⟩ :=
+      LocalRewritePattern.exists_refined_getVar? valueRefinement state'Dom hParentIn hParentVal
+        hParentDom hDom₂ hParentNotRes
+    obtain rfl := RuntimeValue.reg_of_isRefinedBy hTvRef
+    obtain ⟨s₁, hI₁, hMem₁, hRes₁, -⟩ :=
+      interpretOp_riscv_unaryReg_imm_forward (state := state') (inBounds := by grind)
+        (res := Data.RISCV.slli (BitVec.ofInt 6 (64 - (bw : Int))) r)
+        (fun rt bo mem => slli_interpretOp' _ _ rt bo mem)
+        hShlType hShlProps hShlOperands hShlResTypes hTvVal
+    obtain ⟨s₂, hI₂, hMem₂, hRes₂, -⟩ :=
+      interpretOp_riscv_unaryReg_imm_forward (state := s₁) (inBounds := by grind)
+        (res := Data.RISCV.srli (BitVec.ofInt 6 (64 - (bw : Int)))
+          (Data.RISCV.slli (BitVec.ofInt 6 (64 - (bw : Int))) r))
+        (fun rt bo mem => srli_interpretOp' _ _ rt bo mem)
+        hSrlType hSrlProps hSrlOperands hSrlResTypes hRes₁
+    refine ⟨s₂, by simp [interpretOpList_cons, hI₁, hI₂, liftM, monadLift, MonadLift.monadLift,
+      Interp], by grind, ?_⟩
+    refine ⟨#[RuntimeValue.reg (Data.RISCV.srli (BitVec.ofInt 6 (64 - (bw : Int)))
+      (Data.RISCV.slli (BitVec.ofInt 6 (64 - (bw : Int))) r))],
+      by simp [hRes₂, Option.bind, Option.map], ?_⟩
+    exact RuntimeValue.arrayIsRefinedBy_singleton.mpr
+      (by simp [RuntimeValue.isRefinedBy,
+        toReg_toInt_slli_srli (Nat.pos_of_ne_zero hbw0) (by omega)])
+
+/-- info: 'Veir.reconcileRegIntCastLocal_preservesSemantics' depends on axioms: [propext,
+ Classical.choice,
+ Quot.sound,
+ floatEqOfToBitsEq,
+ OperationPtr.dominates,
+ OperationPtr.dominatesIp,
+ OperationPtr.dominatesIp_before,
+ OperationPtr.strictlyDominates_of_getDefiningOp!_of_mem_getOperands!,
+ ValuePtr.dominatesIp,
+ ValuePtr.dominatesIp_before_WfRewriter_createOp,
+ ValuePtr.dominatesIp_before_of_strictlyDominates,
+ IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates,
+ toReg_toInt_zextb._native.bv_decide.ax_1_11,
+ MemoryState.llvmLoad._native.bv_decide.ax_8] -/
+#guard_msgs in
+#print axioms reconcileRegIntCastLocal_preservesSemantics
+
+end Veir


### PR DESCRIPTION
Port the cast-reconciliation rewrites to `LocalRewritePattern` (removing 22 `sorry`s) and prove `PreservesSemantics` for the surviving `reg <-> i64`, `reg <-> ptr`, and `reg -> iX -> reg` rules; drop the identity-cast and `iX -> iY -> iX` rules, whose casts the interpreter gives no semantics, and fix a soundness bug where an `i0` round trip lowered to a wrapping `slli`/`srli` pair.