### PR TITLE
feat: remove `HasOpInfo.moduleOpCode` in favor of `HasDialect`

### DIFF
--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -176,7 +176,6 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | _ => false
 
 instance : HasOpInfo OpCode where
-  moduleOpCode := .builtin .module
   hasSideEffects := OpCode.hasSideEffects
   isConstantLike := OpCode.isConstantLike
   hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -48,7 +48,6 @@ opcodes and whether or not their regions have SSA dominance.
 -/
 class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
-  moduleOpCode: opCode
   /--
   Whether an operation with this opcode and these properties may have
   effects that make it ineligible for transformations that add /

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR
 public import Veir.Rewriter.InsertPoint
 public import Veir.Rewriter.LinkedList
+public import Veir.Dialects.Builtin.OpInfo
 
 public section
 namespace Veir
@@ -994,20 +995,23 @@ theorem Rewriter.createOp_fieldsInBounds
   grind
 
 @[irreducible]
-def IRContext.create OpInfo [HasOpInfo OpInfo] : Option (IRContext OpInfo × OperationPtr) :=
+def IRContext.create OpInfo [HasOpInfo OpInfo] [HasDialect OpInfo Builtin]
+    : Option (IRContext OpInfo × OperationPtr) :=
   rlet (ctx, region) ← Rewriter.createRegion (empty OpInfo)
-  rlet (ctx, operation) ← Rewriter.createOp ctx HasOpInfo.moduleOpCode #[] #[] #[] #[region] default none
+  rlet (ctx, operation) ← Rewriter.createOp ctx Builtin.module #[] #[] #[] #[region] default none
   rlet (ctx, block) ← Rewriter.createBlock ctx #[] (some (.atEnd region)) (by grind) (by grind)
   return (ctx, operation)
 
 @[grind →]
-theorem IRContext.create_fieldsInBounds {op: OperationPtr} (h : IRContext.create OpInfo = some (ctx, op)) :
+theorem IRContext.create_fieldsInBounds {op: OperationPtr} [HasDialect OpInfo Builtin]
+    (h : IRContext.create OpInfo = some (ctx, op)) :
     ctx.FieldsInBounds := by
   simp only [IRContext.create] at h
   grind
 
 @[grind →]
-theorem IRContext.create_inBounds {op: OperationPtr} (h : IRContext.create OpInfo = some (ctx, op)) :
+theorem IRContext.create_inBounds {op: OperationPtr} [HasDialect OpInfo Builtin]
+    (h : IRContext.create OpInfo = some (ctx, op)) :
     op.InBounds ctx := by
   simp only [IRContext.create] at h
   grind (gen := 10)

--- a/Veir/Rewriter/WellFormed/IRContext.lean
+++ b/Veir/Rewriter/WellFormed/IRContext.lean
@@ -17,7 +17,7 @@ namespace Veir
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
 
-theorem IRContext.wellFormed_IRContext_create :
+theorem IRContext.wellFormed_IRContext_create [HasDialect OpInfo Builtin] :
     IRContext.create OpInfo = some (ctx, op) →
     ctx.WellFormed := by
   simp only [create]

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -491,7 +491,7 @@ Create a new IR context with a single `builtin.module` operation at the top-leve
 The operation contains a single region, which contains a single empty block.
 -/
 @[inline]
-def WfIRContext.create (OpInfo : Type) [HasOpInfo OpInfo]
+def WfIRContext.create (OpInfo : Type) [HasOpInfo OpInfo] [HasDialect OpInfo Builtin]
     : Option (WfIRContext OpInfo × OperationPtr) := do
   rlet (ctx, op) ← IRContext.create OpInfo
   return (⟨ctx, by grind [IRContext.wellFormed_IRContext_create]⟩, op)
@@ -501,7 +501,7 @@ Create a new IR context with a single `builtin.module` operation at the top-leve
 the context could not be created.
 The operation contains a single region, which contains a single empty block.
 -/
-def WfIRContext.create! (OpInfo : Type) [HasOpInfo OpInfo]
+def WfIRContext.create! (OpInfo : Type) [HasOpInfo OpInfo] [HasDialect OpInfo Builtin]
     : WfIRContext OpInfo × OperationPtr :=
   if let some result := WfIRContext.create OpInfo then
     result

--- a/Veir/Rewriter/WfRewriter/InBounds.lean
+++ b/Veir/Rewriter/WfRewriter/InBounds.lean
@@ -190,7 +190,7 @@ theorem WfRewriter.createOp_inBounds_mono
 /-! ## `WfIRContext.create` -/
 
 @[grind →]
-theorem WfIRContext.create_new_inBounds
+theorem WfIRContext.create_new_inBounds [HasDialect OpInfo Builtin]
     (heq : WfIRContext.create OpInfo = some (ctx', op)) :
     op.InBounds ctx'.raw := by
   grind [WfIRContext.create]


### PR DESCRIPTION
`HasOpInfo.moduleOpCode` was used to assert that the `builtin.module` opcode exist. Instead of requiring this for all `OpInfo`, we require `HasDialect OpInfo Builtin` in the functions that actually use this.