### PR TITLE
refactor: add `HasDialectOpInfo` for all dialects

### DIFF
--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -1,0 +1,22 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Builtin.propertiesOf (op : Builtin) : Type :=
+match op with
+| .unregistered => UnregisteredProperties
+| _ => Unit
+
+instance : HasDialectOpInfo Builtin where
+  propertiesOf := Builtin.propertiesOf
+
+end
+
+end Veir

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -1,0 +1,20 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Datapath.propertiesOf (_op : Datapath) : Type :=
+  Unit
+
+instance : HasDialectOpInfo Datapath where
+  propertiesOf := Datapath.propertiesOf
+
+end
+
+end Veir

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -1,0 +1,23 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Func.propertiesOf (op : Func) : Type :=
+match op with
+| .func => FuncFuncProperties
+| .call => FuncCallProperties
+| _ => Unit
+
+instance : HasDialectOpInfo Func where
+  propertiesOf := Func.propertiesOf
+
+end
+
+end Veir

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -1,0 +1,20 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Properties
+
+namespace Veir
+
+public section
+
+@[expose, properties_of]
+def Test.propertiesOf (_op : Test) : Type :=
+  Unit
+
+instance : HasDialectOpInfo Test where
+  propertiesOf := Test.propertiesOf
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -1,6 +1,8 @@
 module
 
 public import Veir.Dialects.Arith.OpInfo
+public import Veir.Dialects.Builtin.OpInfo
+public import Veir.Dialects.Func.OpInfo
 public import Veir.Dialects.LLVM.OpInfo
 public import Veir.Dialects.RISCV.OpInfo
 public import Veir.Dialects.RISCV_Cf.OpInfo
@@ -10,6 +12,8 @@ public import Veir.Dialects.ModArith.OpInfo
 public import Veir.Dialects.Cf.OpInfo
 public import Veir.Dialects.Comb.OpInfo
 public import Veir.Dialects.HW.OpInfo
+public import Veir.Dialects.Datapath.OpInfo
+public import Veir.Dialects.Test.OpInfo
 public import Veir.IR.Basic
 
 namespace Veir
@@ -33,10 +37,10 @@ match opCode with
 | .cf op => Cf.propertiesOf op
 | .comb op => Comb.propertiesOf op
 | .hw op => HW.propertiesOf op
-| .builtin .unregistered => UnregisteredProperties
-| .func .func => FuncFuncProperties
-| .func .call => FuncCallProperties
-| _ => Unit
+| .builtin op => Builtin.propertiesOf op
+| .func op => Func.propertiesOf op
+| .datapath op => Datapath.propertiesOf op
+| .test op => Test.propertiesOf op
 
 instance : HasDialectOpInfo OpCode where
   propertiesOf := _propertiesOf


### PR DESCRIPTION
Some dialects were missing `HasDialectOpInfo` files. This fixes it.