### PR TITLE
feat(dominance): Add `hasSSADominance` to `OpInfo`

### DIFF
--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -41,8 +41,26 @@ match opCode with
 instance : HasDialectOpInfo OpCode where
   propertiesOf := _propertiesOf
 
+inductive RegionKind where
+| SSACFG
+| Graph
+deriving Inhabited, Repr, DecidableEq
+
+/--
+  Return the kind of the region with the given index inside this operation.
+  This mirrors MLIR's RegionKindInterface default: regions are SSACFG unless
+  the operation is known to define graph regions.
+-/
+def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
+  match opCode with
+  | .builtin .module
+  | .builtin .unregistered
+  | .test .test => .Graph
+  | _ => .SSACFG
+
 instance : HasOpInfo OpCode where
   moduleOpCode := .builtin .module
+  hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG
 
 abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
 
@@ -359,23 +377,6 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict
   | _ =>
     Std.HashMap.emptyWithCapacity 0
-
-inductive RegionKind where
-| SSACFG
-| Graph
-deriving Inhabited, Repr, DecidableEq
-
-/--
-  Return the kind of the region with the given index inside this operation.
-  This mirrors MLIR's RegionKindInterface default: regions are SSACFG unless
-  the operation is known to define graph regions.
--/
-def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
-  match opCode with
-  | .builtin .module
-  | .builtin .unregistered
-  | .test .test => .Graph
-  | _ => .SSACFG
 
 /--
   Does this OpCode count as an MLIR basic block terminator?

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -35,7 +35,7 @@ instance [HasDialectOpInfo opCode] {op : opCode} : Inhabited (HasDialectOpInfo.p
 instance [HasDialectOpInfo opCode] {op : opCode} : Repr (HasDialectOpInfo.propertiesOf op) where
   reprPrec := HasDialectOpInfo.propertiesRepr.reprPrec
 
-instance [HasDialectOpInfo opCode] {op : opCode} : DecidableEq (HasDialectOpInfo.propertiesOf op) := 
+instance [HasDialectOpInfo opCode] {op : opCode} : DecidableEq (HasDialectOpInfo.propertiesOf op) :=
   HasDialectOpInfo.propertiesDecideEq
 
 instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
@@ -43,13 +43,18 @@ instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
 
 /--
 The `HasOpInfo` type class provides information about opcodes and their properties
-and how to hash, represent, and compare them for equality. It also
-provides a type family `propertyOf` that maps an operation code to the type of
-its properties
+and how to hash, represent, and compare them for equality. It also contains the mapping between
+opcodes and whether or not their regions have SSA dominance.
 -/
 class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
   moduleOpCode: opCode
+  /--
+  Whether definitions in the indexed region must dominate their uses. A false
+  result denotes graph-style semantics, where only a single block can be in the
+  region, and operation order does not impose SSA dominance.
+  -/
+  hasSSADominance : opCode → Nat → Bool
 
 instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
   hash := HasOpInfo.propertiesHash.hash
@@ -60,7 +65,7 @@ instance [HasOpInfo opCode] {op : opCode} : Inhabited (HasOpInfo.propertiesOf op
 instance [HasOpInfo opCode] {op : opCode} : Repr (HasOpInfo.propertiesOf op) where
   reprPrec := HasOpInfo.propertiesRepr.reprPrec
 
-instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) := 
+instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) :=
   HasOpInfo.propertiesDecideEq
 
 instance [HasOpInfo opCode] : DecidableEq opCode :=

--- a/Veir/Interfaces.lean
+++ b/Veir/Interfaces.lean
@@ -1,3 +1,4 @@
 module
 
 import Veir.Interfaces.FunctionInterfaces
+import Veir.Interfaces.RegionKindInterfaces

--- a/Veir/Interfaces/RegionKindInterfaces.lean
+++ b/Veir/Interfaces/RegionKindInterfaces.lean
@@ -1,0 +1,32 @@
+module
+
+public import Veir.IR.WellFormed
+
+/-!
+# RegionKindInterface
+
+This file provides region-kind queries derived from the operation information
+of a region's owning operation.
+-/
+
+public section
+
+namespace Veir
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
+/--
+Whether `region` uses SSA dominance according to its owning operation. Root
+regions use SSA dominance, while other regions inherit the setting of their
+position in the owning operation.
+-/
+@[expose]
+def RegionPtr.hasSSADominance (region : RegionPtr)
+    (ctx : WfIRContext OpInfo) : Bool :=
+  match (region.get! ctx.raw).parent with
+  | none => true
+  | some parent =>
+      HasOpInfo.hasSSADominance (parent.getOpType! ctx.raw)
+        ((parent.get! ctx.raw).regions.idxOf region)
+
+end Veir


### PR DESCRIPTION
Move the region kind interface to `OpInfo`, out of `OpCode`.
This will allow to make more generic functions that would work with any dialects.