### PR TITLE
feat(verifier): Add check that successors have the same parents

### DIFF
--- a/Test/Parsing/scopes.mlir
+++ b/Test/Parsing/scopes.mlir
@@ -1,63 +1,76 @@
 // RUN: veir-opt %s | filecheck %s
 
 "builtin.module"() ({
-  "test.test"() ({
+  "func.func"() <{sym_name = "outer", function_type = () -> ()}> ({
+  ^bb0:
       %a = "test.test"() : () -> i1
   
       "test.test"() ({
           "test.test"(%a) : (i1) -> ()
           %b = "test.test"() : () -> i2
   
-          "test.test"() ({
+          "func.func"() <{sym_name = "inner_i3", function_type = () -> ()}> ({
           ^bb0:
               %c = "test.test"() : () -> i3
+              "cf.br"() [^bb1] : () -> ()
           ^bb1:
               "test.test"(%a, %b, %c) : (i1, i2, i3) -> ()
+              "func.return"() : () -> ()
           }) : () -> ()
   
-          "test.test"() ({
+          "func.func"() <{sym_name = "inner_i4", function_type = () -> ()}> ({
           ^bb0:
               %c = "test.test"() : () -> i4
+              "cf.br"() [^bb1] : () -> ()
           ^bb1:
               "test.test"(%a, %b, %c) : (i1, i2, i4) -> ()
+              "func.return"() : () -> ()
           }) : () -> ()
   
           %c = "test.test"() : () -> i5
           "test.test"(%a, %b, %c) : (i1, i2, i5) -> ()
       }) : () -> ()
-  
+
+      "cf.br"() [^bb1] : () -> ()
   ^bb1:
       %b, %c = "test.test"() : () -> (i6, i7)
       "test.test"(%a, %b, %c) : (i1, i6, i7) -> ()
+      "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     "test.test"() ({
+// CHECK-NEXT:     "func.func"() <{{.*}}> ({
 // CHECK-NEXT:       ^{{.*}}():
 // CHECK-NEXT:         %[[A:.*]] = "test.test"() : () -> i1
 // CHECK-NEXT:         "test.test"() ({
 // CHECK-NEXT:           ^{{.*}}():
 // CHECK-NEXT:             "test.test"(%[[A]]) : (i1) -> ()
 // CHECK-NEXT:             %[[B:.*]] = "test.test"() : () -> i2
-// CHECK-NEXT:             "test.test"() ({
+// CHECK-NEXT:             "func.func"() <{{.*}}> ({
 // CHECK-NEXT:               ^{{.*}}():
 // CHECK-NEXT:                 %[[C3:.*]] = "test.test"() : () -> i3
-// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 "cf.br"() [^[[C3_USE:.*]]] : () -> ()
+// CHECK-NEXT:               ^[[C3_USE]]():
 // CHECK-NEXT:                 "test.test"(%[[A]], %[[B]], %[[C3]]) : (i1, i2, i3) -> ()
+// CHECK-NEXT:                 "func.return"() : () -> ()
 // CHECK-NEXT:             }) : () -> ()
-// CHECK-NEXT:             "test.test"() ({
+// CHECK-NEXT:             "func.func"() <{{.*}}> ({
 // CHECK-NEXT:               ^{{.*}}():
 // CHECK-NEXT:                 %[[C4:.*]] = "test.test"() : () -> i4
-// CHECK-NEXT:               ^{{.*}}():
+// CHECK-NEXT:                 "cf.br"() [^[[C4_USE:.*]]] : () -> ()
+// CHECK-NEXT:               ^[[C4_USE]]():
 // CHECK-NEXT:                 "test.test"(%[[A]], %[[B]], %[[C4]]) : (i1, i2, i4) -> ()
+// CHECK-NEXT:                 "func.return"() : () -> ()
 // CHECK-NEXT:             }) : () -> ()
 // CHECK-NEXT:             %[[C5:.*]] = "test.test"() : () -> i5
 // CHECK-NEXT:             "test.test"(%[[A]], %[[B]], %[[C5]]) : (i1, i2, i5) -> ()
 // CHECK-NEXT:         }) : () -> ()
-// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         "cf.br"() [^[[OUTER_USE:.*]]] : () -> ()
+// CHECK-NEXT:       ^[[OUTER_USE]]():
 // CHECK-NEXT:         %[[B6C7:.*]]:2 = "test.test"() : () -> (i6, i7)
 // CHECK-NEXT:         "test.test"(%[[A]], %[[B6C7]]#0, %[[B6C7]]#1) : (i1, i6, i7) -> ()
+// CHECK-NEXT:         "func.return"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -9,7 +9,6 @@
 
 "builtin.module"() ({
 
-  ^1():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f0"}> ({
       ^1(%0 : i64):
         // A lone `iX -> iX` cast is not a round trip, so nothing reconciles it away.
@@ -22,7 +21,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^2():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f1"}> ({
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
@@ -34,7 +32,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^3():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f2"}> ({
       ^1(%0 : i64):
         // the remaining cast is unused
@@ -47,7 +44,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^4():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f3"}> ({
       ^1(%0 : i64):
         // the remaining cast is used
@@ -62,7 +58,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^5():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f4"}> ({
       ^1(%0 : i64):
         // The `reg -> reg` cast in the middle breaks the `reg -> i64 -> reg` round trip: no
@@ -78,7 +73,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^6():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f5"}> ({
       ^1(%0 : i64):
         // pairs of casts
@@ -96,7 +90,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^7():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f6"}> ({
       ^1(%0 : !riscv.reg):
         // identity cast on block argument: not a round trip, so it survives the pass
@@ -108,7 +101,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^8():
     "func.func"()  <{function_type = (i8) -> (), sym_name = "f7"}> ({
       ^1(%0 : i8):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i8) -> i8
@@ -119,7 +111,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^9():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f8"}> ({
       ^1(%0 : i64):
         // `iX -> iY -> iX` round trips are not reconciled: the interpreter gives an
@@ -139,7 +130,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^10():
     "func.func"()  <{function_type = (i32) -> (), sym_name = "f9"}> ({
       ^1(%0 : i32):
         // i32 -> reg -> i32
@@ -156,7 +146,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^11():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f10"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i32 -> reg : should not be folded away.
@@ -169,7 +158,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^12():
     "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "f11"}> ({
       ^1(%0 : !llvm.ptr):
         // ptr -> reg -> ptr (64-bit)
@@ -184,7 +172,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^13():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f12"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> ptr -> reg (64-bit)
@@ -196,7 +183,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^14():
     "func.func"()  <{function_type = (i32) -> (), sym_name = "f13"}> ({
       ^1(%0 : i32):
         // i32 -> reg -> i32  (reg is also used elsewhere)
@@ -215,7 +201,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^15():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f14"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i16 -> reg : should not be folded away.
@@ -228,7 +213,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
     
-  ^16():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f15"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i8 -> reg : should not be folded away.
@@ -241,7 +225,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^17():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f16"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i14 -> reg : should not be folded away.
@@ -255,7 +238,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^18():
     "func.func"()  <{function_type = (!riscv.reg) -> (), sym_name = "f17"}> ({
       ^1(%0 : !riscv.reg):
         // reg -> i0 -> reg : the round trip is the constant zero, which the `slli`/`srli`

--- a/Test/Passes/CastsReconciliation/coerce_function_boundaries.mlir
+++ b/Test/Passes/CastsReconciliation/coerce_function_boundaries.mlir
@@ -13,7 +13,6 @@
   // A lowered function (it contains a `riscv.addi`): its `i64` argument and result
   // are coerced to `!riscv.reg`, and the reg<->i64 round-trip casts are removed, so
   // the `riscv.addi` consumes the register argument directly.
-  ^1():
     "func.func"() <{sym_name = "lowered", function_type = (i64) -> i64}> ({
     ^bb(%a: i64):
       %r = "builtin.unrealized_conversion_cast"(%a) : (i64) -> !riscv.reg
@@ -29,7 +28,6 @@
   // `llvm.func` is handled too: the `i64` argument and result are coerced to
   // `!riscv.reg`, the `!llvm.func<...>` spelling is preserved, and `llvm.return`'s
   // operand is coerced. i32 boundaries would be left untouched (unsound to reconcile).
-  ^3():
     "llvm.func"() <{sym_name = "llvmlowered", function_type = !llvm.func<i64 (i64)>}> ({
     ^bb(%a: i64):
       %r = "builtin.unrealized_conversion_cast"(%a) : (i64) -> !riscv.reg
@@ -44,7 +42,6 @@
 
   // Pointers are 64-bit, so `!llvm.ptr` boundaries coerce to `!riscv.reg` too (the
   // `reg <-> ptr` round-trip is the identity and reconciles away).
-  ^4():
     "func.func"() <{sym_name = "ptrfn", function_type = (!llvm.ptr) -> !llvm.ptr}> ({
     ^bb(%p: !llvm.ptr):
       %r = "builtin.unrealized_conversion_cast"(%p) : (!llvm.ptr) -> !riscv.reg
@@ -62,7 +59,6 @@
   // patterns do *not* simply erase it: the `function_type` becomes `(!riscv.reg) -> !riscv.reg`
   // while the residual `reg -> i32 -> reg` truncation on both the argument and the return
   // operand is reconciled into an explicit `zextw`.
-  ^5():
     "func.func"() <{sym_name = "i32fn", function_type = (i32) -> i32}> ({
     ^bb(%a: i32):
       %r = "builtin.unrealized_conversion_cast"(%a) : (i32) -> !riscv.reg

--- a/Test/Passes/CastsReconciliation/error.mlir
+++ b/Test/Passes/CastsReconciliation/error.mlir
@@ -8,7 +8,6 @@
 
 "builtin.module"() ({
 
-  ^1():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "foo"}> ({
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i8
@@ -22,7 +21,6 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
-  ^2():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "bar"}> ({
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg

--- a/Test/Passes/DCE/basic.mlir
+++ b/Test/Passes/DCE/basic.mlir
@@ -5,7 +5,6 @@
 "builtin.module"() ({
   
   // An operation that returns one unused result
-  ^4():
     "func.func"()  <{function_type = (i64) -> (), sym_name = "foo"}> ({
       ^6(%1 : i64):
         %2 = "llvm.add"(%1, %1) : (i64, i64) -> i64
@@ -18,7 +17,6 @@
     }) : () -> ()
   
   // A chain of operations that is eventually unused
-  ^5():
     "func.func"()  <{function_type = () -> (), sym_name = "bar"}> ({
       ^6():
         %1 = "arith.constant"() <{ "value" = 1 : i64 }> : () -> i64
@@ -34,7 +32,6 @@
     }) : () -> ()
   
   // A chain of operations that is eventually used
-  ^6():
     "func.func"()  <{function_type = () -> (), sym_name = "baz"}> ({
       ^6():
         %1 = "arith.constant"() <{ "value" = 1 : i64 }> : () -> i64
@@ -53,4 +50,3 @@
         "func.return"() : () -> ()
     }) : () -> ()
 }) : () -> ()
-

--- a/Test/Verifier/graph_region_multiple_blocks.mlir
+++ b/Test/Verifier/graph_region_multiple_blocks.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+^bb0:
+^bb1:
+}) : () -> ()
+
+// CHECK: Graph regions may contain at most one block

--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -4,6 +4,7 @@ import UnitTest.Parser
 import UnitTest.AttrParser
 import UnitTest.MlirParser
 import UnitTest.IR.Operation
+import UnitTest.Verifier
 import UnitTest.FP
 import UnitTest.Bitblasting.Bitblasting
 import UnitTest.DataFlowFramework.Dominance

--- a/UnitTest/Verifier.lean
+++ b/UnitTest/Verifier.lean
@@ -1,0 +1,56 @@
+import Veir.Rewriter.WfRewriter.Basic
+import Veir.Verifier
+
+open Veir
+
+/--
+Build a well-formed IR context with one deliberately invalid CFG edge. The
+source and target blocks belong to distinct regions, which cannot be expressed
+through the MLIR parser because block references are region-scoped.
+
+The resulting IR has this shape (the dashed arrow is the invalid successor):
+
+```text
+module
+└─ moduleRegion
+   └─ moduleBlock
+      ├─ test.test op
+      │  └─ sourceRegion
+      │     └─ sourceBlock
+      │        └─ cf.br ─ ─ ─ ┐
+      └─ test.test op         │
+         └─ targetRegion      │ invalid cross-region edge
+            └─ targetBlock ◀─ ┘
+```
+-/
+private def contextWithCrossRegionSuccessor : Except String (WfIRContext OpCode) := do
+  let (ctx, moduleOp) := WfIRContext.create! OpCode
+  let moduleRegion := moduleOp.getRegion! ctx.raw 0
+  let moduleBlock := (moduleRegion.get! ctx.raw).firstBlock.get!
+
+  let (ctx, sourceRegion) := WfRewriter.createRegion! ctx
+  let (ctx, sourceBlock) :=
+    WfRewriter.createBlock! ctx #[] (some (.atEnd sourceRegion))
+
+  let (ctx, targetRegion) := WfRewriter.createRegion! ctx
+  let (ctx, targetBlock) :=
+    WfRewriter.createBlock! ctx #[] (some (.atEnd targetRegion))
+
+  let (ctx, _) :=
+      (WfRewriter.createOp! ctx (.test .test) #[] #[] #[] #[sourceRegion] ()
+        (some (.atEnd moduleBlock))).get!
+  let (ctx, _) :=
+      (WfRewriter.createOp! ctx (.test .test) #[] #[] #[] #[targetRegion] ()
+        (some (.atEnd moduleBlock))).get!
+
+  let (ctx, _) :=
+      (WfRewriter.createOp! ctx (.cf .br) #[] #[] #[targetBlock] #[] ()
+        (some (.atEnd sourceBlock))).get!
+  return ctx
+
+private def verifyCrossRegionSuccessor : Except String Unit := do
+  let ctx ← contextWithCrossRegionSuccessor
+  ctx.verify
+
+#guard verifyCrossRegionSuccessor =
+  .error "Block successors must belong to the same region as their predecessor"

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -41,8 +41,26 @@ match opCode with
 instance : HasDialectOpInfo OpCode where
   propertiesOf := _propertiesOf
 
+inductive RegionKind where
+| SSACFG
+| Graph
+deriving Inhabited, Repr, DecidableEq
+
+/--
+  Return the kind of the region with the given index inside this operation.
+  This mirrors MLIR's RegionKindInterface default: regions are SSACFG unless
+  the operation is known to define graph regions.
+-/
+def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
+  match opCode with
+  | .builtin .module
+  | .builtin .unregistered
+  | .test .test => .Graph
+  | _ => .SSACFG
+
 instance : HasOpInfo OpCode where
   moduleOpCode := .builtin .module
+  hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG
 
 abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
 
@@ -359,23 +377,6 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict
   | _ =>
     Std.HashMap.emptyWithCapacity 0
-
-inductive RegionKind where
-| SSACFG
-| Graph
-deriving Inhabited, Repr, DecidableEq
-
-/--
-  Return the kind of the region with the given index inside this operation.
-  This mirrors MLIR's RegionKindInterface default: regions are SSACFG unless
-  the operation is known to define graph regions.
--/
-def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
-  match opCode with
-  | .builtin .module
-  | .builtin .unregistered
-  | .test .test => .Graph
-  | _ => .SSACFG
 
 /--
   Does this OpCode count as an MLIR basic block terminator?

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -35,7 +35,7 @@ instance [HasDialectOpInfo opCode] {op : opCode} : Inhabited (HasDialectOpInfo.p
 instance [HasDialectOpInfo opCode] {op : opCode} : Repr (HasDialectOpInfo.propertiesOf op) where
   reprPrec := HasDialectOpInfo.propertiesRepr.reprPrec
 
-instance [HasDialectOpInfo opCode] {op : opCode} : DecidableEq (HasDialectOpInfo.propertiesOf op) := 
+instance [HasDialectOpInfo opCode] {op : opCode} : DecidableEq (HasDialectOpInfo.propertiesOf op) :=
   HasDialectOpInfo.propertiesDecideEq
 
 instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
@@ -43,13 +43,18 @@ instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
 
 /--
 The `HasOpInfo` type class provides information about opcodes and their properties
-and how to hash, represent, and compare them for equality. It also
-provides a type family `propertyOf` that maps an operation code to the type of
-its properties
+and how to hash, represent, and compare them for equality. It also contains the mapping between
+opcodes and whether or not their regions have SSA dominance.
 -/
 class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
   moduleOpCode: opCode
+  /--
+  Whether definitions in the indexed region must dominate their uses. A false
+  result denotes graph-style semantics, where only a single block can be in the
+  region, and operation order does not impose SSA dominance.
+  -/
+  hasSSADominance : opCode → Nat → Bool
 
 instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
   hash := HasOpInfo.propertiesHash.hash
@@ -60,7 +65,7 @@ instance [HasOpInfo opCode] {op : opCode} : Inhabited (HasOpInfo.propertiesOf op
 instance [HasOpInfo opCode] {op : opCode} : Repr (HasOpInfo.propertiesOf op) where
   reprPrec := HasOpInfo.propertiesRepr.reprPrec
 
-instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) := 
+instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) :=
   HasOpInfo.propertiesDecideEq
 
 instance [HasOpInfo opCode] : DecidableEq opCode :=

--- a/Veir/Interfaces.lean
+++ b/Veir/Interfaces.lean
@@ -1,3 +1,4 @@
 module
 
 import Veir.Interfaces.FunctionInterfaces
+import Veir.Interfaces.RegionKindInterfaces

--- a/Veir/Interfaces/RegionKindInterfaces.lean
+++ b/Veir/Interfaces/RegionKindInterfaces.lean
@@ -1,0 +1,32 @@
+module
+
+public import Veir.IR.WellFormed
+
+/-!
+# RegionKindInterface
+
+This file provides region-kind queries derived from the operation information
+of a region's owning operation.
+-/
+
+public section
+
+namespace Veir
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
+/--
+Whether `region` uses SSA dominance according to its owning operation. Root
+regions use SSA dominance, while other regions inherit the setting of their
+position in the owning operation.
+-/
+@[expose]
+def RegionPtr.hasSSADominance (region : RegionPtr)
+    (ctx : WfIRContext OpInfo) : Bool :=
+  match (region.get! ctx.raw).parent with
+  | none => true
+  | some parent =>
+      HasOpInfo.hasSSADominance (parent.getOpType! ctx.raw)
+        ((parent.get! ctx.raw).regions.idxOf region)
+
+end Veir

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -10,6 +10,8 @@ import Veir.ForLean
 
 namespace Veir
 
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
 /--
   Walk up from `op` (a return-like terminator named `opName`) to the
   operation that encloses its parent region, i.e. the enclosing function
@@ -976,7 +978,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
 /--
   Return the kind of this region.
 -/
-def RegionPtr.getRegionKind (region : RegionPtr) (ctx : WfIRContext OpCode) : RegionKind :=
+public def RegionPtr.getRegionKind (region : RegionPtr) (ctx : WfIRContext OpCode) : RegionKind :=
   match (region.get! ctx.raw).parent with
   | some parentOp =>
     let parent := parentOp.get! ctx.raw
@@ -1006,12 +1008,33 @@ def BlockPtr.verifyTerminator (block : BlockPtr) (ctx : WfIRContext OpCode)
     if !(lastOp.getOpType! ctx.raw).isTerminator then
       throw "Expected the last operation of a block to be a terminator"
 
+/--
+  Check that every successor belongs to the same region as its predecessor.
+-/
+private def WfIRContext.successorsHaveSameParent (ctx : WfIRContext OpInfo) : Bool :=
+  ctx.raw.blocks.keys.all fun block =>
+    (block.getSuccessors! ctx.raw).all fun successor =>
+      (successor.get! ctx.raw).parent = (block.get! ctx.raw).parent
+
+/-- Check that a graph region contains at most one block. -/
+private def WfIRContext.graphRegionsHaveAtMostOneBlock (ctx : WfIRContext OpCode) : Bool :=
+  ctx.raw.regions.keys.all fun region =>
+    if region.getRegionKind ctx = .Graph then
+      let body := region.get! ctx.raw
+      body.firstBlock = body.lastBlock
+    else
+      true
+
 public section
 
 /--
-  Verify that all operations in the IRContext satisfy their local invariants.
+Verify the structural invariants of the IR context and the local invariants of all its operations.
 -/
 def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
+  if !ctx.successorsHaveSameParent then
+    throw "Block successors must belong to the same region as their predecessor"
+  if !ctx.graphRegionsHaveAtMostOneBlock then
+    throw "Graph regions may contain at most one block"
   ctx.raw.forOpsDepM (fun op opIn => do
     op.verifyLocalInvariants ctx opIn
     if let .riscv _ := op.getOpType ctx.raw opIn then
@@ -1027,10 +1050,54 @@ def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
     | none => pure ())
 
 /--
-Assert that all operations in the IRContext satisfy their local invariants.
+Assert that the IR context satisfies its structural and local invariants.
 -/
 def WfIRContext.Verified (ctx : WfIRContext OpCode) : Prop :=
   ctx.verify = .ok ()
+
+/-- A verified context satisfies the same-parent successor check. -/
+private theorem WfIRContext.Verified.successorsHaveSameParent
+    {ctx : WfIRContext OpCode} (ctxVerified : ctx.Verified) :
+    ctx.successorsHaveSameParent := by
+  simp only [WfIRContext.Verified, WfIRContext.verify] at ctxVerified
+  split at ctxVerified
+  · trivial
+  · grind
+
+/-- Every successor of a block in a verified context belongs to the block's parent region. -/
+@[grind →]
+theorem WfIRContext.Verified.successor_parent
+    {ctx : WfIRContext OpCode} (ctxVerified : ctx.Verified)
+    {source : BlockPtr} (sourceIn : source.InBounds ctx.raw)
+    (hsourceParent : (source.get! ctx.raw).parent = some region)
+    (hsuccessor : successor ∈ source.getSuccessors! ctx.raw) :
+    (successor.get! ctx.raw).parent = some region := by
+  have hcheck := ctxVerified.successorsHaveSameParent
+  have hsourceKeys : source ∈ ctx.raw.blocks.keys := by grind [source.inBounds_def]
+  grind [Array.getElem_of_mem hsuccessor, (List.all_eq_true.mp hcheck) source hsourceKeys]
+
+/-- A verified context satisfies the single-block graph-region check. -/
+private theorem WfIRContext.Verified.graphRegionsHaveAtMostOneBlock
+    {ctx : WfIRContext OpCode} (ctxVerified : ctx.Verified) :
+    ctx.graphRegionsHaveAtMostOneBlock := by
+  simp only [WfIRContext.Verified, WfIRContext.verify] at ctxVerified
+  split at ctxVerified
+  · trivial
+  · split at ctxVerified
+    · trivial
+    · grind
+
+/-- The first and last block of a graph region in a verified context are the same. -/
+@[grind →]
+theorem WfIRContext.Verified.graph_region_firstBlock_eq_lastBlock
+    {ctx : WfIRContext OpCode} (ctxVerified : ctx.Verified)
+    {region : RegionPtr} (regionIn : region.InBounds ctx.raw)
+    (hregionKind : region.getRegionKind ctx = .Graph) :
+    (region.get! ctx.raw).firstBlock = (region.get! ctx.raw).lastBlock := by
+  have hcheck := ctxVerified.graphRegionsHaveAtMostOneBlock
+  have hregionKeys : region ∈ ctx.raw.regions.keys := by grind [region.inBounds_def]
+  have hregionCheck := (List.all_eq_true.mp hcheck) region hregionKeys
+  grind
 
 /--
 Assert that a given operation satisfies its local invariants.


### PR DESCRIPTION
This adds two checks on regions:
* A graph region has at most one block (checked by asserting the first and last block are equal)
* The successors of a block are in the same region