### PR TITLE
feat: Add `HasDialect` infrastructure

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -4,6 +4,7 @@ import UnitTest.Parser
 import UnitTest.AttrParser
 import UnitTest.MlirParser
 import UnitTest.IR.Operation
+import UnitTest.Dialect
 import UnitTest.Verifier
 import UnitTest.FP
 import UnitTest.Bitblasting.Bitblasting

--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -1,0 +1,56 @@
+module
+
+import Veir.Pass
+meta import Veir.GlobalOpInfo
+
+open Veir
+
+/-! Dialects registered in the global opcode type have a generated membership instance. -/
+
+example : HasDialect OpCode Arith := inferInstance
+example : HasDialect OpCode Builtin := inferInstance
+
+/-! Dialects can define conversion functions to and from the global opcode type. -/
+abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arith]
+    : Option Arith :=
+  toDialect? Arith op
+
+/-! Some tests for the conversion functions from and to the global opcode type. -/
+#guard Arith.from? (Arith.addi : OpCode) = some Arith.addi
+#guard Arith.from? (OpCode.builtin .module) = none
+
+/-! A future function for getting the properties of an operation, while getting the expected
+properties type based on the dialect, not the global opcode. -/
+def Veir.OperationPtr.getProperties!' {OpInfo Dialect : Type} [HasOpInfo OpInfo]
+    [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect) :
+    HasDialectOpInfo.propertiesOf opCode :=
+  op.getProperties! ctx opCode
+
+def Veir.OperationPtr.setProperties!' {OpInfo Dialect : Type} [HasOpInfo OpInfo]
+    [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo) (opCode : Dialect)
+    (props : HasDialectOpInfo.propertiesOf opCode) : WfIRContext OpInfo :=
+  WfRewriter.setProperties! ctx op (HasDialect.ofDialectProperties OpInfo opCode props)
+
+/--
+A minimal pass that can be instantiated for any ambient opcode type containing
+the Arith dialect. It exercises both opcode projection and property transport.
+-/
+private def genericArithAwarePass {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Arith] : Pass OpInfo where
+  name := "generic-arith-aware-test"
+  description := "Compile-time test for dialect-generic passes."
+  run := fun ctx op _ => do
+    /- Matching an `arith` operation, here an `addi`. -/
+    let some .addi := Arith.from? (op.getOpType! ctx.raw) | return ctx
+    /- Getting the property of an operation with a type based on the dialect. -/
+    let _a := op.getProperties!' ctx.raw Arith.addi
+    /- Check that we automatically derive the correct properties type. -/
+    let _b : ArithIntegerOverflowFlagsProperties := _a
+    /- Create -/
+    let ctx := op.setProperties!' ctx Arith.addi
+      (ArithIntegerOverflowFlagsProperties.mk { nsw := true, nuw := false })
+    return ctx
+
+example : Pass OpCode := genericArithAwarePass

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -1,5 +1,6 @@
 module
 
+import Veir.Meta.OpCode
 public import Veir.Dialects.Arith.OpInfo
 public import Veir.Dialects.Builtin.OpInfo
 public import Veir.Dialects.Func.OpInfo
@@ -161,6 +162,8 @@ instance : HasOpInfo OpCode where
   moduleOpCode := .builtin .module
   hasSideEffects := OpCode.hasSideEffects
   hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG
+
+#generate_has_dialect_instances OpCode
 
 abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
 

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -64,6 +64,108 @@ class HasOpInfo (opCode: Type)
   -/
   hasSSADominance : opCode → Nat → Bool
 
+/--
+`HasDialect OpInfo Dialect` states that `OpInfo` contains the operations from
+`Dialect`.
+
+It defines an injection from dialect-local opcodes to the combined opcode type, and
+a projection from the combined opcode type to dialect-local opcodes.
+The class also records that the dialect-local property family agree with the combined
+property family on the injected opcodes.
+-/
+class HasDialect (OpInfo Dialect : Type) [HasOpInfo OpInfo] [HasDialectOpInfo Dialect] where
+  /--
+  Given a dialect opcode, get the equivalent opcode.
+  `Veir.ofDialect` or a coercion should be used instead of calling this function.
+  -/
+  inject : Dialect → OpInfo
+  /--
+  Given a global opcode, get the equivalent dialect opcode, if it belongs to the dialect.
+  `Veir.toDialect?` should be used instead of calling this function.
+  -/
+  project : OpInfo → Option Dialect
+  /-- The equivalence between the project and inject functions. -/
+  project_eq_some_iff (opInfo : OpInfo) (op : Dialect) :
+    project opInfo = some op ↔ inject op = opInfo
+  /-- The equivalence between the properties of the injected opcode and the dialect opcode. -/
+  properties_eq (op : Dialect) :
+    HasOpInfo.propertiesOf (inject op) = HasDialectOpInfo.propertiesOf op
+
+/--
+Project a global opcode to a dialect. Returns `none` when the opcode belongs
+to another dialect.
+-/
+def toDialect? (Dialect : Type) {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialectOpInfo Dialect] [dialectInj : HasDialect OpInfo Dialect] (opInfo : OpInfo) :
+    Option Dialect :=
+  HasDialect.project opInfo
+
+def ofDialect {Dialect : Type} (OpInfo : Type) [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+    [dialectInj : HasDialect OpInfo Dialect] (op : Dialect) :
+    OpInfo :=
+  HasDialect.inject op
+
+/-- Coercion from a dialect opcode to the global opcode type. -/
+instance {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (op : Dialect) :
+    CoeDep Dialect op OpInfo where
+  coe := ofDialect OpInfo op
+
+namespace HasDialect
+
+variable {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+  [dialectInj : HasDialect OpInfo Dialect]
+
+/-- Projecting an injected dialect opcode recovers that opcode. -/
+@[simp, grind =]
+theorem toDialect?_ofDialect (op : Dialect) :
+    toDialect? Dialect (ofDialect OpInfo op) = some op := by
+  simp [ofDialect, toDialect?, HasDialect.project_eq_some_iff]
+
+/-- A dialect's injection into an global opcode type is injective. -/
+theorem ofDialect_injective (op₁ op₂ : Dialect) :
+    ofDialect OpInfo op₁ = ofDialect OpInfo op₂ →
+    op₁ = op₂ := by
+  intro h
+  grind [congrArg (toDialect? Dialect) h]
+
+/-- Convert dialect-local properties to the global property family. -/
+def ofDialectProperties (OpInfo : Type) [HasOpInfo OpInfo] [dialectInj : HasDialect OpInfo Dialect]
+    (op : Dialect) (props : HasDialectOpInfo.propertiesOf op) :
+    HasOpInfo.propertiesOf (opCode := OpInfo) op :=
+  dialectInj.properties_eq op ▸ props
+
+/-- Convert global properties of an injected opcode back to dialect-local properties. -/
+def toDialectProperties (op : Dialect)
+    (props : HasOpInfo.propertiesOf (opCode := OpInfo) op) :
+    HasDialectOpInfo.propertiesOf op :=
+  (dialectInj.properties_eq op).symm ▸ props
+
+/-- Coercion from a dialect property to the global property type. -/
+instance {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (x : Dialect) :
+    CoeHead (HasOpInfo.propertiesOf (opCode := OpInfo) x)
+      (HasDialectOpInfo.propertiesOf x) where
+  coe := HasDialect.toDialectProperties x
+
+/- Projecting an injected properties recover the original properties. -/
+@[simp, grind =]
+theorem toDialectProperties_ofDialectProperties (op : Dialect)
+    (props : HasDialectOpInfo.propertiesOf op) :
+    toDialectProperties op (ofDialectProperties OpInfo op props) =
+      props := by
+  grind [toDialectProperties, ofDialectProperties]
+
+/-- A property injection into a combined property family in injective. -/
+@[simp, grind =]
+theorem ofDialectProperties_toDialectProperties (op : Dialect)
+    (props : HasOpInfo.propertiesOf (opCode := OpInfo) op) :
+    ofDialectProperties OpInfo op (toDialectProperties op props) =
+      props := by
+  grind [ofDialectProperties, toDialectProperties]
+
+end HasDialect
+
 instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
   hash := HasOpInfo.propertiesHash.hash
 

--- a/Veir/Meta/OpCode.lean
+++ b/Veir/Meta/OpCode.lean
@@ -91,6 +91,28 @@ meta def emitName (ds : Array Dialect) : TermElabM Command := do
   `(def $(mkIdent `OpCode.name) (op : $(mkIdent `OpCode)) : ByteArray := match op with $alts:matchAlt* )
 
 /--
+Generate a `HasDialect OpInfo Dialect` instance for the inductive `opInfo` with
+constructor `ctorName` of type `'dialectName' → 'opInfo'`.
+-/
+meta def mkHasDialectInstance (opInfo ctorName dialectName : Name) : TermElabM Command := do
+  let hasDialect := mkIdent (Name.mkStr2 "Veir" "HasDialect")
+  let dialectType := mkIdent dialectName
+  let ctor := mkIdent ctorName
+  let project ←
+    `(fun
+      | $ctor op => some op
+      | _ => none)
+  `(instance : $hasDialect $(mkIdent opInfo) $dialectType where
+      inject := $ctor
+      project := $project
+      project_eq_some_iff := by
+        intros opInfo op
+        cases opInfo <;> simp [eq_comm]
+      properties_eq := by
+        intro op
+        cases op <;> rfl)
+
+/--
 Generates the type `OpCodes`, and its functions `fromName` and `name`.
 It does so by gathering all inductive types annotated with `@[opcodes]`.
 
@@ -123,3 +145,24 @@ elab "#generate_op_codes" : command  => do
   elabCommand <| ← Command.liftTermElabM <| emitFromName dialects
   elabCommand <| ← Command.liftTermElabM <| emitName dialects
   pure ()
+
+/--
+Generate a `HasDialect OpInfo Dialect` instance for every dialect constructor
+of the merged `OpInfo` inductive. This command must be invoked after
+`HasOpInfo OpInfo` and all dialect-local `HasDialectOpInfo` instances have been
+defined.
+-/
+elab "#generate_has_dialect_instances" opInfo:ident : command => do
+  let opInfoName ← resolveGlobalConstNoOverload opInfo
+  let env ← getEnv
+  let some (.inductInfo info) := env.find? opInfoName
+    | throwError m!"Type {opInfoName} is not defined or not an inductive."
+  for ctorName in info.ctors do
+    let some (.ctorInfo ctorInfo) := env.find? ctorName
+      | throwError m!"Constructor {ctorName} is not defined."
+    let .forallE _ (.const dialectName _) resultType _ := ctorInfo.type
+      | throwError m!"Constructor {ctorName} must have exactly one dialect opcode argument."
+    unless resultType.isConstOf opInfoName do
+      throwError m!"Constructor {ctorName} does not construct {opInfoName}."
+    elabCommand <| ← Command.liftTermElabM <|
+      mkHasDialectInstance opInfoName ctorName dialectName


### PR DESCRIPTION
`HasDialect` allows a global opcode type to specify that it contains the opcodes of a dialect. This allows for instance to write passes that only requires that the `Arith` dialect is registered, plus arbitrary other dialects.

We can move from dialect opcodes to global opcodes with `toDialect?` and `ofDialect`, and similarly with `ofDialectProperties` and `toDialectProperties` for properties.