### PR TITLE
feat: add setFunctionType to FunctionOpInterface

### DIFF
--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.GlobalOpInfo
 public import Veir.IR.Fields
+public import Veir.Rewriter.WfRewriter
 
 /-!
 # FunctionOpInterface
@@ -77,6 +78,40 @@ grind_pattern getFunctionBody!_inBounds => (getFunctionBody! funcOp raw), raw.Fi
 /-- Returns the first block in the body region. -/
 def getEntryBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option BlockPtr :=
   ((getFunctionBody! funcOp raw).get! raw).firstBlock
+
+/-!
+## Type Attribute Handling
+-/
+
+/-- Sets the function type to the given input/output type lists.
+    `llvm.func` is canonicalized to the `.llvmFunctionType` spelling, regardless of
+    which spelling the original attribute used. -/
+def setFunctionType (wfCtx : WfIRContext OpCode) (funcOp : OperationPtr)
+    (inputs outputs : Array Attribute)
+    (opInBounds : funcOp.InBounds wfCtx.raw := by grind) : WfIRContext OpCode :=
+  match h : funcOp.getOpType wfCtx.raw opInBounds with
+  | .func .func =>
+    let ftType : TypeAttr := ⟨.functionType { inputs, outputs }, by simp⟩
+    let props : FuncFuncProperties := funcOp.getProperties! wfCtx.raw (.func .func)
+    let newProps : FuncFuncProperties := { props with function_type := some ftType }
+    WfRewriter.setProperties (opCode := .func .func) wfCtx funcOp newProps opInBounds
+  | .llvm .func =>
+    let ftType : TypeAttr := ⟨.llvmFunctionType { inputs, outputs }, by simp⟩
+    let props : LLVMFuncProperties := funcOp.getProperties! wfCtx.raw (.llvm .func)
+    let newProps : LLVMFuncProperties := { props with function_type := some ftType }
+    WfRewriter.setProperties (opCode := .llvm .func) wfCtx funcOp newProps opInBounds
+  | _ => wfCtx
+
+/-- Sets the function type to the given input/output type lists, panicking if the op
+    is out of bounds.
+    `llvm.func` is canonicalized to the `.llvmFunctionType` spelling, regardless of
+    which spelling the original attribute used. -/
+def setFunctionType! (c : WfIRContext OpCode) (funcOp : OperationPtr)
+    (inputs outputs : Array Attribute) : WfIRContext OpCode :=
+  if opInBounds : funcOp.InBounds c.raw then
+    setFunctionType c funcOp inputs outputs opInBounds
+  else
+    panic "FunctionOpInterface.setFunctionType! failed: operation is out of bounds"
 
 /-!
 ## Argument and Result Handling

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -120,30 +120,6 @@ def returnOpCodeFor : OpCode → OpCode
   | _ => .func .return
 
 set_option warn.sorry false in
-/-- Rewrite a function op's `function_type` to the given input/output type lists.
-    `llvm.func` is canonicalized to the `.llvmFunctionType` spelling, regardless of
-    which spelling the original attribute used. -/
-def setFunctionType (c : WfIRContext OpCode) (funcOp : OperationPtr)
-    (inputs outputs : Array Attribute) : WfIRContext OpCode :=
-  let ftType : TypeAttr :=
-    match funcOp.getOpType! c.raw with
-    | .llvm .func => ⟨.llvmFunctionType { inputs, outputs }, by simp⟩
-    | _ => ⟨.functionType { inputs, outputs }, by simp⟩
-  match funcOp.getOpType! c.raw with
-  | .func .func =>
-    let props : FuncFuncProperties := funcOp.getProperties! c.raw (.func .func)
-    let newEntries := props.extra.entries.map fun (k, v) =>
-      if k == "function_type".toUTF8 then (k, ftType.val) else (k, v)
-    let newProps : FuncFuncProperties :=
-      { props with function_type := some ftType, extra := DictionaryAttr.fromArray newEntries }
-    ⟨funcOp.setProperties (opCode := .func .func) c.raw newProps sorry sorry, sorry⟩
-  | .llvm .func =>
-    let props : LLVMFuncProperties := funcOp.getProperties! c.raw (.llvm .func)
-    let newProps : LLVMFuncProperties := { props with function_type := some ftType }
-    ⟨funcOp.setProperties (opCode := .llvm .func) c.raw newProps sorry sorry, sorry⟩
-  | _ => c
-
-set_option warn.sorry false in
 /-- Coerce one function's `i32`/`i64` arguments and return values to `!riscv.reg`,
     inserting bridging casts and rewriting the `function_type` to match. Handles both
     `func.func` and `llvm.func`. -/
@@ -191,7 +167,7 @@ def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
         -- a return's operand count equals the function's declared result count.
         outputs := outputs.set! j (.registerType ⟨none⟩)
   -- (3) Rewrite the function_type to reflect the coerced boundary types.
-  ctx := setFunctionType ctx funcOp inputs outputs
+  ctx := FunctionOpInterface.setFunctionType! ctx funcOp inputs outputs
   return ctx
 
 def coerceFunctionBoundaries (ctx : WfIRContext OpCode) :


### PR DESCRIPTION
Follows #1108.

Removes the `sorry`s in `setFunctionInterface` and moves it into `FunctionOpInterface`.
Also applies missing changes in `setFunctionInterface` related to the `FuncFuncProperties` changes in #1075.