### PR TITLE
fix(isel): getelementptr miscompiles zero-sized element types

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/getelementptr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/getelementptr.mlir
@@ -58,6 +58,17 @@
         // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> !llvm.ptr
 
+        // scale 0: a zero-sized element type also satisfies `scale &&& (scale - 1) == 0`, so it must
+        // not take the power-of-two path -- `Nat.log2 0 = 0` would emit `idx << 0`, i.e. `ptr + idx`
+        // instead of `ptr`. It takes the `li`/`mul` path, computing `ptr + idx * 0 = ptr`.
+        %g0 = "llvm.getelementptr"(%p, %i) <{elem_type = !llvm.array<0 x i32>, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.mul"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "riscv.add"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> !llvm.ptr
+
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -943,7 +943,12 @@ def getelementptr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
         #[] #[] () none
       pure (ctx, #[addOp], addOp)
     | _ =>
-      if scale &&& (scale - 1) == 0 then
+      /- `0 < scale` excludes zero-sized element types (`i0`, `!llvm.array<0 x _>`), for which
+         `scale &&& (scale - 1) == 0` also holds but `Nat.log2 0 = 0` would emit `idx << 0`, i.e.
+         `ptr + idx` rather than `ptr`. `Nat.log2 scale < 64` excludes element sizes of `2^64` and
+         beyond, whose shift amount does not fit the 6-bit immediate. Both fall through to the
+         `li`/`mul` form below, which truncates modulo `2^64` exactly as the source does. -/
+      if 0 < scale ∧ scale &&& (scale - 1) = 0 ∧ Nat.log2 scale < 64 then
         /- scale is a power of two: ptr + (idx << log2 scale) -/
         let k := RISCVImmediateProperties.mk (IntegerAttr.mk (Nat.log2 scale) (IntegerType.mk 64))
         let (ctx, slliOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[iReg]


### PR DESCRIPTION
The power-of-two fast path in `getelementptr_local` guards on `scale &&& (scale - 1) == 0`, which is also true for `scale = 0`, so a zero-sized element type (`i0`, `!llvm.array<0 x _>`) emitted `idx << Nat.log2 0` and the pattern computed `ptr + idx` where `llvm.getelementptr` semantics say `ptr + idx * 0 = ptr`. The fast path now additionally requires `0 < scale` and `Nat.log2 scale < 64`, the latter excluding element sizes of `2^64` and beyond whose shift amount does not fit the 6-bit `slli` immediate. Both cases fall through to the `li`/`mul` form, which truncates modulo `2^64` exactly as the interpreter does and is therefore correct at every scale.