### PR TITLE
feat: Verify sym_name attribute on func.func and llvm.func

### DIFF
--- a/Test/Func/identity.mlir
+++ b/Test/Func/identity.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   ^4():
-    "func.func"()  <{function_type = (i32) -> i32}> ({
+    "func.func"()  <{function_type = (i32) -> i32, sym_name="foo"}> ({
       ^6(%arg6_0 : i32):
         "func.return"(%arg6_0) : (i32) -> ()
   }) : () -> ()
@@ -10,7 +10,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^4():
-// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> i32}> ({
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> i32, "sym_name" = "foo"}> ({
 // CHECK-NEXT:       ^6(%arg6_0 : i32):
 // CHECK-NEXT:         "func.return"(%arg6_0) : (i32) -> ()
 // CHECK-NEXT:   }) : () -> ()

--- a/Test/LLVM/getelementptr.mlir
+++ b/Test/LLVM/getelementptr.mlir
@@ -5,7 +5,7 @@
 // (-2147483648) entries in rawConstantIndices.
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (!llvm.ptr, i64, i64, i64, i64)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (!llvm.ptr, i64, i64, i64, i64)>, sym_name = "foo"}> ({
     ^bb0(%ptr: !llvm.ptr, %i: i64, %j: i64, %k: i64, %l: i64):
 
       // 1 dynamic index: ptr[i]
@@ -42,7 +42,7 @@
 
 // CHECK:       "builtin.module"() ({
 // CHECK-NEXT:    ^{{.*}}():
-// CHECK-NEXT:      "llvm.func"() <{"function_type" = !llvm.func<void (!llvm.ptr, i64, i64, i64, i64)>}> ({
+// CHECK-NEXT:      "llvm.func"() <{"function_type" = !llvm.func<void (!llvm.ptr, i64, i64, i64, i64)>, "sym_name" = "foo"}> ({
 // CHECK-NEXT:        ^{{.*}}(%{{.*}} : !llvm.ptr, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64, %{{.*}} : i64):
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = i8, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
 // CHECK-NEXT:          %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}, %{{.*}}) <{"elem_type" = !llvm.array<10 x i8>, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648, -2147483648>}> : (!llvm.ptr, i64, i64) -> !llvm.ptr

--- a/Test/Passes/CSE/basic.mlir
+++ b/Test/Passes/CSE/basic.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 ^bb0(%arg0 : i32, %arg1 : i32):
     %sum0 = "llvm.add"(%arg0, %arg1) : (i32, i32) -> i32
     %sum1 = "llvm.add"(%arg0, %arg1) : (i32, i32) -> i32

--- a/Test/Passes/CSE/constants_and_attrs.mlir
+++ b/Test/Passes/CSE/constants_and_attrs.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 ^bb0(%arg0 : i32, %arg1 : i32):
     %c0_i32 = "llvm.mlir.constant"() <{value = 7 : i32}> : () -> i32
     %c1_i32 = "llvm.mlir.constant"() <{value = 7 : i32}> : () -> i32

--- a/Test/Passes/CSE/exact_and_misc_flags.mlir
+++ b/Test/Passes/CSE/exact_and_misc_flags.mlir
@@ -4,7 +4,7 @@
 // operation's identity.
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 
 // `lshr exact` is distinct from plain `lshr`.
 ^lshr_exact(%m : i32, %n : i32):

--- a/Test/Passes/CSE/icmp_eq_ne.mlir
+++ b/Test/Passes/CSE/icmp_eq_ne.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 ^bb0(%arg0 : i32, %arg1 : i32):
     %icmp_eq0 = "llvm.icmp"(%arg0, %arg1) <{predicate = 0 : i64}> : (i32, i32) -> i1
     %icmp_eq_commuted = "llvm.icmp"(%arg1, %arg0) <{predicate = 0 : i64}> : (i32, i32) -> i1

--- a/Test/Passes/CSE/icmp_inverse_predicates.mlir
+++ b/Test/Passes/CSE/icmp_inverse_predicates.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 ^bb0(%arg0 : i32, %arg1 : i32):
     %icmp_slt0 = "llvm.icmp"(%arg0, %arg1) <{predicate = 2 : i64}> : (i32, i32) -> i1
     %icmp_sgt_inverse = "llvm.icmp"(%arg1, %arg0) <{predicate = 4 : i64}> : (i32, i32) -> i1

--- a/Test/Passes/CSE/icmp_slt_same_predicate.mlir
+++ b/Test/Passes/CSE/icmp_slt_same_predicate.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 ^bb0(%arg0 : i32, %arg1 : i32):
     %icmp_slt0 = "llvm.icmp"(%arg0, %arg1) <{predicate = 2 : i64}> : (i32, i32) -> i1
     %icmp_slt_commuted = "llvm.icmp"(%arg1, %arg0) <{predicate = 2 : i64}> : (i32, i32) -> i1

--- a/Test/Passes/CSE/memory.mlir
+++ b/Test/Passes/CSE/memory.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (!llvm.ptr)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (!llvm.ptr)>, sym_name = "foo"}> ({
 ^bb0(%ptr : !llvm.ptr):
     %load0 = "llvm.load"(%ptr) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
     %load1 = "llvm.load"(%ptr) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32

--- a/Test/Passes/CSE/overflow_flags.mlir
+++ b/Test/Passes/CSE/overflow_flags.mlir
@@ -5,7 +5,7 @@
 // and flags are never silently dropped.
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 
 // `add nsw` merges with `add nsw`; flagless `add` stays separate.
 ^add_nsw(%a : i32, %b : i32):

--- a/Test/Passes/CSE/pure_ops.mlir
+++ b/Test/Passes/CSE/pure_ops.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=cse --allow-unregistered-dialect | filecheck %s
 
 "builtin.module"() ({
-  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>}> ({
+  "llvm.func"()  <{function_type = !llvm.func<void (i32, i32)>, sym_name = "foo"}> ({
 ^bb0(%arg0 : i32, %arg1 : i32):
     // Pure integer divs and remainders are non-commutative; duplicates with
     // the same operands merge, swapped operands stay distinct. Soundness

--- a/Test/Passes/Canonicalize/commute_constant_riscv.mlir
+++ b/Test/Passes/Canonicalize/commute_constant_riscv.mlir
@@ -3,7 +3,7 @@
 // A commutative `riscv` op with the `riscv.li` constant on the left: the
 // constant is pushed to the right-hand side.
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "foo"}> ({
     ^bb0(%x : !riscv.reg):
       // CHECK:      ^{{.*}}(%[[X:.*]] : !riscv.reg):
       %c = "riscv.li"() <{"value" = 5 : i64}> : () -> !riscv.reg

--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -10,7 +10,7 @@
 "builtin.module"() ({
 
   ^1():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f0"}> ({
       ^1(%0 : i64):
         // A lone `iX -> iX` cast is not a round trip, so nothing reconciles it away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i64
@@ -23,7 +23,7 @@
     }) : () -> ()
 
   ^2():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f1"}> ({
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
         "test.test"(%1) : (!riscv.reg) -> ()
@@ -35,7 +35,7 @@
     }) : () -> ()
 
   ^3():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f2"}> ({
       ^1(%0 : i64):
         // the remaining cast is unused
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
@@ -48,7 +48,7 @@
     }) : () -> ()
 
   ^4():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f3"}> ({
       ^1(%0 : i64):
         // the remaining cast is used
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
@@ -63,7 +63,7 @@
     }) : () -> ()
 
   ^5():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f4"}> ({
       ^1(%0 : i64):
         // The `reg -> reg` cast in the middle breaks the `reg -> i64 -> reg` round trip: no
         // pair of adjacent casts returns to its own input type, so nothing reconciles.
@@ -79,7 +79,7 @@
     }) : () -> ()
 
   ^6():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f5"}> ({
       ^1(%0 : i64):
         // pairs of casts
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
@@ -97,7 +97,7 @@
     }) : () -> ()
 
   ^7():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f6"}> ({
       ^1(%0 : !riscv.reg):
         // identity cast on block argument: not a round trip, so it survives the pass
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> !riscv.reg
@@ -109,7 +109,7 @@
     }) : () -> ()
 
   ^8():
-    "func.func"()  <{function_type = (i8) -> ()}> ({
+    "func.func"()  <{function_type = (i8) -> (), sym_name = "f7"}> ({
       ^1(%0 : i8):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> i8
         "test.test"(%1) : (i8) -> ()
@@ -120,7 +120,7 @@
     }) : () -> ()
 
   ^9():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f8"}> ({
       ^1(%0 : i64):
         // `iX -> iY -> iX` round trips are not reconciled: the interpreter gives an
         // integer-to-integer cast no semantics, so the pass leaves these alone.
@@ -140,7 +140,7 @@
     }) : () -> ()
 
   ^10():
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "f9"}> ({
       ^1(%0 : i32):
         // i32 -> reg -> i32
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !riscv.reg
@@ -157,7 +157,7 @@
     }) : () -> ()
 
   ^11():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f10"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i32 -> reg : should not be folded away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i32
@@ -170,7 +170,7 @@
     }) : () -> ()
 
   ^12():
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "f11"}> ({
       ^1(%0 : !llvm.ptr):
         // ptr -> reg -> ptr (64-bit)
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!llvm.ptr) -> !riscv.reg
@@ -185,7 +185,7 @@
     }) : () -> ()
 
   ^13():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f12"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> ptr -> reg (64-bit)
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> !llvm.ptr
@@ -197,7 +197,7 @@
     }) : () -> ()
 
   ^14():
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "f13"}> ({
       ^1(%0 : i32):
         // i32 -> reg -> i32  (reg is also used elsewhere)
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !riscv.reg
@@ -216,7 +216,7 @@
     }) : () -> ()
 
   ^15():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f14"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i16 -> reg : should not be folded away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i16
@@ -229,7 +229,7 @@
     }) : () -> ()
     
   ^16():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f15"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i8 -> reg : should not be folded away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i8
@@ -242,7 +242,7 @@
     }) : () -> ()
 
   ^17():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f16"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i14 -> reg : should not be folded away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!riscv.reg) -> i14
@@ -256,7 +256,7 @@
     }) : () -> ()
 
   ^18():
-    "func.func"()  <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f17"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i0 -> reg : the round trip is the constant zero, which the `slli`/`srli`
         // pair cannot compute (its 6-bit shift amount `64 - 0` wraps back to `0`).

--- a/Test/Passes/CastsReconciliation/error.mlir
+++ b/Test/Passes/CastsReconciliation/error.mlir
@@ -9,7 +9,7 @@
 "builtin.module"() ({
 
   ^1():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "foo"}> ({
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i8
         %2 = "builtin.unrealized_conversion_cast"(%1) : (i8) -> i64
@@ -23,7 +23,7 @@
     }) : () -> ()
 
   ^2():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "bar"}> ({
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32

--- a/Test/Passes/DCE/basic.mlir
+++ b/Test/Passes/DCE/basic.mlir
@@ -6,12 +6,12 @@
   
   // An operation that returns one unused result
   ^4():
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "foo"}> ({
       ^6(%1 : i64):
         %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64
         "test.test"(%1) : (i64) -> ()
         // The unused %2 is removed; the sink stays right after the block header.
-        // CHECK:      "func.func"() <{"function_type" = (i64) -> ()}> ({
+        // CHECK:      "func.func"() <{"function_type" = (i64) -> (), "sym_name" = "foo"}> ({
         // CHECK-NEXT: ^{{.*}}(%{{.*}} : i64):
         // CHECK-NEXT: "test.test"(%{{.*}}) : (i64) -> ()
         "func.return"() : () -> ()
@@ -19,7 +19,7 @@
   
   // A chain of operations that is eventually unused
   ^5():
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "bar"}> ({
       ^6():
         %1 = "arith.constant"() <{ "value" = 1 : i64 }> : () -> i64
         %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64
@@ -35,7 +35,7 @@
   
   // A chain of operations that is eventually used
   ^6():
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "baz"}> ({
       ^6():
         %1 = "arith.constant"() <{ "value" = 1 : i64 }> : () -> i64
         %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/add.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb(%a: i64, %b: i64):
         %add = "llvm.add"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -26,7 +26,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: i32, %b: i32):
         %add = "llvm.add"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/add_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb(%a: i16, %b: i16):
         %add = "llvm.add"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.add"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/and.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/and.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f0"}> ({
     ^bb(%a: i64, %b: i64):
         %add = "llvm.and"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -10,7 +10,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f1"}> ({
     ^bb(%a: i32, %b: i32):
         %and32 = "llvm.and"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
@@ -19,7 +19,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i8, i8) -> ()}> ({
+    "func.func"()  <{function_type = (i8, i8) -> (), sym_name = "f2"}> ({
     ^bb(%a: i8, %b: i8):
         %and8 = "llvm.and"(%a, %b) : (i8, i8) -> i8
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
@@ -28,7 +28,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i1, i1) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i1) -> (), sym_name = "f3"}> ({
     ^bb(%a: i1, %b: i1):
         %and1 = "llvm.and"(%a, %b) : (i1, i1) -> i1
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i1) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/and_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/and_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb(%a: i16, %b: i16):
         %add = "llvm.and"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.and"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/andn_orn_xnor.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/andn_orn_xnor.mlir
@@ -8,7 +8,7 @@
 
 "builtin.module"() ({
     // and x (not y) -> riscv.andn
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f0"}> ({
     ^bb0(%x: i64, %y: i64):
         %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
         %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
@@ -17,7 +17,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
     // or x (not y) -> riscv.orn
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f1"}> ({
     ^bb0(%x: i64, %y: i64):
         %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
         %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
@@ -26,7 +26,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
     // xor x (not y) -> riscv.xnor  (i.e. ~(x ^ y))
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f2"}> ({
     ^bb0(%x: i64, %y: i64):
         %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
         %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64
@@ -35,7 +35,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
     // The `not` is accepted on either operand: and (not y) x -> riscv.andn
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f3"}> ({
     ^bb0(%x: i64, %y: i64):
         %ones = "llvm.mlir.constant"() <{ "value" = -1 : i64 }> : () -> i64
         %not = "llvm.xor"(%y, %ones) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb(%a: i64, %b: i64):
         %add = "llvm.ashr"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -10,7 +10,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: i32, %b: i32):
         %ashr32 = "llvm.ashr"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
@@ -19,7 +19,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i8, i8) -> ()}> ({
+    "func.func"()  <{function_type = (i8, i8) -> (), sym_name = "baz"}> ({
     ^bb(%a: i8, %b: i8):
         %ashr8 = "llvm.ashr"(%a, %b) : (i8, i8) -> i8
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/ashr_exact.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr_exact.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb(%a: i64, %b: i64):
         %add = "llvm.ashr"(%a, %b) <{exact}> : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/ashr_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb(%a: i16, %b: i16):
         %add = "llvm.ashr"(%a, %b) : (i16, i16) -> i16
         // CHECK:      %{{.*}} = "llvm.ashr"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/binopi.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/binopi.mlir
@@ -7,7 +7,7 @@
 
 "builtin.module"() ({
     // llvm.add x (const imm12) -> riscv.addi x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f0"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.add"(%a, %c) : (i64, i64) -> i64
@@ -17,7 +17,7 @@
     }) : () -> ()
 
     // llvm.or x (const imm12) -> riscv.ori x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f1"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
         %r = "llvm.or"(%a, %c) : (i64, i64) -> i64
@@ -26,7 +26,7 @@
     }) : () -> ()
 
     // llvm.and x (const imm12) -> riscv.andi x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f2"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 6 : i64}> : () -> i64
         %r = "llvm.and"(%a, %c) : (i64, i64) -> i64
@@ -35,7 +35,7 @@
     }) : () -> ()
 
     // llvm.xor x (const imm12) -> riscv.xori x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f3"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -2048 : i64}> : () -> i64
         %r = "llvm.xor"(%a, %c) : (i64, i64) -> i64
@@ -44,7 +44,7 @@
     }) : () -> ()
 
     // Out-of-range immediate: not selected here (stays `llvm.add`).
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f4"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 2048 : i64}> : () -> i64
         %r = "llvm.add"(%a, %c) : (i64, i64) -> i64
@@ -53,7 +53,7 @@
     }) : () -> ()
 
     // Constant on the left: not matched (mirrors PatGprImm's `(OpNode GPR, imm)`).
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f5"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.add"(%c, %a) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/bit_intrinsics.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/bit_intrinsics.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "foo"}> ({
     ^bb(%a: i64):
         %ctlz = "llvm.intr.ctlz"(%a) <{is_zero_poison = false}> : (i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -51,7 +51,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: i32):
         %ctlz32 = "llvm.intr.ctlz"(%a) <{is_zero_poison = false}> : (i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/bitcast.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/bitcast.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, !llvm.byte<32>) -> ()}> ({
+    "func.func"()  <{function_type = (i64, !llvm.byte<32>) -> (), sym_name = "foo"}> ({
     ^bb0(%a : i64, %b : !llvm.byte<32>):
         %c = "llvm.bitcast"(%a) : (i64) -> !llvm.byte<64>
         // CHECK:           %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/const.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/const.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "foo"}> ({
     ^bb():
         %c1 = "llvm.mlir.constant"() <{"value" = -1 : i64 }> : () -> i64
         // CHECK: %[[A:.*]] = "riscv.li"() <{"value" = -1 : i64}> : () -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
     // llvm.udiv x, 8 -> riscv.srli x, 3
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f0"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
         %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
     }) : () -> ()
 
     // llvm.udiv x, 8 (i32) -> riscv.srliw x, 3
-    "func.func"() <{function_type = (i32) -> i32}> ({
+    "func.func"() <{function_type = (i32) -> i32, sym_name = "f1"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
         %r = "llvm.udiv"(%a, %c) : (i32, i32) -> i32
@@ -22,7 +22,7 @@
 
     // udiv by 2^63: its bit pattern (0x8000...0) is decoded as the negative decimal
     // -9223372036854775808, but is still a valid *unsigned* power-of-two divisor.
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f2"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -9223372036854775808 : i64}> : () -> i64
         %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
@@ -34,7 +34,7 @@
     // set, so it is not a power of two -- even though its magnitude as a signed
     // `Int` (2^62) would incorrectly look like one under a naive sign/magnitude
     // check that didn't first reduce it mod 2^64. Must stay unselected.
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f3"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -4611686018427387904 : i64}> : () -> i64
         %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
@@ -44,7 +44,7 @@
 
     // Not a power of two: left unselected here (the generic isel-riscv64 pass
     // picks it up as a plain `riscv.divu`).
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f4"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 6 : i64}> : () -> i64
         %r = "llvm.udiv"(%a, %c) : (i64, i64) -> i64
@@ -53,7 +53,7 @@
     }) : () -> ()
 
     // llvm.sdiv exact x, 8 -> riscv.srai x, 3 (no negation needed)
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f5"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
         %r = "llvm.sdiv"(%a, %c) <{exact}> : (i64, i64) -> i64
@@ -63,7 +63,7 @@
     }) : () -> ()
 
     // llvm.sdiv exact x, -8 -> riscv.srai x, 3, then negate via `sub 0, _`.
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f6"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -8 : i64}> : () -> i64
         %r = "llvm.sdiv"(%a, %c) <{exact}> : (i64, i64) -> i64
@@ -74,7 +74,7 @@
     }) : () -> ()
 
     // i32 exact variant.
-    "func.func"() <{function_type = (i32) -> i32}> ({
+    "func.func"() <{function_type = (i32) -> i32, sym_name = "f7"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
         %r = "llvm.sdiv"(%a, %c) <{exact}> : (i32, i32) -> i32
@@ -83,7 +83,7 @@
     }) : () -> ()
 
     // General (non-exact) llvm.sdiv x, 8 -> the biased 4-instruction sequence.
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f8"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
         %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
@@ -95,7 +95,7 @@
     }) : () -> ()
 
     // General llvm.sdiv x, -8 -> the biased sequence plus a final negation.
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f9"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -8 : i64}> : () -> i64
         %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
@@ -109,7 +109,7 @@
     }) : () -> ()
 
     // i32 general variant.
-    "func.func"() <{function_type = (i32) -> i32}> ({
+    "func.func"() <{function_type = (i32) -> i32, sym_name = "f10"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
         %r = "llvm.sdiv"(%a, %c) : (i32, i32) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/freeze.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/freeze.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i32) -> (), sym_name = "foo"}> ({
     ^bb0(%a : i64, %b: i32):
         %freeze = "llvm.freeze"(%a) : (i64) -> i64
         %freezeinv = "llvm.freeze"(%b) : (i32) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/fshl_general.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshl_general.mlir
@@ -12,7 +12,7 @@
 "builtin.module"() ({
 
     // General i64 fshl -> sll / (srli 1 + srl ~z) / or, no rotate instruction.
-    "func.func"()  <{function_type = (i64, i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64, %s: i64):
         %r = "llvm.intr.fshl"(%a, %b, %s) : (i64, i64, i64) -> i64
         // CHECK: %[[NOTZ:.*]] = "riscv.xori"(%[[Z:.*]]) <{"value" = -1 : i64}>
@@ -25,7 +25,7 @@
     }) : () -> ()
 
     // General i64 fshr -> (slli 1 + sll ~z) / srl / or, no rotate instruction.
-    "func.func"()  <{function_type = (i64, i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64, i64) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i64, %b: i64, %s: i64):
         %r = "llvm.intr.fshr"(%a, %b, %s) : (i64, i64, i64) -> i64
         // CHECK: %[[NOTZ:.*]] = "riscv.xori"(%[[Z:.*]]) <{"value" = -1 : i64}>
@@ -38,7 +38,7 @@
     }) : () -> ()
 
     // General i32 fshl -> the `w`-suffixed shifts (sllw / srliw / srlw / or).
-    "func.func"()  <{function_type = (i32, i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32, i32) -> (), sym_name = "baz"}> ({
     ^bb0(%a: i32, %b: i32, %s: i32):
         %r = "llvm.intr.fshl"(%a, %b, %s) : (i32, i32, i32) -> i32
         // CHECK: %[[NOTZ:.*]] = "riscv.xori"(%[[Z:.*]]) <{"value" = -1 : i64}>

--- a/Test/Passes/InstructionSelection/RISCV64/getelementptr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/getelementptr.mlir
@@ -4,7 +4,7 @@
 // where `scale` is the byte size of the element type.
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (!llvm.ptr, i64) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%p: !llvm.ptr, %i: i64):
         // scale 1 (i8): ptr + idx -> riscv.add
         %g1 = "llvm.getelementptr"(%p, %i) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr

--- a/Test/Passes/InstructionSelection/RISCV64/getelementptr_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/getelementptr_invalid.mlir
@@ -3,7 +3,7 @@
 // Negative tests: these cases are not lowered, we leave them for future work.
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (!llvm.ptr, i32, i64) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr, i32, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%p: !llvm.ptr, %i32: i32, %i: i64):
         // non-i64 index
         %a = "llvm.getelementptr"(%p, %i32) <{elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr

--- a/Test/Passes/InstructionSelection/RISCV64/icmp.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %r_0 = "llvm.icmp"(%a, %b) <{predicate = 0 : i64}> : (i64, i64) -> i1
         // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -62,7 +62,7 @@
         // CHECK-NEXT: [[E:%.*]] = "builtin.unrealized_conversion_cast"([[D]]) : (!riscv.reg) -> i1
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i32, %b: i32):
         %r_0 = "llvm.icmp"(%a, %b) <{predicate = 0 : i64}> : (i32, i32) -> i1
         // CHECK:      [[A:%.*]] = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_imm.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_imm.mlir
@@ -9,7 +9,7 @@
 
 "builtin.module"() ({
     // sge: a >=s 5  ->  xori (slti a 5) 1
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "f0"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 5 : i64}> : (i64, i64) -> i1
@@ -21,7 +21,7 @@
     }) : () -> ()
 
     // uge: a >=u 5  ->  xori (sltiu a 5) 1
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "f1"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 9 : i64}> : (i64, i64) -> i1
@@ -33,7 +33,7 @@
     }) : () -> ()
 
     // sle: a <=s 5  ->  slti a 6   (x <= C  ==  x < C+1)
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "f2"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 3 : i64}> : (i64, i64) -> i1
@@ -45,7 +45,7 @@
     }) : () -> ()
 
     // ule: a <=u 5  ->  sltiu a 6
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "f3"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 7 : i64}> : (i64, i64) -> i1
@@ -59,7 +59,7 @@
     // Bail: sle against 2047 would need immediate 2048, which does not fit a
     // signed 12-bit field, so the peephole defers to the reg-reg lowering and
     // the `llvm.icmp` is left for `isel-riscv64` (not run here).
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "f4"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 2047 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 3 : i64}> : (i64, i64) -> i1
@@ -70,7 +70,7 @@
     }) : () -> ()
 
     // Bail: ule against -1 (unsigned UINT_MAX) is excluded, since C+1 wraps to 0.
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "f5"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 7 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_zero.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_zero.mlir
@@ -8,7 +8,7 @@
 
 "builtin.module"() ({
     // eq, zero on the right: a == 0
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "foo"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 0 : i64}> : (i64, i64) -> i1
@@ -19,7 +19,7 @@
     }) : () -> ()
 
     // ne, zero on the right: a != 0  ->  riscv.sltu 0 a (no xor)
-    "func.func"() <{function_type = (i64) -> (i1)}> ({
+    "func.func"() <{function_type = (i64) -> (i1), sym_name = "bar"}> ({
     ^bb0(%a: i64):
         %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %z) <{predicate = 1 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/InstructionSelection/RISCV64/li.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/li.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "foo"}> ({
         %one = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
         %two = "llvm.mlir.constant"() <{ "value" = 2 : i64 }> : () -> i64
         // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 1 : i64}> : () -> !riscv.reg
@@ -11,7 +11,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "bar"}> ({
         %one = "llvm.mlir.constant"() <{ "value" = 1 : i32 }> : () -> i32
         // CHECK: [[C:%.*]] = "riscv.li"() <{"value" = 1 : i32}> : () -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[C]]) : (!riscv.reg) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/li_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/li_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "foo"}> ({
         %one = "llvm.mlir.constant"() <{ "value" = 1 : i16 }> : () -> i16
         %two = "llvm.mlir.constant"() <{ "value" = 2 : i16 }> : () -> i16
         // CHECK:      %{{.*}} = "llvm.mlir.constant"() <{"value" = 1 : i16}> : () -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/load.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "foo"}> ({
     ^bb0(%a: !llvm.ptr):
         %val = "llvm.load"(%a) : (!llvm.ptr) -> i64
         // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
@@ -11,7 +11,7 @@
     }) : () -> ()
 
     // i32 load lowers to `riscv.lw`
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "bar"}> ({
     ^bb0(%a: !llvm.ptr):
         %val = "llvm.load"(%a) : (!llvm.ptr) -> i32
         // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
@@ -21,7 +21,7 @@
     }) : () -> ()
 
     // i8 load lowers to `riscv.lb`.
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "baz"}> ({
     ^bb0(%a: !llvm.ptr):
         %val = "llvm.load"(%a) : (!llvm.ptr) -> i8
         // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "foo"}> ({
     ^bb0(%a: !llvm.ptr):
         // i16 loads are not supported (only i64/i32/i8), so this stays un-lowered.
         %val = "llvm.load"(%a) : (!llvm.ptr) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %lshr = "llvm.lshr"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -27,7 +27,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (!llvm.byte<64>, i64) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.byte<64>, i64) -> (), sym_name = "bar"}> ({
     ^bb0(%a: !llvm.byte<64>, %b: i64):
         %lshr = "llvm.lshr"(%a, %b) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.byte<64>) -> !riscv.reg
@@ -38,7 +38,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "baz"}> ({
     ^bb(%a: i32, %b: i32):
         %lshr = "llvm.lshr"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/lshr_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.lshr"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.lshr"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/minmax_rotate.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/minmax_rotate.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
 
     // llvm.intr.smax -> riscv.max
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f0"}> ({
     ^bb0(%a: i64, %b: i64):
         %r = "llvm.intr.smax"(%a, %b) : (i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.max"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -11,7 +11,7 @@
     }) : () -> ()
 
     // llvm.intr.smin -> riscv.min
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f1"}> ({
     ^bb0(%a: i64, %b: i64):
         %r = "llvm.intr.smin"(%a, %b) : (i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.min"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -19,7 +19,7 @@
     }) : () -> ()
 
     // llvm.intr.umax -> riscv.maxu
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f2"}> ({
     ^bb0(%a: i64, %b: i64):
         %r = "llvm.intr.umax"(%a, %b) : (i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.maxu"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -27,7 +27,7 @@
     }) : () -> ()
 
     // llvm.intr.umin -> riscv.minu
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f3"}> ({
     ^bb0(%a: i64, %b: i64):
         %r = "llvm.intr.umin"(%a, %b) : (i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.minu"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -35,7 +35,7 @@
     }) : () -> ()
 
     // fshl with identical data operands is a rotate-left -> riscv.rol
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f4"}> ({
     ^bb0(%a: i64, %s: i64):
         %r = "llvm.intr.fshl"(%a, %a, %s) : (i64, i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.rol"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -43,7 +43,7 @@
     }) : () -> ()
 
     // fshr with identical data operands is a rotate-right -> riscv.ror
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f5"}> ({
     ^bb0(%a: i64, %s: i64):
         %r = "llvm.intr.fshr"(%a, %a, %s) : (i64, i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.ror"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -51,7 +51,7 @@
     }) : () -> ()
 
     // i32 smax: sextw before max for correct signed comparison
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f6"}> ({
     ^bb0(%a: i32, %b: i32):
         %r = "llvm.intr.smax"(%a, %b) : (i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.sextw"(%{{.*}}) : (!riscv.reg) -> !riscv.reg
@@ -61,7 +61,7 @@
     }) : () -> ()
 
     // i32 smin: sextw before min for correct signed comparison
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f7"}> ({
     ^bb0(%a: i32, %b: i32):
         %r = "llvm.intr.smin"(%a, %b) : (i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.sextw"(%{{.*}}) : (!riscv.reg) -> !riscv.reg
@@ -71,7 +71,7 @@
     }) : () -> ()
 
     // i32 umax: zero-extended values work correctly with maxu
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f8"}> ({
     ^bb0(%a: i32, %b: i32):
         %r = "llvm.intr.umax"(%a, %b) : (i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.maxu"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -79,7 +79,7 @@
     }) : () -> ()
 
     // i32 umin: zero-extended values work correctly with minu
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f9"}> ({
     ^bb0(%a: i32, %b: i32):
         %r = "llvm.intr.umin"(%a, %b) : (i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.minu"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -87,7 +87,7 @@
     }) : () -> ()
 
     // i32 fshl (rotate-left) -> riscv.rolw
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f10"}> ({
     ^bb0(%a: i32, %s: i32):
         %r = "llvm.intr.fshl"(%a, %a, %s) : (i32, i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.rolw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -95,7 +95,7 @@
     }) : () -> ()
 
     // i32 fshr (rotate-right) -> riscv.rorw
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f11"}> ({
     ^bb0(%a: i32, %s: i32):
         %r = "llvm.intr.fshr"(%a, %a, %s) : (i32, i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.rorw"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/mul.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/mul.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %mul = "llvm.mul"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -26,7 +26,7 @@
     
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i32, %b: i32):
         %mul32 = "llvm.mul"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/mul_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/mul_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.mul"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.mul"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/or.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f0"}> ({
     ^bb0(%a: i64, %b: i64):
         %add = "llvm.or"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -16,7 +16,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "f1"}> ({
     ^bb(%a: i32, %b: i32):
         %or = "llvm.or"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg
@@ -25,7 +25,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i32
         "func.return"() : () -> ()
     }) : () -> ()
-        "func.func"()  <{function_type = (i8, i8) -> ()}> ({
+        "func.func"()  <{function_type = (i8, i8) -> (), sym_name = "f2"}> ({
     ^bb(%a: i8, %b: i8):
         %and8 = "llvm.or"(%a, %b) : (i8, i8) -> i8
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i8) -> !riscv.reg
@@ -34,7 +34,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i8
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i1, i1) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i1) -> (), sym_name = "f3"}> ({
     ^bb(%a: i1, %b: i1):
         %and1 = "llvm.or"(%a, %b) : (i1, i1) -> i1
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i1) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.or"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/orcb.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/orcb.mlir
@@ -9,7 +9,7 @@
 
 "builtin.module"() ({
     // Y = 0: right operand is `M` itself, left is `shl M 8`, mask 0x0101_0101_0101_0101.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f0"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 72340172838076673 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -21,7 +21,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
     // Y = 3: left is `shl M 5`, right is `lshr M 3`, mask 0x0808_0808_0808_0808.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f1"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 578721382704613384 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -37,7 +37,7 @@
     // Y = 7: left is `shl M 1`, right is `lshr M 7`, mask 0x8080_8080_8080_8080.
     // This is the top-bit-of-each-byte mask, whose i64 value is "negative"; it
     // exercises the signed/unsigned normalization in the matcher's mask check.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f2"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 9259542123273814144 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -52,7 +52,7 @@
     }) : () -> ()
     // Y = 0 with the mask on the left operand of the `and` (`and %mask %z`): the
     // matcher accepts the mask constant on either side.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f3"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 72340172838076673 : i64 }> : () -> i64
         %m = "llvm.and"(%mask, %z) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/orcb_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/orcb_invalid.mlir
@@ -10,7 +10,7 @@
 "builtin.module"() ({
     // Wrong mask: `2` is not a per-byte bit-`Y` mask, so a byte of `M` could have
     // a bit other than bit 0 set and `(M << 8) - M` is not `orc.b M`.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f0"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 2 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -23,7 +23,7 @@
     }) : () -> ()
     // No `and` at all: the shifted value is a bare argument, so the soundness gate
     // has nothing to prove each byte has only bit `Y` set. (Unsound to fuse.)
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f1"}> ({
     ^bb0(%z: i64):
         %c8 = "llvm.mlir.constant"() <{ "value" = 8 : i64 }> : () -> i64
         %shl = "llvm.shl"(%z, %c8) : (i64, i64) -> i64
@@ -34,7 +34,7 @@
     }) : () -> ()
     // Shift-amount mismatch: mask is for Y=3 and `shl` is by 5 (Y=3), but `lshr`
     // is by 2 instead of 3.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f2"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 578721382704613384 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -49,7 +49,7 @@
     }) : () -> ()
     // Mask/shift inconsistency: shifts say Y=3 (`shl` 5, `lshr` 3) but the mask is
     // the Y=0 mask `0x0101_0101_0101_0101` rather than `0x0808_0808_0808_0808`.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f3"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 72340172838076673 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -64,7 +64,7 @@
     }) : () -> ()
     // Different masked values: the `shl` operand and the right operand are distinct
     // `and` results, so they are not the same `M`.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f4"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 72340172838076673 : i64 }> : () -> i64
         %m1 = "llvm.and"(%z, %mask) : (i64, i64) -> i64
@@ -77,7 +77,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
     // Out-of-range left shift: `shl` by 9 gives Y = 8 - 9 < 0, outside `0 ≤ Y < 8`.
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f5"}> ({
     ^bb0(%z: i64):
         %mask = "llvm.mlir.constant"() <{ "value" = 72340172838076673 : i64 }> : () -> i64
         %m = "llvm.and"(%z, %mask) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/poison.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/poison.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = () -> ()}> ({
+    "func.func"()  <{function_type = () -> (), sym_name = "foo"}> ({
         %one = "llvm.mlir.poison"() : () -> i1
         // CHECK: [[A:%.*]] = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"([[A]]) : (!riscv.reg) -> i1

--- a/Test/Passes/InstructionSelection/RISCV64/riscv_combine_srl_sra_signbit.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/riscv_combine_srl_sra_signbit.mlir
@@ -10,7 +10,7 @@
     // riscv.srli 63 (riscv.srai 5 x) -> riscv.srli 63 x: the inner shift amount is
     // discarded, and only the outer `srli 63` (renamed here, since a new op is
     // created) survives.
-    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
     ^bb(%x: !riscv.reg):
         %sra = "riscv.srai"(%x) <{"value" = 5 : i64}> : (!riscv.reg) -> !riscv.reg
         %srl = "riscv.srli"(%sra) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -20,7 +20,7 @@
     }) : () -> ()
 
     // i32 analogue: riscv.srliw 31 (riscv.sraiw 7 x) -> riscv.srliw 31 x.
-    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
     ^bb(%x: !riscv.reg):
         %sraw = "riscv.sraiw"(%x) <{"value" = 7 : i64}> : (!riscv.reg) -> !riscv.reg
         %srlw = "riscv.srliw"(%sraw) <{"value" = 31 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -31,7 +31,7 @@
 
     // Outer shift amount not (width - 1): the pattern must not fire, so both
     // instructions survive.
-    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
     ^bb(%x: !riscv.reg):
         %sra = "riscv.srai"(%x) <{"value" = 5 : i64}> : (!riscv.reg) -> !riscv.reg
         %srl = "riscv.srli"(%sra) <{"value" = 62 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -41,7 +41,7 @@
     }) : () -> ()
 
     // No inner `srai`: not matched, `riscv.srli` is left as-is.
-    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+    "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
     ^bb(%x: !riscv.reg):
         %srl = "riscv.srli"(%x) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
         // CHECK:      %{{.*}} = "riscv.srli"(%{{.*}}) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/rotate_const.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/rotate_const.mlir
@@ -7,7 +7,7 @@
 "builtin.module"() ({
 
     // fshr(a, a, 5) is rotate-right by 5 -> rori a, 5
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f0"}> ({
     ^bb0(%a: i64):
         %c = "llvm.mlir.constant"() <{ "value" = 5 : i64 }> : () -> i64
         %r = "llvm.intr.fshr"(%a, %a, %c) : (i64, i64, i64) -> i64
@@ -16,7 +16,7 @@
     }) : () -> ()
 
     // fshl(a, a, 5) is rotate-left by 5 == rotate-right by 59 -> rori a, 59
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f1"}> ({
     ^bb0(%a: i64):
         %c = "llvm.mlir.constant"() <{ "value" = 5 : i64 }> : () -> i64
         %l = "llvm.intr.fshl"(%a, %a, %c) : (i64, i64, i64) -> i64
@@ -25,7 +25,7 @@
     }) : () -> ()
 
     // A rotate by 0 stays a (no-op) rotate: fshl/fshr by 0 -> rori a, 0
-    "func.func"()  <{function_type = (i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64) -> (), sym_name = "f2"}> ({
     ^bb0(%a: i64):
         %c = "llvm.mlir.constant"() <{ "value" = 0 : i64 }> : () -> i64
         %l = "llvm.intr.fshl"(%a, %a, %c) : (i64, i64, i64) -> i64
@@ -35,7 +35,7 @@
     }) : () -> ()
 
     // i32: fshr(a, a, 5) is rotate-right by 5 -> roriw a, 5
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "f3"}> ({
     ^bb0(%a: i32):
         %c = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
         %r = "llvm.intr.fshr"(%a, %a, %c) : (i32, i32, i32) -> i32
@@ -44,7 +44,7 @@
     }) : () -> ()
 
     // i32: fshl(a, a, 5) is rotate-left by 5 == rotate-right by 27 -> roriw a, 27
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "f4"}> ({
     ^bb0(%a: i32):
         %c = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
         %l = "llvm.intr.fshl"(%a, %a, %c) : (i32, i32, i32) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/saturating_i64.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/saturating_i64.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
 
     // llvm.intr.sadd.sat.i64 -> LLVM RV64+Zicond signed saturating-add sequence
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f0"}> ({
     ^bb0(%x: i64, %y: i64):
         %r = "llvm.intr.sadd.sat"(%x, %y) : (i64, i64) -> i64
         // CHECK:      "riscv.add"
@@ -20,7 +20,7 @@
     }) : () -> ()
 
     // llvm.intr.ssub.sat.i64 -> LLVM RV64+Zicond signed saturating-sub sequence
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f1"}> ({
     ^bb0(%x: i64, %y: i64):
         %r = "llvm.intr.ssub.sat"(%x, %y) : (i64, i64) -> i64
         // CHECK:      "riscv.sub"
@@ -37,7 +37,7 @@
     }) : () -> ()
 
     // llvm.intr.uadd.sat.i64 -> not y; minu x, not-y; add
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f2"}> ({
     ^bb0(%x: i64, %y: i64):
         %r = "llvm.intr.uadd.sat"(%x, %y) : (i64, i64) -> i64
         // CHECK:      "riscv.xori"({{.*}}) <{"value" = -1 : i64}>
@@ -47,7 +47,7 @@
     }) : () -> ()
 
     // llvm.intr.usub.sat.i64 -> maxu x, y; sub y
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f3"}> ({
     ^bb0(%x: i64, %y: i64):
         %r = "llvm.intr.usub.sat"(%x, %y) : (i64, i64) -> i64
         // CHECK:      "riscv.maxu"
@@ -56,7 +56,7 @@
     }) : () -> ()
 
     // llvm.intr.sshl.sat.i64 -> LLVM RV64+Zicond signed saturating-shl sequence
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f4"}> ({
     ^bb0(%x: i64, %y: i64):
         %r = "llvm.intr.sshl.sat"(%x, %y) : (i64, i64) -> i64
         // CHECK:      "riscv.sll"
@@ -72,7 +72,7 @@
     }) : () -> ()
 
     // llvm.intr.ushl.sat.i64 -> LLVM RV64 unsigned saturating-shl sequence
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "f5"}> ({
     ^bb0(%x: i64, %y: i64):
         %r = "llvm.intr.ushl.sat"(%x, %y) : (i64, i64) -> i64
         // CHECK:      "riscv.sll"

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %sdiv = "llvm.sdiv"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -16,7 +16,7 @@
 
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i32, %b: i32):
         %sdiv32 = "llvm.sdiv"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %sdiv = "llvm.sdiv"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.sdiv"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_by2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_by2.mlir
@@ -11,7 +11,7 @@
 "builtin.module"() ({
     // llvm.sdiv x, 2 -> riscv.srli 63 x / riscv.add x _ / riscv.srai 1 _
     // (no `riscv.srai 63` sign-splat survives).
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64
         %r = "llvm.sdiv"(%a, %c) : (i64, i64) -> i64
@@ -23,7 +23,7 @@
     }) : () -> ()
 
     // i32 analogue: riscv.srliw 31 x / riscv.addw x _ / riscv.sraiw 1 _.
-    "func.func"() <{function_type = (i32) -> i32}> ({
+    "func.func"() <{function_type = (i32) -> i32, sym_name = "bar"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 2 : i32}> : () -> i32
         %r = "llvm.sdiv"(%a, %c) : (i32, i32) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/select_zicond.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
 
     // select c, t, 0 -> riscv.czeroeqz t, c
-    "func.func"()  <{function_type = (i1, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i64) -> (), sym_name = "f0"}> ({
     ^bb0(%c: i1, %t: i64):
         %zero = "llvm.mlir.constant"() <{ "value" = 0 : i64 }> : () -> i64
         %r = "llvm.select"(%c, %t, %zero) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
     }) : () -> ()
 
     // select c, 0, f -> riscv.czeronez f, c
-    "func.func"()  <{function_type = (i1, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i64) -> (), sym_name = "f1"}> ({
     ^bb0(%c: i1, %f: i64):
         %zero = "llvm.mlir.constant"() <{ "value" = 0 : i64 }> : () -> i64
         %r = "llvm.select"(%c, %zero, %f) : (i1, i64, i64) -> i64
@@ -21,7 +21,7 @@
     }) : () -> ()
 
     // general select c, t, f -> or (czero.eqz t, c) (czero.nez f, c)
-    "func.func"()  <{function_type = (i1, i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i64, i64) -> (), sym_name = "f2"}> ({
     ^bb0(%c: i1, %t: i64, %f: i64):
         %r = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64
         // CHECK-DAG: %{{.*}} = "riscv.czeroeqz"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -31,7 +31,7 @@
     }) : () -> ()
 
     // i32: select c, t, 0 -> riscv.czeroeqz t, c
-    "func.func"()  <{function_type = (i1, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i32) -> (), sym_name = "f3"}> ({
     ^bb0(%c: i1, %t: i32):
         %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
         %r = "llvm.select"(%c, %t, %zero) : (i1, i32, i32) -> i32
@@ -40,7 +40,7 @@
     }) : () -> ()
 
     // i32: select c, 0, f -> riscv.czeronez f, c
-    "func.func"()  <{function_type = (i1, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i32) -> (), sym_name = "f4"}> ({
     ^bb0(%c: i1, %f: i32):
         %zero = "llvm.mlir.constant"() <{ "value" = 0 : i32 }> : () -> i32
         %r = "llvm.select"(%c, %zero, %f) : (i1, i32, i32) -> i32
@@ -49,7 +49,7 @@
     }) : () -> ()
 
     // i32: general select
-    "func.func"()  <{function_type = (i1, i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i32, i32) -> (), sym_name = "f5"}> ({
     ^bb0(%c: i1, %t: i32, %f: i32):
         %r = "llvm.select"(%c, %t, %f) : (i1, i32, i32) -> i32
         // CHECK-DAG: %{{.*}} = "riscv.czeroeqz"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -59,7 +59,7 @@
     }) : () -> ()
     
     // i1: general select
-    "func.func"()  <{function_type = (i1, i1, i1) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i1, i1) -> (), sym_name = "f6"}> ({
     ^bb0(%c: i1, %t: i1, %f: i1):
         %r = "llvm.select"(%c, %t, %f) : (i1, i1, i1) -> i1
         // CHECK-DAG: %{{.*}} = "riscv.czeroeqz"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/sext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sext.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i1, i16, i32, i42, i8) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i16, i32, i42, i8) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i1, %b: i16, %c: i32, %d: i42, %e: i8):
         %sexta = "llvm.sext"(%b) : (i16) -> i64
         %sextb = "llvm.sext"(%b) : (i16) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/sext_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sext_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i128, i42) -> ()}> ({
+    "func.func"()  <{function_type = (i128, i42) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i128, %b : i42):
         %sexta = "llvm.sext"(%a) : (i128) -> i256
         // CHECK:      %{{.*}} = "llvm.sext"(%{{.*}}) : (i128) -> i256

--- a/Test/Passes/InstructionSelection/RISCV64/shifti.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shifti.mlir
@@ -5,7 +5,7 @@
 
 "builtin.module"() ({
     // llvm.shl x (const) -> riscv.slli x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f0"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %r = "llvm.shl"(%a, %c) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
     }) : () -> ()
 
     // llvm.lshr x (const) -> riscv.srli x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f1"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 63 : i64}> : () -> i64
         %r = "llvm.lshr"(%a, %c) : (i64, i64) -> i64
@@ -23,7 +23,7 @@
     }) : () -> ()
 
     // llvm.ashr x (const) -> riscv.srai x imm
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f2"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
         %r = "llvm.ashr"(%a, %c) : (i64, i64) -> i64
@@ -32,7 +32,7 @@
     }) : () -> ()
 
     // Shift amount out of [0,63]: not selected here (stays `llvm.shl`).
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f3"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 64 : i64}> : () -> i64
         %r = "llvm.shl"(%a, %c) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/shl.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %shl = "llvm.shl"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -27,7 +27,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: i32, %b: i32):
         %shl = "llvm.shl"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/shl_byte.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl_byte.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (!llvm.byte<64>, !llvm.byte<64>) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.byte<64>, !llvm.byte<64>) -> (), sym_name = "foo"}> ({
     ^bb0(%a: !llvm.byte<64>, %b: i64):
         %shl = "llvm.shl"(%a, %b) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.byte<64>) -> !riscv.reg
@@ -26,7 +26,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (!llvm.byte<32>, i32) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.byte<32>, i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: !llvm.byte<32>, %b: i32):
         %shl = "llvm.shl"(%a, %b) : (!llvm.byte<32>, i32) -> !llvm.byte<32>
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!llvm.byte<32>) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/shl_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/shl_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.shl"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.shl"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/single_bit.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/single_bit.mlir
@@ -8,7 +8,7 @@
 
 "builtin.module"() ({
     // or x (1 << 40) -> riscv.bseti x 40
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f0"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 1099511627776 : i64}> : () -> i64
         %r = "llvm.or"(%a, %c) : (i64, i64) -> i64
@@ -17,7 +17,7 @@
     }) : () -> ()
 
     // xor x (1 << 40) -> riscv.binvi x 40
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f1"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 1099511627776 : i64}> : () -> i64
         %r = "llvm.xor"(%a, %c) : (i64, i64) -> i64
@@ -26,7 +26,7 @@
     }) : () -> ()
 
     // and x (~(1 << 40)) -> riscv.bclri x 40
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f2"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -1099511627777 : i64}> : () -> i64
         %r = "llvm.and"(%a, %c) : (i64, i64) -> i64
@@ -35,7 +35,7 @@
     }) : () -> ()
 
     // and (lshr x 5) 1 -> riscv.bexti x 5
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f3"}> ({
     ^bb(%a: i64):
         %sh = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
@@ -46,7 +46,7 @@
     }) : () -> ()
 
     // Single-bit mask that DOES fit imm12: handled by ori, not bseti.
-    "func.func"() <{function_type = (i64) -> i64}> ({
+    "func.func"() <{function_type = (i64) -> i64, sym_name = "f4"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 1024 : i64}> : () -> i64
         %r = "llvm.or"(%a, %c) : (i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/slliuw.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/slliuw.mlir
@@ -6,7 +6,7 @@
 
 "builtin.module"() ({
     // shl (zext x) 3 -> riscv.slliuw x 3
-    "func.func"() <{function_type = (i32) -> i64}> ({
+    "func.func"() <{function_type = (i32) -> i64, sym_name = "foo"}> ({
     ^bb(%a: i32):
         %z = "llvm.zext"(%a) : (i32) -> i64
         %c = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/slti.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/slti.mlir
@@ -9,7 +9,7 @@
 
 "builtin.module"() ({
     // icmp slt x (const imm12) -> riscv.slti x imm   (predicate 2 = slt)
-    "func.func"() <{function_type = (i64) -> i1}> ({
+    "func.func"() <{function_type = (i64) -> i1, sym_name = "f0"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %c) <{"predicate" = 2 : i64}> : (i64, i64) -> i1
@@ -18,7 +18,7 @@
     }) : () -> ()
 
     // icmp ult x (const imm12) -> riscv.sltiu x imm   (predicate 6 = ult)
-    "func.func"() <{function_type = (i64) -> i1}> ({
+    "func.func"() <{function_type = (i64) -> i1, sym_name = "f1"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 2047 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %c) <{"predicate" = 6 : i64}> : (i64, i64) -> i1
@@ -29,7 +29,7 @@
     // icmp sgt: no immediate form (predicate 4 = sgt) -> stays `llvm.icmp`.
     // The reg-reg lowering (slt with swapped operands) is already the same
     // instruction count, and is strictly better for the `> 0` case via x0.
-    "func.func"() <{function_type = (i64) -> i1}> ({
+    "func.func"() <{function_type = (i64) -> i1, sym_name = "f2"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %c) <{"predicate" = 4 : i64}> : (i64, i64) -> i1
@@ -38,7 +38,7 @@
     }) : () -> ()
 
     // Out-of-range immediate: not selected here (stays `llvm.icmp`).
-    "func.func"() <{function_type = (i64) -> i1}> ({
+    "func.func"() <{function_type = (i64) -> i1, sym_name = "f3"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 2048 : i64}> : () -> i64
         %r = "llvm.icmp"(%a, %c) <{"predicate" = 2 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/InstructionSelection/RISCV64/srem.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/srem.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %srem = "llvm.srem"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -11,7 +11,7 @@
 
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i32, %b: i32):
         %srem32 = "llvm.srem"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/srem_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/srem_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %srem = "llvm.srem"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.srem"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/store.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/store.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "foo"}> ({
     ^bb0(%a: !llvm.ptr, %b : i64):
         "llvm.store"(%b, %a) : (i64, !llvm.ptr) -> ()
         // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
@@ -11,7 +11,7 @@
     }) : () -> ()
 
     // i32 store lowers to `riscv.sw`.
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "bar"}> ({
     ^bb0(%a: !llvm.ptr, %b : i32):
         "llvm.store"(%b, %a) : (i32, !llvm.ptr) -> ()
         // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
@@ -21,7 +21,7 @@
     }) : () -> ()
 
     // i8 store lowers to `riscv.sb`.
-    "func.func"()  <{function_type = (!llvm.ptr) -> ()}> ({
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "baz"}> ({
     ^bb0(%a: !llvm.ptr, %b : i8):
         "llvm.store"(%b, %a) : (i8, !llvm.ptr) -> ()
         // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/sub.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %sub = "llvm.sub"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -27,7 +27,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: i32, %b: i32):
         %sub = "llvm.sub"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/sub_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.sub"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.sub"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/trunc.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/trunc.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i32, !llvm.byte<32>) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i32, !llvm.byte<32>) -> (), sym_name = "foo"}> ({
     ^bb0(%b : i16, %c: i32, %d: !llvm.byte<32>):
         %truncb = "llvm.trunc"(%b) : (i16) -> i8
         %truncc = "llvm.trunc"(%c) : (i32) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/udiv.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %udiv = "llvm.udiv"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -16,7 +16,7 @@
 
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i32, %b: i32):
         %udiv32 = "llvm.udiv"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %udiv = "llvm.udiv"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.udiv"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/urem.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/urem.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %urem = "llvm.urem"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -11,7 +11,7 @@
 
         "func.return"() : () -> ()
     }) : () -> ()
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb0(%a: i32, %b: i32):
         %urem32 = "llvm.urem"(%a, %b) : (i32, i32) -> i32
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i32) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/urem_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/urem_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %urem = "llvm.urem"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.urem"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/word.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/word.mlir
@@ -7,7 +7,7 @@
 
 "builtin.module"() ({
     // i32 add x (const imm12) -> riscv.addiw x imm
-    "func.func"() <{function_type = (i32) -> i32}> ({
+    "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
         %r = "llvm.add"(%a, %c) : (i32, i32) -> i32
@@ -16,7 +16,7 @@
     }) : () -> ()
 
     // i32 shl x (const in [0,31]) -> riscv.slliw x imm
-    "func.func"() <{function_type = (i32) -> i32}> ({
+    "func.func"() <{function_type = (i32) -> i32, sym_name = "bar"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
         %r = "llvm.shl"(%a, %c) : (i32, i32) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/word_rotate.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/word_rotate.mlir
@@ -8,7 +8,7 @@
 "builtin.module"() ({
 
     // fshr(a, a, 5) is rotate-right by 5 -> roriw a, 5
-    "func.func"() <{function_type = (i32) -> ()}> ({
+    "func.func"() <{function_type = (i32) -> (), sym_name = "f0"}> ({
     ^bb0(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
         %r = "llvm.intr.fshr"(%a, %a, %c) : (i32, i32, i32) -> i32
@@ -17,7 +17,7 @@
     }) : () -> ()
 
     // fshl(a, a, 5) is rotate-left by 5 == rotate-right by 27 -> roriw a, 27
-    "func.func"() <{function_type = (i32) -> ()}> ({
+    "func.func"() <{function_type = (i32) -> (), sym_name = "f1"}> ({
     ^bb0(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
         %l = "llvm.intr.fshl"(%a, %a, %c) : (i32, i32, i32) -> i32
@@ -26,7 +26,7 @@
     }) : () -> ()
 
     // A rotate by 0 stays a (no-op) rotate: fshl/fshr by 0 -> roriw a, 0
-    "func.func"() <{function_type = (i32) -> ()}> ({
+    "func.func"() <{function_type = (i32) -> (), sym_name = "f2"}> ({
     ^bb0(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 0 : i32}> : () -> i32
         %l = "llvm.intr.fshl"(%a, %a, %c) : (i32, i32, i32) -> i32
@@ -36,7 +36,7 @@
     }) : () -> ()
 
     // i64 rotate-left is not selected here (stays `llvm.intr.fshl` for isel-riscv64).
-    "func.func"() <{function_type = (i64) -> ()}> ({
+    "func.func"() <{function_type = (i64) -> (), sym_name = "f3"}> ({
     ^bb0(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
         %l = "llvm.intr.fshl"(%a, %a, %c) : (i64, i64, i64) -> i64

--- a/Test/Passes/InstructionSelection/RISCV64/xor.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/xor.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i64, i64) -> ()}> ({
+    "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i64, %b: i64):
         %add = "llvm.xor"(%a, %b) : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
@@ -12,7 +12,7 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-    "func.func"()  <{function_type = (i32, i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32, i32) -> (), sym_name = "bar"}> ({
     ^bb(%a: i32, %b: i32):
         %xor = "llvm.xor"(%a, %b) : (i32, i32) -> i32
         // i32 xor uses the plain `xor` (no `W` variant)

--- a/Test/Passes/InstructionSelection/RISCV64/xor_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/xor_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i16, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i16, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.xor"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.xor"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16

--- a/Test/Passes/InstructionSelection/RISCV64/zext.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/zext.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-sdag-riscv64,isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i1, i16, i32, i42, i8) -> ()}> ({
+    "func.func"()  <{function_type = (i1, i16, i32, i42, i8) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i1, %b: i16, %c: i32, %d: i42, %e : i8):
         %sexta = "llvm.zext"(%b) : (i16) -> i64
         %sextb = "llvm.zext"(%b) : (i16) -> i32

--- a/Test/Passes/InstructionSelection/RISCV64/zext_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/zext_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
 
 "builtin.module"() ({
-    "func.func"()  <{function_type = (i128, i16) -> ()}> ({
+    "func.func"()  <{function_type = (i128, i16) -> (), sym_name = "foo"}> ({
     ^bb0(%a: i128, %b : i42):
         %zexta = "llvm.zext"(%a) : (i128) -> i256
         // CHECK:      %{{.*}} = "llvm.zext"(%{{.*}}) : (i128) -> i256

--- a/Test/Passes/RISCVCombines/AMinusBMinusC.mlir
+++ b/Test/Passes/RISCVCombines/AMinusBMinusC.mlir
@@ -4,7 +4,7 @@
 // subtraction turns the nested subtract into an add of the swapped difference.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%a: i64, %b: i64, %c: i64):
     %inner = "llvm.sub"(%b, %c) : (i64, i64) -> i64
     %r = "llvm.sub"(%a, %inner) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the inner op is an add, not a sub, so the identity does not apply.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i64, %b: i64, %c: i64):
     %inner = "llvm.add"(%b, %c) : (i64, i64) -> i64
     %r = "llvm.sub"(%a, %inner) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/APlusC1MinusC2.mlir
+++ b/Test/Passes/RISCVCombines/APlusC1MinusC2.mlir
@@ -4,7 +4,7 @@
 // constant adjustments to A collapse into a single add of their difference.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%a: i64):
     %c1 = "llvm.mlir.constant"() <{value = 10 : i64}> : () -> i64
     %c2 = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: the subtracted operand is not a constant, so no fold.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i64, %y: i64):
     %c1 = "llvm.mlir.constant"() <{value = 10 : i64}> : () -> i64
     %add = "llvm.add"(%a, %c1) : (i64, i64) -> i64
@@ -23,7 +23,7 @@
   }) : () -> ()
 
   // Negative case: the added operand is not a constant, so no fold.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "baz"}> ({
   ^bb0(%a: i64, %x: i64):
     %c2 = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %add = "llvm.add"(%a, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/AndAndAnd.mlir
+++ b/Test/Passes/RISCVCombines/AndAndAnd.mlir
@@ -4,7 +4,7 @@
 // masking operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %ax = "llvm.and"(%x, %z) : (i64, i64) -> i64
     %ay = "llvm.and"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct masks, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %ax = "llvm.and"(%x, %z0) : (i64, i64) -> i64
     %ay = "llvm.and"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/AndAshrAshr.mlir
+++ b/Test/Passes/RISCVCombines/AndAshrAshr.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.ashr"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.ashr"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.ashr"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.ashr"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/AndLshrLshr.mlir
+++ b/Test/Passes/RISCVCombines/AndLshrLshr.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.lshr"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.lshr"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.lshr"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.lshr"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/AndSextSext.mlir
+++ b/Test/Passes/RISCVCombines/AndSextSext.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %ex = "llvm.sext"(%x) : (i32) -> i64
     %ey = "llvm.sext"(%y) : (i32) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `sext`, so nothing is hoisted.
-  "func.func"() <{function_type = (i32, i64) -> i64}> ({
+  "func.func"() <{function_type = (i32, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i64):
     %ex = "llvm.sext"(%x) : (i32) -> i64
     %r = "llvm.and"(%ex, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/AndShlShl.mlir
+++ b/Test/Passes/RISCVCombines/AndShlShl.mlir
@@ -5,7 +5,7 @@
 // `and`. Only fires when both shift amounts are the same value `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.shl"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.shl"(%y, %z) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: distinct shift amounts, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.shl"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.shl"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/AndTruncTrunc.mlir
+++ b/Test/Passes/RISCVCombines/AndTruncTrunc.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %ex = "llvm.trunc"(%x) : (i64) -> i32
     %ey = "llvm.trunc"(%y) : (i64) -> i32
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `trunc`, so nothing is hoisted.
-  "func.func"() <{function_type = (i64, i32) -> i32}> ({
+  "func.func"() <{function_type = (i64, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i32):
     %ex = "llvm.trunc"(%x) : (i64) -> i32
     %r = "llvm.and"(%ex, %y) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/AndZextZext.mlir
+++ b/Test/Passes/RISCVCombines/AndZextZext.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %ex = "llvm.zext"(%x) : (i32) -> i64
     %ey = "llvm.zext"(%y) : (i32) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `zext`, so nothing is hoisted.
-  "func.func"() <{function_type = (i32, i64) -> i64}> ({
+  "func.func"() <{function_type = (i32, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i64):
     %ex = "llvm.zext"(%x) : (i32) -> i64
     %r = "llvm.and"(%ex, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/C2MinusAPlusC1.mlir
+++ b/Test/Passes/RISCVCombines/C2MinusAPlusC1.mlir
@@ -4,7 +4,7 @@
 // constant, leaving one subtract of A.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%a: i64):
     %c1 = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %c2 = "llvm.mlir.constant"() <{value = 10 : i64}> : () -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: the minuend is not a constant, so no fold.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i64, %y: i64):
     %c1 = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %add = "llvm.add"(%a, %c1) : (i64, i64) -> i64
@@ -23,7 +23,7 @@
   }) : () -> ()
 
   // Negative case: the added operand is not a constant, so no fold.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "baz"}> ({
   ^bb0(%a: i64, %x: i64):
     %c2 = "llvm.mlir.constant"() <{value = 10 : i64}> : () -> i64
     %add = "llvm.add"(%a, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/NotAPlusNegOne_rw.mlir
+++ b/Test/Passes/RISCVCombines/NotAPlusNegOne_rw.mlir
@@ -3,7 +3,7 @@
 // `not (X + -1)` is `-X`: since `~(X - 1) == -X`, it rewrites to `sub 0, X`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
     %add = "llvm.add"(%x, %m1) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the added constant is -2, not -1, so the identity fails.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
     %m2 = "llvm.mlir.constant"() <{value = -2 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/OrAndAnd.mlir
+++ b/Test/Passes/RISCVCombines/OrAndAnd.mlir
@@ -4,7 +4,7 @@
 // masking operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %ax = "llvm.and"(%x, %z) : (i64, i64) -> i64
     %ay = "llvm.and"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct masks, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %ax = "llvm.and"(%x, %z0) : (i64, i64) -> i64
     %ay = "llvm.and"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/OrAshrAshr.mlir
+++ b/Test/Passes/RISCVCombines/OrAshrAshr.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.ashr"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.ashr"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.ashr"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.ashr"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/OrLshrLshr.mlir
+++ b/Test/Passes/RISCVCombines/OrLshrLshr.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.lshr"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.lshr"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.lshr"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.lshr"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/OrSextSext.mlir
+++ b/Test/Passes/RISCVCombines/OrSextSext.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %ex = "llvm.sext"(%x) : (i32) -> i64
     %ey = "llvm.sext"(%y) : (i32) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `sext`, so nothing is hoisted.
-  "func.func"() <{function_type = (i32, i64) -> i64}> ({
+  "func.func"() <{function_type = (i32, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i64):
     %ex = "llvm.sext"(%x) : (i32) -> i64
     %r = "llvm.or"(%ex, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/OrShlShl.mlir
+++ b/Test/Passes/RISCVCombines/OrShlShl.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.shl"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.shl"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.shl"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.shl"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/OrTruncTrunc.mlir
+++ b/Test/Passes/RISCVCombines/OrTruncTrunc.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %ex = "llvm.trunc"(%x) : (i64) -> i32
     %ey = "llvm.trunc"(%y) : (i64) -> i32
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `trunc`, so nothing is hoisted.
-  "func.func"() <{function_type = (i64, i32) -> i32}> ({
+  "func.func"() <{function_type = (i64, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i32):
     %ex = "llvm.trunc"(%x) : (i64) -> i32
     %r = "llvm.or"(%ex, %y) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/OrZextZext.mlir
+++ b/Test/Passes/RISCVCombines/OrZextZext.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %ex = "llvm.zext"(%x) : (i32) -> i64
     %ey = "llvm.zext"(%y) : (i32) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `zext`, so nothing is hoisted.
-  "func.func"() <{function_type = (i32, i64) -> i64}> ({
+  "func.func"() <{function_type = (i32, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i64):
     %ex = "llvm.zext"(%x) : (i32) -> i64
     %r = "llvm.or"(%ex, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/SubSmaxSub.mlir
+++ b/Test/Passes/RISCVCombines/SubSmaxSub.mlir
@@ -5,7 +5,7 @@
 // resulting `smin` consumes it directly.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // Negative case: the max is `umax`, not `smax`, so the signed pattern does not fire.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/SubSminSub.mlir
+++ b/Test/Passes/RISCVCombines/SubSminSub.mlir
@@ -6,7 +6,7 @@
 // consumes it directly.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64
@@ -16,7 +16,7 @@
   }) : () -> ()
 
   // Negative case: the min is `umin`, not `smin`, so the signed pattern does not fire.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/SubUmaxSub.mlir
+++ b/Test/Passes/RISCVCombines/SubUmaxSub.mlir
@@ -5,7 +5,7 @@
 // directly.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // Negative case: the outer subtrahend is 1, not 0, so the negation identity does not apply.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/SubUminSub.mlir
+++ b/Test/Passes/RISCVCombines/SubUminSub.mlir
@@ -5,7 +5,7 @@
 // consumes it directly.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // Negative case: the min is `smin`, not `umin`, so the unsigned pattern does not fire.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %sub = "llvm.sub"(%zero, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/XorAndAnd.mlir
+++ b/Test/Passes/RISCVCombines/XorAndAnd.mlir
@@ -4,7 +4,7 @@
 // masking operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %ax = "llvm.and"(%x, %z) : (i64, i64) -> i64
     %ay = "llvm.and"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct masks, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %ax = "llvm.and"(%x, %z0) : (i64, i64) -> i64
     %ay = "llvm.and"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/XorAshrAshr.mlir
+++ b/Test/Passes/RISCVCombines/XorAshrAshr.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.ashr"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.ashr"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.ashr"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.ashr"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/XorLshrLshr.mlir
+++ b/Test/Passes/RISCVCombines/XorLshrLshr.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.lshr"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.lshr"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.lshr"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.lshr"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/XorSextSext.mlir
+++ b/Test/Passes/RISCVCombines/XorSextSext.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %ex = "llvm.sext"(%x) : (i32) -> i64
     %ey = "llvm.sext"(%y) : (i32) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `sext`, so nothing is hoisted.
-  "func.func"() <{function_type = (i32, i64) -> i64}> ({
+  "func.func"() <{function_type = (i32, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i64):
     %ex = "llvm.sext"(%x) : (i32) -> i64
     %r = "llvm.xor"(%ex, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/XorShlShl.mlir
+++ b/Test/Passes/RISCVCombines/XorShlShl.mlir
@@ -4,7 +4,7 @@
 // second operand `Z`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %sx = "llvm.shl"(%x, %z) : (i64, i64) -> i64
     %sy = "llvm.shl"(%y, %z) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: distinct second operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z0: i64, %z1: i64):
     %sx = "llvm.shl"(%x, %z0) : (i64, i64) -> i64
     %sy = "llvm.shl"(%y, %z1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/XorTruncTrunc.mlir
+++ b/Test/Passes/RISCVCombines/XorTruncTrunc.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %ex = "llvm.trunc"(%x) : (i64) -> i32
     %ey = "llvm.trunc"(%y) : (i64) -> i32
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `trunc`, so nothing is hoisted.
-  "func.func"() <{function_type = (i64, i32) -> i32}> ({
+  "func.func"() <{function_type = (i64, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i32):
     %ex = "llvm.trunc"(%x) : (i64) -> i32
     %r = "llvm.xor"(%ex, %y) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/XorZextZext.mlir
+++ b/Test/Passes/RISCVCombines/XorZextZext.mlir
@@ -5,7 +5,7 @@
 // bitwise op on the narrow operands and casting once.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %ex = "llvm.zext"(%x) : (i32) -> i64
     %ey = "llvm.zext"(%y) : (i32) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: only one operand is a `zext`, so nothing is hoisted.
-  "func.func"() <{function_type = (i32, i64) -> i64}> ({
+  "func.func"() <{function_type = (i32, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i64):
     %ex = "llvm.zext"(%x) : (i32) -> i64
     %r = "llvm.xor"(%ex, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/add_shift.mlir
+++ b/Test/Passes/RISCVCombines/add_shift.mlir
@@ -4,7 +4,7 @@
 // the same as shifting then subtracting.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%a: i64, %b: i64, %c: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %negb = "llvm.sub"(%zero, %b) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: the shifted value is not a negation of anything (plain shl).
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i64, %b: i64, %c: i64):
     %sh = "llvm.shl"(%b, %c) : (i64, i64) -> i64
     %r = "llvm.add"(%a, %sh) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/add_shift_commute.mlir
+++ b/Test/Passes/RISCVCombines/add_shift_commute.mlir
@@ -4,7 +4,7 @@
 // shifted (negated) value as the add's first operand.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%a: i64, %b: i64, %c: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %negb = "llvm.sub"(%zero, %b) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: no negation feeding the shift.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i64, %b: i64, %c: i64):
     %sh = "llvm.shl"(%b, %c) : (i64, i64) -> i64
     %r = "llvm.add"(%sh, %a) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/and_xor_or_to_xor_and.mlir
+++ b/Test/Passes/RISCVCombines/and_xor_or_to_xor_and.mlir
@@ -3,7 +3,7 @@
 // `(X | Y) & ~Y` is `X & ~Y`: the `| Y` is redundant once `~Y` is and'd in.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
     %or = "llvm.or"(%x, %y) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: the xor constant is -2, not -1, so `noty` is not `~Y`.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %m2 = "llvm.mlir.constant"() <{value = -2 : i64}> : () -> i64
     %or = "llvm.or"(%x, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/ashr_left_to_zero.mlir
+++ b/Test/Passes/RISCVCombines/ashr_left_to_zero.mlir
@@ -3,7 +3,7 @@
 // `ashr 0, x` is `0`: arithmetically shifting zero right by any amount is still zero.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %r = "llvm.ashr"(%zero, %x) : (i64, i64) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the shifted value is 1, not 0, so the shift is not eliminated.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
     %r = "llvm.ashr"(%one, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/bitreverse_lshr.mlir
+++ b/Test/Passes/RISCVCombines/bitreverse_lshr.mlir
@@ -4,7 +4,7 @@
 // again equals a single shift left.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %bx = "llvm.intr.bitreverse"(%x) : (i64) -> i64
     %s = "llvm.lshr"(%bx, %y) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: the inner value is not a bitreverse, so the pattern does not fire.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %s = "llvm.lshr"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.intr.bitreverse"(%s) : (i64) -> i64

--- a/Test/Passes/RISCVCombines/bitreverse_shl.mlir
+++ b/Test/Passes/RISCVCombines/bitreverse_shl.mlir
@@ -4,7 +4,7 @@
 // again equals a single logical right shift.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %bx = "llvm.intr.bitreverse"(%x) : (i64) -> i64
     %s = "llvm.shl"(%bx, %y) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: the inner value is not a bitreverse, so the pattern does not fire.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %s = "llvm.shl"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.intr.bitreverse"(%s) : (i64) -> i64

--- a/Test/Passes/RISCVCombines/canonicalize_icmp.mlir
+++ b/Test/Passes/RISCVCombines/canonicalize_icmp.mlir
@@ -7,7 +7,7 @@
 
 "builtin.module"() ({
   // slt with constant on the left -> sgt with constant on the right.
-  "func.func"() <{function_type = (i32) -> i1}> ({
+  "func.func"() <{function_type = (i32) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.icmp"(%c, %x) <{predicate = 2 : i64}> : (i32, i32) -> i1
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // eq is symmetric: predicate is unchanged, operands still swapped.
-  "func.func"() <{function_type = (i32) -> i1}> ({
+  "func.func"() <{function_type = (i32) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.icmp"(%c, %x) <{predicate = 0 : i64}> : (i32, i32) -> i1
@@ -23,7 +23,7 @@
   }) : () -> ()
 
   // Negative case: constant already on the right, so nothing to canonicalize.
-  "func.func"() <{function_type = (i32) -> i1}> ({
+  "func.func"() <{function_type = (i32) -> i1, sym_name = "baz"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.icmp"(%x, %c) <{predicate = 2 : i64}> : (i32, i32) -> i1

--- a/Test/Passes/RISCVCombines/combine_or_of_and_l.mlir
+++ b/Test/Passes/RISCVCombines/combine_or_of_and_l.mlir
@@ -4,7 +4,7 @@
 // Here the `and` is the LEFT operand of the `or`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %and = "llvm.and"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.or"(%and, %x) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: neither `and` operand is the other `or` operand, so no absorption.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %and = "llvm.and"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.or"(%and, %z) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/combine_or_of_and_r.mlir
+++ b/Test/Passes/RISCVCombines/combine_or_of_and_r.mlir
@@ -4,7 +4,7 @@
 // Here the `and` is the RIGHT operand of the `or`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %and = "llvm.and"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.or"(%x, %and) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: neither `and` operand is the other `or` operand, so no absorption.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %and = "llvm.and"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.or"(%z, %and) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/commute_int_constant_to_rhs.mlir
+++ b/Test/Passes/RISCVCombines/commute_int_constant_to_rhs.mlir
@@ -6,7 +6,7 @@
 
 "builtin.module"() ({
   // add
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f0"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.add"(%c, %x) : (i32, i32) -> i32
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // mul
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f1"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.mul"(%c, %x) : (i32, i32) -> i32
@@ -22,7 +22,7 @@
   }) : () -> ()
 
   // and
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f2"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.and"(%c, %x) : (i32, i32) -> i32
@@ -30,7 +30,7 @@
   }) : () -> ()
 
   // or
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f3"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.or"(%c, %x) : (i32, i32) -> i32
@@ -38,7 +38,7 @@
   }) : () -> ()
 
   // xor
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f4"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.xor"(%c, %x) : (i32, i32) -> i32
@@ -46,7 +46,7 @@
   }) : () -> ()
 
   // Negative case: constant already on the right, so nothing to commute.
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "f5"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.add"(%x, %c) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/constant_fold_binop.mlir
+++ b/Test/Passes/RISCVCombines/constant_fold_binop.mlir
@@ -6,7 +6,7 @@
 
 "builtin.module"() ({
   // add(5, 7) = 12
-  "func.func"() <{function_type = () -> i32}> ({
+  "func.func"() <{function_type = () -> i32, sym_name = "foo"}> ({
   ^bb0():
     %a = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %b = "llvm.mlir.constant"() <{value = 7 : i32}> : () -> i32
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // sub(20, 8) = 12
-  "func.func"() <{function_type = () -> i32}> ({
+  "func.func"() <{function_type = () -> i32, sym_name = "bar"}> ({
   ^bb0():
     %a = "llvm.mlir.constant"() <{value = 20 : i32}> : () -> i32
     %b = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
@@ -24,7 +24,7 @@
   }) : () -> ()
 
   // smin(4, 9) = 4
-  "func.func"() <{function_type = () -> i32}> ({
+  "func.func"() <{function_type = () -> i32, sym_name = "baz"}> ({
   ^bb0():
     %a = "llvm.mlir.constant"() <{value = 4 : i32}> : () -> i32
     %b = "llvm.mlir.constant"() <{value = 9 : i32}> : () -> i32

--- a/Test/Passes/RISCVCombines/double_icmp_zero_and_combine.mlir
+++ b/Test/Passes/RISCVCombines/double_icmp_zero_and_combine.mlir
@@ -3,7 +3,7 @@
 // `(X == 0) & (Y == 0)` holds iff `(X | Y) == 0`, saving one comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %cx = "llvm.icmp"(%x, %z) <{predicate = 0 : i64}> : (i64, i64) -> i1
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: comparisons are `ne`, not `eq`, so this rule does not apply.
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %cx = "llvm.icmp"(%x, %z) <{predicate = 1 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/double_icmp_zero_or_combine.mlir
+++ b/Test/Passes/RISCVCombines/double_icmp_zero_or_combine.mlir
@@ -3,7 +3,7 @@
 // `(X != 0) | (Y != 0)` holds iff `(X | Y) != 0`, saving one comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %cx = "llvm.icmp"(%x, %z) <{predicate = 1 : i64}> : (i64, i64) -> i1
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: comparisons are `eq`, not `ne`, so this rule does not apply.
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %cx = "llvm.icmp"(%x, %z) <{predicate = 0 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/drop_sextw_low_word.mlir
+++ b/Test/Passes/RISCVCombines/drop_sextw_low_word.mlir
@@ -5,7 +5,7 @@
 // is redundant and gets dropped.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %sy = "riscv.sextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -13,21 +13,21 @@
     "func.return"(%sum) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.addiw"(%sx) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
     "func.return"(%y) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.roriw"(%sx) <{"value" = 7 : i64}> : (!riscv.reg) -> !riscv.reg
     "func.return"(%y) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.srliw"(%sx) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -35,7 +35,7 @@
   }) : () -> ()
 
   // `zextw` reads only bits 31:0, so a `sextw` feeding it is redundant too.
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f4"}> ({
   ^bb0(%x: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.zextw"(%sx) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/drop_sextw_sw.mlir
+++ b/Test/Passes/RISCVCombines/drop_sextw_sw.mlir
@@ -6,14 +6,14 @@
 // pointer and must be left untouched, even if it too is fed by a `riscv.sextw`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "foo"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %sval = "riscv.sextw"(%val) : (!riscv.reg) -> !riscv.reg
     "riscv.sw"(%addr, %sval) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "bar"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %saddr = "riscv.sextw"(%addr) : (!riscv.reg) -> !riscv.reg
     %sval = "riscv.sextw"(%val) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/drop_slli_srli_bool.mlir
+++ b/Test/Passes/RISCVCombines/drop_slli_srli_bool.mlir
@@ -5,7 +5,7 @@
 // bit 63, and `srli 63` moves it straight back -- an identity for such `X`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %c = "riscv.sltu"(%x, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %s = "riscv.slli"(%c) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -13,7 +13,7 @@
     "func.return"(%r) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %c = "riscv.slt"(%x, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %s = "riscv.slli"(%c) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -21,7 +21,7 @@
     "func.return"(%r) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg):
     %c = "riscv.sltiu"(%x) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
     %s = "riscv.slli"(%c) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -29,7 +29,7 @@
     "func.return"(%r) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg):
     %c = "riscv.seqz"(%x) : (!riscv.reg) -> !riscv.reg
     %s = "riscv.slli"(%c) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -39,7 +39,7 @@
 
   // Negative case: the shifted value isn't known to be 0/1 (it's an ordinary
   // `add`), so the shift pair must stay.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f4"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %c = "riscv.add"(%x, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %s = "riscv.slli"(%c) <{"value" = 63 : i64}> : (!riscv.reg) -> !riscv.reg
@@ -48,7 +48,7 @@
   }) : () -> ()
 
   // Negative case: wrong shift amount (not width-1) must not be touched.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f5"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %c = "riscv.sltu"(%x, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
     %s = "riscv.slli"(%c) <{"value" = 62 : i64}> : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/drop_zextw_low_word.mlir
+++ b/Test/Passes/RISCVCombines/drop_zextw_low_word.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=riscv-combine | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %zy = "riscv.zextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -9,28 +9,28 @@
     "func.return"(%sum) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.addiw"(%zx) <{"value" = 1 : i64}> : (!riscv.reg) -> !riscv.reg
     "func.return"(%y) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.roriw"(%zx) <{"value" = 7 : i64}> : (!riscv.reg) -> !riscv.reg
     "func.return"(%y) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.srliw"(%zx) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
     "func.return"(%y) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f4"}> ({
   ^bb0(%x: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %y = "riscv.sextw"(%zx) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/drop_zextw_sw.mlir
+++ b/Test/Passes/RISCVCombines/drop_zextw_sw.mlir
@@ -6,14 +6,14 @@
 // fed by a `riscv.zextw`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "foo"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %zval = "riscv.zextw"(%val) : (!riscv.reg) -> !riscv.reg
     "riscv.sw"(%addr, %zval) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "bar"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %zaddr = "riscv.zextw"(%addr) : (!riscv.reg) -> !riscv.reg
     %zval = "riscv.zextw"(%val) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/ext_bitwise_byte_half.mlir
+++ b/Test/Passes/RISCVCombines/ext_bitwise_byte_half.mlir
@@ -8,7 +8,7 @@
 
 "builtin.module"() ({
   // zextb + and: one guarded operand suffices.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextb"(%x) : (!riscv.reg) -> !riscv.reg
     %a = "riscv.and"(%zx, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -17,7 +17,7 @@
   }) : () -> ()
 
   // zexth + or: both operands guarded.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zexth"(%x) : (!riscv.reg) -> !riscv.reg
     %zy = "riscv.zexth"(%y) : (!riscv.reg) -> !riscv.reg
@@ -27,7 +27,7 @@
   }) : () -> ()
 
   // sextb + xor: both operands guarded.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextb"(%x) : (!riscv.reg) -> !riscv.reg
     %sy = "riscv.sextb"(%y) : (!riscv.reg) -> !riscv.reg
@@ -37,7 +37,7 @@
   }) : () -> ()
 
   // sexth + and: both operands guarded (sign-extension needs both even for `and`).
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sexth"(%x) : (!riscv.reg) -> !riscv.reg
     %sy = "riscv.sexth"(%y) : (!riscv.reg) -> !riscv.reg
@@ -47,7 +47,7 @@
   }) : () -> ()
 
   // Negative: `or` needs both operands guarded -- one `zextb` is not enough.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f4"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextb"(%x) : (!riscv.reg) -> !riscv.reg
     %o = "riscv.or"(%zx, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -56,7 +56,7 @@
   }) : () -> ()
 
   // Negative: a *sign*-extension needs both operands guarded even for `and`.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f5"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextb"(%x) : (!riscv.reg) -> !riscv.reg
     %a = "riscv.and"(%sx, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/ext_idempotent_byte_half.mlir
+++ b/Test/Passes/RISCVCombines/ext_idempotent_byte_half.mlir
@@ -4,28 +4,28 @@
 // idempotent, so the redundant outer one is dropped.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg):
     %i = "riscv.zextb"(%x) : (!riscv.reg) -> !riscv.reg
     %o = "riscv.zextb"(%i) : (!riscv.reg) -> !riscv.reg
     "func.return"(%o) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg):
     %i = "riscv.zexth"(%x) : (!riscv.reg) -> !riscv.reg
     %o = "riscv.zexth"(%i) : (!riscv.reg) -> !riscv.reg
     "func.return"(%o) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg):
     %i = "riscv.sextb"(%x) : (!riscv.reg) -> !riscv.reg
     %o = "riscv.sextb"(%i) : (!riscv.reg) -> !riscv.reg
     "func.return"(%o) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg):
     %i = "riscv.sexth"(%x) : (!riscv.reg) -> !riscv.reg
     %o = "riscv.sexth"(%i) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/ext_li_byte_half.mlir
+++ b/Test/Passes/RISCVCombines/ext_li_byte_half.mlir
@@ -7,7 +7,7 @@
 
 "builtin.module"() ({
   // zextb: 200 is in [0, 2^8) -> fold.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = 200 : i32}> : () -> !riscv.reg
     %z = "riscv.zextb"(%c) : (!riscv.reg) -> !riscv.reg
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // zexth: 1000 is in [0, 2^16) -> fold.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = 1000 : i32}> : () -> !riscv.reg
     %z = "riscv.zexth"(%c) : (!riscv.reg) -> !riscv.reg
@@ -23,7 +23,7 @@
   }) : () -> ()
 
   // sextb: -100 is in [-2^7, 2^7) -> fold.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = -100 : i32}> : () -> !riscv.reg
     %z = "riscv.sextb"(%c) : (!riscv.reg) -> !riscv.reg
@@ -31,7 +31,7 @@
   }) : () -> ()
 
   // sexth: -1000 is in [-2^15, 2^15) -> fold.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = -1000 : i32}> : () -> !riscv.reg
     %z = "riscv.sexth"(%c) : (!riscv.reg) -> !riscv.reg
@@ -40,7 +40,7 @@
 
   // Negative case: 200 is outside the *signed* byte range [-128, 128), so its
   // sign-extension differs -- the `sextb` must stay.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f4"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = 200 : i32}> : () -> !riscv.reg
     %z = "riscv.sextb"(%c) : (!riscv.reg) -> !riscv.reg
@@ -49,7 +49,7 @@
 
   // Negative case: a negative immediate is sign-extended, so bits above the byte
   // aren't clear -- the `zextb` must stay.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f5"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = -1 : i32}> : () -> !riscv.reg
     %z = "riscv.zextb"(%c) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/ext_store_byte_half.mlir
+++ b/Test/Passes/RISCVCombines/ext_store_byte_half.mlir
@@ -5,28 +5,28 @@
 // matching-width extension feeding that operand is redundant and gets dropped.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "f0"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %zval = "riscv.zexth"(%val) : (!riscv.reg) -> !riscv.reg
     "riscv.sh"(%addr, %zval) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "f1"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %sval = "riscv.sexth"(%val) : (!riscv.reg) -> !riscv.reg
     "riscv.sh"(%addr, %sval) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "f2"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %zval = "riscv.zextb"(%val) : (!riscv.reg) -> !riscv.reg
     "riscv.sb"(%addr, %zval) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> ()}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> (), sym_name = "f3"}> ({
   ^bb0(%addr: !riscv.reg, %val: !riscv.reg):
     %sval = "riscv.sextb"(%val) : (!riscv.reg) -> !riscv.reg
     "riscv.sb"(%addr, %sval) <{"value" = 0 : i64}> : (!riscv.reg, !riscv.reg) -> ()

--- a/Test/Passes/RISCVCombines/ext_x0_byte_half.mlir
+++ b/Test/Passes/RISCVCombines/ext_x0_byte_half.mlir
@@ -4,28 +4,28 @@
 // hard-wired zero register `x0` (which reads as 0) is a no-op.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0():
     %x0 = "rv64.get_register"() : () -> !riscv.reg<x0>
     %z = "riscv.zextb"(%x0) : (!riscv.reg<x0>) -> !riscv.reg
     "func.return"(%z) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0():
     %x0 = "rv64.get_register"() : () -> !riscv.reg<x0>
     %z = "riscv.zexth"(%x0) : (!riscv.reg<x0>) -> !riscv.reg
     "func.return"(%z) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0():
     %x0 = "rv64.get_register"() : () -> !riscv.reg<x0>
     %z = "riscv.sextb"(%x0) : (!riscv.reg<x0>) -> !riscv.reg
     "func.return"(%z) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0():
     %x0 = "rv64.get_register"() : () -> !riscv.reg<x0>
     %z = "riscv.sexth"(%x0) : (!riscv.reg<x0>) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/funnel_shift_left_zero.mlir
+++ b/Test/Passes/RISCVCombines/funnel_shift_left_zero.mlir
@@ -3,7 +3,7 @@
 // `fshl x, y, 0` is `x`: a funnel shift left by zero returns the high operand.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %r = "llvm.intr.fshl"(%x, %y, %z) : (i64, i64, i64) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the shift amount is nonzero, so the funnel shift stays.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %n = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %r = "llvm.intr.fshl"(%x, %y, %n) : (i64, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/funnel_shift_or_shift_to_funnel_shift_left.mlir
+++ b/Test/Passes/RISCVCombines/funnel_shift_or_shift_to_funnel_shift_left.mlir
@@ -4,7 +4,7 @@
 // plain shift is subsumed by the funnel shift.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32, %z: i32, %y: i32):
     %f = "llvm.intr.fshl"(%x, %z, %y) : (i32, i32, i32) -> i32
     %s = "llvm.shl"(%x, %y) : (i32, i32) -> i32
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Commuted operand order: shl on the left, fshl on the right.
-  "func.func"() <{function_type = (i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i32, %z: i32, %y: i32):
     %f = "llvm.intr.fshl"(%x, %z, %y) : (i32, i32, i32) -> i32
     %s = "llvm.shl"(%x, %y) : (i32, i32) -> i32
@@ -23,7 +23,7 @@
 
   // Negative case: the shl base differs from the funnel-shift data operand, so the
   // OR stays.
-  "func.func"() <{function_type = (i32, i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32, i32) -> i32, sym_name = "baz"}> ({
   ^bb0(%x: i32, %z: i32, %y: i32, %w: i32):
     %f = "llvm.intr.fshl"(%x, %z, %y) : (i32, i32, i32) -> i32
     %s = "llvm.shl"(%w, %y) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/funnel_shift_or_shift_to_funnel_shift_right.mlir
+++ b/Test/Passes/RISCVCombines/funnel_shift_or_shift_to_funnel_shift_right.mlir
@@ -4,7 +4,7 @@
 // plain shift is subsumed by the funnel shift.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%z: i32, %x: i32, %y: i32):
     %f = "llvm.intr.fshr"(%z, %x, %y) : (i32, i32, i32) -> i32
     %s = "llvm.lshr"(%x, %y) : (i32, i32) -> i32
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Commuted operand order: lshr on the left, fshr on the right.
-  "func.func"() <{function_type = (i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%z: i32, %x: i32, %y: i32):
     %f = "llvm.intr.fshr"(%z, %x, %y) : (i32, i32, i32) -> i32
     %s = "llvm.lshr"(%x, %y) : (i32, i32) -> i32
@@ -23,7 +23,7 @@
 
   // Negative case: the lshr base differs from the funnel-shift data operand, so the
   // OR stays.
-  "func.func"() <{function_type = (i32, i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32, i32) -> i32, sym_name = "baz"}> ({
   ^bb0(%z: i32, %x: i32, %y: i32, %w: i32):
     %f = "llvm.intr.fshr"(%z, %x, %y) : (i32, i32, i32) -> i32
     %s = "llvm.lshr"(%w, %y) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/funnel_shift_overshift.mlir
+++ b/Test/Passes/RISCVCombines/funnel_shift_overshift.mlir
@@ -6,7 +6,7 @@
 
 "builtin.module"() ({
   // fshl by 35 on i32 reduces the amount to 35 % 32 = 3.
-  "func.func"() <{function_type = (i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32, %y: i32):
     %c = "llvm.mlir.constant"() <{value = 35 : i32}> : () -> i32
     %r = "llvm.intr.fshl"(%x, %y, %c) : (i32, i32, i32) -> i32
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // fshr by 40 on i32 reduces the amount to 40 % 32 = 8.
-  "func.func"() <{function_type = (i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i32):
     %c = "llvm.mlir.constant"() <{value = 40 : i32}> : () -> i32
     %r = "llvm.intr.fshr"(%x, %y, %c) : (i32, i32, i32) -> i32
@@ -22,7 +22,7 @@
   }) : () -> ()
 
   // Negative case: the amount is already less than the width, so it stays.
-  "func.func"() <{function_type = (i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32) -> i32, sym_name = "baz"}> ({
   ^bb0(%x: i32, %y: i32):
     %c = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
     %r = "llvm.intr.fshl"(%x, %y, %c) : (i32, i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/funnel_shift_right_zero.mlir
+++ b/Test/Passes/RISCVCombines/funnel_shift_right_zero.mlir
@@ -3,7 +3,7 @@
 // `fshr x, y, 0` is `y`: a funnel shift right by zero returns the low operand.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %z = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %r = "llvm.intr.fshr"(%x, %y, %z) : (i64, i64, i64) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the shift amount is nonzero, so the funnel shift stays.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %n = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %r = "llvm.intr.fshr"(%x, %y, %n) : (i64, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/li_zero_to_x0.mlir
+++ b/Test/Passes/RISCVCombines/li_zero_to_x0.mlir
@@ -7,7 +7,7 @@
 // forwarded as a generic `!riscv.reg` block argument.
 
 "builtin.module"() ({
-    "func.func"() <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"() <{function_type = (!riscv.reg) -> (), sym_name = "foo"}> ({
     ^bb0(%x: !riscv.reg):
         %z = "riscv.li"() <{value = 0 : i64}> : () -> !riscv.reg
         %s = "riscv.slt"(%z, %x) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -17,7 +17,7 @@
     }) : () -> ()
 
     // A non-zero constant must be left untouched.
-    "func.func"() <{function_type = (!riscv.reg) -> ()}> ({
+    "func.func"() <{function_type = (!riscv.reg) -> (), sym_name = "bar"}> ({
     ^bb0(%x: !riscv.reg):
         %one = "riscv.li"() <{value = 1 : i64}> : () -> !riscv.reg
         %s = "riscv.slt"(%one, %x) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/lshr_left_to_zero.mlir
+++ b/Test/Passes/RISCVCombines/lshr_left_to_zero.mlir
@@ -3,7 +3,7 @@
 // `lshr 0, x` is `0`: logically shifting zero right by any amount is still zero.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %r = "llvm.lshr"(%zero, %x) : (i64, i64) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the shifted value is 1, not 0, so the shift is not eliminated.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
     %r = "llvm.lshr"(%one, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/lshr_of_trunc_of_lshr.mlir
+++ b/Test/Passes/RISCVCombines/lshr_of_trunc_of_lshr.mlir
@@ -4,7 +4,7 @@
 // right shifts compose at x's full width, then one trunc narrows the result.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i32}> ({
+  "func.func"() <{function_type = (i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %c1 = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
     %inner = "llvm.lshr"(%x, %c1) : (i64, i64) -> i64
@@ -15,7 +15,7 @@
   }) : () -> ()
 
   // Negative case: the outer shift amount is not a constant, so the pattern does not fire.
-  "func.func"() <{function_type = (i64, i32) -> i32}> ({
+  "func.func"() <{function_type = (i64, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %s: i32):
     %c1 = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
     %inner = "llvm.lshr"(%x, %c1) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/mul_left_to_zero.mlir
+++ b/Test/Passes/RISCVCombines/mul_left_to_zero.mlir
@@ -3,7 +3,7 @@
 // `mul 0, x` is `0`: multiplying by zero is always zero.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %r = "llvm.mul"(%zero, %x) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
 
   // Negative case: the left factor is 3, not 0, so the multiply is not eliminated.
   // (3 is not a power of two, so `mul_to_shl` does not fire either.)
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %three = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %r = "llvm.mul"(%three, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/mul_to_shl.mlir
+++ b/Test/Passes/RISCVCombines/mul_to_shl.mlir
@@ -3,7 +3,7 @@
 // `mul x, 2^k` is `shl x, k`: multiplication by a power of two is a shift.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 16 : i32}> : () -> i32
     %r = "llvm.mul"(%x, %c) : (i32, i32) -> i32
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: 3 is not a power of two, so the pattern does not fire.
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
     %r = "llvm.mul"(%x, %c) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/mulo_by_2_signed.mlir
+++ b/Test/Passes/RISCVCombines/mulo_by_2_signed.mlir
@@ -3,7 +3,7 @@
 // `mul x, 2` becomes `add x, x`; the constant 2 must match exactly.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %c2 = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64
     %r = "llvm.mul"(%x, %c2) : (i64, i64) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: multiplying by 3 does not fold to a self-add.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %c3 = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %r = "llvm.mul"(%x, %c3) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/narrow_binop_add.mlir
+++ b/Test/Passes/RISCVCombines/narrow_binop_add.mlir
@@ -5,7 +5,7 @@
 // the add redone at the narrow width. The constant operand must be second.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i32}> ({
+  "func.func"() <{function_type = (i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %c = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
     %add = "llvm.add"(%x, %c) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: the second operand is not a constant, so the pattern does not fire.
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.trunc"(%add) : (i64) -> i32

--- a/Test/Passes/RISCVCombines/narrow_binop_mul.mlir
+++ b/Test/Passes/RISCVCombines/narrow_binop_mul.mlir
@@ -5,7 +5,7 @@
 // mul redone at the narrow width. The constant operand must be second.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i32}> ({
+  "func.func"() <{function_type = (i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %c = "llvm.mlir.constant"() <{value = 3 : i64}> : () -> i64
     %mul = "llvm.mul"(%x, %c) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: the second operand is not a constant, so the pattern does not fire.
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %mul = "llvm.mul"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.trunc"(%mul) : (i64) -> i32

--- a/Test/Passes/RISCVCombines/narrow_binop_sub.mlir
+++ b/Test/Passes/RISCVCombines/narrow_binop_sub.mlir
@@ -5,7 +5,7 @@
 // sub redone at the narrow width. The constant operand must be second.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i32}> ({
+  "func.func"() <{function_type = (i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %c = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
     %sub = "llvm.sub"(%x, %c) : (i64, i64) -> i64
@@ -14,7 +14,7 @@
   }) : () -> ()
 
   // Negative case: the second operand is not a constant, so the pattern does not fire.
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %sub = "llvm.sub"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.trunc"(%sub) : (i64) -> i32

--- a/Test/Passes/RISCVCombines/not_cmp_fold_eq.mlir
+++ b/Test/Passes/RISCVCombines/not_cmp_fold_eq.mlir
@@ -4,7 +4,7 @@
 // `icmp ne X Y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %cmp = "llvm.icmp"(%x, %y) <{predicate = 0 : i64}> : (i64, i64) -> i1
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
@@ -14,7 +14,7 @@
 
   // Negative case: xor with 1 (not all-ones for a wider type) — here the value is
   // still on i1 but xored against a non-icmp, so nothing folds.
-  "func.func"() <{function_type = (i64, i64, i1) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i1) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %b: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %r = "llvm.xor"(%b, %m1) : (i1, i1) -> i1

--- a/Test/Passes/RISCVCombines/not_cmp_fold_ne.mlir
+++ b/Test/Passes/RISCVCombines/not_cmp_fold_ne.mlir
@@ -4,7 +4,7 @@
 // `icmp eq X Y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %cmp = "llvm.icmp"(%x, %y) <{predicate = 1 : i64}> : (i64, i64) -> i1
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
@@ -14,7 +14,7 @@
 
   // Negative case: xor with 1 (not all-ones for a wider type) — here the value is
   // still on i1 but xored against a non-icmp, so nothing folds.
-  "func.func"() <{function_type = (i64, i64, i1) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i1) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %b: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %r = "llvm.xor"(%b, %m1) : (i1, i1) -> i1

--- a/Test/Passes/RISCVCombines/not_cmp_fold_sge.mlir
+++ b/Test/Passes/RISCVCombines/not_cmp_fold_sge.mlir
@@ -4,7 +4,7 @@
 // `icmp slt X Y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %cmp = "llvm.icmp"(%x, %y) <{predicate = 5 : i64}> : (i64, i64) -> i1
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
@@ -14,7 +14,7 @@
 
   // Negative case: xor with 1 (not all-ones for a wider type) — here the value is
   // still on i1 but xored against a non-icmp, so nothing folds.
-  "func.func"() <{function_type = (i64, i64, i1) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i1) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %b: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %r = "llvm.xor"(%b, %m1) : (i1, i1) -> i1

--- a/Test/Passes/RISCVCombines/not_cmp_fold_sgt.mlir
+++ b/Test/Passes/RISCVCombines/not_cmp_fold_sgt.mlir
@@ -4,7 +4,7 @@
 // `icmp sle X Y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %cmp = "llvm.icmp"(%x, %y) <{predicate = 4 : i64}> : (i64, i64) -> i1
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
@@ -14,7 +14,7 @@
 
   // Negative case: xor with 1 (not all-ones for a wider type) — here the value is
   // still on i1 but xored against a non-icmp, so nothing folds.
-  "func.func"() <{function_type = (i64, i64, i1) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i1) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %b: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %r = "llvm.xor"(%b, %m1) : (i1, i1) -> i1

--- a/Test/Passes/RISCVCombines/not_cmp_fold_uge.mlir
+++ b/Test/Passes/RISCVCombines/not_cmp_fold_uge.mlir
@@ -4,7 +4,7 @@
 // `icmp ult X Y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %cmp = "llvm.icmp"(%x, %y) <{predicate = 9 : i64}> : (i64, i64) -> i1
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
@@ -14,7 +14,7 @@
 
   // Negative case: xor with 1 (not all-ones for a wider type) — here the value is
   // still on i1 but xored against a non-icmp, so nothing folds.
-  "func.func"() <{function_type = (i64, i64, i1) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i1) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %b: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %r = "llvm.xor"(%b, %m1) : (i1, i1) -> i1

--- a/Test/Passes/RISCVCombines/not_cmp_fold_ugt.mlir
+++ b/Test/Passes/RISCVCombines/not_cmp_fold_ugt.mlir
@@ -4,7 +4,7 @@
 // `icmp ule X Y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %cmp = "llvm.icmp"(%x, %y) <{predicate = 8 : i64}> : (i64, i64) -> i1
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
@@ -14,7 +14,7 @@
 
   // Negative case: xor with 1 (not all-ones for a wider type) — here the value is
   // still on i1 but xored against a non-icmp, so nothing folds.
-  "func.func"() <{function_type = (i64, i64, i1) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i1) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %b: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %r = "llvm.xor"(%b, %m1) : (i1, i1) -> i1

--- a/Test/Passes/RISCVCombines/or_and_xor_to_xor_or.mlir
+++ b/Test/Passes/RISCVCombines/or_and_xor_to_xor_or.mlir
@@ -3,7 +3,7 @@
 // `(X & Y) | ~Y` is `X | ~Y`: the `& Y` is redundant once `~Y` is or'd in.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
     %and = "llvm.and"(%x, %y) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: the xor constant is -2, not -1, so `noty` is not `~Y`.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %m2 = "llvm.mlir.constant"() <{value = -2 : i64}> : () -> i64
     %and = "llvm.and"(%x, %y) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/redundant_binop_in_equality_XMinusYEqX.mlir
+++ b/Test/Passes/RISCVCombines/redundant_binop_in_equality_XMinusYEqX.mlir
@@ -4,7 +4,7 @@
 // cancels out of the comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %op = "llvm.sub"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %x) <{predicate = 0 : i64}> : (i64, i64) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the comparison's RHS is not the shared operand of the binop.
-  "func.func"() <{function_type = (i64, i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %op = "llvm.sub"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %w) <{predicate = 0 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/redundant_binop_in_equality_XMinusYNeX.mlir
+++ b/Test/Passes/RISCVCombines/redundant_binop_in_equality_XMinusYNeX.mlir
@@ -4,7 +4,7 @@
 // cancels out of the comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %op = "llvm.sub"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %x) <{predicate = 1 : i64}> : (i64, i64) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the comparison's RHS is not the shared operand of the binop.
-  "func.func"() <{function_type = (i64, i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %op = "llvm.sub"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %w) <{predicate = 1 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/redundant_binop_in_equality_XPlusYEqX.mlir
+++ b/Test/Passes/RISCVCombines/redundant_binop_in_equality_XPlusYEqX.mlir
@@ -4,7 +4,7 @@
 // cancels out of the comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %op = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %x) <{predicate = 0 : i64}> : (i64, i64) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the comparison's RHS is not the shared operand of the binop.
-  "func.func"() <{function_type = (i64, i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %op = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %w) <{predicate = 0 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/redundant_binop_in_equality_XPlusYNeX.mlir
+++ b/Test/Passes/RISCVCombines/redundant_binop_in_equality_XPlusYNeX.mlir
@@ -4,7 +4,7 @@
 // cancels out of the comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %op = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %x) <{predicate = 1 : i64}> : (i64, i64) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the comparison's RHS is not the shared operand of the binop.
-  "func.func"() <{function_type = (i64, i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %op = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %w) <{predicate = 1 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/redundant_binop_in_equality_XXorYEqX.mlir
+++ b/Test/Passes/RISCVCombines/redundant_binop_in_equality_XXorYEqX.mlir
@@ -4,7 +4,7 @@
 // cancels out of the comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %op = "llvm.xor"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %x) <{predicate = 0 : i64}> : (i64, i64) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the comparison's RHS is not the shared operand of the binop.
-  "func.func"() <{function_type = (i64, i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %op = "llvm.xor"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %w) <{predicate = 0 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/redundant_binop_in_equality_XXorYNeX.mlir
+++ b/Test/Passes/RISCVCombines/redundant_binop_in_equality_XXorYNeX.mlir
@@ -4,7 +4,7 @@
 // cancels out of the comparison.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64) -> i1, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %op = "llvm.xor"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %x) <{predicate = 1 : i64}> : (i64, i64) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the comparison's RHS is not the shared operand of the binop.
-  "func.func"() <{function_type = (i64, i64, i64) -> i1}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i1, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %op = "llvm.xor"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.icmp"(%op, %w) <{predicate = 1 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/RISCVCombines/select_0_1.mlir
+++ b/Test/Passes/RISCVCombines/select_0_1.mlir
@@ -3,7 +3,7 @@
 // `select c, 0, 1` is `zext (not c)`: the condition is inverted, then widened.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "foo"}> ({
   ^bb0(%c: i1):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: arms are 0 and 2, not 0 and 1.
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "bar"}> ({
   ^bb0(%c: i1):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %two = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/select_0_neg1.mlir
+++ b/Test/Passes/RISCVCombines/select_0_neg1.mlir
@@ -3,7 +3,7 @@
 // `select c, 0, -1` is `sext (not c)`: invert the condition, then sign-extend.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "foo"}> ({
   ^bb0(%c: i1):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %m1 = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: arms are 0 and 1, so this is select_0_1's shape (zext), not sext.
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "bar"}> ({
   ^bb0(%c: i1):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/select_1_0.mlir
+++ b/Test/Passes/RISCVCombines/select_1_0.mlir
@@ -3,7 +3,7 @@
 // `select c, 1, 0` is exactly `zext c` (a boolean widened to the result type).
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "foo"}> ({
   ^bb0(%c: i1):
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: arms are 2 and 0, not 1 and 0.
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "bar"}> ({
   ^bb0(%c: i1):
     %two = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/select_constant_cmp_false.mlir
+++ b/Test/Passes/RISCVCombines/select_constant_cmp_false.mlir
@@ -4,7 +4,7 @@
 // `(0 ? x : y) -> y`. The `select` is erased and its uses forwarded to `y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%t: i64, %f: i64):
     %c = "llvm.mlir.constant"() <{value = 0 : i1}> : () -> i1
     %r = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64
@@ -13,7 +13,7 @@
 
   // Negative case: a constant-`1` condition is handled by the `true` rule, not
   // this one -- here it must not fold to the false operand.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%t: i64, %f: i64):
     %c = "llvm.mlir.constant"() <{value = 1 : i1}> : () -> i1
     %r = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_constant_cmp_true.mlir
+++ b/Test/Passes/RISCVCombines/select_constant_cmp_true.mlir
@@ -4,7 +4,7 @@
 // `(1 ? x : y) -> x`. The `select` is erased and its uses forwarded to `x`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%t: i64, %f: i64):
     %c = "llvm.mlir.constant"() <{value = 1 : i1}> : () -> i1
     %r = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: a non-constant condition leaves the `select` in place.
-  "func.func"() <{function_type = (i1, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i1, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%c: i1, %t: i64, %f: i64):
     %r = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64
     "func.return"(%r) : (i64) -> ()

--- a/Test/Passes/RISCVCombines/select_neg1_0.mlir
+++ b/Test/Passes/RISCVCombines/select_neg1_0.mlir
@@ -3,7 +3,7 @@
 // `select c, -1, 0` is `sext c` (all-ones when true, zero when false).
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "foo"}> ({
   ^bb0(%c: i1):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: arms are 1 and 0, not -1 and 0 (that is select_1_0's shape).
-  "func.func"() <{function_type = (i1) -> i64}> ({
+  "func.func"() <{function_type = (i1) -> i64, sym_name = "bar"}> ({
   ^bb0(%c: i1):
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/select_not.mlir
+++ b/Test/Passes/RISCVCombines/select_not.mlir
@@ -3,7 +3,7 @@
 // `select (not c), x, y` is `select c, y, x`: folding the not into swapped arms.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i1, i32, i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%c: i1, %x: i32, %y: i32):
     %m1 = "llvm.mlir.constant"() <{value = -1 : i1}> : () -> i1
     %nc = "llvm.xor"(%c, %m1) : (i1, i1) -> i1
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the condition is not a `not` (xor with -1), so the pattern does not fire.
-  "func.func"() <{function_type = (i1, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i1, i32, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%c: i1, %x: i32, %y: i32):
     %r = "llvm.select"(%c, %x, %y) : (i1, i32, i32) -> i32
     "func.return"(%r) : (i32) -> ()

--- a/Test/Passes/RISCVCombines/select_of_truncate_rw.mlir
+++ b/Test/Passes/RISCVCombines/select_of_truncate_rw.mlir
@@ -4,7 +4,7 @@
 // `trunc (select c, t, f) -> select c, (trunc t), (trunc f)`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1, i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i1, i64, i64) -> i32, sym_name = "foo"}> ({
   ^bb0(%c: i1, %t: i64, %f: i64):
     %s = "llvm.select"(%c, %t, %f) : (i1, i64, i64) -> i64
     %r = "llvm.trunc"(%s) : (i64) -> i32
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the trunc feeds an add, not a select.
-  "func.func"() <{function_type = (i64, i64) -> i32}> ({
+  "func.func"() <{function_type = (i64, i64) -> i32, sym_name = "bar"}> ({
   ^bb0(%a: i64, %b: i64):
     %s = "llvm.add"(%a, %b) : (i64, i64) -> i64
     %r = "llvm.trunc"(%s) : (i64) -> i32

--- a/Test/Passes/RISCVCombines/select_of_zext_rw.mlir
+++ b/Test/Passes/RISCVCombines/select_of_zext_rw.mlir
@@ -4,7 +4,7 @@
 // `zext (select c, t, f) -> select c, (zext t), (zext f)`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1, i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i1, i32, i32) -> i64, sym_name = "foo"}> ({
   ^bb0(%c: i1, %t: i32, %f: i32):
     %s = "llvm.select"(%c, %t, %f) : (i1, i32, i32) -> i32
     %z = "llvm.zext"(%s) : (i32) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the zext feeds an add, not a select.
-  "func.func"() <{function_type = (i32, i32) -> i64}> ({
+  "func.func"() <{function_type = (i32, i32) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i32, %b: i32):
     %s = "llvm.add"(%a, %b) : (i32, i32) -> i32
     %z = "llvm.zext"(%s) : (i32) -> i64

--- a/Test/Passes/RISCVCombines/select_same_val_self.mlir
+++ b/Test/Passes/RISCVCombines/select_same_val_self.mlir
@@ -5,14 +5,14 @@
 // dead condition) can be dropped.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i1, i64) -> i64}> ({
+  "func.func"() <{function_type = (i1, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%c: i1, %x: i64):
     %r = "llvm.select"(%c, %x, %x) : (i1, i64, i64) -> i64
     "func.return"(%r) : (i64) -> ()
   }) : () -> ()
 
   // Negative case: distinct arms, so the `select` must stay.
-  "func.func"() <{function_type = (i1, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i1, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%c: i1, %x: i64, %y: i64):
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
     "func.return"(%r) : (i64) -> ()

--- a/Test/Passes/RISCVCombines/select_to_iminmax_sge.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_sge.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 5 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 5 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_sgt.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_sgt.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 4 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 4 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_sle.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_sle.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 3 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 3 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_slt.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_slt.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 2 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 2 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_uge.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_uge.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 9 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 9 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_ugt.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_ugt.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 8 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 8 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_ule.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_ule.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 7 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 7 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/select_to_iminmax_ult.mlir
+++ b/Test/Passes/RISCVCombines/select_to_iminmax_ult.mlir
@@ -4,7 +4,7 @@
 // must be exactly the select's true/false values.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 6 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %y) : (i1, i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the compared operands don't match the select operands.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %z: i64):
     %c = "llvm.icmp"(%x, %y) <{predicate = 6 : i64}> : (i64, i64) -> i1
     %r = "llvm.select"(%c, %x, %z) : (i1, i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/sext_of_sext.mlir
+++ b/Test/Passes/RISCVCombines/sext_of_sext.mlir
@@ -3,7 +3,7 @@
 // `sext (sext x)` collapses to a single `sext x` to the outer width.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i8) -> i64}> ({
+  "func.func"() <{function_type = (i8) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i8):
     %s0 = "llvm.sext"(%x) : (i8) -> i32
     %s1 = "llvm.sext"(%s0) : (i32) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: a single sext is left alone.
-  "func.func"() <{function_type = (i8) -> i64}> ({
+  "func.func"() <{function_type = (i8) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i8):
     %s = "llvm.sext"(%x) : (i8) -> i64
     "func.return"(%s) : (i64) -> ()

--- a/Test/Passes/RISCVCombines/sextw_bitwise.mlir
+++ b/Test/Passes/RISCVCombines/sextw_bitwise.mlir
@@ -5,7 +5,7 @@
 // if each operand's bits 63:32 already equal its bit 31, so do the result's.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %sy = "riscv.sextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -14,7 +14,7 @@
     "func.return"(%sa) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %sy = "riscv.sextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -23,7 +23,7 @@
     "func.return"(%so) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %sy = "riscv.sextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -34,7 +34,7 @@
 
   // Negative case: only one operand is `sextw`-guarded, so the result's upper
   // bits aren't known to match bit 31 -- the outer `sextw` must stay.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %sx = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %e = "riscv.xor"(%sx, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/sextw_li_low32.mlir
+++ b/Test/Passes/RISCVCombines/sextw_li_low32.mlir
@@ -6,7 +6,7 @@
 // unlike the unsigned range of `zextw_li_low32`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "foo"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = 16 : i32}> : () -> !riscv.reg
     %s = "riscv.sextw"(%c) : (!riscv.reg) -> !riscv.reg
@@ -15,7 +15,7 @@
 
   // A negative immediate is fine here: -1 is already sign-extended, so `sextw`
   // is redundant (this is where the sext range differs from the zext one).
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "bar"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = -1 : i32}> : () -> !riscv.reg
     %s = "riscv.sextw"(%c) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/sextw_sextw.mlir
+++ b/Test/Passes/RISCVCombines/sextw_sextw.mlir
@@ -3,7 +3,7 @@
 // Sign extension is idempotent: `riscv.sextw (riscv.sextw x) -> riscv.sextw x`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "foo"}> ({
   ^bb0(%x: !riscv.reg):
     %inner = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     %outer = "riscv.sextw"(%inner) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/sextw_x0.mlir
+++ b/Test/Passes/RISCVCombines/sextw_x0.mlir
@@ -4,7 +4,7 @@
 // reads as 0, and 0 is its own sign-extension.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "foo"}> ({
   ^bb0():
     %x0 = "rv64.get_register"() : () -> !riscv.reg<x0>
     %s = "riscv.sextw"(%x0) : (!riscv.reg<x0>) -> !riscv.reg
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: a plain (non-`x0`-typed) register must be left alone.
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "bar"}> ({
   ^bb0(%x: !riscv.reg):
     %s = "riscv.sextw"(%x) : (!riscv.reg) -> !riscv.reg
     "func.return"(%s) : (!riscv.reg) -> ()

--- a/Test/Passes/RISCVCombines/shl_left_to_zero.mlir
+++ b/Test/Passes/RISCVCombines/shl_left_to_zero.mlir
@@ -3,7 +3,7 @@
 // `shl 0, x` is `0`: shifting zero left by any amount is still zero.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %zero = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
     %r = "llvm.shl"(%zero, %x) : (i64, i64) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the shifted value is 1, not 0, so the shift is not eliminated.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64):
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
     %r = "llvm.shl"(%one, %x) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/sub_add_reg_x_add_y_sub_x.mlir
+++ b/Test/Passes/RISCVCombines/sub_add_reg_x_add_y_sub_x.mlir
@@ -4,7 +4,7 @@
 // is erased and its uses forwarded to `y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %s = "llvm.sub"(%add, %x) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the subtrahend is not the `add`'s first operand, so no fold.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %s = "llvm.sub"(%add, %w) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/sub_add_reg_x_add_y_sub_y.mlir
+++ b/Test/Passes/RISCVCombines/sub_add_reg_x_add_y_sub_y.mlir
@@ -4,7 +4,7 @@
 // is erased and its uses forwarded to `x`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %s = "llvm.sub"(%add, %y) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the subtrahend is not the `add`'s second operand, so no fold.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %s = "llvm.sub"(%add, %w) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/sub_add_reg_x_sub_x_add_y.mlir
+++ b/Test/Passes/RISCVCombines/sub_add_reg_x_sub_x_add_y.mlir
@@ -4,7 +4,7 @@
 // as `0 - y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %s = "llvm.sub"(%x, %add) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the minuend is not the `add`'s first operand, so no fold.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %add = "llvm.add"(%x, %y) : (i64, i64) -> i64
     %s = "llvm.sub"(%w, %add) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/sub_add_reg_x_sub_y_add_x.mlir
+++ b/Test/Passes/RISCVCombines/sub_add_reg_x_sub_y_add_x.mlir
@@ -4,7 +4,7 @@
 // as `0 - y`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %add = "llvm.add"(%y, %x) : (i64, i64) -> i64
     %s = "llvm.sub"(%x, %add) : (i64, i64) -> i64
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the minuend is not the `add`'s second operand, so no fold.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %add = "llvm.add"(%y, %x) : (i64, i64) -> i64
     %s = "llvm.sub"(%w, %add) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/sub_of_mul_const.mlir
+++ b/Test/Passes/RISCVCombines/sub_of_mul_const.mlir
@@ -3,7 +3,7 @@
 // `sub a, (mul x, C)` is `add a, (mul x, -C)` when C is a constant.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%a: i32, %x: i32):
     %c = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
     %m = "llvm.mul"(%x, %c) : (i32, i32) -> i32
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: the mul's second operand is not a constant, so the pattern does not fire.
-  "func.func"() <{function_type = (i32, i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%a: i32, %x: i32, %y: i32):
     %m = "llvm.mul"(%x, %y) : (i32, i32) -> i32
     %r = "llvm.sub"(%a, %m) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/sub_one_from_sub_rw.mlir
+++ b/Test/Passes/RISCVCombines/sub_one_from_sub_rw.mlir
@@ -4,7 +4,7 @@
 // `add (xor B, -1), A`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%a: i64, %b: i64):
     %sub = "llvm.sub"(%a, %b) : (i64, i64) -> i64
     %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
@@ -13,7 +13,7 @@
   }) : () -> ()
 
   // Negative case: subtracting 2 (not 1) from the inner sub does not match.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%a: i64, %b: i64):
     %sub = "llvm.sub"(%a, %b) : (i64, i64) -> i64
     %two = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64

--- a/Test/Passes/RISCVCombines/sub_to_add.mlir
+++ b/Test/Passes/RISCVCombines/sub_to_add.mlir
@@ -3,7 +3,7 @@
 // `sub x, C` is `add x, -C` when the second operand is a constant.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 7 : i32}> : () -> i32
     %r = "llvm.sub"(%x, %c) : (i32, i32) -> i32
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the second operand is not a constant, so the pattern does not fire.
-  "func.func"() <{function_type = (i32, i32) -> i32}> ({
+  "func.func"() <{function_type = (i32, i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i32, %y: i32):
     %r = "llvm.sub"(%x, %y) : (i32, i32) -> i32
     "func.return"(%r) : (i32) -> ()

--- a/Test/Passes/RISCVCombines/trunc_of_zext.mlir
+++ b/Test/Passes/RISCVCombines/trunc_of_zext.mlir
@@ -3,7 +3,7 @@
 // `trunc (zext x)` that round-trips back to `x`'s type folds to `x`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %z = "llvm.zext"(%x) : (i32) -> i64
     %t = "llvm.trunc"(%z) : (i64) -> i32
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the trunc target width doesn't match x's width (i32 -> i16).
-  "func.func"() <{function_type = (i32) -> i16}> ({
+  "func.func"() <{function_type = (i32) -> i16, sym_name = "bar"}> ({
   ^bb0(%x: i32):
     %z = "llvm.zext"(%x) : (i32) -> i64
     %t = "llvm.trunc"(%z) : (i64) -> i16

--- a/Test/Passes/RISCVCombines/truncate_of_sext.mlir
+++ b/Test/Passes/RISCVCombines/truncate_of_sext.mlir
@@ -3,7 +3,7 @@
 // `trunc (sext x)` that round-trips back to `x`'s type folds to `x`.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %s = "llvm.sext"(%x) : (i32) -> i64
     %t = "llvm.trunc"(%s) : (i64) -> i32
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: the trunc target width doesn't match x's width (i32 -> i16).
-  "func.func"() <{function_type = (i32) -> i16}> ({
+  "func.func"() <{function_type = (i32) -> i16, sym_name = "bar"}> ({
   ^bb0(%x: i32):
     %s = "llvm.sext"(%x) : (i32) -> i64
     %t = "llvm.trunc"(%s) : (i64) -> i16

--- a/Test/Passes/RISCVCombines/udiv_by_pow2.mlir
+++ b/Test/Passes/RISCVCombines/udiv_by_pow2.mlir
@@ -3,7 +3,7 @@
 // `udiv x, 2^k` is `lshr x, k`: unsigned division by a power of two is a shift.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
     %r = "llvm.udiv"(%x, %c) : (i32, i32) -> i32
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: 6 is not a power of two, so the pattern does not fire.
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 6 : i32}> : () -> i32
     %r = "llvm.udiv"(%x, %c) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/urem_pow2_to_mask.mlir
+++ b/Test/Passes/RISCVCombines/urem_pow2_to_mask.mlir
@@ -4,7 +4,7 @@
 // bitmask.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "foo"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
     %r = "llvm.urem"(%x, %c) : (i32, i32) -> i32
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: 6 is not a power of two, so the pattern does not fire.
-  "func.func"() <{function_type = (i32) -> i32}> ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "bar"}> ({
   ^bb0(%x: i32):
     %c = "llvm.mlir.constant"() <{value = 6 : i32}> : () -> i32
     %r = "llvm.urem"(%x, %c) : (i32, i32) -> i32

--- a/Test/Passes/RISCVCombines/xor_of_and_with_same_reg.mlir
+++ b/Test/Passes/RISCVCombines/xor_of_and_with_same_reg.mlir
@@ -4,7 +4,7 @@
 // i.e. `(~x) & y`. It rewrites to `and (xor x, -1), y` -- an `andn`-shaped form.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64, %y: i64):
     %a = "llvm.and"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.xor"(%a, %y) : (i64, i64) -> i64
@@ -13,7 +13,7 @@
 
   // Negative case: the `xor`'s second operand is not the `and`'s operand, so no
   // fold.
-  "func.func"() <{function_type = (i64, i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64, %w: i64):
     %a = "llvm.and"(%x, %y) : (i64, i64) -> i64
     %r = "llvm.xor"(%a, %w) : (i64, i64) -> i64

--- a/Test/Passes/RISCVCombines/xor_self_to_zero.mlir
+++ b/Test/Passes/RISCVCombines/xor_self_to_zero.mlir
@@ -6,14 +6,14 @@
 
 "builtin.module"() ({
   // Positive case: i64 `xor x x` folds to constant 0.
-  "func.func"() <{function_type = (i64) -> i64}> ({
+  "func.func"() <{function_type = (i64) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i64):
     %r = "llvm.xor"(%x, %x) : (i64, i64) -> i64
     "func.return"(%r) : (i64) -> ()
   }) : () -> ()
 
   // Negative case: distinct operands, so the rule must not fire.
-  "func.func"() <{function_type = (i64, i64) -> i64}> ({
+  "func.func"() <{function_type = (i64, i64) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i64, %y: i64):
     %r = "llvm.xor"(%x, %y) : (i64, i64) -> i64
     "func.return"(%r) : (i64) -> ()
@@ -21,12 +21,12 @@
 }) : () -> ()
 
 // The i64 `xor` is replaced by a constant zero; the operand is now dead.
-// CHECK:      "func.func"() <{"function_type" = (i64) -> i64}>
+// CHECK:      "func.func"() <{"function_type" = (i64) -> i64, "sym_name" = "foo"}>
 // CHECK:      %[[Z:.*]] = "llvm.mlir.constant"() <{"value" = 0 : i64}> : () -> i64
 // CHECK-NEXT: "func.return"(%[[Z]]) : (i64) -> ()
 
 // Distinct operands: the `xor` survives untouched.
-// CHECK:      "func.func"() <{"function_type" = (i64, i64) -> i64}>
+// CHECK:      "func.func"() <{"function_type" = (i64, i64) -> i64, "sym_name" = "bar"}>
 // CHECK:      ^{{.*}}(%[[DX:.*]] : i64, %[[DY:.*]] : i64):
 // CHECK-NEXT: %[[DR:.*]] = "llvm.xor"(%[[DX]], %[[DY]]) : (i64, i64) -> i64
 // CHECK-NEXT: "func.return"(%[[DR]]) : (i64) -> ()

--- a/Test/Passes/RISCVCombines/zext_of_zext.mlir
+++ b/Test/Passes/RISCVCombines/zext_of_zext.mlir
@@ -3,7 +3,7 @@
 // `zext (zext x)` collapses to a single `zext x` to the outer width.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (i8) -> i64}> ({
+  "func.func"() <{function_type = (i8) -> i64, sym_name = "foo"}> ({
   ^bb0(%x: i8):
     %z0 = "llvm.zext"(%x) : (i8) -> i32
     %z1 = "llvm.zext"(%z0) : (i32) -> i64
@@ -11,7 +11,7 @@
   }) : () -> ()
 
   // Negative case: a single zext is left alone.
-  "func.func"() <{function_type = (i8) -> i64}> ({
+  "func.func"() <{function_type = (i8) -> i64, sym_name = "bar"}> ({
   ^bb0(%x: i8):
     %z = "llvm.zext"(%x) : (i8) -> i64
     "func.return"(%z) : (i64) -> ()

--- a/Test/Passes/RISCVCombines/zextw_bitwise.mlir
+++ b/Test/Passes/RISCVCombines/zextw_bitwise.mlir
@@ -5,7 +5,7 @@
 // are then guaranteed clear already.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f0"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %zy = "riscv.zextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -14,7 +14,7 @@
     "func.return"(%za) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f1"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %zy = "riscv.zextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -23,7 +23,7 @@
     "func.return"(%zo) : (!riscv.reg) -> ()
   }) : () -> ()
 
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f2"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %zy = "riscv.zextw"(%y) : (!riscv.reg) -> !riscv.reg
@@ -35,7 +35,7 @@
   // `and` only needs *one* `zextw`-guarded operand: `and` clears a result bit
   // whenever either operand's bit is clear, so bits 63:32 of the `and` are known
   // clear even though `%y` is unguarded -- the outer `zextw` folds away.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f3"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %a = "riscv.and"(%zx, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -46,7 +46,7 @@
   // Negative case: `xor` (unlike `and`) needs *both* operands `zextw`-guarded;
   // with only one, the result's upper bits aren't known clear -- the outer
   // `zextw` must stay.
-  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg, !riscv.reg) -> !riscv.reg, sym_name = "f4"}> ({
   ^bb0(%x: !riscv.reg, %y: !riscv.reg):
     %zx = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %e = "riscv.xor"(%zx, %y) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/zextw_li_low32.mlir
+++ b/Test/Passes/RISCVCombines/zextw_li_low32.mlir
@@ -4,7 +4,7 @@
 // materialized 64-bit value already has bits 63:32 clear in that range.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "foo"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = 16 : i32}> : () -> !riscv.reg
     %z = "riscv.zextw"(%c) : (!riscv.reg) -> !riscv.reg
@@ -13,7 +13,7 @@
 
   // Negative case: a negative immediate's 64-bit materialization does *not*
   // have bits 63:32 clear (it's sign-extended), so the `zextw` must stay.
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "bar"}> ({
   ^bb0():
     %c = "riscv.li"() <{"value" = -1 : i32}> : () -> !riscv.reg
     %z = "riscv.zextw"(%c) : (!riscv.reg) -> !riscv.reg

--- a/Test/Passes/RISCVCombines/zextw_x0.mlir
+++ b/Test/Passes/RISCVCombines/zextw_x0.mlir
@@ -4,7 +4,7 @@
 // reads as 0, so it already has bits 63:32 clear.
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> !riscv.reg}> ({
+  "func.func"() <{function_type = () -> !riscv.reg, sym_name = "foo"}> ({
   ^bb0():
     %x0 = "rv64.get_register"() : () -> !riscv.reg<x0>
     %z = "riscv.zextw"(%x0) : (!riscv.reg<x0>) -> !riscv.reg
@@ -12,7 +12,7 @@
   }) : () -> ()
 
   // Negative case: a plain (non-`x0`-typed) register must be left alone.
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "bar"}> ({
   ^bb0(%x: !riscv.reg):
     %z = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     "func.return"(%z) : (!riscv.reg) -> ()

--- a/Test/Passes/RISCVCombines/zextw_zextw.mlir
+++ b/Test/Passes/RISCVCombines/zextw_zextw.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s -p=riscv-combine | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg}> ({
+  "func.func"() <{function_type = (!riscv.reg) -> !riscv.reg, sym_name = "foo"}> ({
   ^bb0(%x: !riscv.reg):
     %inner = "riscv.zextw"(%x) : (!riscv.reg) -> !riscv.reg
     %outer = "riscv.zextw"(%inner) : (!riscv.reg) -> !riscv.reg

--- a/Test/RISCV_Cf/branches.mlir
+++ b/Test/RISCV_Cf/branches.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   ^4():
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "foo"}> ({
       ^6(%arg6_0 : i32):
         "riscv_cf.branch"(%arg6_0) [^7] : (i32) -> ()
       ^7(%arg7_0 : i32):
@@ -20,7 +20,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> ()}> ({
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> (), "sym_name" = "foo"}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:         "riscv_cf.branch"(%{{.*}}) [^[[b_blt:.*]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[b_blt]](%{{.*}} : i32):

--- a/Test/RISCV_Cf/identity.mlir
+++ b/Test/RISCV_Cf/identity.mlir
@@ -2,7 +2,7 @@
 
 "builtin.module"() ({
   ^4():
-    "func.func"()  <{function_type = (i32) -> ()}> ({
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "foo"}> ({
       ^6(%arg6_0 : i32):
         "riscv_cf.branch"(%arg6_0) [^7] : (i32) -> ()
       ^7(%arg7_0 : i32):
@@ -16,7 +16,7 @@
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> ()}> ({
+// CHECK-NEXT:     "func.func"() <{"function_type" = (i32) -> (), "sym_name" = "foo"}> ({
 // CHECK-NEXT:       ^{{.*}}(%{{.*}} : i32):
 // CHECK-NEXT:         "riscv_cf.branch"(%{{.*}}) [^[[b1:.*]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[b1]](%{{.*}} : i32):

--- a/Test/Verifier/func_func_missing_sym_name.mlir
+++ b/Test/Verifier/func_func_missing_sym_name.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> ()}> ({
+  ^bb0():
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected symbol name

--- a/Test/Verifier/llvm_func_missing_sym_name.mlir
+++ b/Test/Verifier/llvm_func_missing_sym_name.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>}> ({
+  ^bb0():
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected symbol name

--- a/Test/Verifier/module_body_no_terminator.mlir
+++ b/Test/Verifier/module_body_no_terminator.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-opt %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> ()}> ({
+  "func.func"() <{function_type = () -> (), sym_name="foo"}> ({
   ^bb0():
     "func.return"() : () -> ()
   }) : () -> ()

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -506,6 +506,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     if (FunctionOpInterface.getFunctionType? op ctx.raw).isNone then
       throw "Expected function type"
+    if (FunctionOpInterface.getSymName? op ctx.raw).isNone then
+      throw "Expected symbol name"
     pure ()
   | .func .call => do
     if op.getNumRegions ctx.raw opIn ≠ 0 then
@@ -668,6 +670,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 successors"
     if (FunctionOpInterface.getFunctionType? op ctx.raw).isNone then
       throw "Expected function type"
+    if (FunctionOpInterface.getSymName? op ctx.raw).isNone then
+      throw "Expected symbol name"
     pure ()
   | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => do
     op.verifyPlainOpCounts ctx opIn 2 1


### PR DESCRIPTION
`func.func` and `llvm.func` require the `sym_name` attribute, but this is not currently enforced and many tests do not declare it.
This is now enforced by the verifier.

This PR is split into two commits to make review easier:
The first adds the check itself and tests for the expected error message.

The second updates existing tests that were missing `sym_name`.
This was automated with a script: functions are now named `foo`, `bar`, `baz`, or `f0`, `f1`, ... when there are more than three.