### PR TITLE
fix: properly handle FuncFuncProperties.function_type

### DIFF
--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -345,6 +345,8 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     let mut dict := Std.HashMap.ofList props.extra.entries.toList
     if let some sym_name := props.sym_name then
       dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
+    if let some function_type := props.function_type then
+      dict := dict.insert "function_type".toUTF8  function_type
     dict
   | .builtin .unregistered =>
     Std.HashMap.ofList props.properties.entries.toList

--- a/Veir/Properties.lean
+++ b/Veir/Properties.lean
@@ -555,7 +555,7 @@ def FuncFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
       else pure (some attr.asType)
     | none => pure none
   let extra := DictionaryAttr.fromArray
-    (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8)
+    (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8 && k ≠ "function_type".toUTF8)
   return { sym_name := symName, function_type := funcType, extra }
 
 /--


### PR DESCRIPTION
In #1075, I added `function_type` to `FuncFuncProperties` to align it with `LLVMFuncProperties`. This was done because it simplifies the newly added `FunctionOpInterface` and because MLIR’s `FunctionOpInterface` treats function_type as a required ODS argument.

This wasn’t done properly: `function_type` remained duplicated in `FuncFuncProperties.extra`, and `FuncFuncProperties.function_type` was not written out in `Properties.toAttrDict`.
The duplication caused the bug to go undetected.