### PR TITLE
feat(instcombine): Use `LocalRewritePattern` in the instcombine pass

### DIFF
--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -14,214 +14,258 @@ namespace Veir
 /-! ## Pattern Rewrites -/
 
 /-- Rewrites `x * 2` to `x + x`. -/
-def mulITwoToAddi (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, properties) := matchMuli op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def mulITwoToAddi_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, properties) := matchMuli op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 2 then
-    return rewriter
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .add) #[lhs.getType! rewriter.ctx.raw] #[lhs, lhs]
-    #[] #[] properties (some $ .before op)
-  return rewriter.replaceOp! op newOp
+    return (ctx, none)
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[lhs.getType! ctx.raw] #[lhs, lhs]
+    #[] #[] properties none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
+
+def mulITwoToAddi (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite mulITwoToAddi_local rewriter op opInBounds
 
 /-- Rewrites `x * 0` to `0`. -/
-def mulIZeroToCst (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchMuli op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def mulIZeroToCst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchMuli op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 0 then
-    return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx.raw).val
-    | return rewriter
+    return (ctx, none)
+  let .integerType type := (lhs.getType! ctx.raw).val
+    | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
-    #[] #[] cstProp (some $ .before op)
-  return rewriter.replaceOp! op newOp
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+    #[] #[] cstProp none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
-set_option warn.sorry false in
+def mulIZeroToCst (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite mulIZeroToCst_local rewriter op opInBounds
+
 /-- Rewrites `x + 0` to `x`. -/
-def addiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchAddi op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def addiZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchAddi op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 0 then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
 
-set_option warn.sorry false in
+def addiZeroToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite addiZeroToX_local rewriter op opInBounds
+
 /-- Rewrites `x * 1` to `x`. -/
-def mulIOneToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchMuli op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def mulIOneToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchMuli op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 1 then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
 
-set_option warn.sorry false in
+def mulIOneToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite mulIOneToX_local rewriter op opInBounds
+
 /-- Rewrites `x - 0` to `x`. -/
-def subiZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchSubi op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def subiZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchSubi op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 0 then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
+
+def subiZeroToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite subiZeroToX_local rewriter op opInBounds
 
 /-- Rewrites `x - x` to `0`. -/
-def subiSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchSubi op rewriter.ctx
-    | return rewriter
+def subiSelfToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchSubi op ctx
+    | return (ctx, none)
   if lhs ≠ rhs then
-    return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx.raw).val
-    | return rewriter
+    return (ctx, none)
+  let .integerType type := (lhs.getType! ctx.raw).val
+    | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
-    #[] #[] cstProp (some $ .before op)
-  return rewriter.replaceOp! op newOp
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+    #[] #[] cstProp none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
-set_option warn.sorry false in
+def subiSelfToZero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite subiSelfToZero_local rewriter op opInBounds
+
 /-- Rewrites `x & x` to `x`. -/
-def andiSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs) := matchAndi op rewriter.ctx
-    | return rewriter
+def andiSelfToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs) := matchAndi op ctx
+    | return (ctx, none)
   if lhs ≠ rhs then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
+
+def andiSelfToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite andiSelfToX_local rewriter op opInBounds
 
 /-- Rewrites `x & 0` to `0`. -/
-def andiZeroToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs) := matchAndi op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def andiZeroToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs) := matchAndi op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 0 then
-    return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx.raw).val
-    | return rewriter
+    return (ctx, none)
+  let .integerType type := (lhs.getType! ctx.raw).val
+    | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
-    #[] #[] cstProp (some $ .before op)
-  return rewriter.replaceOp! op newOp
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+    #[] #[] cstProp none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
-set_option warn.sorry false in
+def andiZeroToZero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite andiZeroToZero_local rewriter op opInBounds
+
 /-- Rewrites `x | 0` to `x`. -/
-def oriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchOri op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def oriZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchOri op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 0 then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
 
-set_option warn.sorry false in
+def oriZeroToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite oriZeroToX_local rewriter op opInBounds
+
 /-- Rewrites `x | x` to `x`. -/
-def oriSelfToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs, _) := matchOri op rewriter.ctx
-    | return rewriter
+def oriSelfToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs, _) := matchOri op ctx
+    | return (ctx, none)
   if lhs ≠ rhs then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
 
-set_option warn.sorry false in
+def oriSelfToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite oriSelfToX_local rewriter op opInBounds
+
 /-- Rewrites `x ^ 0` to `x`. -/
-def xoriZeroToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs) := matchXori op rewriter.ctx
-    | return rewriter
-  let some cst := matchConstantIntVal rhs rewriter.ctx
-    | return rewriter
+def xoriZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs) := matchXori op ctx
+    | return (ctx, none)
+  let some cst := matchConstantIntVal rhs ctx
+    | return (ctx, none)
   if cst.value ≠ 0 then
-    return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) lhs sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+    return (ctx, none)
+  some (ctx, some (#[], #[lhs]))
+
+def xoriZeroToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite xoriZeroToX_local rewriter op opInBounds
 
 /-- Rewrites `x ^ x` to `0`. -/
-def xoriSelfToZero (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some (lhs, rhs) := matchXori op rewriter.ctx
-    | return rewriter
+def xoriSelfToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some (lhs, rhs) := matchXori op ctx
+    | return (ctx, none)
   if lhs ≠ rhs then
-    return rewriter
-  let .integerType type := (lhs.getType! rewriter.ctx.raw).val
-    | return rewriter
+    return (ctx, none)
+  let .integerType type := (lhs.getType! ctx.raw).val
+    | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .mlir__constant) #[lhs.getType! rewriter.ctx.raw] #[]
-    #[] #[] cstProp (some $ .before op)
-  return rewriter.replaceOp! op newOp
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+    #[] #[] cstProp none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
-set_option warn.sorry false in
+def xoriSelfToZero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite xoriSelfToZero_local rewriter op opInBounds
+
 /-- Rewrites `~~x` to `x`. -/
-def notNotToX (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some outerNotted := matchNot (op.getResult 0) rewriter.ctx
-    | return rewriter
-  let some inner := matchNot outerNotted rewriter.ctx
-    | return rewriter
-  let rewriter := rewriter.replaceValue (op.getResult 0) inner sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+def notNotToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some outerNotted := matchNot (op.getResult 0) ctx
+    | return (ctx, none)
+  let some inner := matchNot outerNotted ctx
+    | return (ctx, none)
+  some (ctx, some (#[], #[inner]))
+
+def notNotToX (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite notNotToX_local rewriter op opInBounds
 
 /-- Rewrites `~(~a & ~b)` to `a | b` (DeMorgan). -/
 /- TODO: the precondition should be strengthened by some hasOneUse() checks -/
-def deMorganAndToOr (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some andVal := matchNot (op.getResult 0) rewriter.ctx
-    | return rewriter
+def deMorganAndToOr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some andVal := matchNot (op.getResult 0) ctx
+    | return (ctx, none)
   let .opResult andResPtr := andVal
-    | return rewriter
-  let some (andL, andR) := matchAndi andResPtr.op rewriter.ctx
-    | return rewriter
-  let some a := matchNot andL rewriter.ctx
-    | return rewriter
-  let some b := matchNot andR rewriter.ctx
-    | return rewriter
-  let resultType := a.getType! rewriter.ctx.raw
+    | return (ctx, none)
+  let some (andL, andR) := matchAndi andResPtr.op ctx
+    | return (ctx, none)
+  let some a := matchNot andL ctx
+    | return (ctx, none)
+  let some b := matchNot andR ctx
+    | return (ctx, none)
+  let resultType := a.getType! ctx.raw
   let orProps : DisjointProperties := { disjoint := false }
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .or) #[resultType] #[a, b]
-    #[] #[] orProps (some $ .before op)
-  return rewriter.replaceOp! op newOp
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .or) #[resultType] #[a, b]
+    #[] #[] orProps none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
+
+def deMorganAndToOr (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite deMorganAndToOr_local rewriter op opInBounds
 
 /-- Rewrites `~(~a | ~b)` to `a & b` (DeMorgan). -/
 /- TODO: the precondition should be strengthened by some hasOneUse() checks -/
-def deMorganOrToAnd (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) :
-    Option (PatternRewriter OpCode) := do
-  let some orVal := matchNot (op.getResult 0) rewriter.ctx
-    | return rewriter
+def deMorganOrToAnd_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some orVal := matchNot (op.getResult 0) ctx
+    | return (ctx, none)
   let .opResult orResPtr := orVal
-    | return rewriter
-  let some (orL, orR, _) := matchOri orResPtr.op rewriter.ctx
-    | return rewriter
-  let some a := matchNot orL rewriter.ctx
-    | return rewriter
-  let some b := matchNot orR rewriter.ctx
-    | return rewriter
-  let resultType := a.getType! rewriter.ctx.raw
-  let (rewriter, newOp) ← rewriter.createOp! (.llvm .and) #[resultType] #[a, b]
-    #[] #[] () (some $ .before op)
-  return rewriter.replaceOp! op newOp
+    | return (ctx, none)
+  let some (orL, orR, _) := matchOri orResPtr.op ctx
+    | return (ctx, none)
+  let some a := matchNot orL ctx
+    | return (ctx, none)
+  let some b := matchNot orR ctx
+    | return (ctx, none)
+  let resultType := a.getType! ctx.raw
+  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[resultType] #[a, b]
+    #[] #[] () none
+  some (ctx, some (#[newOp], #[newOp.getResult 0]))
+
+def deMorganOrToAnd (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite deMorganOrToAnd_local rewriter op opInBounds
 
 def InstCombinePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do


### PR DESCRIPTION
Restate every rewrite pattern in the instcombine pass as a
`LocalRewritePattern`: `foo_local` threads a `WfIRContext`, creates
detached operations, and returns the new operations together with the
replacement values, while `foo` becomes a thin
`RewritePattern.fromLocalRewrite` wrapper so the pattern list is
unchanged.

This removes all `sorry`s from the pass, and is a first step towards
reasoning about these patterns.