### PR TITLE
fix(parser): Parse more than utf8

### DIFF
--- a/Test/Builtin/parse_non_utf8_string_literal.mlir
+++ b/Test/Builtin/parse_non_utf8_string_literal.mlir
@@ -1,0 +1,8 @@
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, alignment = 1 : i64, constant, dso_local, global_type = !llvm.array<274 x i8>, linkage = #llvm.linkage<internal>, sym_name = "sqlite3UpperToLower", unnamed_addr = 0 : i64, value = "\00\01\02\03\04\05\06\07\08\09\0A\0B\0C\0D\0E\0F\10\11\12\13\14\15\16\17\18\19\1A\1B\1C\1D\1E\1F !\22#$%&'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\7F\80\81\82\83\84\85\86\87\88\89\8A\8B\8C\8D\8E\8F\90\91\92\93\94\95\96\97\98\99\9A\9B\9C\9D\9E\9F\A0\A1\A2\A3\A4\A5\A6\A7\A8\A9\AA\AB\AC\AD\AE\AF\B0\B1\B2\B3\B4\B5\B6\B7\B8\B9\BA\BB\BC\BD\BE\BF\C0\C1\C2\C3\C4\C5\C6\C7\C8\C9\CA\CB\CC\CD\CE\CF\D0\D1\D2\D3\D4\D5\D6\D7\D8\D9\DA\DB\DC\DD\DE\DF\E0\E1\E2\E3\E4\E5\E6\E7\E8\E9\EA\EB\EC\ED\EE\EF\F0\F1\F2\F3\F4\F5\F6\F7\F8\F9\FA\FB\FC\FD\FE\FF\01\00\00\01\01\00\00\01\00\01\00\01\01\00\01\00\00\01", visibility_ = 0 : i64}> ({
+  }) : () -> ()
+  // CHECK: "sym_name" = "sqlite3UpperToLower"
+  // CHECK: "value" = "\00\01\02\03\04\05\06\07\08\t\n\0B\0C\0D\0E\0F\10\11\12\13\14\15\16\17\18\19\1A\1B\1C\1D\1E\1F !\"#$%&'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\7F\80\81\82\83\84\85\86\87\88\89\8A\8B\8C\8D\8E\8F\90\91\92\93\94\95\96\97\98\99\9A\9B\9C\9D\9E\9F\A0\A1\A2\A3\A4\A5\A6\A7\A8\A9\AA\AB\AC\AD\AE\AF\B0\B1\B2\B3\B4\B5\B6\B7\B8\B9\BA\BB\BC\BD\BE\BF\C0\C1\C2\C3\C4\C5\C6\C7\C8\C9\CA\CB\CC\CD\CE\CF\D0\D1\D2\D3\D4\D5\D6\D7\D8\D9\DA\DB\DC\DD\DE\DF\E0\E1\E2\E3\E4\E5\E6\E7\E8\E9\EA\EB\EC\ED\EE\EF\F0\F1\F2\F3\F4\F5\F6\F7\F8\F9\FA\FB\FC\FD\FE\FF\01\00\00\01\01\00\00\01\00\01\00\01\01\00\01\00\00\01"
+}) : () -> ()

--- a/UnitTest/Parser.lean
+++ b/UnitTest/Parser.lean
@@ -238,83 +238,89 @@ end parseKeyword
 
 section parseStringLiteral
 
+private def parseStringLiteralStr : EStateM ParserError ParserState String :=
+  parseStringLiteral >>= fun b => return String.fromUTF8! b
+
+private def parseOptionalStringLiteralStr : EStateM ParserError ParserState (Option String) :=
+  parseOptionalStringLiteral >>= fun ob => return ob.map String.fromUTF8!
+
 /--
   info: "Success: hello world!"
 -/
 #guard_msgs in
-#eval testParser "\"hello world!\"" parseStringLiteral
+#eval testParser "\"hello world!\"" parseStringLiteralStr
 
 /-- info: <test>:1:1: error: string literal expected
 hello world!
 ^ -/
 #guard_msgs (whitespace := exact) in
-#eval testParser "hello world!" parseStringLiteral
+#eval testParser "hello world!" parseStringLiteralStr
 
 /--
   info: <unknown location>: error: expected '"' in string literal
 -/
 #guard_msgs in
-#eval testParser "\"unterminated string" parseStringLiteral
+#eval testParser "\"unterminated string" parseStringLiteralStr
 
 /--
   info: "Success: \n"
 -/
 #guard_msgs in
-#eval testParser "\"\\n\"" parseStringLiteral
+#eval testParser "\"\\n\"" parseStringLiteralStr
 
 /--
   info: "Success: hello\tworld"
 -/
 #guard_msgs in
-#eval testParser "\"hello\\tworld\"" parseStringLiteral
+#eval testParser "\"hello\\tworld\"" parseStringLiteralStr
 
 /--
   info: "Success: say \"hi\""
 -/
 #guard_msgs in
-#eval testParser "\"say \\\"hi\\\"\"" parseStringLiteral
+#eval testParser "\"say \\\"hi\\\"\"" parseStringLiteralStr
 
 /--
   info: "Success: back\\slash"
 -/
 #guard_msgs in
-#eval testParser "\"back\\\\slash\"" parseStringLiteral
+#eval testParser "\"back\\\\slash\"" parseStringLiteralStr
 
 /--
   info: "Success: A"
 -/
 #guard_msgs in
-#eval testParser "\"\\41\"" parseStringLiteral
+#eval testParser "\"\\41\"" parseStringLiteralStr
 
 /--
   info: "Success: a"
 -/
 #guard_msgs in
-#eval testParser "\"\\61\"" parseStringLiteral
+#eval testParser "\"\\61\"" parseStringLiteralStr
 
 /--
   info: "Success: *"
 -/
 #guard_msgs in
-#eval testParser "\"\\2a\"" parseStringLiteral
+#eval testParser "\"\\2a\"" parseStringLiteralStr
 
 /--
   info: "Success: *"
 -/
 #guard_msgs in
-#eval testParser "\"\\2A\"" parseStringLiteral
+#eval testParser "\"\\2A\"" parseStringLiteralStr
 
 /--
   info: "Success: O"
 -/
 #guard_msgs in
-#eval testParser "\"\\4f\"" parseStringLiteral
+#eval testParser "\"\\4f\"" parseStringLiteralStr
 
 /--
   info: "Success: O"
 -/
 #guard_msgs in
-#eval testParser "\"\\4F\"" parseStringLiteral
+#eval testParser "\"\\4F\"" parseStringLiteralStr
 
 /-!
 `\c3\a9` is the two-byte UTF-8 encoding of é (U+00E9).
@@ -325,31 +331,52 @@ since single-byte values with a letter first digit (>= 0xA0) aren't valid UTF-8 
   info: "Success: é"
 -/
 #guard_msgs in
-#eval testParser "\"\\c3\\a9\"" parseStringLiteral
+#eval testParser "\"\\c3\\a9\"" parseStringLiteralStr
 
 /--
   info: "Success: é"
 -/
 #guard_msgs in
-#eval testParser "\"\\C3\\A9\"" parseStringLiteral
+#eval testParser "\"\\C3\\A9\"" parseStringLiteralStr
 
 /--
   info: "Success: é"
 -/
 #guard_msgs in
-#eval testParser "\"\\c3\\A9\"" parseStringLiteral
+#eval testParser "\"\\c3\\A9\"" parseStringLiteralStr
 
 /--
   info: "Success: é"
 -/
 #guard_msgs in
-#eval testParser "\"\\C3\\a9\"" parseStringLiteral
+#eval testParser "\"\\C3\\a9\"" parseStringLiteralStr
 
 /--
   info: "Success: (some (hello world!))"
 -/
 #guard_msgs in
-#eval testParser "\"hello world!\"" parseOptionalStringLiteral
+#eval testParser "\"hello world!\"" parseOptionalStringLiteralStr
+
+/-!
+{\t, \n, \"} and {\09, \0A, \22} are printed as {\t, \n, \"}.
+-/
+/--
+  info: "Success: (some (\t\n\"hello world\t\n\"))"
+-/
+#guard_msgs in
+#eval testParser "\"\\t\\n\\\"hello world\\09\\0A\\22\"" parseOptionalStringLiteralStr
+
+/--
+  info: "Success: none"
+-/
+#guard_msgs in
+#eval testParser "0" parseOptionalStringLiteralStr
+
+/--
+  info: "Success: none"
+-/
+#guard_msgs in
+#eval testParser "" parseOptionalStringLiteralStr
 
 end parseStringLiteral
 

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -754,18 +754,27 @@ instance : ToString RegisterType where
 instance : ToString RegisterAttr where
   toString attr := s!"{attr.value} : !riscv.reg"
 
-def escapeStringLiteral (s : String) : String := Id.run do
+private def hexDigit (n : UInt8) : Char :=
+  if n < 10 then Char.ofNat (n.toNat + '0'.toNat)
+  else Char.ofNat (n.toNat - 10 + 'A'.toNat)
+
+def escapeStringLiteral (b : ByteArray) : String := Id.run do
   let mut result := ""
-  for c in s.toList do
-    if c == '\\' then result := result ++ "\\\\"
-    else if c == '"' then result := result ++ "\\\""
-    else if c == '\n' then result := result ++ "\\n"
-    else if c == '\t' then result := result ++ "\\t"
-    else result := result.push c
+  for byte in b do
+    if byte == '\\'.toUInt8 then result := result ++ "\\\\"
+    else if byte == '"'.toUInt8 then result := result ++ "\\\""
+    else if byte == '\n'.toUInt8 then result := result ++ "\\n"
+    else if byte == '\t'.toUInt8 then result := result ++ "\\t"
+    else if byte >= 0x20 && byte < 0x7F then result := result.push (Char.ofNat byte.toNat)
+    else
+      /- LLVM convention: encode hex as \HH. -/
+      result := result.push '\\'
+      result := result.push (hexDigit (byte >>> 4))
+      result := result.push (hexDigit (byte &&& 0x0F))
   return result
 
 instance : ToString StringAttr where
-  toString attr := s!"\"{escapeStringLiteral (String.fromUTF8! attr.value)}\""
+  toString attr := s!"\"{escapeStringLiteral attr.value}\""
 
 instance : ToString UnitAttr where
   toString _ := "unit"

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -158,9 +158,9 @@ def parseOptionalIntegerAttr : AttrParserM (Option IntegerAttr) := do
   Its syntax is a string literal enclosed in double quotes, e.g., `"foo"`.
 -/
 def parseOptionalStringAttr : AttrParserM (Option StringAttr) := do
-  let some str ← parseOptionalStringLiteral
+  let some bytes ← parseOptionalStringLiteral
     | return none
-  return some (StringAttr.mk str.toByteArray)
+  return some (StringAttr.mk bytes)
 
 /--
 Parse a float attribute, if present.

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -640,23 +640,25 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   let results ← parseOpResults
   let opNameStart ← getPos
   let some opName ← parseOptionalStringLiteral | return none
+  let some opNameStr := String.fromUTF8? opName
+    | throwAt opNameStart s!"op '{escapeStringLiteral opName}' not a valid UTF8 string."
   let operands ← parseOperands
   let blockOperands ← parseBlockOperands
 
   /- Get the operation opcode. -/
-  let opId := OpCode.fromName opName.toByteArray
+  let opId := OpCode.fromName opName
 
   if let .builtin .unregistered := opId then
     if !(← get).allowUnregisteredDialect then
       throwAt opNameStart
-        s!"op '{opName}' is not registered. Consider using --allow-unregistered-dialect."
+        s!"op '{opNameStr}' is not registered. Consider using --allow-unregistered-dialect."
 
   let properties ← parseOpProperties opId
   /- For `builtin.unregistered`, record the original op name in the properties so it can be
      printed back out. The properties dictionary itself has already been populated by
      `Properties.fromAttrDict` (see `UnregisteredProperties.fromAttrDict`). -/
   let properties : propertiesOf opId := match opId, properties with
-    | .builtin .unregistered, props => { props with opName := opName.toByteArray }
+    | .builtin .unregistered, props => { props with opName := opName }
     | _, props => props
   let regions ← parseOpRegions
   let attrs ← parseOpAttributes
@@ -667,11 +669,11 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
 
   /- Check that the number of results matches with the operation type. -/
   if outputTypes.size ≠ numResults then
-    throwAt opNameStart s!"operation '{opName}' declares {outputTypes.size} result types, but {numResults} result values were provided"
+    throwAt opNameStart s!"operation '{opNameStr}' declares {outputTypes.size} result types, but {numResults} result values were provided"
 
   /- Check that the number and types of operands matches with the operation type. -/
   if inputTypes.size ≠ operands.size then
-    throwAt opNameStart s!"operation '{opName}' declares {inputTypes.size} operand types, but {operands.size} operands were provided"
+    throwAt opNameStart s!"operation '{opNameStr}' declares {inputTypes.size} operand types, but {operands.size} operands were provided"
   let operands ← operands.zip inputTypes |>.mapM (fun (operand, type) => resolveOperand operand type)
 
   let op ← modifyContextM' fun ctx => do

--- a/Veir/Parser/Parser.lean
+++ b/Veir/Parser/Parser.lean
@@ -282,40 +282,38 @@ private def processEscapes (input : ByteArray) (basePos : Nat) : Except ParserEr
   return result
 
 /--
-  Parse optionally a string literal.
-  If the next token is a string literal, consume it and return its string value.
-  Otherwise, return none.
+  Parse optionally a (byte) string literal.
+  If the next token is a string literal, consume it and return its raw bytes
+  after processing escape sequences. Otherwise, return none.
   Handles escape sequences: `\\`, `\"`, `\n`, `\t`, and `\HH`.
 -/
-def parseOptionalStringLiteral : M (Option String) := do
+def parseOptionalStringLiteral : M (Option ByteArray) := do
   match ← parseOptionalToken .stringLit with
   | some token =>
     let slice : Slice := {start := token.slice.start + 1, stop := { byteOffset := token.slice.stop.byteOffset - 1 }} -- remove quotes
     let raw := slice.of ((← get).input)
     let processed ← ofExcept (processEscapes raw (token.slice.start.byteOffset + 1))
-    match String.fromUTF8? processed with
-    | some str => return some str
-    | none => throwAt token.slice.start "internal error: failed converting string literal"
+    return some processed
   | none => return none
 
 /--
-  Parse a string literal.
+  Parse a (byte) string literal.
   Raise an error if the next token is not a string literal.
 -/
-def parseStringLiteral (errorMsg : String := "string literal expected") : M String := do
+def parseStringLiteral (errorMsg : String := "string literal expected") : M ByteArray := do
   match ← parseOptionalStringLiteral with
-  | some str => return str
+  | some bytes => return bytes
   | none => throwAtCurrentPos errorMsg
 
 /--
-  Parses either an identifier or a string literal, if present.
+  Parses either an identifier or a (byte) string literal, if present.
 -/
 def parseOptionalIdentifierOrStringLiteral : M (Option ByteArray) := do
   match ← parseOptionalIdentifier with
   | some ident => return ident
   | none =>
     match ← parseOptionalStringLiteral with
-    | some str => return some str.toByteArray
+    | some bytes => return some bytes
     | none => return none
 
 /--


### PR DESCRIPTION
fix(parse): Extend parser to parse more than UTF-8 (#954).

`sqlite3.c` has a char table that needs to be parsed. This PR allows non-UTF-8 to be parsed too. The three chars {\n,\t,\"} are still printed as human-readable, even if their corresponding hex codes are parsed. 

The main change is that `Parser.parseStringLiteral` now returns a `ByteArray`, rather than a `String`. Some of the previous uses (`AttrParser`, `MlirParser`)  converted to `Byte` anyway; these calculations have now gone. 
On the other hand, `UnitTest/Parser` has a wrapper to convert to `String` for comparison. 