### PR TITLE
feat: add FunctionOpInterface

### DIFF
--- a/Test/Cf/cond_br_branch_weights.mlir
+++ b/Test/Cf/cond_br_branch_weights.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   ^4():
-    "func.func"() ({
+    "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
       ^6(%arg6_0 : i32):
         "cf.br"(%arg6_0) [^7] : (i32) -> ()
       ^7(%arg7_0 : i32):
@@ -13,7 +13,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "func.func"() ({
+// CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:         "cf.br"(%{{.*}}) [^[[tgt:.*]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[tgt]](%{{.*}} : i32):

--- a/Test/Cf/identity.mlir
+++ b/Test/Cf/identity.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   ^4():
-    "func.func"() ({
+	"func.func"() <{"function_type" = (i32) -> (), "sym_name" = "identity"}> ({
       ^6(%arg6_0 : i32):
         "cf.br"(%arg6_0) [^7] : (i32) -> ()
       ^7(%arg7_0 : i32):
@@ -13,7 +13,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "func.func"() ({
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> (), "sym_name" = "identity"}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:         "cf.br"(%{{.*}}) [^[[tgt:.*]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[tgt]](%{{.*}} : i32):

--- a/Test/Interpreter/LLVM/unreachable.mlir
+++ b/Test/Interpreter/LLVM/unreachable.mlir
@@ -2,7 +2,7 @@
 
 // Executing `llvm.unreachable` is immediate undefined behaviour.
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main"}> ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
     "llvm.unreachable"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Verifier/empty_block.mlir
+++ b/Test/Verifier/empty_block.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() ({
+  "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
   ^bb0():
   }) : () -> ()
 }) : () -> ()

--- a/Test/Verifier/missing_terminator.mlir
+++ b/Test/Verifier/missing_terminator.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
   ^bb0():
     %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
   }) : () -> ()

--- a/Veir/Interfaces.lean
+++ b/Veir/Interfaces.lean
@@ -1,0 +1,3 @@
+module
+
+import Veir.Interfaces.FunctionInterfaces

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -94,7 +94,7 @@ def getArgumentTypes? (funcOp: OperationPtr) (raw: IRContext OpCode) :
   ft.inputs
 
 /-- Returns the number of function results. -/
-public def getNumResults? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Nat := do
+def getNumResults? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Nat := do
   rlet ft ← getFunctionType? funcOp raw
   ft.outputs.size
 

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -110,6 +110,6 @@ def getResultTypes! (funcOp : OperationPtr) (raw : IRContext OpCode) : Array Att
 
 end FunctionOpInterface
 
-end -- public section
+end
 
 end Veir

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -1,0 +1,102 @@
+module
+
+/- FunctionOpInterface
+
+  This file provides the `FunctionOpInterface` interface, which provides support
+  for interacting with operations that behave like functions.
+  Currently, this supports llvm.func and func.func.
+
+  Also see:
+  https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+-/
+
+public import Veir.GlobalOpInfo
+public import Veir.IR.Fields
+
+namespace Veir
+
+public section
+
+namespace FunctionOpInterface
+
+/-- Returns the symbol name of the function. -/
+public def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr :=
+  match funcOp.getOpType! raw with
+  | .func .func =>
+    (funcOp.getProperties! raw (.func .func) : FuncFuncProperties).sym_name
+  | .llvm .func =>
+    (funcOp.getProperties! raw (.llvm .func) : LLVMFuncProperties).sym_name
+  | _ => none
+
+/-- Returns the type of the function. -/
+public def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
+    Option FunctionType := do
+  match funcOp.getOpType! raw with
+  | .func .func =>
+    let ta ← (funcOp.getProperties! raw (.func .func) : FuncFuncProperties).function_type
+    match ta.val with
+    | .functionType ft => some ft
+    | _ => none
+  | .llvm .func =>
+    let ta ← (funcOp.getProperties! raw (.llvm .func) : LLVMFuncProperties).function_type
+    match ta.val with
+    | .llvmFunctionType ft => some ft
+    | _ => none
+  | _ => none
+
+/-
+  Body Handling
+-/
+
+/-- Returns the region containing the body of this function. -/
+public def getFunctionBody (funcOp : OperationPtr) (raw : IRContext OpCode)
+    (opInBounds : funcOp.InBounds raw := by grind)
+    (hasRegion : 0 < funcOp.getNumRegions raw opInBounds := by grind) : RegionPtr :=
+  funcOp.getRegion raw 0 opInBounds hasRegion
+
+public def getFunctionBody! (funcOp : OperationPtr) (raw : IRContext OpCode) : RegionPtr :=
+  funcOp.getRegion! raw 0
+
+@[grind =_, eq_bang ←]
+theorem getFunctionBody!_eq_getFunctionBody {funcOp : OperationPtr} {raw : IRContext OpCode}
+    {opInBounds} (hasRegion : 0 < funcOp.getNumRegions raw opInBounds) :
+    getFunctionBody! funcOp raw = getFunctionBody funcOp raw opInBounds hasRegion := by
+  grind [getFunctionBody, getFunctionBody!]
+
+theorem getFunctionBody!_inBounds
+    (ctxInBounds : raw.FieldsInBounds)
+    (opInBounds : funcOp.InBounds raw)
+    (hasRegion : 0 < funcOp.getNumRegions! raw) :
+    (getFunctionBody! funcOp raw).InBounds raw := by
+  grind [getFunctionBody!, OperationPtr.getRegions!_inBounds]
+
+grind_pattern getFunctionBody!_inBounds => (getFunctionBody! funcOp raw), raw.FieldsInBounds
+
+/-- Returns the first block in the body region. -/
+public def getFirstBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
+  ((getFunctionBody! funcOp raw).get! raw).firstBlock
+
+/-- Returns the last block in the body region. -/
+public def getLastBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
+  ((getFunctionBody! funcOp raw).get! raw).lastBlock
+
+/-
+  Argument and Result Handling
+-/
+
+/-- Returns the number of function arguments. -/
+public def getNumArguments? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Nat := do
+  rlet ft ← getFunctionType? funcOp raw
+  ft.inputs.size
+
+/-- Returns the result types of the function. -/
+public def getResultTypes? (funcOp : OperationPtr) (raw : IRContext OpCode) :
+    Option (Array Attribute) := do
+  rlet ft ← getFunctionType? funcOp raw
+  ft.outputs
+
+end FunctionOpInterface
+
+end -- public section
+
+end Veir

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -80,8 +80,8 @@ public def getFirstBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Opt
 public def getLastBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
   ((getFunctionBody! funcOp raw).get! raw).lastBlock
 
-/-
-  Argument and Result Handling
+/-!
+## Argument and Result Handling
 -/
 
 /-- Returns the number of function arguments. -/

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -1,13 +1,14 @@
 module
 
-/- FunctionOpInterface
+/-!
+# FunctionOpInterface
 
-  This file provides the `FunctionOpInterface` interface, which provides support
-  for interacting with operations that behave like functions.
-  Currently, this supports llvm.func and func.func.
+This file provides the `FunctionOpInterface` interface, which provides support
+for interacting with operations that behave like functions.
+Currently, this supports llvm.func and func.func.
 
-  Also see:
-  https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/FunctionInterfaces.td
+Also see:
+https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/FunctionInterfaces.td
 -/
 
 public import Veir.GlobalOpInfo

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -1,5 +1,8 @@
 module
 
+public import Veir.GlobalOpInfo
+public import Veir.IR.Fields
+
 /-!
 # FunctionOpInterface
 
@@ -11,9 +14,6 @@ Also see:
 https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/FunctionInterfaces.td
 -/
 
-public import Veir.GlobalOpInfo
-public import Veir.IR.Fields
-
 namespace Veir
 
 public section
@@ -21,7 +21,7 @@ public section
 namespace FunctionOpInterface
 
 /-- Returns the symbol name of the function. -/
-public def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr :=
+def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr :=
   match funcOp.getOpType! raw with
   | .func .func =>
     (funcOp.getProperties! raw (.func .func) : FuncFuncProperties).sym_name
@@ -30,7 +30,7 @@ public def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option
   | _ => none
 
 /-- Returns the type of the function. -/
-public def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
+def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
     Option FunctionType := do
   match funcOp.getOpType! raw with
   | .func .func =>
@@ -50,12 +50,13 @@ public def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
 -/
 
 /-- Returns the region containing the body of this function. -/
-public def getFunctionBody (funcOp : OperationPtr) (raw : IRContext OpCode)
+def getFunctionBody (funcOp : OperationPtr) (raw : IRContext OpCode)
     (opInBounds : funcOp.InBounds raw := by grind)
     (hasRegion : 0 < funcOp.getNumRegions raw opInBounds := by grind) : RegionPtr :=
   funcOp.getRegion raw 0 opInBounds hasRegion
 
-public def getFunctionBody! (funcOp : OperationPtr) (raw : IRContext OpCode) : RegionPtr :=
+/-- Returns the region containing the body of this function. -/
+def getFunctionBody! (funcOp : OperationPtr) (raw : IRContext OpCode) : RegionPtr :=
   funcOp.getRegion! raw 0
 
 @[grind =_, eq_bang ←]
@@ -74,27 +75,38 @@ theorem getFunctionBody!_inBounds
 grind_pattern getFunctionBody!_inBounds => (getFunctionBody! funcOp raw), raw.FieldsInBounds
 
 /-- Returns the first block in the body region. -/
-public def getFirstBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
+def getEntryBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
   ((getFunctionBody! funcOp raw).get! raw).firstBlock
-
-/-- Returns the last block in the body region. -/
-public def getLastBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
-  ((getFunctionBody! funcOp raw).get! raw).lastBlock
 
 /-!
 ## Argument and Result Handling
 -/
 
 /-- Returns the number of function arguments. -/
-public def getNumArguments? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Nat := do
+def getNumArguments? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Nat := do
   rlet ft ← getFunctionType? funcOp raw
   ft.inputs.size
 
+/-- Returns the argument types of the function. -/
+def getArgumentTypes? (funcOp: OperationPtr) (raw: IRContext OpCode) :
+    Option (Array Attribute) := do
+  rlet ft ← getFunctionType? funcOp raw
+  ft.inputs
+
+/-- Returns the number of function results. -/
+public def getNumResults? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Nat := do
+  rlet ft ← getFunctionType? funcOp raw
+  ft.outputs.size
+
 /-- Returns the result types of the function. -/
-public def getResultTypes? (funcOp : OperationPtr) (raw : IRContext OpCode) :
+def getResultTypes? (funcOp : OperationPtr) (raw : IRContext OpCode) :
     Option (Array Attribute) := do
   rlet ft ← getFunctionType? funcOp raw
   ft.outputs
+
+/-- Returns the result types of the function. -/
+def getResultTypes! (funcOp : OperationPtr) (raw : IRContext OpCode) : Array Attribute :=
+  (getResultTypes? funcOp raw).get!
 
 end FunctionOpInterface
 

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -44,8 +44,8 @@ public def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
     | _ => none
   | _ => none
 
-/-
-  Body Handling
+/-!
+## Body Handling
 -/
 
 /-- Returns the region containing the body of this function. -/

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -10,6 +10,7 @@ import Veir.Data.HW.Basic
 import Veir.Data.Casting
 import Veir.Properties
 import Veir.GlobalOpInfo
+import Veir.Interfaces.FunctionInterfaces
 
 open Veir.Data
 /-!
@@ -1712,7 +1713,7 @@ def interpretFunction (op : OperationPtr) (values : Array RuntimeValue) {ctx : W
     none
   else
     let state : InterpreterState ctx := ⟨.empty ctx, mem⟩
-    let (state, results) ← interpretRegion (op.getRegion ctx.raw 0) values state
+    let (state, results) ← interpretRegion (FunctionOpInterface.getFunctionBody op ctx.raw) values state
     return (state.memory, results)
 
 /--

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -116,16 +116,6 @@ def OperationPtr.isRefinedByAsFunction (op₁ : OperationPtr) (ctx₁ : WfIRCont
       (interpretFunction op₂ valuesTarget mem (ctx := ctx₂) op₂In)
 
 /--
-The symbol name (`sym_name`) of `op` when it is a `func.func` operation, and `none` otherwise.
-Used to match a source function against a target function carrying the same name.
--/
-def OperationPtr.funcSymName? (op : OperationPtr) (ctx : IRContext OpCode) : Option StringAttr :=
-  let opType := op.getOpType! ctx
-  match opType, (op.getProperties! ctx opType) with
-    | .llvm .func, props => props.sym_name
-    | _, _ => none
-
-/--
 `op` is a top-level function of the module operation `moduleOp` (in `ctx`): it is a `func.func`
 operation whose parent operation is `moduleOp`.
 -/

--- a/Veir/MIRPrinter.lean
+++ b/Veir/MIRPrinter.lean
@@ -403,7 +403,7 @@ def emitTrampoline (t : Nat) (s : Nat) : IO Unit := do
 
 /-- Print a full MIR module for the given `main` function. -/
 def printMIR (ctx : IRContext OpCode) (funcOp : OperationPtr) : IO Unit := do
-  let allBlocks := collectBlocks ctx (FunctionOpInterface.getFirstBlock? funcOp ctx)
+  let allBlocks := collectBlocks ctx (FunctionOpInterface.getEntryBlock? funcOp ctx)
   -- Drop blocks unreachable from the entry: a real codegen prunes them, and
   -- they break MIR liveness (their values aren't dominated by any real path).
   let reach :=

--- a/Veir/MIRPrinter.lean
+++ b/Veir/MIRPrinter.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Basic
 public import Veir.Properties
 public import Veir.GlobalOpInfo
+public import Veir.Interfaces.FunctionInterfaces
 
 import Veir.IR.Grind
 
@@ -402,8 +403,7 @@ def emitTrampoline (t : Nat) (s : Nat) : IO Unit := do
 
 /-- Print a full MIR module for the given `main` function. -/
 def printMIR (ctx : IRContext OpCode) (funcOp : OperationPtr) : IO Unit := do
-  let region := funcOp.getRegion! ctx 0
-  let allBlocks := collectBlocks ctx (region.get! ctx).firstBlock
+  let allBlocks := collectBlocks ctx (FunctionOpInterface.getFirstBlock? funcOp ctx)
   -- Drop blocks unreachable from the entry: a real codegen prunes them, and
   -- they break MIR liveness (their values aren't dominated by any real path).
   let reach :=

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -4,6 +4,7 @@ import Veir.Passes.Matching
 import Veir.Passes.DCE.dce
 import Veir.Rewriter.WfRewriter
 import Veir.Properties
+import Veir.Interfaces.FunctionInterfaces
 
 namespace Veir
 
@@ -148,13 +149,11 @@ def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
   -- Shadow the parameter: from here on `ctx` always names the latest version, with no
   -- separate old binding left around to second-guess.
   let mut ctx := ctx
-  let region := funcOp.getRegion! ctx.raw 0
-  let some entry := (region.get! ctx.raw).firstBlock | return ctx
+  let some entry := FunctionOpInterface.getFirstBlock? funcOp ctx.raw | return ctx
   let returnCode := returnOpCodeFor (funcOp.getOpType! ctx.raw)
   -- Default the output types to the currently-declared ones, then flip coerced positions.
   -- This preserves non-integer results and `llvm.func`'s `void` return.
-  let declaredFt := (readFunctionType? ctx.raw funcOp).getD { inputs := #[], outputs := #[] }
-  let mut outputs : Array Attribute := declaredFt.outputs
+  let mut outputs : Array Attribute := (FunctionOpInterface.getResultTypes? funcOp ctx.raw).getD #[]
   -- (1) Coerce entry-block arguments (the function parameters). This mirrors the
   --     block-argument coercion in `isel-br-riscv64`, which skips entry blocks.
   let mut inputs : Array Attribute := #[]

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -132,7 +132,8 @@ def setFunctionType (c : WfIRContext OpCode) (funcOp : OperationPtr)
     let props : FuncFuncProperties := funcOp.getProperties! c.raw (.func .func)
     let newEntries := props.extra.entries.map fun (k, v) =>
       if k == "function_type".toUTF8 then (k, ftType.val) else (k, v)
-    let newProps : FuncFuncProperties := { props with extra := DictionaryAttr.fromArray newEntries }
+    let newProps : FuncFuncProperties :=
+      { props with function_type := some ftType, extra := DictionaryAttr.fromArray newEntries }
     ⟨funcOp.setProperties (opCode := .func .func) c.raw newProps sorry sorry, sorry⟩
   | .llvm .func =>
     let props : LLVMFuncProperties := funcOp.getProperties! c.raw (.llvm .func)

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -150,11 +150,11 @@ def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
   -- Shadow the parameter: from here on `ctx` always names the latest version, with no
   -- separate old binding left around to second-guess.
   let mut ctx := ctx
-  let some entry := FunctionOpInterface.getFirstBlock? funcOp ctx.raw | return ctx
+  let some entry := FunctionOpInterface.getEntryBlock? funcOp ctx.raw | return ctx
   let returnCode := returnOpCodeFor (funcOp.getOpType! ctx.raw)
   -- Default the output types to the currently-declared ones, then flip coerced positions.
   -- This preserves non-integer results and `llvm.func`'s `void` return.
-  let mut outputs : Array Attribute := (FunctionOpInterface.getResultTypes? funcOp ctx.raw).getD #[]
+  let mut outputs : Array Attribute := FunctionOpInterface.getResultTypes! funcOp ctx.raw
   -- (1) Coerce entry-block arguments (the function parameters). This mirrors the
   --     block-argument coercion in `isel-br-riscv64`, which skips entry blocks.
   let mut inputs : Array Attribute := #[]

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -538,6 +538,7 @@ def HWConstantProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribut
 -/
 structure FuncFuncProperties where
   sym_name : Option StringAttr
+  function_type : Option TypeAttr
   extra : DictionaryAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
@@ -547,9 +548,15 @@ def FuncFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
     | some (.stringAttr s) => pure (some s)
     | some attr => throw s!"func.func: expected 'sym_name' to be a string attribute, but got {attr}"
     | none => pure none
+  let funcType ← match attrDict["function_type".toUTF8]? with
+    | some attr =>
+      if _ : attr.isType = false then
+        throw "func.func: expected 'function_type' to be a type attribute"
+      else pure (some attr.asType)
+    | none => pure none
   let extra := DictionaryAttr.fromArray
     (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8)
-  return { sym_name := symName, extra }
+  return { sym_name := symName, function_type := funcType , extra }
 
 /--
   Properties of the `func.call` operation. The `callee` is first-class; all

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -556,7 +556,7 @@ def FuncFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
     | none => pure none
   let extra := DictionaryAttr.fromArray
     (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8)
-  return { sym_name := symName, function_type := funcType , extra }
+  return { sym_name := symName, function_type := funcType, extra }
 
 /--
   Properties of the `func.call` operation. The `callee` is first-class; all

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -5,6 +5,7 @@ public import Veir.IR.Fields
 public import Veir.Properties
 public import Veir.GlobalOpInfo
 public import Veir.IR.WellFormed
+public import Veir.Interfaces.FunctionInterfaces
 import Veir.ForLean
 
 namespace Veir
@@ -19,25 +20,6 @@ def OperationPtr.getEnclosingFunctionOp (op : OperationPtr) (ctx : WfIRContext O
   match op.getParentOp! ctx.raw with
   | some funcOp => pure funcOp
   | none => throw s!"Expected {opName} to have an enclosing function operation"
-
-/-- Read a function op's declared `function_type`. `func.func` keeps it in `extra`;
-    `llvm.func` has a first-class `function_type` field. -/
-public def readFunctionType? (raw : IRContext OpCode) (funcOp : OperationPtr) :
-    Option FunctionType :=
-  match funcOp.getOpType! raw with
-  | .func .func =>
-    match (funcOp.getProperties! raw (.func .func) : FuncFuncProperties).extra.entries.find?
-        (fun e => e.1 == "function_type".toUTF8) with
-    | some (_, .functionType ft) => some ft
-    | _ => none
-  | .llvm .func =>
-    match (funcOp.getProperties! raw (.llvm .func) : LLVMFuncProperties).function_type with
-    | some ta =>
-      match ta.val with
-      | .functionType ft | .llvmFunctionType ft => some ft
-      | _ => none
-    | none => none
-  | _ => none
 
 /--
   Type compatibility for matching an actual value's type against a declared type.
@@ -63,9 +45,8 @@ def OperationPtr.verifyFuncReturnTypes (op : OperationPtr) (ctx : WfIRContext Op
   let funcOp ← op.getEnclosingFunctionOp ctx "func.return"
   let .func .func := funcOp.getOpType! ctx.raw
     | throw "Expected func.return to be enclosed by func.func"
-  let some ft := readFunctionType? ctx.raw funcOp
+  let some outputs := FunctionOpInterface.getResultTypes? funcOp ctx.raw
     | throw "Expected enclosing func.func to have a function_type attribute"
-  let outputs := ft.outputs
   if op.getNumOperands ctx.raw opIn ≠ outputs.size then
     throw s!"Expected func.return to have {outputs.size} operand(s)"
   let opTypes := op.getOperandTypes! ctx.raw
@@ -83,7 +64,7 @@ def OperationPtr.verifyLLVMReturnTypes (op : OperationPtr) (ctx : WfIRContext Op
   let funcOp ← op.getEnclosingFunctionOp ctx "llvm.return"
   let .llvm .func := funcOp.getOpType! ctx.raw
     | throw "Expected llvm.return to be enclosed by llvm.func"
-  let some ft := readFunctionType? ctx.raw funcOp
+  let some ft := FunctionOpInterface.getFunctionType? funcOp ctx.raw
     | throw "Expected enclosing llvm.func to have a function_type attribute"
   -- A single `llvm.void` result corresponds to no return operands.
   let outputs := match ft.outputs with

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -504,6 +504,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 results"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    if (FunctionOpInterface.getFunctionType? op ctx.raw).isNone then
+      throw "Expected function type"
     pure ()
   | .func .call => do
     if op.getNumRegions ctx.raw opIn ≠ 0 then
@@ -664,6 +666,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 1 region"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    if (FunctionOpInterface.getFunctionType? op ctx.raw).isNone then
+      throw "Expected function type"
     pure ()
   | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => do
     op.verifyPlainOpCounts ctx opIn 2 1

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -4,6 +4,7 @@ import Veir.IR.Basic
 import Veir.Verifier
 import Veir.Interpreter.Basic
 import Veir.Panic
+import Veir.Interfaces.FunctionInterfaces
 
 /-!
   # Veir Interpreter CLI Tool
@@ -34,28 +35,12 @@ def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode �
 
 /-- Returns true if `op` is a viable zero-argument `@main` function. -/
 private def isZeroArgMainFunc (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
-  let opType := op.getOpType! ctx
-  let check : (opCode : OpCode) → propertiesOf opCode → Bool
-    | .llvm .func, props =>
-      if let some symName := props.sym_name then
-        String.fromUTF8! symName.value == "main" &&
-        match props.function_type with
-        | some ft =>
-          match ft.val with
-          | .llvmFunctionType funcType => funcType.inputs.isEmpty
-          | _ => false
-        | none => false
-      else false
-    | .func .func, props =>
-      if let some symName := props.sym_name then
-        String.fromUTF8! symName.value == "main" &&
-        let region := op.getRegion! ctx 0
-        match (region.get! ctx).firstBlock with
-        | some block => block.getNumArguments! ctx == 0
-        | none => false
-      else false
-    | _, _ => false
-  check opType (op.getProperties! ctx opType)
+  match FunctionOpInterface.getSymName? op ctx with
+  | some symName =>
+      String.fromUTF8! symName.value == "main" &&
+        (FunctionOpInterface.getNumArguments? op ctx == some 0)
+  | none =>
+      false
 
 /-- Scan the module's top-level ops for entry points. -/
 partial def scanEntryPoints (ctx : IRContext OpCode) (op : Option OperationPtr)


### PR DESCRIPTION
Addresses #607.
This adds `FunctionOpInterface`, which provides generic functions for interacting with function-like ops (currently `func.func` and `llvm.func`).

This is intended as an equivalent of MLIR's `FunctionOpInterface` (https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/FunctionInterfaces.td).

This initial PR limits itself to query functions and mostly only implements functions that can simplify some existing code.

This also fixes an issue where VEIR incorrectly accepted `func.func/llvm.func` operations without the required `function_type` attribute due to the previous handling of function arguments.