### PR TITLE
feat: Add new axiom about behavior of interpreter on branches

### DIFF
--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -507,17 +507,15 @@ theorem interpretOpChain_eq_interpretTerminatedOpList_of_firstOp
 
 end interpretOpList
 
-set_option warn.sorry false in
 /-- An operation that verifies does not fail interpretation as long as the operands conform to
 the declared operand types. -/
-theorem exists_interpretOp'_eq_some {ctx : WfIRContext OpCode} {op : OperationPtr}
+axiom exists_interpretOp'_eq_some {ctx : WfIRContext OpCode} {op : OperationPtr}
     {opInBounds : op.InBounds ctx.raw} (opVerify : OperationPtr.Verified ctx op opInBounds)
     (operandConforms : RuntimeValue.ArrayConforms operands (op.getOperandTypes! ctx.raw))
     (mem : MemoryState) :
-  ∃ res, op.interpret ctx.raw operands mem = some res := by sorry
+  ∃ res, op.interpret ctx.raw operands mem = some res
 
-set_option warn.sorry false in
-theorem interpretOp'_monotone
+axiom interpretOp'_monotone
     (opType : OpCode) (properties : propertiesOf opType) (resultTypes : Array TypeAttr)
     (operands operands' : Array RuntimeValue) (blockOperands : Array BlockPtr) (mem : MemoryState) :
     operands ⊒ operands' →
@@ -525,17 +523,36 @@ theorem interpretOp'_monotone
       (fun r₁ r₂ => r₁.1 ⊒ r₂.1 ∧ r₁.2.1 = r₂.2.1 ∧
         ControlFlowAction.optionIsRefinedBy r₁.2.2 r₂.2.2)
       (interpretOp' opType properties resultTypes operands blockOperands mem)
-      (interpretOp' opType properties resultTypes operands' blockOperands mem) := by
-  sorry
+      (interpretOp' opType properties resultTypes operands' blockOperands mem)
 
-set_option warn.sorry false in
 /--
 A successful operation interpretation returns result values that conform to the declared
 `resultTypes` when the operation verifies.
 -/
-theorem interpretOp'_results_conform {ctx : WfIRContext OpCode}
+axiom interpretOp'_results_conform {ctx : WfIRContext OpCode}
     {opInBounds : op.InBounds ctx.raw} (opVerif : op.Verified ctx opInBounds)
     (conforms : RuntimeValue.ArrayConforms operands (op.getOperandTypes! ctx.raw))
     (h : op.interpret ctx.raw operands mem = some (.ok (vals, mem', act))) :
-    RuntimeValue.ArrayConforms vals (op.getResultTypes! ctx.raw) := by
-  sorry
+    RuntimeValue.ArrayConforms vals (op.getResultTypes! ctx.raw)
+
+/--
+A branch control-flow action returned by interpreting an operation always targets one of the
+provided successor blocks.
+-/
+axiom interpretOp'_branch_dest_mem
+    (h : interpretOp' opType properties resultTypes operands blockOperands mem
+      = some (.ok (vals, mem', some (.branch res dest)))) :
+    dest ∈ blockOperands
+
+/--
+A branch control-flow action returned by interpreting an operation always targets one of the
+operation successors.
+-/
+theorem interpretOp_branch_dest_mem_getSuccessors!
+    {ctx : WfIRContext OpCode} {op : OperationPtr} {state state' : InterpreterState ctx}
+    {inBounds : op.InBounds ctx.raw} {res : Array RuntimeValue} {dest : BlockPtr}
+    (h : interpretOp op state inBounds = some (.ok (state', some (.branch res dest)))) :
+    dest ∈ op.getSuccessors! ctx.raw := by
+  obtain ⟨operandValues, resValues, mem', varState', hOperand, hInterp', hSetRes, hStateEq⟩ :=
+    interpretOp_some_iff.mp h
+  exact interpretOp'_branch_dest_mem hInterp'


### PR DESCRIPTION
Operation that branches should only do so on blocks that are part of their successors. This is unproven yet, so it is moved as an axiom.

I also moved the other functions from sorries to axioms, as this is better to figure out what sorries a definition depends on.