### PR TITLE
chore(test): bump mlir version

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -30,7 +30,7 @@ config.substitutions.append(("VEIR_ROUNDTRIP", f".lake/build/bin/veir-opt{exe_su
 config.substitutions.append(("VEIR_UNREGISTERED_ROUNDTRIP", f".lake/build/bin/veir-opt{exe_suffix} %s --allow-unregistered-dialect | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | filecheck %s"))
 
 mlir_opt = lit.util.which('mlir-opt')
-mlir_versions_supported = ['22', '23']
+mlir_versions_supported = ['22', '23', '24']
 
 result = subprocess.run(['lake', 'build'], cwd =veir_root)
 


### PR DESCRIPTION
sigh... MLIR tests were getting skipped on my machines since version had moved to 24 and I didn't notice