### PR TITLE
feat(cse): support operations that return multiple values

### DIFF
--- a/Test/Passes/CSE/multi_result.mlir
+++ b/Test/Passes/CSE/multi_result.mlir
@@ -1,0 +1,40 @@
+// RUN: veir-opt %s -p=cse --allow-unregistered-dialect | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32, i32) -> (), sym_name = "multi_result"}> ({
+  ^bb0(%a : i32, %b : i32):
+    // CSE commuted addui_extended operations and redirect both results.
+    %sum0, %overflow0 = "arith.addui_extended"(%a, %b) : (i32, i32) -> (i32, i1)
+    %sum1, %overflow1 = "arith.addui_extended"(%b, %a) : (i32, i32) -> (i32, i1)
+
+    // Rewriting %sum1 to %sum0 also exposes this single-result CSE.
+    %use0 = "arith.addi"(%sum0, %a) : (i32, i32) -> i32
+    %use1 = "arith.addi"(%sum1, %a) : (i32, i32) -> i32
+    "test.test"(%sum0, %overflow0, %sum1, %overflow1, %use0, %use1)
+      : (i32, i1, i32, i1, i32, i32) -> ()
+
+    // Signed and unsigned extended multiplies each CSE across commuted
+    // operands, but their distinct opcodes keep them from merging together.
+    %slo0, %shi0 = "arith.mulsi_extended"(%a, %b) : (i32, i32) -> (i32, i32)
+    %slo1, %shi1 = "arith.mulsi_extended"(%b, %a) : (i32, i32) -> (i32, i32)
+    %ulo0, %uhi0 = "arith.mului_extended"(%a, %b) : (i32, i32) -> (i32, i32)
+    %ulo1, %uhi1 = "arith.mului_extended"(%b, %a) : (i32, i32) -> (i32, i32)
+    "test.test"(%slo0, %shi0, %slo1, %shi1, %ulo0, %uhi0, %ulo1, %uhi1)
+      : (i32, i32, i32, i32, i32, i32, i32, i32) -> ()
+    "func.return"() : () -> ()
+
+    // CHECK-LABEL: "sym_name" = "multi_result"
+    // CHECK:      ^{{[0-9]+}}(%[[A:[^ ]*]] : i32, %[[B:[^ ]*]] : i32):
+    // CHECK-NEXT: %[[ADD:.*]]:2 = "arith.addui_extended"(%[[A]], %[[B]]) : (i32, i32) -> (i32, i1)
+    // CHECK-NEXT: %[[USE:.*]] = "arith.addi"(%[[ADD]]#0, %[[A]]) : (i32, i32) -> i32
+    // CHECK-NEXT: "test.test"(%[[ADD]]#0, %[[ADD]]#1, %[[ADD]]#0, %[[ADD]]#1, %[[USE]], %[[USE]])
+    // CHECK-NEXT: %[[SMUL:.*]]:2 = "arith.mulsi_extended"(%[[A]], %[[B]])
+    // CHECK-SAME:   : (i32, i32) -> (i32, i32)
+    // CHECK-NEXT: %[[UMUL:.*]]:2 = "arith.mului_extended"(%[[A]], %[[B]])
+    // CHECK-SAME:   : (i32, i32) -> (i32, i32)
+    // CHECK-NEXT: "test.test"(%[[SMUL]]#0, %[[SMUL]]#1,
+    // CHECK-SAME: %[[SMUL]]#0, %[[SMUL]]#1, %[[UMUL]]#0, %[[UMUL]]#1,
+    // CHECK-SAME: %[[UMUL]]#0, %[[UMUL]]#1)
+    // CHECK-NEXT: "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Veir/Passes/CSE.lean
+++ b/Veir/Passes/CSE.lean
@@ -11,7 +11,6 @@ import Veir.Data.LLVM.Int.Basic
   * it only reasons within one basic block;
   * it only considers arithmetic operations (including icmps, select,
     and ext/trunc);
-  * it only works for instructions that return at least one result;
   * distinct UB flags are treated as distinct instructions;
   * it only supports the LLVM, arith, and mod_arith dialects;
   * it does not use a worklist or iterate to fixpoint, so it may leave

--- a/Veir/Passes/CSE.lean
+++ b/Veir/Passes/CSE.lean
@@ -11,7 +11,7 @@ import Veir.Data.LLVM.Int.Basic
   * it only reasons within one basic block;
   * it only considers arithmetic operations (including icmps, select,
     and ext/trunc);
-  * it only works for instructions that return a single result;
+  * it only works for instructions that return at least one result;
   * distinct UB flags are treated as distinct instructions;
   * it only supports the LLVM, arith, and mod_arith dialects;
   * it does not use a worklist or iterate to fixpoint, so it may leave
@@ -29,13 +29,13 @@ instance : Hashable Kind where
   hash k := mixHash (hash k.fst) (hash k.snd)
 
 /-- This is the basis for CSE: if two instructions have the same Key,
-    then they compute the same value: they are interchangeable. In
-    that case we can remove one of them and switch all of its uses to
-    the other. Proving this will be the crux of the eventual
-    correctness proof for this pass. -/
+    then they compute the same ordered sequence of result values. In
+    that case we can remove one of them and switch every result's uses
+    to the corresponding result of the other. Proving this will be the
+    crux of the eventual correctness proof for this pass. -/
 structure Key where
   kind : Kind
-  resultType : TypeAttr
+  resultTypes : Array TypeAttr
   operands : Array ValuePtr
 deriving DecidableEq, BEq, Hashable
 
@@ -45,7 +45,7 @@ def makeKey
     Key :=
   {
     kind
-    resultType := (op.getResult 0 : ValuePtr).getType! ctx
+    resultTypes := op.getResultTypes! ctx
     operands
   }
 
@@ -109,7 +109,7 @@ def icmpKey
     None. -/
 def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
   guard ((op.get! ctx).attrs.entries.size = 0)
-  guard (op.getNumResults! ctx = 1)
+  guard (op.getNumResults! ctx > 0)
   let opType := op.getOpType! ctx
   let properties := op.getProperties! ctx opType
   let kind : Kind := ⟨opType, properties⟩
@@ -118,8 +118,9 @@ def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
   | .llvm .intr__smax | .llvm .intr__smin | .llvm .intr__umax | .llvm .intr__umin
   | .arith .addi | .arith .muli | .arith .andi | .arith .ori | .arith .xori
   | .arith .maxsi | .arith .maxui | .arith .minsi | .arith .minui
+  | .arith .addui_extended | .arith .mulsi_extended | .arith .mului_extended
   -- mod_arith carries its modulus in the operand and result types, and
-  -- `Key` includes the result type, so ops on different moduli never
+  -- `Key` includes the result types, so ops on different moduli never
   -- collide.
   | .mod_arith .add | .mod_arith .mul =>
       return commutativeBinopKey ctx op kind
@@ -142,8 +143,6 @@ def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
   | .arith .divsi | .arith .divui | .arith .remsi | .arith .remui
   | .arith .ceildivsi | .arith .ceildivui | .arith .floordivsi
   | .arith .extsi | .arith .extui | .arith .trunci
-  -- The `*_extended` ops are commutative too, but they return two
-  -- results, so the single-result guard above already rejects them.
   | .arith .select
   | .mod_arith .sub | .mod_arith .constant =>
       return ordinaryKey ctx op kind
@@ -164,8 +163,7 @@ def processBlock
     if let some key := key? ctx.raw op then
         match available[key]? with
         | some earlier =>
-            ctx := WfRewriter.replaceValue! ctx (op.getResult 0) (earlier.getResult 0)
-            ctx := WfRewriter.eraseOp! ctx op
+            ctx := WfRewriter.replaceOp! ctx op earlier
         | none =>
             available := available.insert key op
     current := next


### PR DESCRIPTION
CSE had an arbitrary limitation that it only handled instructions that returned a single value. this fixes that, and it turns out to be super easy!