### PR TITLE
feat: Improve some get-set lemmas for `getProperties`

### DIFF
--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -100,8 +100,11 @@ theorem OpOperandPtr.get!_OperationPtr_allocEmpty  {opOperand : OpOperandPtr}
 @[simp, grind =>]
 theorem OperationPtr.getProperties!_OperationPtr_allocEmpty {operation : OperationPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
-    operation.getProperties! ctx' ty =
-    if operation = op' then properties else operation.getProperties! ctx ty := by
+    operation.getProperties! ctx' ty' =
+    if operation = op' then
+      if h : ty' = ty then h ▸ properties else default
+    else
+      operation.getProperties! ctx ty' := by
   grind
 
 @[grind =>]

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -166,11 +166,15 @@ grind_pattern OperationPtr.attrs!_createEmptyOp =>
 
 theorem OperationPtr.getProperties!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
-    operation.getProperties! ctx' opType = if operation = op then properties else operation.getProperties! ctx opType := by
+    operation.getProperties! ctx' opType' =
+    if operation = op then
+      if h : opType = opType' then h ▸ properties else default
+    else
+      operation.getProperties! ctx opType' := by
   grind [Operation.empty]
 
 grind_pattern OperationPtr.getProperties!_createEmptyOp =>
-  Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getProperties! ctx' opType
+  Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getProperties! ctx' opType'
 
 theorem OperationPtr.getNumResults!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
@@ -482,8 +486,11 @@ theorem OperationPtr.attrs!_createOp {operation : OperationPtr} :
 theorem OperationPtr.getProperties!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
-    operation.getProperties! ctx' opType =
-    if operation = newOp then properties else operation.getProperties! ctx opType := by
+    operation.getProperties! ctx' opType' =
+    if operation = newOp then
+      if h : opType = opType' then h ▸ properties else default
+    else
+      operation.getProperties! ctx opType' := by
   simp only [Rewriter.createOp]
   grind (gen := 20)
 


### PR DESCRIPTION
Lemmas about `getProperties` and `createOp` were not general enough, and would not trigger when `getProperties` would use a different `opType` than the one used by `createOp`.