### PR TITLE
feat(rewriter): Add setAttributes, setProperties with GetSet lemmas

### DIFF
--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -286,6 +286,38 @@ theorem Rewriter.replaceUse_fieldsInBounds :
      ctx.FieldsInBounds → (replaceUse ctx use newValue useIn newIn ctxIn).FieldsInBounds := by
   grind [replaceUse]
 
+/-- Set the attributes of an operation. -/
+def Rewriter.setAttributes (ctx: IRContext OpInfo) (op: OperationPtr) (newAttrs : DictionaryAttr)
+    (opIn : op.InBounds ctx := by grind) : IRContext OpInfo :=
+  op.setAttributes ctx newAttrs opIn
+
+@[grind =]
+theorem Rewriter.setAttributes_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (setAttributes ctx op newAttrs opIn) ↔ ptr.InBounds ctx := by
+  grind [setAttributes]
+
+@[grind .]
+theorem Rewriter.setAttributes_fieldsInBounds :
+    ctx.FieldsInBounds → (setAttributes ctx op newAttrs opIn).FieldsInBounds := by
+  grind [setAttributes, OperationPtr.setAttributes_fieldsInBounds]
+
+/-- Set the properties of an operation. -/
+def Rewriter.setProperties {opCode : OpInfo} (ctx: IRContext OpInfo) (op: OperationPtr)
+    (newProps: HasOpInfo.propertiesOf opCode)
+    (opIn : op.InBounds ctx := by grind)
+    (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
+  op.setProperties ctx newProps opIn hprop
+
+@[grind =]
+theorem Rewriter.setProperties_inBounds (ptr : GenericPtr) :
+    ptr.InBounds (setProperties ctx op newProperties opIn hprop) ↔ ptr.InBounds ctx := by
+  grind [setProperties]
+
+@[grind .]
+theorem Rewriter.setProperties_fieldsInBounds :
+    ctx.FieldsInBounds → (setProperties ctx op newProperties opIn hprop).FieldsInBounds := by
+  grind [setProperties, OperationPtr.setProperties_fieldsInBounds]
+
 /--
 Set the type of a value (an op result or a block argument).
 -/

--- a/Veir/Rewriter/GetSet.lean
+++ b/Veir/Rewriter/GetSet.lean
@@ -10,6 +10,7 @@ public import Veir.Rewriter.GetSet.Results
 public import Veir.Rewriter.GetSet.Value
 public import Veir.Rewriter.GetSet.Regions
 public import Veir.Rewriter.GetSet.Operands
+public import Veir.Rewriter.GetSet.Operation
 public import Veir.Rewriter.GetSet.BlockOperands
 public import Veir.Rewriter.GetSet.CreateOp
 public import Veir.Rewriter.GetSet.CreateRegion

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -56,7 +56,7 @@ variable {op : OperationPtr} {newAttrs : DictionaryAttr} {opIn : op.InBounds ctx
 
 attribute [local grind] Rewriter.setAttributes
 
-@[simp ,grind =]
+@[simp, grind =]
 theorem BlockPtr.get!_setAttributes {block : BlockPtr} :
     block.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     block.get! ctx := by
@@ -217,8 +217,8 @@ theorem BlockOperandPtrPtr.get!_setAttributes {blockOperandPtr : BlockOperandPtr
 
 @[simp, grind =]
 theorem BlockPtr.getNumArguments!_setAttributes {block : BlockPtr} :
-    (block.getNumArguments! (Rewriter.setAttributes ctx op newAttrs opIn)) =
-    (block.getNumArguments! ctx) := by
+    block.getNumArguments! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    block.getNumArguments! ctx := by
   grind
 
 @[simp, grind =]
@@ -279,7 +279,7 @@ variable {opCode: OpInfo} {op : OperationPtr} {newProps : HasOpInfo.propertiesOf
 
 attribute [local grind] Rewriter.setProperties
 
-@[simp ,grind =]
+@[simp, grind =]
 theorem BlockPtr.get!_setProperties {block : BlockPtr} :
     block.get! (Rewriter.setProperties ctx op newProps opIn hprop) =
     block.get! ctx := by
@@ -443,8 +443,8 @@ theorem BlockOperandPtrPtr.get!_setProperties {blockOperandPtr : BlockOperandPtr
 
 @[simp, grind =]
 theorem BlockPtr.getNumArguments!_setProperties {block : BlockPtr} :
-    (block.getNumArguments! (Rewriter.setProperties ctx op newProps opIn)) =
-    (block.getNumArguments! ctx) := by
+    block.getNumArguments! (Rewriter.setProperties ctx op newProps opIn) =
+    block.getNumArguments! ctx := by
   grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -1,0 +1,500 @@
+module
+
+public import Veir.Rewriter.Basic
+import all Veir.Rewriter.Basic
+
+public section
+
+/-
+ - The getters we consider are:
+ - * BlockPtr.get! optionally replaced by the following special cases:
+ -   * Block.firstUse
+ -   * Block.prev
+ -   * Block.next
+ -   * Block.parent
+ -   * Block.firstOp
+ -   * Block.lastOp
+ - * OperationPtr.get! optionally replaced by the following special cases:
+ -   * Operation.prev
+ -   * Operation.next
+ -   * Operation.parent
+ -   * OperationPtr.getOpType!
+ -   * Operation.attrs
+ - * OperationPtr.getProperties!
+ - * OperationPtr.getNumResults!
+ - * OpResultPtr.get!
+ - * OperationPtr.getNumOperands!
+ - * OpOperandPtr.get! optionally replaced by the following special case:
+ - * OperationPtr.getOperands!
+ - * OperationPtr.getNumSuccessors!
+ - * BlockOperandPtr.get!
+ - * OperationPtr.getSuccessor!
+ - * OperationPtr.getSuccessors!
+ - * OperationPtr.getNumRegions!
+ - * OperationPtr.getRegion!
+ - * BlockOperandPtrPtr.get!
+ - * BlockPtr.getNumArguments!
+ - * BlockArgumentPtr.get!
+ - * RegionPtr.get! with optionally special cases for:
+ -   * firstBlock
+ -   * lastBlock
+ -   * parent
+ - * ValuePtr.getFirstUse!
+ - * ValuePtr.getType!
+ - * OpOperandPtrPtr.get!
+ -/
+
+namespace Veir
+
+variable {OpInfo} [HasOpInfo OpInfo]
+variable {ctx : IRContext OpInfo}
+/-! ## `Rewriter.setAttributes` -/
+
+section Rewriter.setAttributes
+
+variable {op : OperationPtr} {newAttrs : DictionaryAttr} {opIn : op.InBounds ctx}
+
+attribute [local grind] Rewriter.setAttributes
+
+@[simp ,grind =]
+theorem BlockPtr.get!_setAttributes {block : BlockPtr} :
+    block.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    block.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstUse!_setAttributes {block : BlockPtr} :
+    (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).firstUse =
+    (block.get! ctx).firstUse := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.prev!_setAttributes {block : BlockPtr} :
+    (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).prev =
+    (block.get! ctx).prev := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.next!_setAttributes {block : BlockPtr} :
+    (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).next =
+    (block.get! ctx).next := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.parent!_setAttributes {block : BlockPtr} :
+    (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).parent =
+    (block.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstOp!_setAttributes {block : BlockPtr} :
+    (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).firstOp =
+    (block.get! ctx).firstOp := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.lastOp!_setAttributes {block : BlockPtr} :
+    (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).lastOp =
+    (block.get! ctx).lastOp := by
+  grind
+
+@[grind =]
+theorem OperationPtr.get!_setAttributes {op' : OperationPtr} :
+    op'.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    if op' = op then
+      { op'.get! ctx with attrs := newAttrs }
+    else
+      op'.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.prev!_setAttributes {op' : OperationPtr} :
+    (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).prev =
+    (op'.get! ctx).prev := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.next!_setAttributes {op' : OperationPtr} :
+    (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).next =
+    (op'.get! ctx).next := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.parent!_setAttributes {op' : OperationPtr} :
+    (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).parent =
+    (op'.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_setAttributes {op' : OperationPtr} :
+    op'.getOpType! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getOpType! ctx := by
+  grind
+
+@[grind =]
+theorem OperationPtr.attrs!_setAttributes {op' : OperationPtr} :
+    (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).attrs =
+    if op' = op then newAttrs else (op'.get! ctx).attrs  := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getProperties!_setAttributes {op' : OperationPtr} :
+    op'.getProperties! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getProperties! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumResults!_setAttributes {op' : OperationPtr} :
+    op'.getNumResults! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getNumResults! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpResultPtr.get!_setAttributes {opResult : OpResultPtr} :
+    opResult.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    opResult.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumOperands!_setAttributes {op' : OperationPtr} :
+    op'.getNumOperands! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getNumOperands! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpOperandPtr.get!_setAttributes {opOperand : OpOperandPtr} :
+    opOperand.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    opOperand.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperands!_setAttributes {op' : OperationPtr} :
+    op'.getOperands! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getOperands! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumSuccessors!_setAttributes {op' : OperationPtr} :
+    op'.getNumSuccessors! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getNumSuccessors! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockOperandPtr.get!_setAttributes {blockOperand : BlockOperandPtr} :
+    blockOperand.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    blockOperand.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessor!_setAttributes {op' : OperationPtr} :
+    op'.getSuccessor! (Rewriter.setAttributes ctx op newAttrs opIn) index =
+    op'.getSuccessor! ctx index := by
+  grind [OperationPtr.getSuccessor!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessors!_setAttributes {op' : OperationPtr} :
+    op'.getSuccessors! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getSuccessors! ctx := by
+  grind [OperationPtr.getSuccessors!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getNumRegions!_setAttributes {op' : OperationPtr} :
+    op'.getNumRegions! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    op'.getNumRegions! ctx := by
+  grind [OperationPtr.getSuccessors!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getRegion!_setAttributes {op' : OperationPtr} :
+    op'.getRegion! (Rewriter.setAttributes ctx op newAttrs opIn) index =
+    op'.getRegion! ctx index := by
+  grind [OperationPtr.getSuccessors!_def]
+
+@[simp, grind =]
+theorem BlockOperandPtrPtr.get!_setAttributes {blockOperandPtr : BlockOperandPtrPtr} :
+    blockOperandPtr.get!  (Rewriter.setAttributes ctx op newAttrs opIn) =
+    blockOperandPtr.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.getNumArguments!_setAttributes {block : BlockPtr} :
+    (block.getNumArguments! (Rewriter.setAttributes ctx op newAttrs opIn)) =
+    (block.getNumArguments! ctx) := by
+  grind
+
+@[simp, grind =]
+theorem BlockArgumentPtr.get!_setAttributes {blockArgument : BlockArgumentPtr} :
+    blockArgument.get!  (Rewriter.setAttributes ctx op newAttrs opIn) =
+    blockArgument.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.get!_setAttributes {region : RegionPtr} :
+    region.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    region.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.firstBlock!_setAttributes {region : RegionPtr} :
+    (region.get! (Rewriter.setAttributes ctx op newAttrs opIn)).firstBlock =
+    (region.get! ctx).firstBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.lastBlock!_setAttributes {region : RegionPtr} :
+    (region.get! (Rewriter.setAttributes ctx op newAttrs opIn)).lastBlock =
+    (region.get! ctx).lastBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.parent!_setAttributes {region : RegionPtr} :
+    (region.get! (Rewriter.setAttributes ctx op newAttrs opIn)).parent =
+    (region.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem ValuePtr.getFirstUse!_setAttributes {value : ValuePtr} :
+    value.getFirstUse! (Rewriter.setAttributes ctx op newAttrs opIn)  =
+    value.getFirstUse! ctx := by
+  grind
+
+@[simp, grind =]
+theorem ValuePtr.getType!_setAttributes {value : ValuePtr} :
+    value.getType! (Rewriter.setAttributes ctx op newAttrs opIn)  =
+    value.getType! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpOperandPtrPtr.get!_setAttributes {opOperandPtr : OpOperandPtrPtr} :
+    opOperandPtr.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
+    opOperandPtr.get! ctx := by
+  grind
+
+end Rewriter.setAttributes
+/-! ## `Rewriter.setProperties` -/
+
+section Rewriter.setProperties
+
+variable {opCode: OpInfo} {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode} {opIn : op.InBounds ctx}
+         {opIn: op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
+
+attribute [local grind] Rewriter.setProperties
+
+@[simp ,grind =]
+theorem BlockPtr.get!_setProperties {block : BlockPtr} :
+    block.get! (Rewriter.setProperties ctx op newProps opIn hprop) =
+    block.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstUse!_setProperties {block : BlockPtr} :
+    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).firstUse =
+    (block.get! ctx).firstUse := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.prev!_setProperties {block : BlockPtr} :
+    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).prev =
+    (block.get! ctx).prev := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.next!_setProperties {block : BlockPtr} :
+    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).next =
+    (block.get! ctx).next := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.parent!_setProperties {block : BlockPtr} :
+    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).parent =
+    (block.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstOp!_setProperties {block : BlockPtr} :
+    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).firstOp =
+    (block.get! ctx).firstOp := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.lastOp!_setProperties {block : BlockPtr} :
+    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).lastOp =
+    (block.get! ctx).lastOp := by
+  grind
+
+@[grind =]
+theorem OperationPtr.get!_setProperties {operation : OperationPtr} :
+    operation.get! (Rewriter.setProperties ctx op newProps opIn hprop) =
+    if operation = op then
+      { operation.get! ctx with opType := op.getOpType! ctx, properties := hprop ▸ newProps }
+    else
+      operation.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.prev!_setProperties {op' : OperationPtr} :
+    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).prev =
+    (op'.get! ctx).prev := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.next!_setProperties {op' : OperationPtr} :
+    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).next =
+    (op'.get! ctx).next := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.parent!_setProperties {op' : OperationPtr} :
+    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).parent =
+    (op'.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_setProperties {op' : OperationPtr} :
+    op'.getOpType! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getOpType! ctx := by
+  grind
+
+@[simp ,grind =]
+theorem OperationPtr.attrs!_setProperties {op' : OperationPtr} :
+    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).attrs =
+    (op'.get! ctx).attrs := by
+  grind
+
+@[grind =]
+theorem OperationPtr.getProperties!_setProperties {op' : OperationPtr} {opCode' : OpInfo}:
+    op'.getProperties! (Rewriter.setProperties ctx op newProps opIn hprop) opCode' =
+    if op' = op then
+      if h: opCode' = opCode then h ▸ newProps else default
+    else
+      op'.getProperties! ctx opCode' := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumResults!_setProperties {op' : OperationPtr} :
+    op'.getNumResults! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumResults! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpResultPtr.get!_setProperties {opResult : OpResultPtr} :
+    opResult.get! (Rewriter.setProperties ctx op newProps opIn) =
+    opResult.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumOperands!_setProperties {op' : OperationPtr} :
+    op'.getNumOperands! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumOperands! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpOperandPtr.get!_setProperties {opOperand : OpOperandPtr} :
+    opOperand.get! (Rewriter.setProperties ctx op newProps opIn) =
+    opOperand.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperands!_setProperties {op' : OperationPtr} :
+    op'.getOperands! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getOperands! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumSuccessors!_setProperties {op' : OperationPtr} :
+    op'.getNumSuccessors! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumSuccessors! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockOperandPtr.get!_setProperties {blockOperand : BlockOperandPtr} :
+    blockOperand.get! (Rewriter.setProperties ctx op newProps opIn) =
+    blockOperand.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessor!_setProperties {op' : OperationPtr} :
+    op'.getSuccessor! (Rewriter.setProperties ctx op newProps opIn) index =
+    op'.getSuccessor! ctx index := by
+  grind [OperationPtr.getSuccessor!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessors!_setProperties {op' : OperationPtr} :
+    op'.getSuccessors! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getSuccessors! ctx := by
+  grind [OperationPtr.getSuccessors!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getNumRegions!_setProperties {op' : OperationPtr} :
+    op'.getNumRegions! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumRegions! ctx := by
+  grind [OperationPtr.getSuccessors!_def]
+
+@[simp, grind =]
+theorem OperationPtr.getRegion!_setProperties {op' : OperationPtr} :
+    op'.getRegion! (Rewriter.setProperties ctx op newProps opIn) index =
+    op'.getRegion! ctx index := by
+  grind [OperationPtr.getSuccessors!_def]
+
+@[simp, grind =]
+theorem BlockOperandPtrPtr.get!_setProperties {blockOperandPtr : BlockOperandPtrPtr} :
+    blockOperandPtr.get!  (Rewriter.setProperties ctx op newProps opIn) =
+    blockOperandPtr.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.getNumArguments!_setProperties {block : BlockPtr} :
+    (block.getNumArguments! (Rewriter.setProperties ctx op newProps opIn)) =
+    (block.getNumArguments! ctx) := by
+  grind
+
+@[simp, grind =]
+theorem BlockArgumentPtr.get!_setProperties {blockArgument : BlockArgumentPtr} :
+    blockArgument.get!  (Rewriter.setProperties ctx op newProps opIn) =
+    blockArgument.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.get!_setProperties {region : RegionPtr} :
+    region.get! (Rewriter.setProperties ctx op newProps opIn) =
+    region.get! ctx := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.firstBlock!_setProperties {region : RegionPtr} :
+    (region.get! (Rewriter.setProperties ctx op newProps opIn)).firstBlock =
+    (region.get! ctx).firstBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.lastBlock!_setProperties {region : RegionPtr} :
+    (region.get! (Rewriter.setProperties ctx op newProps opIn)).lastBlock =
+    (region.get! ctx).lastBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.parent!_setProperties {region : RegionPtr} :
+    (region.get! (Rewriter.setProperties ctx op newProps opIn)).parent =
+    (region.get! ctx).parent := by
+  grind
+
+@[simp, grind =]
+theorem ValuePtr.getFirstUse!_setProperties {value : ValuePtr} :
+    value.getFirstUse! (Rewriter.setProperties ctx op newProps opIn)  =
+    value.getFirstUse! ctx := by
+  grind
+
+@[simp, grind =]
+theorem ValuePtr.getType!_setProperties {value : ValuePtr} :
+    value.getType! (Rewriter.setProperties ctx op newProps opIn)  =
+    value.getType! ctx := by
+  grind
+
+@[simp, grind =]
+theorem OpOperandPtrPtr.get!_setProperties {opOperandPtr : OpOperandPtrPtr} :
+    opOperandPtr.get! (Rewriter.setProperties ctx op newProps opIn) =
+    opOperandPtr.get! ctx := by
+  grind
+
+end Rewriter.setProperties
+
+end Veir

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -305,7 +305,73 @@ theorem BlockPtr.operationList_operationPtr_setAttributes
   simp only [←BlockPtr.operationList_iff_BlockPtr_OpChain]
   grind [BlockPtr.opChain_OperationPtr_setAttributes]
 
+theorem Rewriter.setAttributes_WellFormed
+    (hctx : ctx.WellFormed) :
+    (Rewriter.setAttributes ctx op newProps hop).WellFormed := by
+   grind [setAttributes, OperationPtr.setAttributes_WellFormed]
+
 end setAttributes
+
+section setProperties
+
+theorem OperationPtr.setProperties_WellFormed {opCode : OpInfo} (ctx: IRContext OpInfo)
+  (op: OperationPtr) (hctx : ctx.WellFormed) (hop : op.InBounds ctx)
+  (hprop : op.getOpType! ctx = opCode := by grind)
+  (newProperties: HasOpInfo.propertiesOf opCode) :
+  (op.setProperties ctx newProperties hop hprop).WellFormed := by
+  have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := hctx
+  constructor
+  · grind
+  · intro val hval
+    have ⟨array, harray⟩ := h₂ val (by grind)
+    exists array
+    simp only [Std.ExtHashSet.filter_empty] at harray ⊢
+    apply ValuePtr.DefUse.unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+  · intro blk hblk
+    have ⟨array, harray⟩ := h₃ blk (by grind)
+    exists array
+    simp only [Std.ExtHashSet.filter_empty] at harray ⊢
+    apply BlockPtr.DefUse.unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+  · intro blk hblk
+    have ⟨array, harray⟩ := h₄ blk (by grind)
+    exists array
+    apply BlockPtr.OpChain_unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+  · intro reg hreg
+    have ⟨array, harray⟩ := h₅ reg (by grind)
+    exists array
+    apply RegionPtr.blockChain_unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+  · intro op' hop'
+    have h_wf := h₆ op' (by grind)
+    apply OperationPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+  · intro blk hblk
+    have h_wf := h₇ blk (by grind)
+    apply BlockPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+  · intro reg hreg
+    have h_wf := h₈ reg (by grind)
+    apply RegionPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+
+theorem BlockPtr.opChain_OperationPtr_setProperties
+    (hWf : BlockPtr.OpChain block' ctx array)
+    {op : OperationPtr} (hop : op.InBounds ctx)
+    {opCode : OpInfo} (newProps : HasOpInfo.propertiesOf opCode)
+    (hprop : op.getOpType! ctx = opCode := by grind) :
+    BlockPtr.OpChain block' (op.setProperties ctx newProps hop hprop) array := by
+  apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
+
+@[grind =]
+theorem BlockPtr.operationList_operationPtr_setProperties
+    (hctx : ctx.WellFormed) :
+    BlockPtr.operationList block' (OperationPtr.setProperties op ctx newProps hop hprop) ctx' blockInBounds' =
+    BlockPtr.operationList block' ctx hctx (by grind) := by
+  simp only [← BlockPtr.operationList_iff_BlockPtr_OpChain]
+  grind [BlockPtr.opChain_OperationPtr_setProperties]
+
+theorem Rewriter.setProperties_WellFormed
+    (hctx : ctx.WellFormed) :
+    (Rewriter.setProperties ctx op newProps hop hprop).WellFormed := by
+   grind [setProperties, OperationPtr.setProperties_WellFormed]
+
+end setProperties
 
 theorem Rewriter.detachOperands.loop_wellFormed
     (wf : IRContext.WellFormed ctx missingOperands missingSuccessors)

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -152,6 +152,45 @@ def WfRewriter.replaceOperand! (wfCtx : WfIRContext OpInfo) (use : OpOperandPtr)
   else
     panic! "WfRewriter.replaceOperand! failed: operand use is out of bounds"
 
+/-- Set the attributes of an operation. -/
+@[inline]
+def WfRewriter.setAttributes (wfCtx : WfIRContext OpInfo) (op : OperationPtr) (newAttrs : DictionaryAttr)
+    (opIn : op.InBounds wfCtx.raw := by grind) : WfIRContext OpInfo :=
+  ⟨Rewriter.setAttributes wfCtx.raw op newAttrs opIn,
+    by grind [Rewriter.setAttributes_WellFormed]⟩
+
+/-- Set the attributes of an operation, panicking if the operation is out of bounds. -/
+def WfRewriter.setAttributes! (wfCtx : WfIRContext OpInfo) (op : OperationPtr) (newAttrs : DictionaryAttr)
+    : WfIRContext OpInfo :=
+  if hop : op.InBounds wfCtx.raw then
+    WfRewriter.setAttributes wfCtx op newAttrs hop
+  else
+    panic! "WfRewriter.replaceOperand! failed: operation is out of bounds"
+
+/-- Set the properties of an operation. -/
+@[inline]
+def WfRewriter.setProperties {opCode : OpInfo} (wfCtx : WfIRContext OpInfo) (op : OperationPtr)
+    (newProps : HasOpInfo.propertiesOf opCode)
+    (opIn : op.InBounds wfCtx.raw := by grind)
+    (hprop : op.getOpType! wfCtx.raw = opCode := by grind) :
+    WfIRContext OpInfo :=
+  ⟨Rewriter.setProperties wfCtx.raw op newProps opIn hprop,
+    by grind [Rewriter.setProperties_WellFormed]⟩
+
+/--
+Set the properties of an operation, panicking if the operation is out of bounds, or if the
+property types don't match.
+-/
+def WfRewriter.setProperties! {opCode : OpInfo} (wfCtx : WfIRContext OpInfo) (op : OperationPtr)
+    (newProperties : HasOpInfo.propertiesOf opCode) : WfIRContext OpInfo :=
+  if opIn : op.InBounds wfCtx.raw then
+    if hprop : op.getOpType! wfCtx.raw = opCode then
+      WfRewriter.setProperties wfCtx op newProperties opIn hprop
+    else
+      panic! "WfRewriter.setProperties! failed: property types don't match"
+  else
+    panic! "WfRewriter.setProperties! failed: operation is out of bounds"
+
 /-- Set the type of a value. -/
 @[inline]
 def WfRewriter.setType (wfCtx : WfIRContext OpInfo) (value : ValuePtr) (newType : TypeAttr)

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -165,7 +165,7 @@ def WfRewriter.setAttributes! (wfCtx : WfIRContext OpInfo) (op : OperationPtr) (
   if hop : op.InBounds wfCtx.raw then
     WfRewriter.setAttributes wfCtx op newAttrs hop
   else
-    panic! "WfRewriter.replaceOperand! failed: operation is out of bounds"
+    panic! "WfRewriter.setAttributes! failed: operation is out of bounds"
 
 /-- Set the properties of an operation. -/
 @[inline]

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -877,6 +877,318 @@ theorem OperationPtr.getResultTypes!_WfRewriter_replaceValue :
 
 end WfRewriter.replaceValue
 
+/-! ## `WfRewriter.setAttributes` -/
+
+section WfRewriter.setAttributes
+
+attribute [local grind] WfRewriter.setAttributes
+
+variable {op : OperationPtr} {newAttrs : DictionaryAttr} {opIn : op.InBounds ctx.raw}
+
+@[simp, grind =]
+theorem BlockPtr.prev!_wfRewriter_setAttributes {block : BlockPtr} :
+    (block.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).prev =
+    (block.get! ctx.raw).prev := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.next!_wfRewriter_setAttributes {block : BlockPtr} :
+    (block.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).next =
+    (block.get! ctx.raw).next := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.parent!_wfRewriter_setAttributes {block : BlockPtr} :
+    (block.get! ((WfRewriter.setAttributes ctx op newAttrs opIn).raw)).parent =
+    (block.get! ctx.raw).parent := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstOp!_wfRewriter_setAttributes {block : BlockPtr} :
+    (block.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).firstOp =
+    (block.get! ctx.raw).firstOp := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.lastOp!_wfRewriter_setAttributes {block : BlockPtr} :
+    (block.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).lastOp =
+    (block.get! ctx.raw).lastOp := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.prev!_wfRewriter_setAttributes {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).prev =
+    (op'.get! ctx.raw).prev := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.next!_wfRewriter_setAttributes {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).next =
+    (op'.get! ctx.raw).next := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.parent!_wfRewriter_setAttributes {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).parent =
+    (op'.get! ctx.raw).parent := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getOpType! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getOpType! ctx := by
+  grind
+
+@[grind =]
+theorem OperationPtr.attrs!_wfRewriter_setAttributes {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).attrs =
+    if op' = op then newAttrs else (op'.get! ctx.raw).attrs  := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getProperties!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getProperties! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getProperties! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumResults!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getNumResults! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getNumResults! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumOperands!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getNumOperands! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getNumOperands! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperand!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getOperand! (WfRewriter.setAttributes ctx op newAttrs opIn).raw index =
+    op'.getOperand! ctx.raw index := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperands!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getOperands! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getOperands! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumSuccessors!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getNumSuccessors! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getNumSuccessors! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessor!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getSuccessor! (WfRewriter.setAttributes ctx op newAttrs opIn).raw index =
+    op'.getSuccessor! ctx.raw index := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessors!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getSuccessors! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getSuccessors! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumRegions!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getNumRegions! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getNumRegions! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getRegions!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getRegions! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getRegions! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.firstBlock!_wfRewriter_setAttributes {region : RegionPtr} :
+    (region.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).firstBlock =
+    (region.get! ctx.raw).firstBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.lastBlock!_wfRewriter_setAttributes {region : RegionPtr} :
+    (region.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).lastBlock =
+    (region.get! ctx.raw).lastBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.parent!_wfRewriter_setAttributes {region : RegionPtr} :
+    (region.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).parent =
+    (region.get! ctx.raw).parent := by
+  grind
+
+@[simp, grind =]
+theorem ValuePtr.getType!_wfRewriter_setAttributes {value : ValuePtr} :
+    value.getType! (WfRewriter.setAttributes ctx op newAttrs opIn).raw  =
+    value.getType! ctx.raw := by
+  grind
+
+end WfRewriter.setAttributes
+
+/-! ## `WfRewriter.setProperties` -/
+
+section WfRewriter.setProperties
+
+attribute [local grind] WfRewriter.setProperties
+
+variable {opCode: OpInfo} {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode} {opIn : op.InBounds ctx.raw}
+         {opIn: op.InBounds ctx.raw} {hprop : op.getOpType! ctx.raw = opCode}
+
+@[simp, grind =]
+theorem BlockPtr.prev!_wfRewriter_setProperties {block : BlockPtr} :
+    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).prev =
+    (block.get! ctx.raw).prev := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.next!_wfRewriter_setProperties {block : BlockPtr} :
+    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).next =
+    (block.get! ctx.raw).next := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.parent!_wfRewriter_setProperties {block : BlockPtr} :
+    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop).raw)).parent =
+    (block.get! ctx.raw).parent := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.firstOp!_wfRewriter_setProperties {block : BlockPtr} :
+    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).firstOp =
+    (block.get! ctx.raw).firstOp := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.lastOp!_wfRewriter_setProperties {block : BlockPtr} :
+    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).lastOp =
+    (block.get! ctx.raw).lastOp := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.prev!_wfRewriter_setProperties {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).prev =
+    (op'.get! ctx.raw).prev := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.next!_wfRewriter_setProperties {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).next =
+    (op'.get! ctx.raw).next := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.parent!_wfRewriter_setProperties {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).parent =
+    (op'.get! ctx.raw).parent := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOpType!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getOpType! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getOpType! ctx := by
+  grind
+
+@[simp ,grind =]
+theorem OperationPtr.attrs!_wfRewriter_setProperties {op' : OperationPtr} :
+    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).attrs =
+    (op'.get! ctx.raw).attrs := by
+  grind
+
+@[grind =]
+theorem OperationPtr.getProperties!_wfRewriter_setProperties {op' : OperationPtr} {opCode' : OpInfo}:
+    op'.getProperties! (WfRewriter.setProperties ctx op newProps opIn hprop).raw opCode' =
+    if op' = op then
+      if h: opCode' = opCode then h ▸ newProps else default
+    else
+      op'.getProperties! ctx.raw opCode' := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumResults!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getNumResults! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumResults! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumOperands!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getNumOperands! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumOperands! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperand!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getOperand! (WfRewriter.setProperties ctx op newProps opIn hprop).raw index =
+    op'.getOperand! ctx.raw index := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getOperands!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getOperands! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getOperands! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumSuccessors!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getNumSuccessors! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumSuccessors! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessor!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getSuccessor! (WfRewriter.setProperties ctx op newProps opIn hprop).raw index =
+    op'.getSuccessor! ctx.raw index := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getSuccessors!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getSuccessors! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getSuccessors! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getNumRegions!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getNumRegions! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumRegions! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getRegions!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getRegions! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getRegions! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.firstBlock!_wfRewriter_setProperties {region : RegionPtr} :
+    (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).firstBlock =
+    (region.get! ctx.raw).firstBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.lastBlock!_wfRewriter_setProperties {region : RegionPtr} :
+    (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).lastBlock =
+    (region.get! ctx.raw).lastBlock := by
+  grind
+
+@[simp, grind =]
+theorem RegionPtr.parent!_wfRewriter_setProperties {region : RegionPtr} :
+    (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).parent =
+    (region.get! ctx.raw).parent := by
+  grind
+
+@[simp, grind =]
+theorem ValuePtr.getType!_wfRewriter_setProperties {value : ValuePtr} :
+    value.getType! (WfRewriter.setProperties ctx op newProps opIn hprop).raw  =
+    value.getType! ctx.raw := by
+  grind
+
+end WfRewriter.setProperties
+
 /-! ## `WfRewriter.setType` -/
 
 section WfRewriter.setType

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -1006,6 +1006,18 @@ theorem OperationPtr.getRegions!_wfRewriter_setAttributes {op' : OperationPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getRegion!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getRegion! (WfRewriter.setAttributes ctx op newAttrs opIn).raw index =
+    op'.getRegion! ctx.raw index := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.getNumArguments!_wfRewriter_setAttributes {block : BlockPtr} :
+    block.getNumArguments! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    block.getNumArguments! ctx.raw := by
+  grind
+
+@[simp, grind =]
 theorem RegionPtr.firstBlock!_wfRewriter_setAttributes {region : RegionPtr} :
     (region.get! ((WfRewriter.setAttributes ctx op newAttrs opIn)).raw).firstBlock =
     (region.get! ctx.raw).firstBlock := by
@@ -1027,6 +1039,12 @@ theorem RegionPtr.parent!_wfRewriter_setAttributes {region : RegionPtr} :
 theorem ValuePtr.getType!_wfRewriter_setAttributes {value : ValuePtr} :
     value.getType! (WfRewriter.setAttributes ctx op newAttrs opIn).raw  =
     value.getType! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getResultTypes!_wfRewriter_setAttributes {op' : OperationPtr} :
+    op'.getResultTypes! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
+    op'.getResultTypes! ctx.raw := by
   grind
 
 end WfRewriter.setAttributes
@@ -1170,6 +1188,18 @@ theorem RegionPtr.firstBlock!_wfRewriter_setProperties {region : RegionPtr} :
   grind
 
 @[simp, grind =]
+theorem OperationPtr.getRegion!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getRegion! (WfRewriter.setProperties ctx op newProps opIn hprop).raw index =
+    op'.getRegion! ctx.raw index := by
+  grind
+
+@[simp, grind =]
+theorem BlockPtr.getNumArguments!_wfRewriter_setProperties {block : BlockPtr} :
+    block.getNumArguments! (WfRewriter.setProperties ctx op newProps opIn).raw =
+    block.getNumArguments! ctx.raw := by
+  grind
+
+@[simp, grind =]
 theorem RegionPtr.lastBlock!_wfRewriter_setProperties {region : RegionPtr} :
     (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).lastBlock =
     (region.get! ctx.raw).lastBlock := by
@@ -1185,6 +1215,12 @@ theorem RegionPtr.parent!_wfRewriter_setProperties {region : RegionPtr} :
 theorem ValuePtr.getType!_wfRewriter_setProperties {value : ValuePtr} :
     value.getType! (WfRewriter.setProperties ctx op newProps opIn hprop).raw  =
     value.getType! ctx.raw := by
+  grind
+
+@[simp, grind =]
+theorem OperationPtr.getResultTypes!_wfRewriter_setProperties {op' : OperationPtr} :
+    op'.getResultTypes! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getResultTypes! ctx.raw := by
   grind
 
 end WfRewriter.setProperties


### PR DESCRIPTION
This adds `setAttributes` and `setProperties` to `Rewriter/WfRewriter`, with corresponding GetSet lemmas for each.
This also adds the same proof about `WellFormed` for `setProperties` that already exists for `setAttributes`.

The initial motivation for this was to remove the current `sorry`s in `setFunctionType` (`Passes/CastsReconciliation/Reconciliation.lean`).
This and other potential call sites will be updated in follow-ups to keep this smaller.