### PR TITLE
feat(riscv): absorb offsets into immediate fields of loads and stores, when possible

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/load_store_offset.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_store_offset.mlir
@@ -1,0 +1,115 @@
+// RUN: veir-opt %s -p=isel-riscv64 | filecheck %s
+
+// A `llvm.getelementptr` with a constant index is absorbed into the signed
+// 12-bit offset field of the load or store that uses it, mirroring the
+// `isBaseWithConstantOffset` case of LLVM's `SelectAddrRegImm`. The gep itself
+// becomes dead and is erased, so no address arithmetic remains.
+
+"builtin.module"() ({
+    // i64 element, index 4 -> byte offset 32.
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "fold_ld"}> ({
+    ^bb0(%p: !llvm.ptr):
+        %i = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %v = "llvm.load"(%g) : (!llvm.ptr) -> i64
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "riscv.ld"({{.*}}) <{"value" = 32 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!riscv.reg) -> i64
+        "test.test"(%v) : (i64) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // A negative index gives a negative offset: i32 element, index -1 -> -4.
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "fold_negative"}> ({
+    ^bb0(%p: !llvm.ptr):
+        %i = "llvm.mlir.constant"() <{value = -1 : i64}> : () -> i64
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = i32, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %v = "llvm.load"(%g) : (!llvm.ptr) -> i32
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "riscv.lw"({{.*}}) <{"value" = -4 : i64}> : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!riscv.reg) -> i32
+        "test.test"(%v) : (i32) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // Stores fold the same way: i8 element, index 7 -> byte offset 7.
+    "func.func"()  <{function_type = (!llvm.ptr, i8) -> (), sym_name = "fold_sb"}> ({
+    ^bb0(%p: !llvm.ptr, %x: i8):
+        %i = "llvm.mlir.constant"() <{value = 7 : i64}> : () -> i64
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        "llvm.store"(%x, %g) : (i8, !llvm.ptr) -> ()
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (i8) -> !riscv.reg
+        // CHECK-NEXT: "riscv.sb"({{.*}}, {{.*}}) <{"value" = 7 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // The extreme in-range offsets still fold: 2047 and -2048 with an i8 element.
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "fold_boundaries"}> ({
+    ^bb0(%p: !llvm.ptr):
+        %hi = "llvm.mlir.constant"() <{value = 2047 : i64}> : () -> i64
+        %ghi = "llvm.getelementptr"(%p, %hi) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %vhi = "llvm.load"(%ghi) : (!llvm.ptr) -> i8
+        // CHECK:      {{.*}} = "riscv.lb"({{.*}}) <{"value" = 2047 : i64}> : (!riscv.reg) -> !riscv.reg
+        "test.test"(%vhi) : (i8) -> ()
+        %lo = "llvm.mlir.constant"() <{value = -2048 : i64}> : () -> i64
+        %glo = "llvm.getelementptr"(%p, %lo) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %vlo = "llvm.load"(%glo) : (!llvm.ptr) -> i8
+        // CHECK:      {{.*}} = "riscv.lb"({{.*}}) <{"value" = -2048 : i64}> : (!riscv.reg) -> !riscv.reg
+        "test.test"(%vlo) : (i8) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // The range is checked on the *scaled* offset: the index 1000 fits a signed
+    // 12-bit field but 1000 * 8 = 8000 does not, so the address is computed into
+    // a register by the `getelementptr` lowering and the load keeps offset 0.
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "nofold_scaled_out_of_range"}> ({
+    ^bb0(%p: !llvm.ptr):
+        %i = "llvm.mlir.constant"() <{value = 1000 : i64}> : () -> i64
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %v = "llvm.load"(%g) : (!llvm.ptr) -> i64
+        // CHECK:      {{.*}} = "riscv.li"() <{"value" = 1000 : i64}> : () -> !riscv.reg
+        // CHECK:      {{.*}} = "riscv.sh3add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:      {{.*}} = "riscv.ld"({{.*}}) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+        "test.test"(%v) : (i64) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // A non-constant index has no offset to fold.
+    "func.func"()  <{function_type = (!llvm.ptr, i64) -> (), sym_name = "nofold_dynamic"}> ({
+    ^bb0(%p: !llvm.ptr, %i: i64):
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %v = "llvm.load"(%g) : (!llvm.ptr) -> i64
+        // CHECK:      {{.*}} = "riscv.sh3add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:      {{.*}} = "riscv.ld"({{.*}}) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+        "test.test"(%v) : (i64) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // Folding does not depend on the gep having a single user: as in LLVM, the
+    // load takes the offset and the gep is still selected for its other user,
+    // duplicating the address arithmetic.
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "fold_multi_use"}> ({
+    ^bb0(%p: !llvm.ptr):
+        %i = "llvm.mlir.constant"() <{value = 2 : i64}> : () -> i64
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %v = "llvm.load"(%g) : (!llvm.ptr) -> i64
+        // CHECK:      {{.*}} = "riscv.sh3add"({{.*}}, {{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
+        // CHECK:      {{.*}} = "riscv.ld"({{.*}}) <{"value" = 16 : i64}> : (!riscv.reg) -> !riscv.reg
+        "test.test"(%v) : (i64) -> ()
+        "test.test"(%g) : (!llvm.ptr) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    // Zero-sized element types scale to offset 0, which folds and drops the gep.
+    "func.func"()  <{function_type = (!llvm.ptr) -> (), sym_name = "fold_zero_sized_elem"}> ({
+    ^bb0(%p: !llvm.ptr):
+        %i = "llvm.mlir.constant"() <{value = 5 : i64}> : () -> i64
+        %g = "llvm.getelementptr"(%p, %i) <{elem_type = !llvm.array<0 x i32>, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+        %v = "llvm.load"(%g) : (!llvm.ptr) -> i64
+        // CHECK:      {{.*}} = "builtin.unrealized_conversion_cast"({{.*}}) : (!llvm.ptr) -> !riscv.reg
+        // CHECK-NEXT: {{.*}} = "riscv.ld"({{.*}}) <{"value" = 0 : i64}> : (!riscv.reg) -> !riscv.reg
+        "test.test"(%v) : (i64) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/load_store_offset_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_store_offset_exec.mlir
@@ -1,0 +1,32 @@
+// RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
+// RUN: veir-opt %s -p=isel-riscv64,reconcile-cast > %t && veir-interpret %t | filecheck %s
+// RUN: filecheck %s --check-prefix=ISEL --input-file=%t
+
+// A store and a load through a constant `getelementptr` (index 3 of an i64
+// array = 24 bytes) both fold that offset into the RISC-V offset field. The
+// selected code must observe the same value the LLVM-level program does, and
+// no address arithmetic should survive.
+
+"builtin.module"() ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i64 ()>}> ({
+    ^bb0():
+      %size = "llvm.mlir.constant"() <{ "value" = 8 : i64 }> : () -> i64
+      %array = "llvm.alloca"(%size) <{ "elem_type" = i64 }> : (i64) -> !llvm.ptr
+      %off = "llvm.mlir.constant"() <{ "value" = 3 : i64 }> : () -> i64
+      %val = "llvm.mlir.constant"() <{ "value" = 170 : i64 }> : () -> i64
+      %p1 = "llvm.getelementptr"(%array, %off) <{ elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+      "llvm.store"(%val, %p1) : (i64, !llvm.ptr) -> ()
+      %p2 = "llvm.getelementptr"(%array, %off) <{ elem_type = i64, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+      %out = "llvm.load"(%p2) : (!llvm.ptr) -> i64
+      "llvm.return"(%out) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// SRC: Program output: #[0x00000000000000aa#64]
+// CHECK: Program output: #[0x00000000000000aa#64]
+
+// The `sh3add` that would have scaled the index is gone: both accesses address
+// the alloca directly at offset 24.
+// ISEL-NOT: riscv.sh3add
+// ISEL:     "riscv.sd"({{.*}}, {{.*}}) <{"value" = 24 : i64}> : (!riscv.reg, !riscv.reg) -> ()
+// ISEL:     {{.*}} = "riscv.ld"({{.*}}) <{"value" = 24 : i64}> : (!riscv.reg) -> !riscv.reg

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -1669,17 +1669,18 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   /- Early loop: multi-instruction fusion patterns that must run before the
      per-op lowerings consume their operands. -/
   let early := RewritePattern.GreedyRewritePattern #[load, store]
-  let some ctx := RewritePattern.applyInContext early ctx
-    | throw "Error while applying early address-folding patterns"
+  let ctx ← match RewritePattern.applyInContext early ctx with
+  | none => throw "Error while applying early address-folding patterns"
+  | some ctx => pure ctx
   /- Main loop: the existing per-op lowerings. -/
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral,
     ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, bitcast, load, getelementptr, store,
     smax, smin, umax, umin, saddSat, ssubSat, uaddSat, usubSat, sshlSat, ushlSat, abs,
     fshlConst, fshrConst, fshl, fshr, fshlGeneral, fshrGeneral, poisonConst, freeze]
-  let some ctx := RewritePattern.applyInContext pattern ctx
-    | throw "Error while applying main instruction-selection patterns"
-  pure ctx
+  match RewritePattern.applyInContext pattern ctx with
+  | none => throw "Error while applying main instruction-selection patterns"
+  | some ctx => pure ctx
 
 public def IselRISCV64 : Pass OpCode :=
   { name := "isel-riscv64"

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -847,6 +847,26 @@ def bitcast (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
   RewritePattern.fromLocalRewrite bitcast_local rewriter op opInBounds
 
+/--
+  Split a load/store address into a base register operand and a signed 12-bit
+  immediate offset, mirroring the `isBaseWithConstantOffset` case of LLVM's
+  [`RISCVDAGToDAGISel::SelectAddrRegImm`](https://github.com/llvm/llvm-project/blob/llvmorg-22.1.8/llvm/lib/Target/RISCV/RISCVISelDAGToDAG.cpp#L3175-L3206).
+-/
+def selectAddrRegImm (ptr : ValuePtr) (ctx : IRContext OpCode) : ValuePtr × Int :=
+  let folded : Option (ValuePtr × Int) := do
+    let gepOp ← getDefiningOp ptr ctx
+    let (base, idx, properties) ← matchGetelementptr gepOp ctx
+    /- A single dynamic index with no trailing constant indices, as in `getelementptr_local`. -/
+    guard (properties.rawConstantIndices.values = #[(-2147483648 : Int)])
+    let .integerType itype := (idx.getType! ctx).val | none
+    guard (itype.bitwidth = 64)
+    let c ← matchConstantIntVal idx ctx
+    let scale ← Attribute.sizeOfType properties.elem_type.val
+    let offset := c.value * (scale : Int)
+    guard (-2048 ≤ offset ∧ offset ≤ 2047)
+    return (base, offset)
+  folded.getD (ptr, 0)
+
 /-- llvm.load -> riscv.ld (i64) / riscv.lw (i32) / riscv.lb (i8) -/
 def load_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
@@ -855,23 +875,22 @@ def load_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return (ctx, none)
-  /- cast ptr (!llvm.ptr) -> register -/
-  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+  /- Split the address into a base register and a signed 12-bit offset. -/
+  let (base, offset) := selectAddrRegImm ptr ctx.raw
+  /- cast base (!llvm.ptr) -> register -/
+  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
       #[] #[] () none
-  /- 64-bit `riscv.ld`, or its `lw` (i32) / `lb` (i8) variants. Volatility carries
-     over from the `llvm.load`: the riscv op encodes the same, but the flag keeps
-     later passes from deleting or duplicating the access. -/
-  let zero := RISCVMemProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64)) llvmProps.volatile_
+  let immProps := RISCVMemProperties.mk (IntegerAttr.mk offset (IntegerType.mk 64)) llvmProps.volatile_
   let (ctx, ldOp) ←
     if type'.bitwidth = 8 then
       WfRewriter.createOp! ctx (.riscv .lb) #[RegisterType.mk] #[pcastOp.getResult 0]
-        #[] #[] zero none
+        #[] #[] immProps none
     else if type'.bitwidth = 32 then
       WfRewriter.createOp! ctx (.riscv .lw) #[RegisterType.mk] #[pcastOp.getResult 0]
-        #[] #[] zero none
+        #[] #[] immProps none
     else
       WfRewriter.createOp! ctx (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
-        #[] #[] zero none
+        #[] #[] immProps none
   let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[pcastOp, ldOp, castOp], #[castOp.getResult 0]))
@@ -889,25 +908,27 @@ def store_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let type := arg.getType! ctx.raw
   let .integerType type' := type.val | return (ctx, none)
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return (ctx, none)
-  /- cast ptr (!llvm.ptr) -> register -/
-  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+  /- Split the address into a base register and a signed 12-bit offset. -/
+  let (base, offset) := selectAddrRegImm ptr ctx.raw
+  /- cast base (!llvm.ptr) -> register -/
+  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
       #[] #[] () none
   /- cast value (i64/i32/i8) -> register -/
   let (ctx, valcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[arg]
       #[] #[] () none
-  /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte), with offset zero: operands are (addr, val), no results.
+  /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte): operands are (addr, val), no results.
      Volatility carries over from the `llvm.store`, as in `load_local`. -/
-  let zero := RISCVMemProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64)) llvmProps.volatile_
+  let immProps := RISCVMemProperties.mk (IntegerAttr.mk offset (IntegerType.mk 64)) llvmProps.volatile_
   let (ctx, sdOp) ←
     if type'.bitwidth = 8 then
       WfRewriter.createOp! ctx (.riscv .sb) #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
-        #[] #[] zero none
+        #[] #[] immProps none
     else if type'.bitwidth = 32 then
       WfRewriter.createOp! ctx (.riscv .sw) #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
-        #[] #[] zero none
+        #[] #[] immProps none
     else
       WfRewriter.createOp! ctx (.riscv .sd) #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
-        #[] #[] zero none
+        #[] #[] immProps none
   some (ctx, some (#[pcastOp, valcastOp, sdOp], #[]))
 
 /-- llvm.store -> riscv.sd (i64) / riscv.sw (i32) / riscv.sb (i8) -/
@@ -1644,6 +1665,10 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
     ExceptT String IO (WfIRContext OpCode) := do
   /- Early loop: multi-instruction fusion patterns that must run before the
      per-op lowerings consume their operands. -/
+  let early := RewritePattern.GreedyRewritePattern #[load, store]
+  let ctx ← match RewritePattern.applyInContext early ctx with
+    | none => throw "Error while applying address-folding patterns"
+    | some ctx => pure ctx
   /- Main loop: the existing per-op lowerings. -/
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral, ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, bitcast, load, getelementptr, store,

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -880,6 +880,9 @@ def load_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   /- cast base (!llvm.ptr) -> register -/
   let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
       #[] #[] () none
+  /- 64-bit `riscv.ld`, or its `lw` (i32) / `lb` (i8) variants. Volatility carries
+     over from the `llvm.load`: the riscv op encodes the same, but the flag keeps
+     later passes from deleting or duplicating the access. -/
   let immProps := RISCVMemProperties.mk (IntegerAttr.mk offset (IntegerType.mk 64)) llvmProps.volatile_
   let (ctx, ldOp) ←
     if type'.bitwidth = 8 then
@@ -1666,15 +1669,12 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   /- Early loop: multi-instruction fusion patterns that must run before the
      per-op lowerings consume their operands. -/
   let early := RewritePattern.GreedyRewritePattern #[load, store]
-  let ctx ← match RewritePattern.applyInContext early ctx with
-    | none => throw "Error while applying address-folding patterns"
-    | some ctx => pure ctx
   /- Main loop: the existing per-op lowerings. -/
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral, ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, bitcast, load, getelementptr, store,
     smax, smin, umax, umin, saddSat, ssubSat, uaddSat, usubSat, sshlSat, ushlSat, abs,
     fshlConst, fshrConst, fshl, fshr, fshlGeneral, fshrGeneral, poisonConst, freeze]
-  match RewritePattern.applyInContext pattern ctx with
+  match RewritePattern.applyInContext early ctx >>= RewritePattern.applyInContext pattern with
   | none => throw "Error while applying pattern rewrites"
   | some ctx => pure ctx
 

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -1669,14 +1669,17 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   /- Early loop: multi-instruction fusion patterns that must run before the
      per-op lowerings consume their operands. -/
   let early := RewritePattern.GreedyRewritePattern #[load, store]
+  let some ctx := RewritePattern.applyInContext early ctx
+    | throw "Error while applying early address-folding patterns"
   /- Main loop: the existing per-op lowerings. -/
-  let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral, ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
+  let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral,
+    ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, bitcast, load, getelementptr, store,
     smax, smin, umax, umin, saddSat, ssubSat, uaddSat, usubSat, sshlSat, ushlSat, abs,
     fshlConst, fshrConst, fshl, fshr, fshlGeneral, fshrGeneral, poisonConst, freeze]
-  match RewritePattern.applyInContext early ctx >>= RewritePattern.applyInContext pattern with
-  | none => throw "Error while applying pattern rewrites"
-  | some ctx => pure ctx
+  let some ctx := RewritePattern.applyInContext pattern ctx
+    | throw "Error while applying main instruction-selection patterns"
+  pure ctx
 
 public def IselRISCV64 : Pass OpCode :=
   { name := "isel-riscv64"


### PR DESCRIPTION
there's a lot more to do here. this copies the isel part of LLVM pretty well, but it has a ton of other machinery for doing a good job here. but this will catch the easy cases!!