### PR TITLE
chore: split function boundary coercion into its own pass

### DIFF
--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -1,12 +1,5 @@
 // RUN: veir-opt %s -p=reconcile-cast | filecheck %s
 
-// Note: `reconcile-cast` unconditionally coerces every function's register-width
-// (i64/i32/`!llvm.ptr`) arguments to `!riscv.reg`, inserting a bridging cast at entry
-// (see `coerce_function_boundaries.mlir`). Below, that boundary cast either reconciles
-// away into the round trip already written in the body, or -- when it doesn't -- shows
-// up as an extra leading cast. Functions whose argument is already `!riscv.reg` (or a
-// non-coercible type like `i8`) are unaffected.
-
 "builtin.module"() ({
 
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f0"}> ({
@@ -14,9 +7,8 @@
         // A lone `iX -> iX` cast is not a round trip, so nothing reconciles it away.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i64
         "test.test"(%1) : (i64) -> ()
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i64) -> i64
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> i64
         // CHECK-NEXT:   "test.test"([[I]]) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
@@ -25,35 +17,37 @@
       ^1(%0 : i64):
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
         "test.test"(%1) : (!riscv.reg) -> ()
-        // The boundary's `reg -> i64` cast pairs with this body's `i64 -> reg` cast and
-        // both reconcile away, leaving the register argument used directly.
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   "test.test"([[ARG]]) : (!riscv.reg) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:   "test.test"([[C]]) : (!riscv.reg) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f2"}> ({
       ^1(%0 : i64):
-        // the remaining cast is unused
+        // `i64 -> reg -> i64` freezes poison, so the round trip cannot be removed.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i64
         "test.test"(%2) : (i64) -> ()
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   "test.test"([[C]]) : (i64) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:   [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[C1]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:   "test.test"([[C2]]) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
     "func.func"()  <{function_type = (i64) -> (), sym_name = "f3"}> ({
       ^1(%0 : i64):
-        // the remaining cast is used
+        // The integer-starting round trip cannot be removed, and its register value has
+        // another use.
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> !riscv.reg
         %2 = "test.test"(%1) : (!riscv.reg) -> (!riscv.reg)
         %3 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i64
         "test.test"(%2, %3) : (!riscv.reg, i64) -> ()
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[T:%.*]] = "test.test"([[ARG]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:   [[T:%.*]] = "test.test"([[C]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (!riscv.reg) -> i64
         // CHECK-NEXT:   "test.test"([[T]], [[I]]) : (!riscv.reg, i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
@@ -66,8 +60,9 @@
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> !riscv.reg
         %3 = "builtin.unrealized_conversion_cast"(%2) : (!riscv.reg) -> i64
         "test.test"(%3) : (i64) -> ()
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[R:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[R]]) : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[I]]) : (!riscv.reg) -> i64
         // CHECK-NEXT:   "test.test"([[C]]) : (i64) -> ()
         "func.return"() : () -> ()
@@ -81,12 +76,13 @@
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i64
         %4 = "builtin.unrealized_conversion_cast"(%3) : (!riscv.reg) -> i64
         "test.test"(%2, %4) : (i64, i64) -> ()
-        // Each `i64 -> reg` cast folds to the register argument, leaving the two `reg -> i64`
-        // casts behind as separate (identical) operations.
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   "test.test"([[C1]], [[C2]]) : (i64, i64) -> ()
+        // Integer-starting register round trips freeze poison, so both pairs remain.
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[R1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:   [[R2:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:   [[I1:%.*]] = "builtin.unrealized_conversion_cast"([[R1]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:   [[I2:%.*]] = "builtin.unrealized_conversion_cast"([[R2]]) : (!riscv.reg) -> i64
+        // CHECK-NEXT:   "test.test"([[I1]], [[I2]]) : (i64, i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -120,10 +116,9 @@
         %2 = "builtin.unrealized_conversion_cast"(%1) : (i256) -> i64
         %4 = "builtin.unrealized_conversion_cast"(%3) : (i128) -> i64
         "test.test"(%2, %4) : (i64, i64) -> ()
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:   [[W1:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i64) -> i256
-        // CHECK-NEXT:   [[W2:%.*]] = "builtin.unrealized_conversion_cast"([[C]]) : (i64) -> i128
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:   [[W1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> i256
+        // CHECK-NEXT:   [[W2:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> i128
         // CHECK-NEXT:   [[N1:%.*]] = "builtin.unrealized_conversion_cast"([[W1]]) : (i256) -> i64
         // CHECK-NEXT:   [[N2:%.*]] = "builtin.unrealized_conversion_cast"([[W2]]) : (i128) -> i64
         // CHECK-NEXT:   "test.test"([[N1]], [[N2]]) : (i64, i64) -> ()
@@ -136,13 +131,11 @@
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !riscv.reg
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
         "test.test"(%2) : (i32) -> ()
-        // The `i32 -> reg -> i32` round trip is not itself reconciled (it freezes poison), but
-        // the boundary's `reg -> i32` cast forms a `reg -> i32 -> reg` round trip with the body's
-        // first cast, which lowers to `zextw`. The body's second cast remains.
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[Z:%.*]] = "riscv.zextw"([[ARG]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[Z]]) : (!riscv.reg) -> i32
-        // CHECK-NEXT:   "test.test"([[C]]) : (i32) -> ()
+        // The `i32 -> reg -> i32` round trip is not reconciled because it freezes poison.
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i32):
+        // CHECK-NEXT:   [[R:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i32) -> !riscv.reg
+        // CHECK-NEXT:   [[I:%.*]] = "builtin.unrealized_conversion_cast"([[R]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:   "test.test"([[I]]) : (i32) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -164,11 +157,8 @@
         %1 = "builtin.unrealized_conversion_cast"(%0) : (!llvm.ptr) -> !riscv.reg
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> !llvm.ptr
         "test.test"(%2) : (!llvm.ptr) -> ()
-        // The boundary's `reg -> ptr` cast pairs with the body's `ptr -> reg` cast (both
-        // directions are legal for `ptr`), leaving one `reg -> ptr` cast.
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> !llvm.ptr
-        // CHECK-NEXT:   "test.test"([[C]]) : (!llvm.ptr) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !llvm.ptr):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (!llvm.ptr) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 
@@ -190,13 +180,11 @@
         %2 = "test.test"(%1) : (!riscv.reg) -> (!riscv.reg)
         %3 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
         "test.test"(%2, %3) : (!riscv.reg, i32) -> ()
-        // The boundary's `reg -> i32` cast feeds the body's `i32 -> reg` cast, and that
-        // `reg -> i32 -> reg` round trip lowers to an explicit `zextw`. The body's second
-        // cast then reads the `zextw` result directly.
-        // CHECK:        ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:   [[Z:%.*]] = "riscv.zextw"([[ARG]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:   [[T:%.*]] = "test.test"([[Z]]) : (!riscv.reg) -> !riscv.reg
-        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[Z]]) : (!riscv.reg) -> i32
+        // The integer-starting round trip freezes poison, so both casts remain.
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i32):
+        // CHECK-NEXT:   [[R:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i32) -> !riscv.reg
+        // CHECK-NEXT:   [[T:%.*]] = "test.test"([[R]]) : (!riscv.reg) -> !riscv.reg
+        // CHECK-NEXT:   [[C:%.*]] = "builtin.unrealized_conversion_cast"([[R]]) : (!riscv.reg) -> i32
         // CHECK-NEXT:   "test.test"([[T]], [[C]]) : (!riscv.reg, i32) -> ()
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/CastsReconciliation/error.mlir
+++ b/Test/Passes/CastsReconciliation/error.mlir
@@ -1,11 +1,5 @@
 // RUN: veir-opt %s -p=reconcile-cast | filecheck %s
 
-// Note: `reconcile-cast` unconditionally coerces `i64` function arguments to
-// `!riscv.reg`, inserting a boundary `reg -> i64` cast (see `basic.mlir` and
-// `coerce_function_boundaries.mlir`). Below that boundary cast reconciles into the
-// body's own leading cast where legal, leaving the truncating round trips these cases
-// exist to test untouched.
-
 "builtin.module"() ({
 
     "func.func"()  <{function_type = (i64) -> (), sym_name = "foo"}> ({
@@ -13,9 +7,8 @@
         %1 = "builtin.unrealized_conversion_cast"(%0) : (i64) -> i8
         %2 = "builtin.unrealized_conversion_cast"(%1) : (i8) -> i64
         "test.test"(%2) : (i64) -> ()
-        // CHECK:         ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:    [[C0:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i64
-        // CHECK-NEXT:    [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[C0]]) : (i64) -> i8
+        // CHECK:         ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:    [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> i8
         // CHECK-NEXT:    [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[C1]]) : (i8) -> i64
         // CHECK-NEXT:    "test.test"([[C2]]) : (i64) -> ()
         "func.return"() : () -> ()
@@ -27,13 +20,12 @@
         %2 = "builtin.unrealized_conversion_cast"(%1) : (!riscv.reg) -> i32
         %3 = "builtin.unrealized_conversion_cast"(%2) : (i32) -> i64
         "test.test"(%3) : (i64) -> ()
-        // The boundary's `reg -> i64` cast pairs with the body's `i64 -> reg` cast
-        // (legal both ways for `i64`) and both reconcile away, leaving the `reg -> i32
-        // -> i64` chain, which isn't a round trip back to `reg` so it stays.
-        // CHECK:         ^{{.*}}([[ARG:%.*]] : !riscv.reg):
-        // CHECK-NEXT:    [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!riscv.reg) -> i32
-        // CHECK-NEXT:    [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[C1]]) : (i32) -> i64
-        // CHECK-NEXT:    "test.test"([[C2]]) : (i64) -> ()
+        // No pair of adjacent casts returns to its own input type, so the chain stays.
+        // CHECK:         ^{{.*}}([[ARG:%.*]] : i64):
+        // CHECK-NEXT:    [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (i64) -> !riscv.reg
+        // CHECK-NEXT:    [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[C1]]) : (!riscv.reg) -> i32
+        // CHECK-NEXT:    [[C3:%.*]] = "builtin.unrealized_conversion_cast"([[C2]]) : (i32) -> i64
+        // CHECK-NEXT:    "test.test"([[C3]]) : (i64) -> ()
         "func.return"() : () -> ()
     }) : () -> ()
 

--- a/Test/Passes/FunctionBoundaryCoercion/basic.mlir
+++ b/Test/Passes/FunctionBoundaryCoercion/basic.mlir
@@ -1,6 +1,6 @@
-// RUN: veir-opt %s -p=reconcile-cast | filecheck %s
+// RUN: veir-opt %s -p=coerce-function-boundaries-to-riscv-reg,reconcile-cast | filecheck %s
 
-// The cast-reconciliation pass coerces every function's register-width arguments and
+// The boundary-coercion pass coerces every function's register-width arguments and
 // return values to `!riscv.reg`, inserting bridging casts and rewriting `function_type`,
 // regardless of whether the body has actually been lowered by instruction selection yet
 // (that's the caller's responsibility -- see `notlowered`). For 64-bit boundaries (`i64`,

--- a/Test/Passes/InstructionSelection/RISCV64/add_ext_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/add_ext_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t
 // RUN: veir-interpret %t >> %t
 // RUN: filecheck %s < %t
 

--- a/Test/Passes/InstructionSelection/RISCV64/ashr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/bit_intrinsics_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/bit_intrinsics_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t
 // RUN: veir-interpret %t >> %t
 // RUN: filecheck %s < %t
 

--- a/Test/Passes/InstructionSelection/RISCV64/br_block_args_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/br_block_args_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 // Regression test for a bug in isel-br-riscv64 where block-argument operands
 // passed across a branch were emitted in reverse order, so the successor block

--- a/Test/Passes/InstructionSelection/RISCV64/fshl_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshl_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // fshl(0x123456789ABCDEF0, .., 8) = rotate-left by 8 = 0x3456789ABCDEF012

--- a/Test/Passes/InstructionSelection/RISCV64/fshl_general_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshl_general_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // General (distinct-operand) funnel shift left: not a rotate, so it lowers to the

--- a/Test/Passes/InstructionSelection/RISCV64/fshl_reg_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshl_reg_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // Register-form rotate: the shift amount is computed (5 + 3 = 8) rather than a

--- a/Test/Passes/InstructionSelection/RISCV64/fshr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // fshr(0x123456789ABCDEF0, .., 8) = rotate-right by 8 = 0xF0123456789ABCDE

--- a/Test/Passes/InstructionSelection/RISCV64/fshr_general_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshr_general_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // General (distinct-operand) funnel shift right: not a rotate, so it lowers to the

--- a/Test/Passes/InstructionSelection/RISCV64/fshr_reg_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/fshr_reg_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // Register-form rotate: the shift amount is computed (5 + 3 = 8) rather than a

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i64 ()>}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/load_store_offset_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_store_offset_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=isel-riscv64,reconcile-cast > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=isel-riscv64,coerce-function-boundaries-to-riscv-reg,reconcile-cast > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // A store and a load through a constant `getelementptr` (index 3 of an i64

--- a/Test/Passes/InstructionSelection/RISCV64/lshr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/saturating_i64_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/saturating_i64_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 "builtin.module"() ({

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 // Functional check for `sdivPow2Exact` (positive and negative divisor): evenly
 // divisible signed division by a constant power of two, using the `exact` flag.

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 // Functional check for `sdivPow2` (general, non-`exact`, positive and negative
 // divisor): truncating (round-toward-zero) division by a constant power of two.

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_i32_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_i32_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 // `i32` analogue of sdiv_pow2_exec.mlir (`sdivwPow2`, general non-`exact` form).
 

--- a/Test/Passes/InstructionSelection/RISCV64/smax_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/smax_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // smax(-1, 1) = 1 (signed); distinct from umax. -> riscv.max

--- a/Test/Passes/InstructionSelection/RISCV64/smin_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/smin_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // smin(-1, 1) = -1 (signed); distinct from umin. -> riscv.min

--- a/Test/Passes/InstructionSelection/RISCV64/srem_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/srem_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/sub_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 // Functional check for `udivPow2`: unsigned division by a constant power of two,
 // including the `2^63` boundary (whose bit pattern is decoded as a negative `Int`

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_i32_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_i32_exec.mlir
@@ -1,9 +1,9 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 // `i32` analogue of udiv_pow2_exec.mlir (`udivwPow2`).
 //
-// CHECK is #64 (SRC is #32): reconcile-cast coerces `main`'s `i32` boundary to
+// CHECK is #64 (SRC is #32): coerce-function-boundaries-to-riscv-reg,reconcile-cast coerces `main`'s `i32` boundary to
 // `!riscv.reg`, so post-lowering the declared return type is a register.
 
 "builtin.module"() ({

--- a/Test/Passes/InstructionSelection/RISCV64/umax_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/umax_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // umax(-1, 1) = -1 (unsigned, 0xff..ff is the larger). -> riscv.maxu

--- a/Test/Passes/InstructionSelection/RISCV64/umin_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/umin_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // umin(-1, 1) = 1 (unsigned). -> riscv.minu

--- a/Test/Passes/InstructionSelection/RISCV64/urem_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/urem_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -98,91 +98,9 @@ def reconcileRegIntCastLocal (ctx : WfIRContext OpCode) (op : OperationPtr) :
         #[shlOp.getResult 0] #[] #[] ⟨imm⟩ none
       return (ctx, some (#[shlOp, srlOp], #[srlOp.getResult 0]))
 
-/-! ## Coercing function boundaries to `!riscv.reg`
-
-  Before removing round-trip casts, we rewrite each `func.func` and
-  `llvm.func`'s i32- and i64- and pointer-typed arguments and return
-  values to `!riscv.reg`, inserting `unrealized_conversion_cast`s to
-  bridge to/from the original integer types.
--/
-
-def isRegCoercibleType (t : TypeAttr) : Bool :=
-  match t.val with
-  | .integerType x => x.bitwidth == 64 || x.bitwidth == 32
-  | .llvmPointerType _ => true
-  | _ => false
-
-/-- The return-terminator opcode paired with a function op (`func.return` for
-    `func.func`, `llvm.return` for `llvm.func`). -/
-def returnOpCodeFor : OpCode → OpCode
-  | .llvm .func => .llvm .return
-  | _ => .func .return
-
-set_option warn.sorry false in
-/-- Coerce one function's `i32`/`i64` arguments and return values to `!riscv.reg`,
-    inserting bridging casts and rewriting the `function_type` to match. Handles both
-    `func.func` and `llvm.func`. -/
-def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
-    ExceptT String IO (WfIRContext OpCode) := do
-  -- Shadow the parameter: from here on `ctx` always names the latest version, with no
-  -- separate old binding left around to second-guess.
-  let mut ctx := ctx
-  let some entry := FunctionOpInterface.getEntryBlock? funcOp ctx.raw | return ctx
-  let returnCode := returnOpCodeFor (funcOp.getOpType! ctx.raw)
-  -- Default the output types to the currently-declared ones, then flip coerced positions.
-  -- This preserves non-integer results and `llvm.func`'s `void` return.
-  let mut outputs : Array Attribute := FunctionOpInterface.getResultTypes! funcOp ctx.raw
-  -- (1) Coerce entry-block arguments (the function parameters). This mirrors the
-  --     block-argument coercion in `isel-br-riscv64`, which skips entry blocks.
-  let mut inputs : Array Attribute := #[]
-  for i in List.range (entry.getNumArguments! ctx.raw) do
-    let bap : BlockArgumentPtr := { block := entry, index := i }
-    let origType := (ValuePtr.blockArgument bap).getType! ctx.raw
-    if isRegCoercibleType origType then
-      ctx := WfRewriter.setType ctx bap RegisterType.mk sorry
-      let ip := InsertPoint.atStart entry ctx.raw sorry
-      let some (ctx', cast) := WfRewriter.createOp ctx
-        (.builtin .unrealized_conversion_cast) #[origType] #[] #[] #[] default (some ip)
-        sorry sorry sorry sorry | return ctx
-      let ctx' := WfRewriter.replaceValue ctx' bap (cast.getResult 0) sorry sorry sorry
-      ctx := WfRewriter.pushOperand ctx' cast bap sorry sorry
-      inputs := inputs.push (.registerType ⟨none⟩)
-    else
-      inputs := inputs.push origType.val
-  -- (2) Coerce the operands of every return terminator in this function.
-  let returnOps := ctx.raw.operations.keys.filter fun o =>
-    o.getOpType! ctx.raw == returnCode &&
-      o.getParentOp! ctx.raw == some funcOp
-  for retOp in returnOps do
-    for j in List.range (retOp.getNumOperands! ctx.raw) do
-      let opVal := retOp.getOperand! ctx.raw j
-      let opType := opVal.getType! ctx.raw
-      if isRegCoercibleType opType then
-        let some (ctx', cast) := WfRewriter.createOp ctx
-          (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[opVal] #[] #[] default
-          (some (InsertPoint.before retOp)) sorry sorry sorry sorry | return ctx
-        ctx := WfRewriter.replaceOperand ctx' ⟨retOp, j⟩ (cast.getResult 0) sorry sorry
-        -- The `j`-th operand maps to the `j`-th declared result: the verifier guarantees
-        -- a return's operand count equals the function's declared result count.
-        outputs := outputs.set! j (.registerType ⟨none⟩)
-  -- (3) Rewrite the function_type to reflect the coerced boundary types.
-  ctx := FunctionOpInterface.setFunctionType! ctx funcOp inputs outputs
-  return ctx
-
-def coerceFunctionBoundaries (ctx : WfIRContext OpCode) :
-    ExceptT String IO (WfIRContext OpCode) := do
-  let mut ctx := ctx
-  let funcOps := ctx.raw.operations.keys.filter fun o =>
-    match o.getOpType! ctx.raw with
-    | .func .func | .llvm .func => true
-    | _ => false
-  for funcOp in funcOps do
-    ctx ← coerceFunction ctx funcOp
-  return ctx
 
 def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let ctx ← coerceFunctionBoundaries ctx
   let pattern := RewritePattern.GreedyRewritePattern #[
     .fromLocalRewrite (reconcilePairingCastLocal isRegToI64RoundTrip),
     .fromLocalRewrite (reconcilePairingCastLocal isRiscvRegToPtrCast),

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -1,0 +1,106 @@
+module
+
+public import Veir.Pass
+import Veir.PatternRewriter.Basic
+import Veir.Passes.Matching
+import Veir.Passes.DCE.dce
+import Veir.Rewriter.WfRewriter
+import Veir.Properties
+import Veir.Interfaces.FunctionInterfaces
+
+namespace Veir
+
+/-! ## Coercing function boundaries to `!riscv.reg`
+
+  Before removing round-trip casts, we rewrite each `func.func` and
+  `llvm.func`'s i32- and i64- and pointer-typed arguments and return
+  values to `!riscv.reg`, inserting `unrealized_conversion_cast`s to
+  bridge to/from the original integer types.
+-/
+
+def isRegCoercibleType (t : TypeAttr) : Bool :=
+  match t.val with
+  | .integerType x => x.bitwidth == 64 || x.bitwidth == 32
+  | .llvmPointerType _ => true
+  | _ => false
+
+/-- The return-terminator opcode paired with a function op (`func.return` for
+    `func.func`, `llvm.return` for `llvm.func`). -/
+def returnOpCodeFor : OpCode → OpCode
+  | .llvm .func => .llvm .return
+  | _ => .func .return
+
+set_option warn.sorry false in
+/-- Coerce one function's `i32`/`i64` arguments and return values to `!riscv.reg`,
+    inserting bridging casts and rewriting the `function_type` to match. Handles both
+    `func.func` and `llvm.func`. -/
+def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
+    ExceptT String IO (WfIRContext OpCode) := do
+  -- Shadow the parameter: from here on `ctx` always names the latest version, with no
+  -- separate old binding left around to second-guess.
+  let mut ctx := ctx
+  let some entry := FunctionOpInterface.getEntryBlock? funcOp ctx.raw | return ctx
+  let returnCode := returnOpCodeFor (funcOp.getOpType! ctx.raw)
+  -- Default the output types to the currently-declared ones, then flip coerced positions.
+  -- This preserves non-integer results and `llvm.func`'s `void` return.
+  let mut outputs : Array Attribute := FunctionOpInterface.getResultTypes! funcOp ctx.raw
+  -- (1) Coerce entry-block arguments (the function parameters). This mirrors the
+  --     block-argument coercion in `isel-br-riscv64`, which skips entry blocks.
+  let mut inputs : Array Attribute := #[]
+  for i in List.range (entry.getNumArguments! ctx.raw) do
+    let bap : BlockArgumentPtr := { block := entry, index := i }
+    let origType := (ValuePtr.blockArgument bap).getType! ctx.raw
+    if isRegCoercibleType origType then
+      ctx := WfRewriter.setType ctx bap RegisterType.mk sorry
+      let ip := InsertPoint.atStart entry ctx.raw sorry
+      let some (ctx', cast) := WfRewriter.createOp ctx
+        (.builtin .unrealized_conversion_cast) #[origType] #[] #[] #[] default (some ip)
+        sorry sorry sorry sorry | return ctx
+      let ctx' := WfRewriter.replaceValue ctx' bap (cast.getResult 0) sorry sorry sorry
+      ctx := WfRewriter.pushOperand ctx' cast bap sorry sorry
+      inputs := inputs.push (.registerType ⟨none⟩)
+    else
+      inputs := inputs.push origType.val
+  -- (2) Coerce the operands of every return terminator in this function.
+  let returnOps := ctx.raw.operations.keys.filter fun o =>
+    o.getOpType! ctx.raw == returnCode &&
+      o.getParentOp! ctx.raw == some funcOp
+  for retOp in returnOps do
+    for j in List.range (retOp.getNumOperands! ctx.raw) do
+      let opVal := retOp.getOperand! ctx.raw j
+      let opType := opVal.getType! ctx.raw
+      if isRegCoercibleType opType then
+        let some (ctx', cast) := WfRewriter.createOp ctx
+          (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[opVal] #[] #[] default
+          (some (InsertPoint.before retOp)) sorry sorry sorry sorry | return ctx
+        ctx := WfRewriter.replaceOperand ctx' ⟨retOp, j⟩ (cast.getResult 0) sorry sorry
+        -- The `j`-th operand maps to the `j`-th declared result: the verifier guarantees
+        -- a return's operand count equals the function's declared result count.
+        outputs := outputs.set! j (.registerType ⟨none⟩)
+  -- (3) Rewrite the function_type to reflect the coerced boundary types.
+  ctx := FunctionOpInterface.setFunctionType! ctx funcOp inputs outputs
+  return ctx
+
+def coerceFunctionBoundaries (ctx : WfIRContext OpCode) :
+    ExceptT String IO (WfIRContext OpCode) := do
+  let mut ctx := ctx
+  let funcOps := ctx.raw.operations.keys.filter fun o =>
+    match o.getOpType! ctx.raw with
+    | .func .func | .llvm .func => true
+    | _ => false
+  for funcOp in funcOps do
+    ctx ← coerceFunction ctx funcOp
+  return ctx
+
+
+def CoerceFunctionBoundariesToRiscvRegPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
+    ExceptT String IO (WfIRContext OpCode) := do
+  let ctx ← coerceFunctionBoundaries ctx
+  match RewritePattern.applyInContext (RewritePattern.GreedyRewritePattern #[eliminateDeadOp]) ctx with
+  | none => throw "Error while applying DCE after cast reconciliation"
+  | some ctx => pure ctx
+
+public def CoerceFunctionBoundariesToRiscvRegPass : Pass OpCode :=
+  { name := "coerce-function-boundaries-to-riscv-reg"
+    description := "Coerce function boundaries to `!riscv.reg`."
+    run := CoerceFunctionBoundariesToRiscvRegPass.impl }

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -5,7 +5,6 @@ import Veir.PatternRewriter.Basic
 import Veir.Passes.Matching
 import Veir.Passes.DCE.dce
 import Veir.Rewriter.WfRewriter
-import Veir.Properties
 import Veir.Interfaces.FunctionInterfaces
 
 namespace Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -52,7 +52,7 @@ def passGroups : Std.HashMap String String :=
   (Std.HashMap.emptyWithCapacity 2)
     |>.insert "O" "canonicalize,instcombine,cse,dce"
     |>.insert "riscv"
-        "isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,reconcile-cast,riscv-combine,dce"
+        "isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,coerce-function-boundaries-to-riscv-reg,reconcile-cast,riscv-combine,dce"
 
 /--
   A human-readable description of every pass group and the passes it expands to,

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -14,6 +14,7 @@ import Veir.Passes.InstructionSelection.RISCV64Sdag
 import Veir.Passes.InstructionSelection.RISCV64Branches
 import Veir.Passes.DCE.dce
 import Veir.Passes.CastsReconciliation.Reconciliation
+import Veir.Passes.FunctionBoundaryCoercion.Coercion
 import Veir.Passes.RISCVCombines.Combine
 import Veir.Passes.ModArithToArith
 import Veir.Passes.ArithToLLVM
@@ -36,6 +37,7 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
     |>.insert IselBrRISCV64.name IselBrRISCV64
     |>.insert DCEPass.name DCEPass
     |>.insert CastReconcilePass.name CastReconcilePass
+    |>.insert CoerceFunctionBoundariesToRiscvRegPass.name CoerceFunctionBoundariesToRiscvRegPass
     |>.insert RISCV.Combine.name RISCV.Combine
     |>.insert ModArithToArithPass.name ModArithToArithPass
     |>.insert ArithToLLVMPass.name ArithToLLVMPass


### PR DESCRIPTION
Splits the function boundary type coercion functionality introduced into `reconcile-cast`  into its own pass, `coerce-function-boundaries-to-riscv-reg`, so that `reconcile-casts` can remain a generic pass for non-riscv-usecases.