### PR TITLE
feat(mod_arith): add interpreter semantics for `mod_arith` operations

### DIFF
--- a/Test/Interpreter/ModArith/add.mlir
+++ b/Test/Interpreter/ModArith/add.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !mod_arith.int<251 : i8>}> ({
+    %lhs = "mod_arith.constant"() <{ "value" = 250 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %rhs = "mod_arith.constant"() <{ "value" = 10 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %sum = "mod_arith.add"(%lhs, %rhs) : (!mod_arith.int<251 : i8>, !mod_arith.int<251 : i8>) -> !mod_arith.int<251 : i8>
+    "func.return"(%sum) : (!mod_arith.int<251 : i8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x09#8]

--- a/Test/Interpreter/ModArith/constant.mlir
+++ b/Test/Interpreter/ModArith/constant.mlir
@@ -1,0 +1,10 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !mod_arith.int<17 : i32>}> ({
+    %c3 = "mod_arith.constant"() <{ "value" = 3 : i32 }> : () -> !mod_arith.int<17 : i32>
+    "func.return"(%c3) : (!mod_arith.int<17 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000003#32]

--- a/Test/Interpreter/ModArith/constant_negative.mlir
+++ b/Test/Interpreter/ModArith/constant_negative.mlir
@@ -1,0 +1,11 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !mod_arith.int<17 : i32>}> ({
+    %c = "mod_arith.constant"() <{ "value" = -3 : i32 }> : () -> !mod_arith.int<17 : i32>
+    "func.return"(%c) : (!mod_arith.int<17 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// -3 mod 17 = 14
+// CHECK: Program output: #[0x0000000e#32]

--- a/Test/Interpreter/ModArith/mul.mlir
+++ b/Test/Interpreter/ModArith/mul.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !mod_arith.int<251 : i8>}> ({
+    %lhs = "mod_arith.constant"() <{ "value" = 250 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %rhs = "mod_arith.constant"() <{ "value" = 250 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %product = "mod_arith.mul"(%lhs, %rhs) : (!mod_arith.int<251 : i8>, !mod_arith.int<251 : i8>) -> !mod_arith.int<251 : i8>
+    "func.return"(%product) : (!mod_arith.int<251 : i8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x01#8]

--- a/Test/Interpreter/ModArith/sub.mlir
+++ b/Test/Interpreter/ModArith/sub.mlir
@@ -1,0 +1,12 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !mod_arith.int<251 : i8>}> ({
+    %lhs = "mod_arith.constant"() <{ "value" = 250 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %rhs = "mod_arith.constant"() <{ "value" = 1 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %diff = "mod_arith.sub"(%lhs, %rhs) : (!mod_arith.int<251 : i8>, !mod_arith.int<251 : i8>) -> !mod_arith.int<251 : i8>
+    "func.return"(%diff) : (!mod_arith.int<251 : i8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0xf9#8]

--- a/Test/Interpreter/ModArith/sub_underflow.mlir
+++ b/Test/Interpreter/ModArith/sub_underflow.mlir
@@ -1,0 +1,13 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> !mod_arith.int<251 : i8>}> ({
+    %lhs = "mod_arith.constant"() <{ "value" = 1 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %rhs = "mod_arith.constant"() <{ "value" = 250 : i8 }> : () -> !mod_arith.int<251 : i8>
+    %diff = "mod_arith.sub"(%lhs, %rhs) : (!mod_arith.int<251 : i8>, !mod_arith.int<251 : i8>) -> !mod_arith.int<251 : i8>
+    "func.return"(%diff) : (!mod_arith.int<251 : i8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// (1 - 250) mod 251 = 2
+// CHECK: Program output: #[0x02#8]

--- a/UnitTest/Evaluate.lean
+++ b/UnitTest/Evaluate.lean
@@ -44,12 +44,11 @@ info: "ok"
 #eval! testEvaluateUB
 
 /-- An operation the interpreter does not implement evaluates to `none`. The
-    `mod_arith` dialect is lowered to `arith` before interpretation, so it has
-    no runtime semantics of its own to evaluate against. -/
+    `datapath` dialect models hardware structures with no runtime semantics of
+    their own to evaluate against. -/
 private def testEvaluateUninterpreted : String := Id.run do
-  let m17 : TypeAttr := ModArithType.mk (IntegerAttr.mk 17 (IntegerType.mk 32))
   let operands : Array RuntimeValue := #[.int 32 (.val 13), .int 32 (.val 7)]
-  let none := (foldEvaluate (.mod_arith .add) () #[m17] operands : Option (UBOr (Array RuntimeValue)))
+  let none := (foldEvaluate (.datapath .compress) () #[i32, i32] operands : Option (UBOr (Array RuntimeValue)))
     | return "an uninterpreted operation was evaluated"
   return "ok"
 
@@ -58,3 +57,24 @@ info: "ok"
 -/
 #guard_msgs in
 #eval! testEvaluateUninterpreted
+
+/-- `mod_arith` operations have interpreter semantics and fold modulo the
+    modulus of their result type: (13 + 7) mod 17 = 3. -/
+private def testEvaluateModArithAdd : String := Id.run do
+  let m17 : TypeAttr := ModArithType.mk (IntegerAttr.mk 17 (IntegerType.mk 32))
+  let operands : Array RuntimeValue := #[.int 32 (.val 13), .int 32 (.val 7)]
+  let some (.ok results) :=
+    (foldEvaluate (.mod_arith .add) () #[m17] operands : Option (UBOr (Array RuntimeValue)))
+    | return "mod_arith.add did not evaluate"
+  let result? : Option RuntimeValue := results[0]?
+  let some (.int 32 (.val value)) := result?
+    | return "mod_arith.add produced no i32 result"
+  if value ≠ 3 then
+    return "mod_arith.add produced the wrong value"
+  return "ok"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testEvaluateModArithAdd

--- a/Veir/Data/LLVM/Int/Basic.lean
+++ b/Veir/Data/LLVM/Int/Basic.lean
@@ -96,6 +96,11 @@ def constant (w : Nat) (v : _root_.Int) : Int w := val (BitVec.ofInt w v)
 -/
 def mlir_poison (w : Nat) : Int w := poison
 
+/-- The unsigned value of the integer, or `none` if it is poison. -/
+def toNat? {w : Nat} : Int w → Option Nat
+  | .val v => some v.toNat
+  | .poison => none
+
 /--
 The ‘add’ instruction returns the sum of its two operands.
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -62,7 +62,7 @@ namespace RuntimeValue
   A predicate indicating whether a `RuntimeValue` is a value that is a runtime value
   of a given `TypeAttr`.
 -/
-@[expose, grind]
+@[expose]
 def Conforms (val : RuntimeValue) (ty : TypeAttr) : Prop :=
   match val, ty with
   | .int bw _, ⟨.integerType intType, _⟩ => intType.bitwidth = bw

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -68,6 +68,7 @@ def Conforms (val : RuntimeValue) (ty : TypeAttr) : Prop :=
   | .int bw _, ⟨.integerType intType, _⟩ => intType.bitwidth = bw
   | .float bw _, ⟨.floatType floatType, _⟩ => floatType.bitwidth = bw
   | .byte bw _, ⟨.byteType byteType, _⟩ => byteType.bitwidth = bw
+  | .int bw _, ⟨.modArithType modArithType, _⟩ => modArithType.modulus.type.bitwidth = bw
   | .reg _, ⟨.registerType _, _⟩ => True
   | .addr _, ⟨.llvmPointerType _, _⟩ => True
   | _, _ => False
@@ -108,6 +109,18 @@ theorem Conforms.floatType :
   cases runtimeValue
   case float bw val =>
     simp only [float.injEq, exists_and_left]
+    intro _; subst bw
+    grind
+  all_goals grind
+
+@[grind <=]
+theorem Conforms.modArithType {runtimeValue modArithType h} :
+    Conforms runtimeValue ⟨.modArithType modArithType, h⟩ →
+    ∃ val, runtimeValue = .int modArithType.modulus.type.bitwidth val := by
+  simp only [Conforms]
+  cases runtimeValue
+  case int bw val =>
+    simp only [int.injEq, exists_and_left]
     intro _; subst bw
     grind
   all_goals grind
@@ -730,6 +743,54 @@ def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.prop
     let signOpposite := LLVM.Int.icmp (LLVM.Int.icmp a zero .slt) (LLVM.Int.icmp b zero .slt) .ne
     let cond := LLVM.Int.and notExact signOpposite
     return (#[.int bw (LLVM.Int.select cond (LLVM.Int.add z negOne) z)], none)
+
+
+/-- Matches two integer operands and casts them to the expected bitwidth `bw`. -/
+private def ModArith.binaryOperands (bw : Nat) (operands : Array RuntimeValue) :
+    Option (LLVM.Int bw × LLVM.Int bw) := do
+  let [RuntimeValue.int bw' lhs, RuntimeValue.int bw'' rhs] := operands.toList | none
+  if h : bw' = bw ∧ bw'' = bw then
+    return (lhs.cast h.left, rhs.cast h.right)
+  else
+    none
+
+def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasDialectOpInfo.propertiesOf opType)
+    (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
+    : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
+  match opType with
+  | .constant => do
+    let some resType := resultTypes[0]? | none
+    let .modArithType ⟨⟨mod, ⟨bw⟩⟩⟩ := resType.val | none
+    let res := LLVM.Int.constant bw (properties.value.value % mod)
+    return (#[RuntimeValue.int bw res], none)
+  | .add => do
+    let some resType := resultTypes[0]? | none
+    let .modArithType ⟨⟨mod, ⟨bw⟩⟩⟩ := resType.val | none
+    let some (lhs, rhs) := ModArith.binaryOperands bw operands | none
+    let res :=
+      match lhs.toNat?, rhs.toNat? with
+      | some lhs, some rhs => LLVM.Int.constant bw ((lhs + rhs) % mod)
+      | _, _ => LLVM.Int.poison
+    return (#[RuntimeValue.int bw res], none)
+  | .sub => do
+    let some resType := resultTypes[0]? | none
+    let .modArithType ⟨⟨mod, ⟨bw⟩⟩⟩ := resType.val | none
+    let some (lhs, rhs) := ModArith.binaryOperands bw operands | none
+    let res :=
+      match lhs.toNat?, rhs.toNat? with
+      | some lhs, some rhs => LLVM.Int.constant bw ((lhs - rhs) % mod)
+      | _, _ => LLVM.Int.poison
+    return (#[RuntimeValue.int bw res], none)
+  | .mul => do
+    let some resType := resultTypes[0]? | none
+    let .modArithType ⟨⟨mod, ⟨bw⟩⟩⟩ := resType.val | none
+    let some (lhs, rhs) := ModArith.binaryOperands bw operands | none
+    let res :=
+      match lhs.toNat?, rhs.toNat? with
+      | some lhs, some rhs => LLVM.Int.constant bw ((lhs * rhs) % mod)
+      | _, _ => LLVM.Int.poison
+    return (#[RuntimeValue.int bw res], none)
+
 
 def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
@@ -1614,6 +1675,9 @@ def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
   match opType with
   | .arith arithOp => do
     let (vals, act) ← Arith.interpretOp' arithOp properties resultTypes operands blockOperands
+    return (vals, mem, act)
+  | .mod_arith modArithOp => do
+    let (vals, act) ← ModArith.interpretOp' modArithOp properties resultTypes operands blockOperands
     return (vals, mem, act)
   | .llvm llvmOp => do
     Llvm.interpretOp' llvmOp properties resultTypes operands blockOperands mem

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -778,7 +778,7 @@ def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasDialectOpIn
     let some (lhs, rhs) := ModArith.binaryOperands bw operands | none
     let res :=
       match lhs.toNat?, rhs.toNat? with
-      | some lhs, some rhs => LLVM.Int.constant bw ((lhs - rhs) % mod)
+      | some lhs, some rhs => LLVM.Int.constant bw ((Int.ofNat lhs - rhs) % mod)
       | _, _ => LLVM.Int.poison
     return (#[RuntimeValue.int bw res], none)
   | .mul => do

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -201,7 +201,7 @@ theorem VariableState.getVar?_setArgumentValues?_loop {block : BlockPtr}
   next => grind
   next =>
     simp only [Option.bind_eq_bind, Nat.succ_eq_add_one, Option.bind]
-    grind [cases BlockArgumentPtr, OperationPtr.getResult_def, cases ValuePtr]
+    grind [-RuntimeValue.Conforms, cases BlockArgumentPtr, OperationPtr.getResult_def, cases ValuePtr]
 
 @[grind =>]
 theorem VariableState.getVar?_setArgumentValues? {block : BlockPtr} {values : Array RuntimeValue}

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -201,7 +201,7 @@ theorem VariableState.getVar?_setArgumentValues?_loop {block : BlockPtr}
   next => grind
   next =>
     simp only [Option.bind_eq_bind, Nat.succ_eq_add_one, Option.bind]
-    grind [-RuntimeValue.Conforms, cases BlockArgumentPtr, OperationPtr.getResult_def, cases ValuePtr]
+    grind [cases BlockArgumentPtr, OperationPtr.getResult_def, cases ValuePtr]
 
 @[grind =>]
 theorem VariableState.getVar?_setArgumentValues? {block : BlockPtr} {values : Array RuntimeValue}


### PR DESCRIPTION
Adds interpreter semantics for `mod_arith` operations.

This also introduces a little `LLVM.Int.toNat?` helper to make the semantic definitions a bit prettier, fixes a brittle grind in one of the interpreter lemmas by  removing @[grind <=] from `RuntimeValue.Conforms`, and swaps the `testEvaluateUninterpreted` to a different dialect now that `mod_arith` is no longer uninterpreted.