### PR TITLE
feat(passes): Use the `!` rewriter functions in DCE, CSE and ModArithToArith

### DIFF
--- a/Veir/Passes/CSE.lean
+++ b/Veir/Passes/CSE.lean
@@ -127,7 +127,6 @@ def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
       return ordinaryKey ctx op kind
   | _ => none
 
-set_option warn.sorry false in
 /-- Perform CSE on a single BB: Walk the operations, building up a
     hash of available values. For any operation whose value is already
     available, replace it with the earlier one. -/
@@ -143,14 +142,13 @@ def processBlock
     if let some key := key? ctx.raw op then
         match available[key]? with
         | some earlier =>
-            ctx := WfRewriter.replaceValue ctx (op.getResult 0) (earlier.getResult 0) sorry sorry sorry
-            ctx := WfRewriter.eraseOp ctx op sorry sorry sorry
+            ctx := WfRewriter.replaceValue! ctx (op.getResult 0) (earlier.getResult 0)
+            ctx := WfRewriter.eraseOp! ctx op
         | none =>
             available := available.insert key op
     current := next
   return ctx
 
-set_option warn.sorry false in
 def processAllBlocks (ctx : WfIRContext OpCode) :
     WfIRContext OpCode := Id.run do
   let mut ctx := ctx

--- a/Veir/Passes/DCE/dce.lean
+++ b/Veir/Passes/DCE/dce.lean
@@ -6,12 +6,11 @@ namespace Veir
 
 /-! We implement a dead code elimination pass. -/
 
-set_option warn.sorry false in
 def eliminateDeadOp (rewriter: PatternRewriter OpCode) (op: OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   /- delete operations that are not used and have no side effects -/
   if ¬ op.hasUses! rewriter.ctx.raw && ¬ op.hasSideEffects rewriter.ctx.raw then
-    return rewriter.eraseOp op sorry sorry sorry
+    return rewriter.eraseOp! op
   else
     return rewriter
 

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -97,13 +97,12 @@ abbrev Builder :=
   (ip : InsertPoint) →
   Option (PatternRewriter OpCode × ValuePtr)
 
-set_option warn.sorry false in
 /-- Lower a binary `mod_arith` op `modOp`,
     using intermediate Type iM given storage type iM, with M = `widen` N,
     and using Builder `build` to determine the exact `arith` operations to emit -/
 def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builder)
     (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   -- match op and extract operands:
   let some (operands, _) := matchOp op rewriter.ctx (.mod_arith modOp) 2
     | return rewriter
@@ -122,8 +121,8 @@ def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builde
   let (rewriter, r) ← build rewriter a b q ip
   let (rewriter, r) ← emitArithBinOp rewriter .remui () r q ip
   let (rewriter, r) ← packValue rewriter r modArithType ip
-  let rewriter := rewriter.replaceValue (op.getResult 0) r sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+  let rewriter := rewriter.replaceValue! (op.getResult 0) r
+  return rewriter.eraseOp! op
 
 /-! ## Binary op lowering Patterns -/
 
@@ -150,10 +149,9 @@ def lowerModArithSubOp := lowerModArithBinOp .sub (· + 1) buildSub
 
 /-! ## Constant lowering Pattern -/
 
-set_option warn.sorry false in
 /-- Lower `mod_arith.constant` to an `arith.constant` (assumes value is in `[0, q)` already). -/
 def lowerModArithConstant (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   -- match op and extract attribute:
   let some (_, props) := matchOp op rewriter.ctx (.mod_arith .constant) 0
     | return rewriter
@@ -166,8 +164,8 @@ def lowerModArithConstant (rewriter : PatternRewriter OpCode) (op : OperationPtr
   let ip := InsertPoint.before op
   let (rewriter, r) ← emitArithConstant rewriter c storageType.bitwidth ip
   let (rewriter, out) ← castToModArith rewriter (r : ValuePtr) modArithType ip
-  let rewriter := rewriter.replaceValue (op.getResult 0) out sorry sorry sorry
-  return rewriter.eraseOp op sorry sorry sorry
+  let rewriter := rewriter.replaceValue! (op.getResult 0) out
+  return rewriter.eraseOp! op
 
 /-! ## Pass implementation -/
 


### PR DESCRIPTION
Replace the proof-carrying `replaceValue` and `eraseOp` calls in the
three passes with their panicking `!` variants, which check their
preconditions at runtime instead. This removes all `sorry`s from them.

Dropping the `sorry`s re-enables the unused-variable linter for these
declarations, which exposes that the patterns never use their
`opInBounds` argument; rename it to `_opInBounds`.