### PR TITLE
chore(riscv): normalize optimization pass ordering

### DIFF
--- a/Tools/vsmith
+++ b/Tools/vsmith
@@ -35,8 +35,8 @@ from vsmith_generate import generate
 DEFAULT_PASSES = "instcombine,dce,cse,dce"
 RISCV_PASSES = (
     "canonicalize,instcombine,canonicalize,cse,dce,"
-    "isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,"
-    "canonicalize,reconcile-cast,riscv-combine,dce"
+    "isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,"
+    "reconcile-cast,riscv-combine,dce"
 )
 
 # --- RISC-V MIR execution cross-check -------------------------------------

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -51,7 +51,7 @@ def passGroups : Std.HashMap String String :=
   (Std.HashMap.emptyWithCapacity 2)
     |>.insert "O" "canonicalize,instcombine,cse,dce"
     |>.insert "riscv"
-        "isel-br-riscv64,canonicalize,isel-sdag-riscv64,isel-riscv64,riscv-combine,reconcile-cast,dce"
+        "isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,reconcile-cast,riscv-combine,dce"
 
 /--
   A human-readable description of every pass group and the passes it expands to,


### PR DESCRIPTION
this makes both `vsmith` and `veir-opt -p=riscv` use the same pass ordering that we use in the paper evaluation repo