### PR TITLE
feat(arith): remaining arith dialect interpreter semantics

### DIFF
--- a/Test/Interpreter/Arith/addui_extended.mlir
+++ b/Test/Interpreter/Arith/addui_extended.mlir
@@ -1,0 +1,16 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `arith.addui_extended` returns the w-bit sum and an i1 unsigned-overflow flag.
+// 200 + 100 = 300 -> sum 0x2c, overflow 1.
+// 100 + 100 = 200 -> sum 0xc8, overflow 0.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i1, i8, i1)}> ({
+    %c200 = "arith.constant"() <{ "value" = 200 : i8 }> : () -> i8
+    %c100 = "arith.constant"() <{ "value" = 100 : i8 }> : () -> i8
+    %s1, %o1 = "arith.addui_extended"(%c200, %c100) : (i8, i8) -> (i8, i1)
+    %s2, %o2 = "arith.addui_extended"(%c100, %c100) : (i8, i8) -> (i8, i1)
+    "func.return"(%s1, %o1, %s2, %o2) : (i8, i1, i8, i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x2c#8, 0x1#1, 0xc8#8, 0x0#1]

--- a/Test/Interpreter/Arith/ceildivsi.mlir
+++ b/Test/Interpreter/Arith/ceildivsi.mlir
@@ -1,0 +1,23 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed ceiling division (rounds toward +infinity).
+//  7 /  2 =  4 (0x04)      -7 /  2 = -3 (0xfd)
+//  7 / -2 = -3 (0xfd)      -7 / -2 =  4 (0x04)
+//  6 /  2 =  3 (exact, 0x03)
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8, i8, i8, i8)}> ({
+    %c7  = "arith.constant"() <{ "value" = 7 : i8 }> : () -> i8
+    %cn7 = "arith.constant"() <{ "value" = -7 : i8 }> : () -> i8
+    %c6  = "arith.constant"() <{ "value" = 6 : i8 }> : () -> i8
+    %c2  = "arith.constant"() <{ "value" = 2 : i8 }> : () -> i8
+    %cn2 = "arith.constant"() <{ "value" = -2 : i8 }> : () -> i8
+    %r1 = "arith.ceildivsi"(%c7, %c2) : (i8, i8) -> i8
+    %r2 = "arith.ceildivsi"(%cn7, %c2) : (i8, i8) -> i8
+    %r3 = "arith.ceildivsi"(%c7, %cn2) : (i8, i8) -> i8
+    %r4 = "arith.ceildivsi"(%cn7, %cn2) : (i8, i8) -> i8
+    %r5 = "arith.ceildivsi"(%c6, %c2) : (i8, i8) -> i8
+    "func.return"(%r1, %r2, %r3, %r4, %r5) : (i8, i8, i8, i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x04#8, 0xfd#8, 0xfd#8, 0x04#8, 0x03#8]

--- a/Test/Interpreter/Arith/ceildivsi_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/ceildivsi_div_by_zero.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// A zero divisor is immediate UB, matching arith.divsi.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+    %a = "arith.constant"() <{ "value" = 7 : i8 }> : () -> i8
+    %z = "arith.constant"() <{ "value" = 0 : i8 }> : () -> i8
+    %r = "arith.ceildivsi"(%a, %z) : (i8, i8) -> i8
+    "func.return"(%r) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/ceildivsi_intmin_neg1.mlir
+++ b/Test/Interpreter/Arith/ceildivsi_intmin_neg1.mlir
@@ -1,0 +1,14 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `ceildivsi intMin, -1` is immediate UB (the underlying signed quotient
+// overflows), matching arith.divsi.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+    %intmin = "arith.constant"() <{ "value" = -128 : i8 }> : () -> i8
+    %negone = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
+    %r = "arith.ceildivsi"(%intmin, %negone) : (i8, i8) -> i8
+    "func.return"(%r) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/ceildivui.mlir
+++ b/Test/Interpreter/Arith/ceildivui.mlir
@@ -1,0 +1,23 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Unsigned ceiling division: ceildivui(a, b) = a == 0 ? 0 : ((a-1)/b) + 1.
+// 10 / 3 = 4, 12 / 5 = 3 (2.4 rounds up), 0 / 7 = 0, 8 / 2 = 4 (exact).
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8, i8, i8)}> ({
+    %c10 = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
+    %c12 = "arith.constant"() <{ "value" = 12 : i8 }> : () -> i8
+    %c8  = "arith.constant"() <{ "value" = 8 : i8 }> : () -> i8
+    %c0  = "arith.constant"() <{ "value" = 0 : i8 }> : () -> i8
+    %c3  = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
+    %c5  = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
+    %c7  = "arith.constant"() <{ "value" = 7 : i8 }> : () -> i8
+    %c2  = "arith.constant"() <{ "value" = 2 : i8 }> : () -> i8
+    %r1 = "arith.ceildivui"(%c10, %c3) : (i8, i8) -> i8
+    %r2 = "arith.ceildivui"(%c12, %c5) : (i8, i8) -> i8
+    %r3 = "arith.ceildivui"(%c0, %c7) : (i8, i8) -> i8
+    %r4 = "arith.ceildivui"(%c8, %c2) : (i8, i8) -> i8
+    "func.return"(%r1, %r2, %r3, %r4) : (i8, i8, i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x04#8, 0x03#8, 0x00#8, 0x04#8]

--- a/Test/Interpreter/Arith/ceildivui_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/ceildivui_div_by_zero.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// A zero divisor is immediate UB, matching arith.divui.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+    %a = "arith.constant"() <{ "value" = 10 : i8 }> : () -> i8
+    %z = "arith.constant"() <{ "value" = 0 : i8 }> : () -> i8
+    %r = "arith.ceildivui"(%a, %z) : (i8, i8) -> i8
+    "func.return"(%r) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/cmpi.mlir
+++ b/Test/Interpreter/Arith/cmpi.mlir
@@ -1,0 +1,20 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `arith.cmpi` lowers to `llvm.icmp`; the predicate integer encoding is shared
+// (eq=0, ne=1, slt=2, sle=3, sgt=4, sge=5, ult=6, ule=7, ugt=8, uge=9).
+// Operands: a = 5, b = -3 (0xfd, i.e. unsigned 253).
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i1, i1, i1, i1, i1, i1)}> ({
+    %a = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
+    %b = "arith.constant"() <{ "value" = -3 : i8 }> : () -> i8
+    %eq  = "arith.cmpi"(%a, %b) <{ "predicate" = 0 : i64 }> : (i8, i8) -> i1
+    %ne  = "arith.cmpi"(%a, %b) <{ "predicate" = 1 : i64 }> : (i8, i8) -> i1
+    %slt = "arith.cmpi"(%a, %b) <{ "predicate" = 2 : i64 }> : (i8, i8) -> i1
+    %sgt = "arith.cmpi"(%a, %b) <{ "predicate" = 4 : i64 }> : (i8, i8) -> i1
+    %ult = "arith.cmpi"(%a, %b) <{ "predicate" = 6 : i64 }> : (i8, i8) -> i1
+    %ugt = "arith.cmpi"(%a, %b) <{ "predicate" = 8 : i64 }> : (i8, i8) -> i1
+    "func.return"(%eq, %ne, %slt, %sgt, %ult, %ugt) : (i1, i1, i1, i1, i1, i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0#1, 0x1#1, 0x0#1, 0x1#1, 0x1#1, 0x0#1]

--- a/Test/Interpreter/Arith/floordivsi.mlir
+++ b/Test/Interpreter/Arith/floordivsi.mlir
@@ -1,0 +1,23 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed floor division (rounds toward -infinity).
+//  7 /  2 =  3 (0x03)      -7 /  2 = -4 (0xfc)
+//  7 / -2 = -4 (0xfc)      -7 / -2 =  3 (0x03)
+// -6 /  2 = -3 (exact, 0xfd)
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8, i8, i8, i8)}> ({
+    %c7  = "arith.constant"() <{ "value" = 7 : i8 }> : () -> i8
+    %cn7 = "arith.constant"() <{ "value" = -7 : i8 }> : () -> i8
+    %cn6 = "arith.constant"() <{ "value" = -6 : i8 }> : () -> i8
+    %c2  = "arith.constant"() <{ "value" = 2 : i8 }> : () -> i8
+    %cn2 = "arith.constant"() <{ "value" = -2 : i8 }> : () -> i8
+    %r1 = "arith.floordivsi"(%c7, %c2) : (i8, i8) -> i8
+    %r2 = "arith.floordivsi"(%cn7, %c2) : (i8, i8) -> i8
+    %r3 = "arith.floordivsi"(%c7, %cn2) : (i8, i8) -> i8
+    %r4 = "arith.floordivsi"(%cn7, %cn2) : (i8, i8) -> i8
+    %r5 = "arith.floordivsi"(%cn6, %c2) : (i8, i8) -> i8
+    "func.return"(%r1, %r2, %r3, %r4, %r5) : (i8, i8, i8, i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x03#8, 0xfc#8, 0xfc#8, 0x03#8, 0xfd#8]

--- a/Test/Interpreter/Arith/floordivsi_div_by_zero.mlir
+++ b/Test/Interpreter/Arith/floordivsi_div_by_zero.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// A zero divisor is immediate UB, matching arith.divsi.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+    %a = "arith.constant"() <{ "value" = 7 : i8 }> : () -> i8
+    %z = "arith.constant"() <{ "value" = 0 : i8 }> : () -> i8
+    %r = "arith.floordivsi"(%a, %z) : (i8, i8) -> i8
+    "func.return"(%r) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/floordivsi_intmin_neg1.mlir
+++ b/Test/Interpreter/Arith/floordivsi_intmin_neg1.mlir
@@ -1,0 +1,14 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `floordivsi intMin, -1` is immediate UB (the underlying signed quotient
+// overflows), matching arith.divsi.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i8}> ({
+    %intmin = "arith.constant"() <{ "value" = -128 : i8 }> : () -> i8
+    %negone = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
+    %r = "arith.floordivsi"(%intmin, %negone) : (i8, i8) -> i8
+    "func.return"(%r) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/Arith/minmax.mlir
+++ b/Test/Interpreter/Arith/minmax.mlir
@@ -1,0 +1,17 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// Signed/unsigned min and max. Operands a = 5 (0x05), b = -3 (0xfd = 253).
+// maxsi = 5, minsi = -3, maxui = 253, minui = 5.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8, i8, i8)}> ({
+    %a = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
+    %b = "arith.constant"() <{ "value" = -3 : i8 }> : () -> i8
+    %maxs = "arith.maxsi"(%a, %b) : (i8, i8) -> i8
+    %mins = "arith.minsi"(%a, %b) : (i8, i8) -> i8
+    %maxu = "arith.maxui"(%a, %b) : (i8, i8) -> i8
+    %minu = "arith.minui"(%a, %b) : (i8, i8) -> i8
+    "func.return"(%maxs, %mins, %maxu, %minu) : (i8, i8, i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x05#8, 0xfd#8, 0xfd#8, 0x05#8]

--- a/Test/Interpreter/Arith/mulsi_extended.mlir
+++ b/Test/Interpreter/Arith/mulsi_extended.mlir
@@ -1,0 +1,15 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `arith.mulsi_extended` returns the low and high halves of the 2w-bit signed
+// product. -2 * 3 = -6, represented in 16 bits as 0xfffa: low = 0xfa,
+// high = 0xff. The low half equals `arith.muli`.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8)}> ({
+    %cn2 = "arith.constant"() <{ "value" = -2 : i8 }> : () -> i8
+    %c3  = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
+    %lo, %hi = "arith.mulsi_extended"(%cn2, %c3) : (i8, i8) -> (i8, i8)
+    "func.return"(%lo, %hi) : (i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0xfa#8, 0xff#8]

--- a/Test/Interpreter/Arith/mului_extended.mlir
+++ b/Test/Interpreter/Arith/mului_extended.mlir
@@ -1,0 +1,15 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// `arith.mului_extended` returns the low and high halves of the 2w-bit unsigned
+// product. 254 * 3 = 762 = 0x02fa: low = 0xfa, high = 0x02. The low half
+// equals `arith.muli`.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8)}> ({
+    %c254 = "arith.constant"() <{ "value" = 254 : i8 }> : () -> i8
+    %c3   = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
+    %lo, %hi = "arith.mului_extended"(%c254, %c3) : (i8, i8) -> (i8, i8)
+    "func.return"(%lo, %hi) : (i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0xfa#8, 0x02#8]

--- a/Test/Interpreter/Arith/new_ops_poison.mlir
+++ b/Test/Interpreter/Arith/new_ops_poison.mlir
@@ -1,0 +1,21 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// A poison operand propagates to the result of each new op (both results, for
+// the multi-result ops). Poison is produced here via an nuw addi overflow.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i1, i8, i1, i8, i8, i8, i8)}> ({
+    %c255 = "arith.constant"() <{ "value" = 255 : i8 }> : () -> i8
+    %c3   = "arith.constant"() <{ "value" = 3 : i8 }> : () -> i8
+    %c5   = "arith.constant"() <{ "value" = 5 : i8 }> : () -> i8
+    %poison = "arith.addi"(%c255, %c3) <{"overflowFlags" = #arith.overflow<nuw>}> : (i8, i8) -> i8
+    %maxs = "arith.maxsi"(%poison, %c5) : (i8, i8) -> i8
+    %cmp  = "arith.cmpi"(%poison, %c5) <{ "predicate" = 2 : i64 }> : (i8, i8) -> i1
+    %asum, %aov = "arith.addui_extended"(%poison, %c5) : (i8, i8) -> (i8, i1)
+    %mlo, %mhi = "arith.mulsi_extended"(%poison, %c3) : (i8, i8) -> (i8, i8)
+    %cs = "arith.ceildivsi"(%poison, %c5) : (i8, i8) -> i8
+    %fs = "arith.floordivsi"(%poison, %c5) : (i8, i8) -> i8
+    "func.return"(%maxs, %cmp, %asum, %aov, %mlo, %mhi, %cs, %fs) : (i8, i1, i8, i1, i8, i8, i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[poison, poison, poison, poison, poison, poison, poison, poison]

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -122,6 +122,18 @@ def add {w : Nat} (x y : Int w) (nsw : Bool := false) (nuw : Bool := false) : In
   val (x' + y')
 
 /--
+The overflow (carry-out) bit of an unsigned addition, as produced by the second
+result of `arith.addui_extended`. This lowers to the `i1` overflow value of
+`llvm.uadd.with.overflow`: the result is `1` when the unsigned sum of `x` and `y`
+does not fit in `w` bits, and `0` otherwise. If either operand is poison, the
+result is poison.
+-/
+def uaddOverflowFlag {w : Nat} (x y : Int w) : Int 1 := Id.run do
+  let val x' := x | poison
+  let val y' := y | poison
+  val (BitVec.ofBool (BitVec.uaddOverflow x' y'))
+
+/--
 The `sub` instruction returns the difference of its two operands.
 
 Note that the `sub` instruction is used to represent the `neg` instruction
@@ -270,6 +282,32 @@ def mul {w : Nat} (x y : Int w) (nsw : Bool := false) (nuw : Bool := false) : In
     return poison
 
   val (x' * y')
+
+/--
+The high half of the `2 * w`-bit unsigned product of `x` and `y`, as produced by
+the second (`high`) result of `arith.mului_extended`. The operands are
+zero-extended to `2 * w` bits, multiplied, and the high `w` bits (positions
+`w …< 2*w`) are returned. The corresponding low half is `mul x y`. If either
+operand is poison, the result is poison.
+-/
+def umulHigh {w : Nat} (x y : Int w) : Int w := Id.run do
+  let val x' := x | poison
+  let val y' := y | poison
+  let wide : BitVec (w + w) := x'.zeroExtend (w + w) * y'.zeroExtend (w + w)
+  val (wide.extractLsb' w w)
+
+/--
+The high half of the `2 * w`-bit signed product of `x` and `y`, as produced by
+the second (`high`) result of `arith.mulsi_extended`. The operands are
+sign-extended to `2 * w` bits, multiplied, and the high `w` bits (positions
+`w …< 2*w`) are returned. The corresponding low half is `mul x y`. If either
+operand is poison, the result is poison.
+-/
+def smulHigh {w : Nat} (x y : Int w) : Int w := Id.run do
+  let val x' := x | poison
+  let val y' := y | poison
+  let wide : BitVec (w + w) := x'.signExtend (w + w) * y'.signExtend (w + w)
+  val (wide.extractLsb' w w)
 
 /--
 The ‘udiv’ instruction returns the unsigned integer quotient of its two operands.

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -641,7 +641,124 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simpa using h)
     return (#[.int bw (LLVM.Int.select cond lhs rhs)], none)
-  | _ => none
+  | .cmpi => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    -- `arith.cmpi` lowers to `llvm.icmp`; the arith and LLVM predicate encodings
+    -- coincide, so `properties.predicate` is used directly. Result is `i1`.
+    return (#[.int 1 (LLVM.Int.icmp lhs rhs properties.predicate)], none)
+  | .maxsi => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    return (#[.int bw (LLVM.Int.smax lhs rhs)], none)
+  | .minsi => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    return (#[.int bw (LLVM.Int.smin lhs rhs)], none)
+  | .maxui => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    return (#[.int bw (LLVM.Int.umax lhs rhs)], none)
+  | .minui => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    return (#[.int bw (LLVM.Int.umin lhs rhs)], none)
+  | .addui_extended => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    -- Two results: the `w`-bit sum, then the `i1` unsigned-overflow flag.
+    return (#[.int bw (LLVM.Int.add lhs rhs),
+              .int 1 (LLVM.Int.uaddOverflowFlag lhs rhs)], none)
+  | .mulsi_extended => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    -- Two results: the low half (same as `muli`), then the signed high half.
+    return (#[.int bw (LLVM.Int.mul lhs rhs),
+              .int bw (LLVM.Int.smulHigh lhs rhs)], none)
+  | .mului_extended => do
+    let [.int bw lhs, .int bw' rhs] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let rhs := rhs.cast (by simp at h; exact h)
+    -- Two results: the low half (same as `muli`), then the unsigned high half.
+    return (#[.int bw (LLVM.Int.mul lhs rhs),
+              .int bw (LLVM.Int.umulHigh lhs rhs)], none)
+  | .ceildivui => do
+    let [.int bw a, .int bw' b] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let b := b.cast (by simp at h; exact h)
+    -- Lowering (arith ExpandOps): `a == 0 ? 0 : ((a - 1) udiv b) + 1`. The
+    -- `udiv` makes a zero (or poison) divisor undefined behaviour, exactly as
+    -- for `arith.divui`.
+    match b with
+    | .poison => Interp.ub
+    | .val bv =>
+      if bv = 0 then Interp.ub
+      else
+        let zero : LLVM.Int bw := .val 0
+        let one : LLVM.Int bw := .val 1
+        let isZero := LLVM.Int.icmp a zero .eq
+        let quotient := LLVM.Int.udiv (LLVM.Int.sub a one) b
+        let plusOne := LLVM.Int.add quotient one
+        return (#[.int bw (LLVM.Int.select isZero zero plusOne)], none)
+  | .ceildivsi => do
+    let [.int bw a, .int bw' b] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let b := b.cast (by simp at h; exact h)
+    -- Lowering (arith ExpandOps): `z = a sdiv b;`
+    -- `(a != z*b) && ((a<0) == (b<0)) ? z + 1 : z`. The intermediate `mul`/`add`
+    -- carry no overflow flags (they wrap).
+    let zero : LLVM.Int bw := .val 0
+    let one : LLVM.Int bw := .val 1
+    let z := LLVM.Int.sdiv a b
+    let notExact := LLVM.Int.icmp a (LLVM.Int.mul z b) .ne
+    let signEqual := LLVM.Int.icmp (LLVM.Int.icmp a zero .slt) (LLVM.Int.icmp b zero .slt) .eq
+    let cond := LLVM.Int.and notExact signEqual
+    let result := LLVM.Int.select cond (LLVM.Int.add z one) z
+    -- UB gating mirrors `arith.divsi` (divide-by-zero, INT_MIN / -1).
+    match b with
+    | .poison => Interp.ub
+    | .val bv =>
+      if bv = 0 then Interp.ub
+      else if bv = -1 then
+        match a with
+        | .poison => Interp.ub
+        | .val av =>
+          if av = BitVec.intMin bw then Interp.ub
+          else return (#[.int bw result], none)
+      else return (#[.int bw result], none)
+  | .floordivsi => do
+    let [.int bw a, .int bw' b] := operands.toList | none
+    if h: bw' ≠ bw then none else
+    let b := b.cast (by simp at h; exact h)
+    -- Lowering (arith ExpandOps): `z = a sdiv b;`
+    -- `(a != z*b) && ((a<0) != (b<0)) ? z - 1 : z`. The intermediate `mul`/`add`
+    -- carry no overflow flags (they wrap).
+    let zero : LLVM.Int bw := .val 0
+    let negOne : LLVM.Int bw := .val (BitVec.allOnes bw)
+    let z := LLVM.Int.sdiv a b
+    let notExact := LLVM.Int.icmp a (LLVM.Int.mul z b) .ne
+    let signOpposite := LLVM.Int.icmp (LLVM.Int.icmp a zero .slt) (LLVM.Int.icmp b zero .slt) .ne
+    let cond := LLVM.Int.and notExact signOpposite
+    let result := LLVM.Int.select cond (LLVM.Int.add z negOne) z
+    -- UB gating mirrors `arith.divsi` (divide-by-zero, INT_MIN / -1).
+    match b with
+    | .poison => Interp.ub
+    | .val bv =>
+      if bv = 0 then Interp.ub
+      else if bv = -1 then
+        match a with
+        | .poison => Interp.ub
+        | .val av =>
+          if av = BitVec.intMin bw then Interp.ub
+          else return (#[.int bw result], none)
+      else return (#[.int bw result], none)
 
 def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -372,6 +372,24 @@ instance : Inhabited (Interp α) := ⟨(none : Option (UBOr α))⟩
 @[inline] def Interp.ub : Interp α := some .ub
 
 /--
+  Signal UB if the divisor `b` of an unsigned division or remainder could be
+  zero. A poison divisor may refine to zero, so it is immediate UB just like a
+  concretely-zero one.
+-/
+@[inline] def Interp.checkUnsignedDivision {w : Nat} (b : LLVM.Int w) : Interp Unit :=
+  if b = .poison ∨ b = .val 0 then Interp.ub else pure ()
+
+/--
+  Signal UB if the signed division or remainder `a / b` could be undefined:
+  a zero divisor, or the `intMin / -1` overflow case. As above, poison operands
+  may refine to any value, so they count as possibly triggering either case.
+-/
+@[inline] def Interp.checkSignedDivision {w : Nat} (a b : LLVM.Int w) : Interp Unit := do
+  Interp.checkUnsignedDivision b
+  -- The divisor is now concretely nonzero, so only a concrete `-1` can overflow.
+  if b = .val (-1) ∧ (a = .poison ∨ a = .val (BitVec.intMin w)) then Interp.ub
+
+/--
   Allocate the given number of bytes of memory.
   Return the updated memory state and the freshly allocated address.
 -/
@@ -538,56 +556,26 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    -- A poison divisor could refine to 0, so it is immediate UB just like a
-    -- concrete-zero divisor.
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], none)
+    Interp.checkUnsignedDivision rhs
+    return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], none)
   | .divsi => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else if v' = -1 then
-        -- Divisor is concretely -1; if the dividend could be intMin, the
-        -- overflow case applies and is UB.
-        match lhs with
-        | .poison => Interp.ub
-        | .val v =>
-          if v = BitVec.intMin bw then Interp.ub
-          else return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
-      else
-        return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
+    Interp.checkSignedDivision lhs rhs
+    return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], none)
   | .remui => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else return (#[.int bw (LLVM.Int.urem lhs rhs)], none)
+    Interp.checkUnsignedDivision rhs
+    return (#[.int bw (LLVM.Int.urem lhs rhs)], none)
   | .remsi => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else if v' = -1 then
-        match lhs with
-        | .poison => Interp.ub
-        | .val v =>
-          if v = BitVec.intMin bw then Interp.ub
-          else return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
-      else
-        return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
+    Interp.checkSignedDivision lhs rhs
+    return (#[.int bw (LLVM.Int.srem lhs rhs)], none)
   | .shli => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -696,17 +684,13 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     -- Lowering (arith ExpandOps): `a == 0 ? 0 : ((a - 1) udiv b) + 1`. The
     -- `udiv` makes a zero (or poison) divisor undefined behaviour, exactly as
     -- for `arith.divui`.
-    match b with
-    | .poison => Interp.ub
-    | .val bv =>
-      if bv = 0 then Interp.ub
-      else
-        let zero : LLVM.Int bw := .val 0
-        let one : LLVM.Int bw := .val 1
-        let isZero := LLVM.Int.icmp a zero .eq
-        let quotient := LLVM.Int.udiv (LLVM.Int.sub a one) b
-        let plusOne := LLVM.Int.add quotient one
-        return (#[.int bw (LLVM.Int.select isZero zero plusOne)], none)
+    Interp.checkUnsignedDivision b
+    let zero : LLVM.Int bw := .val 0
+    let one : LLVM.Int bw := .val 1
+    let isZero := LLVM.Int.icmp a zero .eq
+    let quotient := LLVM.Int.udiv (LLVM.Int.sub a one) b
+    let plusOne := LLVM.Int.add quotient one
+    return (#[.int bw (LLVM.Int.select isZero zero plusOne)], none)
   | .ceildivsi => do
     let [.int bw a, .int bw' b] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -716,23 +700,13 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     -- carry no overflow flags (they wrap).
     let zero : LLVM.Int bw := .val 0
     let one : LLVM.Int bw := .val 1
+    -- UB gating mirrors `arith.divsi` (divide-by-zero, INT_MIN / -1).
+    Interp.checkSignedDivision a b
     let z := LLVM.Int.sdiv a b
     let notExact := LLVM.Int.icmp a (LLVM.Int.mul z b) .ne
     let signEqual := LLVM.Int.icmp (LLVM.Int.icmp a zero .slt) (LLVM.Int.icmp b zero .slt) .eq
     let cond := LLVM.Int.and notExact signEqual
-    let result := LLVM.Int.select cond (LLVM.Int.add z one) z
-    -- UB gating mirrors `arith.divsi` (divide-by-zero, INT_MIN / -1).
-    match b with
-    | .poison => Interp.ub
-    | .val bv =>
-      if bv = 0 then Interp.ub
-      else if bv = -1 then
-        match a with
-        | .poison => Interp.ub
-        | .val av =>
-          if av = BitVec.intMin bw then Interp.ub
-          else return (#[.int bw result], none)
-      else return (#[.int bw result], none)
+    return (#[.int bw (LLVM.Int.select cond (LLVM.Int.add z one) z)], none)
   | .floordivsi => do
     let [.int bw a, .int bw' b] := operands.toList | none
     if h: bw' ≠ bw then none else
@@ -742,23 +716,13 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     -- carry no overflow flags (they wrap).
     let zero : LLVM.Int bw := .val 0
     let negOne : LLVM.Int bw := .val (BitVec.allOnes bw)
+    -- UB gating mirrors `arith.divsi` (divide-by-zero, INT_MIN / -1).
+    Interp.checkSignedDivision a b
     let z := LLVM.Int.sdiv a b
     let notExact := LLVM.Int.icmp a (LLVM.Int.mul z b) .ne
     let signOpposite := LLVM.Int.icmp (LLVM.Int.icmp a zero .slt) (LLVM.Int.icmp b zero .slt) .ne
     let cond := LLVM.Int.and notExact signOpposite
-    let result := LLVM.Int.select cond (LLVM.Int.add z negOne) z
-    -- UB gating mirrors `arith.divsi` (divide-by-zero, INT_MIN / -1).
-    match b with
-    | .poison => Interp.ub
-    | .val bv =>
-      if bv = 0 then Interp.ub
-      else if bv = -1 then
-        match a with
-        | .poison => Interp.ub
-        | .val av =>
-          if av = BitVec.intMin bw then Interp.ub
-          else return (#[.int bw result], none)
-      else return (#[.int bw result], none)
+    return (#[.int bw (LLVM.Int.select cond (LLVM.Int.add z negOne) z)], none)
 
 def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
@@ -803,52 +767,26 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.proper
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else if v' = -1 then
-        match lhs with
-        | .poison => Interp.ub
-        | .val v =>
-          if v = BitVec.intMin bw then Interp.ub
-          else return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], mem, none)
-      else
-        return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], mem, none)
+    Interp.checkSignedDivision lhs rhs
+    return (#[.int bw (LLVM.Int.sdiv lhs rhs properties.exact)], mem, none)
   | .udiv => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], mem, none)
+    Interp.checkUnsignedDivision rhs
+    return (#[.int bw (LLVM.Int.udiv lhs rhs properties.exact)], mem, none)
   | .srem => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else if v' = -1 then
-        match lhs with
-        | .poison => Interp.ub
-        | .val v =>
-          if v = BitVec.intMin bw then Interp.ub
-          else return (#[.int bw (LLVM.Int.srem lhs rhs)], mem, none)
-      else
-        return (#[.int bw (LLVM.Int.srem lhs rhs)], mem, none)
+    Interp.checkSignedDivision lhs rhs
+    return (#[.int bw (LLVM.Int.srem lhs rhs)], mem, none)
   | .urem => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
     if h: bw' ≠ bw then none else
     let rhs := rhs.cast (by simp at h; exact h)
-    match rhs with
-    | .poison => Interp.ub
-    | .val v' =>
-      if v' = 0 then Interp.ub
-      else return (#[.int bw (LLVM.Int.urem lhs rhs)], mem, none)
+    Interp.checkUnsignedDivision rhs
+    return (#[.int bw (LLVM.Int.urem lhs rhs)], mem, none)
   | .shl => do
     let [lhs, .int bw' rhs] := operands.toList | none
     match lhs with


### PR DESCRIPTION
I think this is all correct, but of course we want to be careful since nothing here can be proved, since we lack a definitive formal version of `arith`

after this I'll do a pass that lowers arith to llvm (which would be an excellent place to test out Sid's width-independent proofs) with the goal of being able to end up at RISC-V all the way from ModArith.