### PR TITLE
fix(parser): restore block state when parsing empty regions

### DIFF
--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -168,6 +168,21 @@ def testParseOp (s : String) : IO Unit :=
 /--
   info: "builtin.module"() ({
   ^4():
+    "test.test"() [^5] ({    }) : () -> ()
+  ^5():
+    "test.test"() : () -> ()
+}) : () -> ()-/
+#guard_msgs in
+#eval! testParseOp "\"builtin.module\"() ({
+^bb0:
+  \"test.test\"() [^bb1] ({}) : () -> ()
+^bb1:
+  \"test.test\"() : () -> ()
+}) : () -> ()"
+
+/--
+  info: "builtin.module"() ({
+  ^4():
     %5:2 = "test.test"() : () -> (i32, i64)
 }) : () -> ()
 -/

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -719,6 +719,7 @@ partial def parseRegion : MlirParserM RegionPtr := do
 
   /- Case where there are no blocks inside the region. -/
   if (← parseOptionalPunctuation "}") then
+    modifyThe MlirParserState fun s => {s with blocks := oldBlocks}
     return region
 
   /- Parse the first block separately, as it may not have a label. -/


### PR DESCRIPTION
Fixes #1000 (just a missing branch in parser)