### PR TITLE
chore: use the preset risc-v optimization pipeline instead of specifying them individually

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/ashr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/br_block_args_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/br_block_args_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 // Regression test for a bug in isel-br-riscv64 where block-argument operands
 // passed across a branch were emitted in reverse order, so the successor block

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i64 ()>}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/load_store_offset_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_store_offset_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=isel-riscv64,coerce-function-boundaries-to-riscv-reg,reconcile-cast > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // A store and a load through a constant `getelementptr` (index 3 of an i64

--- a/Test/Passes/InstructionSelection/RISCV64/lshr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/saturating_i64_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/saturating_i64_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 "builtin.module"() ({

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/smax_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/smax_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // smax(-1, 1) = 1 (signed); distinct from umax. -> riscv.max

--- a/Test/Passes/InstructionSelection/RISCV64/smin_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/smin_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // smin(-1, 1) = -1 (signed); distinct from umin. -> riscv.min

--- a/Test/Passes/InstructionSelection/RISCV64/srem_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/srem_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/sub_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/umax_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/umax_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // umax(-1, 1) = -1 (unsigned, 0xff..ff is the larger). -> riscv.maxu

--- a/Test/Passes/InstructionSelection/RISCV64/umin_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/umin_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 // RUN: filecheck %s --check-prefix=ISEL --input-file=%t
 
 // umin(-1, 1) = 1 (unsigned). -> riscv.minu

--- a/Test/Passes/InstructionSelection/RISCV64/urem_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/urem_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({


### PR DESCRIPTION
this changes nothing except instead of specifying a bespoke list of RISC-V backend passes, it uses the newish `-p=riscv` option. I think this is useful because we want to keep that list up to date and also avoid random lists of passes being specified lots of different places