### PR TITLE
feat: Make `Interpreter/` files modules

### DIFF
--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -2638,6 +2638,7 @@ end OperationPtr
 /-- `ops` is a contiguous chain of operations in a block `parent` in context `ctx`: each operation's
 `.next` field points to the following operation in the list, and each operation's `.parent` field
 points to `parent`. -/
+@[expose]
 def BlockPtr.OpChainSlice (ctx : IRContext OpInfo) (parent : BlockPtr) : List OperationPtr → Prop
   | [] => True
   | a :: l =>

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1,16 +1,22 @@
-import Veir.IR.Basic
+module
+
+public import Veir.IR.Basic
+public import Veir.Data.LLVM.Int.Basic
+public import Veir.Data.LLVM.Byte.Basic
+public import Veir.Data.RISCV.Reg.Basic
+public import Veir.IR.WellFormed
+public import Veir.GlobalOpInfo
+
 import Veir.Rewriter.Basic
 import Veir.ForLean
-import Veir.IR.WellFormed
 import Veir.Data.Comb.Basic
-import Veir.Data.LLVM.Int.Basic
-import Veir.Data.LLVM.Byte.Basic
-import Veir.Data.RISCV.Reg.Basic
 import Veir.Data.HW.Basic
 import Veir.Data.Casting
 import Veir.Properties
 import Veir.GlobalOpInfo
 import Veir.Interfaces.FunctionInterfaces
+
+public section
 
 open Veir.Data
 /-!
@@ -57,7 +63,7 @@ namespace RuntimeValue
   A predicate indicating whether a `RuntimeValue` is a value that is a runtime value
   of a given `TypeAttr`.
 -/
-@[grind]
+@[expose, grind]
 def Conforms (val : RuntimeValue) (ty : TypeAttr) : Prop :=
   match val, ty with
   | .int bw _, ⟨.integerType intType, _⟩ => intType.bitwidth = bw
@@ -249,6 +255,7 @@ theorem VariableState.ext {s₁ s₂ : VariableState ctx} :
   Get the value of the operands of an operation.
   If any operand is not in the state, return `none`.
 -/
+@[expose]
 def VariableState.getOperandValues (state : VariableState ctx)
     (op : OperationPtr) : Option (Array RuntimeValue) := do
   (op.getOperands! ctx.raw).mapM state.getVar?
@@ -279,22 +286,29 @@ def VariableState.setResultValues? (state : VariableState ctx)
     none
 
 /--
+  Implementation loop for setting the values of block arguments.
+-/
+def VariableState.setArgumentValues?_loop (state : VariableState ctx)
+    (block : BlockPtr) (values : Array RuntimeValue) (i : Nat)
+    (blockInBounds : block.InBounds ctx.raw := by grind)
+    (iInBounds : i ≤ block.getNumArguments! ctx.raw := by grind)
+    : Option (VariableState ctx) :=
+  match i with
+  | 0 => state
+  | i + 1 => do
+    let arg := block.getArgument i
+    let value := values[i]!
+    let newState ← state.setVar? arg value
+    VariableState.setArgumentValues?_loop newState block values i
+
+/--
   Set the values of block arguments.
 -/
 def VariableState.setArgumentValues? (state : VariableState ctx)
     (block : BlockPtr) (values : Array RuntimeValue)
     (blockInBounds : block.InBounds ctx.raw := by grind)
     : Option (VariableState ctx) :=
-  let rec loop (state : VariableState ctx) (i : Nat)
-      (iInBounds : i ≤ block.getNumArguments! ctx.raw := by grind) :=
-    match i with
-    | 0 => state
-    | i + 1 => do
-      let arg := block.getArgument i
-      let value := values[i]!
-      let newState ← state.setVar? arg value
-      loop newState i
-  loop state (block.getNumArguments! ctx.raw)
+  VariableState.setArgumentValues?_loop state block values (block.getNumArguments! ctx.raw)
 
 /--
   How the control flow should proceed after interpreting a terminator.
@@ -316,9 +330,16 @@ inductive UBOr (α : Type) where
   | ub : UBOr α
 deriving Inhabited
 
+@[expose]
 def UBOr.map {α β : Type} (f : α → β) : UBOr α → UBOr β
   | .ok a => .ok (f a)
   | .ub => .ub
+
+@[simp, grind =]
+theorem UBOr.map_ok : UBOr.map f (.ok a) = .ok (f a) := by grind [UBOr.map]
+
+@[simp, grind =]
+theorem UBOr.map_ub : UBOr.map f .ub = .ub := by grind [UBOr.map]
 
 /--
   The interpreter monad. `Option (UBOr α)` has three states:
@@ -326,8 +347,10 @@ def UBOr.map {α β : Type} (f : α → β) : UBOr α → UBOr β
   - `some .ub`     — execution triggered undefined behaviour.
   - `none`         — interpreter could not proceed (malformed IR, unsupported op).
 -/
+@[expose]
 def Interp (α : Type) : Type := Option (UBOr α)
 
+@[expose]
 def Interp.map {α β : Type} (f : α → β) : Interp α → Interp β :=
   Option.map (UBOr.map f)
 
@@ -1587,6 +1610,7 @@ abbrev OperationPtr.interpret (op : OperationPtr) (ctx : IRContext OpCode)
   If any error occurs during interpretation (e.g., unknown operation, missing variable),
   return `none`.
 -/
+@[expose]
 def interpretOp (op : OperationPtr) {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
     (inBounds : op.InBounds ctx.raw := by grind)
     : Interp (InterpreterState ctx × Option ControlFlowAction) := do
@@ -1641,6 +1665,7 @@ def interpretOpList {ctx : WfIRContext OpCode} (ops : List OperationPtr)
   interpretation. If no terminator is encountered, return `none`.
   Return `none` if any errors occur during interpretation.
 -/
+@[expose]
 def interpretTerminatedOpList {ctx : WfIRContext OpCode} (ops : List OperationPtr)
     (state : InterpreterState ctx)
     (opInBounds : ∀ op ∈ ops, op.InBounds ctx.raw := by grind)

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -1,6 +1,14 @@
-import Veir.Interpreter.Basic
+module
+
+public import Veir.IR.OpInfo
+public import Veir.IR.Basic
+public import Veir.GlobalOpInfo
+public import Veir.Interpreter.Basic
+public import Veir.Dominance
+public import Veir.Verifier
+
 import Veir.Interpreter.Lemmas
-import Veir.Dominance
+
 
 /-!
 # Equation Lemma and SSA Invariant
@@ -14,6 +22,7 @@ CompCertSSA semantics are based on small-step operational semantics.
 -/
 
 namespace Veir
+public section
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 
@@ -56,7 +65,7 @@ theorem interpretOp'_eq_ok_implies_memory_eq (h : op.Pure ctx) :
           some (.ok (resValues, memory₂, cf)) →
       memory₁ = memory₂ := by
   rw [h operands memory₁ memory₁]
-  simp only [Interp.map, Option.map, UBOr.map]
+  simp only [Interp.map, Option.map, Interp, UBOr.map]
   grind
 
 end OperationPtr.Pure
@@ -173,8 +182,7 @@ theorem InterpreterState.DefinesDominating.exists_getVar_of_dominatesIp
 /-- All operands operation in a well-dominated program exist in a state that is `DefinesDominating`
 right before the operation. -/
 theorem InterpreterState.DefinesDominating.exists_getOperandValues_eq_some
-    {ctx : WfIRContext OpCode} (ctxDom : ctx.Dom) {state : InterpreterState ctx}
-    {op : OperationPtr} (opInBounds : op.InBounds ctx.raw)
+    (ctxDom : ctx.Dom) {state : InterpreterState ctx}
     (stateDom : state.DefinesDominating (InsertPoint.before op) opInBounds) :
     ∃ val, state.variables.getOperandValues op = some val := by
   simp only [VariableState.getOperandValues, Array.exists_mapM_option_eq_some_iff]
@@ -252,12 +260,12 @@ theorem InterpreterState.EquationLemmaAt.setArgumentValues?_succ_entry (ctxDom :
 /-- Interpreting a verified operation never fails on a state satisfying `DefinesDominating` at the
 operation's location. -/
 theorem InterpreterState.DefinesDominating.interpretOp_ne_none
-    (ctxDom : ctx.Dom) (opInBounds : op.InBounds ctx.raw) {state : InterpreterState ctx}
-    (stateDom : state.DefinesDominating (InsertPoint.before op) opInBounds)
+    (ctxDom : ctx.Dom) {state : InterpreterState ctx}
+    (stateDom : state.DefinesDominating (InsertPoint.before op) ipInBounds)
     (opVerif : op.Verified ctx opInBounds) :
     ∃ state', interpretOp op state opInBounds = some state' := by
   simp only [interpretOp]
-  have ⟨operandValues, hOperandValues⟩ := stateDom.exists_getOperandValues_eq_some ctxDom opInBounds
+  have ⟨operandValues, hOperandValues⟩ := stateDom.exists_getOperandValues_eq_some ctxDom
   simp only [hOperandValues]
   have hconforms : RuntimeValue.ArrayConforms operandValues (op.getOperandTypes! ctx.raw) := by
     grind [VariableState.getOperandValues_conforms]

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -1,9 +1,14 @@
-import Veir.Interpreter.Basic
-import Veir.Dominance
-import Veir.Interpreter.Refinement.Basic
-import Veir.Verifier
+module
+
+public import Veir.Interpreter.Basic
+public import Veir.Dominance
+public import Veir.Verifier
+public import Veir.Interpreter.Refinement.Basic
+
+import all Veir.Interpreter.Basic
 
 namespace Veir
+public section
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx ctx' : WfIRContext OpInfo}
@@ -182,7 +187,7 @@ theorem VariableState.getVar?_setResultValues?_of_value_inBounds
 
 theorem VariableState.getVar?_setArgumentValues?_loop {block : BlockPtr}
     {values : Array RuntimeValue} {i : Nat} {iInBounds blockInBounds} :
-    VariableState.setArgumentValues?.loop block values blockInBounds varState i iInBounds = some varState' →
+    VariableState.setArgumentValues?_loop varState block values i blockInBounds iInBounds = some varState' →
     varState'.getVar? value =
     match value with
     | .blockArgument ⟨block', index⟩ =>
@@ -192,7 +197,7 @@ theorem VariableState.getVar?_setArgumentValues?_loop {block : BlockPtr}
         varState.getVar? value
     | _ =>
       varState.getVar? value := by
-  fun_induction VariableState.setArgumentValues?.loop
+  fun_induction VariableState.setArgumentValues?_loop
   next => grind
   next =>
     simp only [Option.bind_eq_bind, Nat.succ_eq_add_one, Option.bind]
@@ -240,8 +245,8 @@ type. -/
 theorem VariableState.setArgumentValues?_loop_isSome_iff {block : BlockPtr}
     {values : Array RuntimeValue} {i : Nat} {iInBounds blockInBounds} :
     (∀ j, j < i → (values[j]!).Conforms ((block.getArgument j : ValuePtr).getType! ctx.raw)) ↔
-    (∃ v, VariableState.setArgumentValues?.loop block values blockInBounds varState i iInBounds = some v) := by
-  fun_induction VariableState.setArgumentValues?.loop
+    (∃ v, VariableState.setArgumentValues?_loop varState block values i blockInBounds iInBounds = some v) := by
+  fun_induction VariableState.setArgumentValues?_loop
   next => grind
   next varState hin k hk arg value ih =>
     simp only [Option.bind_eq_bind, Option.bind]
@@ -251,7 +256,7 @@ theorem VariableState.setArgumentValues?_loop_isSome_iff {block : BlockPtr}
       simp only [← ih]
       grind
     · rintro ⟨v, hv⟩ j hj
-      rcases hsv : hin.setVar? (ValuePtr.blockArgument arg) value with _ | varState'
+      rcases hsv : varState.setVar? (ValuePtr.blockArgument arg) value with _ | varState'
       · grind
       · grind [ih varState']
 

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -1,6 +1,13 @@
-import Veir.Interpreter.Basic
+module
+
+public import Veir.IR.OpInfo
+public import Veir.Interpreter.Basic
+public import Veir.Rewriter.InsertPoint
+public import Veir.Dominance
+
 import Veir.Data.Refinement
-import Veir.Dominance
+
+public section
 
 /-!
 # Refinement of programs
@@ -26,6 +33,7 @@ namespace Veir
 variable {OpInfo : Type} [HasOpInfo OpInfo] {ctx : WfIRContext OpInfo}
 
 /-- Refinement relation between two runtime values. -/
+@[expose]
 def RuntimeValue.isRefinedBy (source target : RuntimeValue) : Prop :=
   match source, target with
   | .int bw s, .int bw' t => ∃ h : bw = bw', s.cast h ⊒ t
@@ -41,6 +49,7 @@ def RuntimeValue.isRefinedBy (source target : RuntimeValue) : Prop :=
 An array `source` of runtime values is refined by `target`. This asserts that the arrays have
 the same size, and that they refine pointwise.
 -/
+@[expose]
 def RuntimeValue.arrayIsRefinedBy (source target : Array RuntimeValue) : Prop :=
   source.size = target.size ∧
     ∀ (i : Nat) (_ : i < source.size), source[i]! ⊒ target[i]!
@@ -51,6 +60,7 @@ def RuntimeValue.arrayIsRefinedBy (source target : Array RuntimeValue) : Prop :=
 Refinement of memory states, which can involve poison bits being refined into concrete bits.
 This should be kept consistent with the definition of refinement on the byte type.
 -/
+@[expose]
 def MemoryState.isRefinedBy (source target : MemoryState) : Prop :=
   ∀ addr, source.poisonMask.getD addr 0 ||| ((source.contents.getD addr 0 ^^^ ~~~target.contents.getD addr 0) &&& ~~~target.poisonMask.getD addr 0) = 0xff
 
@@ -60,6 +70,7 @@ def MemoryState.isRefinedBy (source target : MemoryState) : Prop :=
 A function interpretation `source` is refined by `target`. This asserts that the final memories
 are equal, and the returned values refine pointwise.
 -/
+@[expose]
 def FunctionResult.isRefinedBy (source target : MemoryState × Array RuntimeValue) : Prop :=
   source.1 = target.1 ∧ source.2 ⊒ target.2
 
@@ -73,6 +84,7 @@ on the underlying values. This asserts:
 * when `source` is undefined behaviour (`some .ub`) or failed interpretation (`none`), `target`
   is unconstrained
 -/
+@[expose]
 def Interp.isRefinedBy (R : α → β → Prop) (source : Interp α) (target : Interp β) : Prop :=
   match source, target with
   | some (.ok a), some (.ok b) => R a b
@@ -84,6 +96,7 @@ def Interp.isRefinedBy (R : α → β → Prop) (source : Interp α) (target : I
 Refinement between two control flow actions: same constructor, equal successor block `dest`, and
 the carried value payloads refine pointwise.
 -/
+@[expose]
 def ControlFlowAction.isRefinedBy : ControlFlowAction → ControlFlowAction → Prop
   | .return vals, .return vals' => vals ⊒ vals'
   | .branch vals dest, .branch vals' dest' => dest = dest' ∧ vals ⊒ vals'
@@ -95,6 +108,7 @@ def ControlFlowAction.isRefinedBy : ControlFlowAction → ControlFlowAction → 
 Refinement between two optional control flow actions. They should either both be `none`, or both be
 `some` and refine.
 -/
+@[expose]
 def ControlFlowAction.optionIsRefinedBy : Option ControlFlowAction → Option ControlFlowAction → Prop
   | none, none => True
   | some a, some b => a.isRefinedBy b
@@ -105,6 +119,7 @@ The function described by source `op₁` (in `ctx₁`) is *refined by* target `o
 for every argument `values` and initial memory `mem`, interpreting `op₁` is refined by interpreting
 `op₂`.
 -/
+@[expose]
 def OperationPtr.isRefinedByAsFunction (op₁ : OperationPtr) (ctx₁ : WfIRContext OpCode)
     (op₂ : OperationPtr) (ctx₂ : WfIRContext OpCode)
     (op₁In : op₁.InBounds ctx₁.raw := by grind)
@@ -133,6 +148,7 @@ the same symbol name.
 In particular, note that `mod₂` may have extra top-level functions that are not in `mod₁`, but
 every function in `mod₁` must be matched by a same-named function in `mod₂` that refines it.
 -/
+@[expose]
 def OperationPtr.isModuleRefinedBy (mod₁ : OperationPtr) (ctx₁ : WfIRContext OpCode)
     (mod₂ : OperationPtr) (ctx₂ : WfIRContext OpCode) : Prop :=
   ∀ (func₁ : OperationPtr) (func₁In : func₁.InBounds ctx₁.raw) (name : StringAttr),
@@ -145,6 +161,7 @@ abbrev ValueMapping (ctx ctx' : WfIRContext OpInfo) : Type :=
   {v : ValuePtr // v.InBounds ctx.raw} → {v : ValuePtr // v.InBounds ctx'.raw}
 
 /-- Apply the value mapping to an array of values with separately their bounds information. -/
+@[expose]
 def ValueMapping.applyToArray {ctx ctx' : WfIRContext OpInfo} (mapping : ValueMapping ctx ctx')
     (vals : Array ValuePtr) (valsIn : ∀ v ∈ vals, v.InBounds ctx.raw := by grind) : Array ValuePtr :=
   vals.attach.map (fun ⟨v, hv⟩ => (mapping ⟨v, valsIn v hv⟩).val)
@@ -181,6 +198,7 @@ A variable state `state` is refined by `state'` through the value renaming `mapp
 variable defined in `state` is, after renaming through `mapping`, also defined in `state'` with a
 value that refines the source value.
 -/
+@[expose]
 def VariableState.isRefinedBy {ctx ctx' : WfIRContext OpInfo}
     (state : VariableState ctx) (state' : VariableState ctx')
     (mapping : ValueMapping ctx ctx') : Prop :=
@@ -194,6 +212,7 @@ An interpreter state `state` is refined by `state'` through the value mapping
 `mapping`: they have the same memory, and the variable state of `state` is refined by the variable
 state of `state'` through `mapping`.
 -/
+@[expose]
 def InterpreterState.isRefinedBy {ctx ctx' : WfIRContext OpInfo}
     (state : InterpreterState ctx) (state' : InterpreterState ctx')
     (mapping : ValueMapping ctx ctx') : Prop :=
@@ -238,11 +257,13 @@ def RefinementPoint.InBounds (point : RefinementPoint) (ctx : IRContext OpInfo) 
 
 @[simp, grind =]
 theorem RefinementPoint.inBounds_at {p : InsertPoint} {ctx : IRContext OpInfo} :
-    (RefinementPoint.at p).InBounds ctx = p.InBounds ctx := rfl
+    (RefinementPoint.at p).InBounds ctx = p.InBounds ctx := by
+  simp [RefinementPoint.InBounds]
 
 @[simp, grind =]
 theorem RefinementPoint.inBounds_blockEntry {b : BlockPtr} {ctx : IRContext OpInfo} :
-    (RefinementPoint.blockEntry b).InBounds ctx = b.InBounds ctx := rfl
+    (RefinementPoint.blockEntry b).InBounds ctx = b.InBounds ctx := by
+  simp [RefinementPoint.InBounds]
 
 /-- Whether `value` is *in scope* at a refinement point. For `.at p` this holds exactly when the
 value dominates `p`; for `.blockEntry b` it must dominate the block entry and not be one of `b`'s
@@ -256,13 +277,15 @@ def ValuePtr.InScopeAt (value : ValuePtr) (point : RefinementPoint) (ctx : WfIRC
 
 @[simp, grind =]
 theorem ValuePtr.inScopeAt_at :
-    ValuePtr.InScopeAt val (.at p) ctx = val.dominatesIp p ctx := rfl
+    ValuePtr.InScopeAt val (.at p) ctx = val.dominatesIp p ctx := by
+  simp [ValuePtr.InScopeAt]
 
 @[simp, grind =]
 theorem ValuePtr.inScopeAt_blockEntry :
     ValuePtr.InScopeAt val (.blockEntry b) ctx =
       (val.dominatesIp (InsertPoint.atStart! b ctx.raw) ctx
-      ∧ val ∉ b.getArguments! ctx.raw) := rfl
+      ∧ val ∉ b.getArguments! ctx.raw) := by
+  simp [ValuePtr.InScopeAt]
 
 /--
 A refinement relation for variable states in two different contexts at different locations.

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -1,4 +1,11 @@
-import Veir.Interpreter.Refinement.Basic
+module
+
+public import Veir.IR.OpInfo
+public import Veir.Interpreter.Refinement.Basic
+
+import all Veir.Interpreter.Refinement.Basic
+
+public section
 
 namespace Veir
 open Veir.Data
@@ -78,7 +85,9 @@ theorem ControlFlowAction.optionIsRefinedBy_refl (cf : Option ControlFlowAction)
 
 theorem RuntimeValue.isRefinedBy_trans {v₁ v₂ v₃ : RuntimeValue}
     (h12 : v₁ ⊒ v₂) (h23 : v₂ ⊒ v₃) : v₁ ⊒ v₃ := by
-  cases v₁ <;> grind [RuntimeValue.isRefinedBy, isRefinedBy_trans, cases RuntimeValue]
+  cases v₁ <;>
+    grind [RuntimeValue.isRefinedBy, isRefinedBy_trans,
+      cases RuntimeValue, LLVM.Byte.isRefinedBy_trans]
 
 theorem MemoryState.isRefinedBy_trans {m1 m2 m3 : MemoryState}
     (h12 : m1 ⊒ m2) (h23 : m2 ⊒ m3) : m1 ⊒ m3 := by

--- a/Veir/Interpreter/Refinement/Monotonicity.lean
+++ b/Veir/Interpreter/Refinement/Monotonicity.lean
@@ -1,6 +1,15 @@
+module
+
+public import Veir.IR.OpInfo
+public import Veir.Interpreter.Refinement.Basic
+public import Veir.Interpreter.Basic
+public import Veir.Verifier
+
+import Veir.Interpreter.Lemmas
 import Veir.Interpreter.EquationLemma
-import Veir.Interpreter.Refinement.Basic
 import Veir.Interpreter.Refinement.Lemmas
+
+public section
 
 /-!
 # Monotonicity of the interpreter


### PR DESCRIPTION
Multiple definitions no need to be exposed because of this. Additionally, this changed the name of a `bv_decide` axiom, so many other files had to be changed.