### PR TITLE
feat: Move `hasSideeffects` to `HasDialectOpInfo`

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -62,8 +62,12 @@ match op with
 | .extui => NnegProperties
 | _ => Unit
 
+def Arith.hasSideEffects (_op : Arith) (_props : Arith.propertiesOf _op) : Bool :=
+  false
+
 instance : HasDialectOpInfo Arith where
   propertiesOf := Arith.propertiesOf
+  hasSideEffects := Arith.hasSideEffects
 
 end
 

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -22,8 +22,14 @@ match op with
 | .unregistered => UnregisteredProperties
 | _ => Unit
 
+def Builtin.hasSideEffects (op : Builtin) (_props : Builtin.propertiesOf op) : Bool :=
+  match op with
+  | .unrealized_conversion_cast => false
+  | _ => true
+
 instance : HasDialectOpInfo Builtin where
   propertiesOf := Builtin.propertiesOf
+  hasSideEffects := Builtin.hasSideEffects
 
 end
 

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -21,8 +21,12 @@ match op with
 | .cond_br => CondBrProperties
 | _ => Unit
 
+def Cf.hasSideEffects (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
+  true
+
 instance : HasDialectOpInfo Cf where
   propertiesOf := Cf.propertiesOf
+  hasSideEffects := Cf.hasSideEffects
 
 end
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -40,8 +40,12 @@ match op with
 | .icmp => CombIcmpProperties
 | _ => Unit
 
+def Comb.hasSideEffects (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
+  false
+
 instance : HasDialectOpInfo Comb where
   propertiesOf := Comb.propertiesOf
+  hasSideEffects := Comb.hasSideEffects
 
 end
 

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -19,8 +19,13 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 def Datapath.propertiesOf (_op : Datapath) : Type :=
   Unit
 
+def Datapath.hasSideEffects
+    (_op : Datapath) (_props : Datapath.propertiesOf _op) : Bool :=
+  false
+
 instance : HasDialectOpInfo Datapath where
   propertiesOf := Datapath.propertiesOf
+  hasSideEffects := Datapath.hasSideEffects
 
 end
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -23,8 +23,12 @@ match op with
 | .call => FuncCallProperties
 | _ => Unit
 
+def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
+  true
+
 instance : HasDialectOpInfo Func where
   propertiesOf := Func.propertiesOf
+  hasSideEffects := Func.hasSideEffects
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -23,8 +23,14 @@ match op with
 | .module => HWModuleProperties
 | _ => Unit
 
+def HW.hasSideEffects (op : HW) (_props : HW.propertiesOf op) : Bool :=
+  match op with
+  | .constant => false
+  | _ => true
+
 instance : HasDialectOpInfo HW where
   propertiesOf := HW.propertiesOf
+  hasSideEffects := HW.hasSideEffects
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -99,8 +99,34 @@ match op with
 | .module_flags => LLVMModuleFlagsProperties
 | _ => Unit
 
+def Llvm.hasSideEffects (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
+  match op, props with
+  -- Volatile loads are definitionally side-effecting.
+  | .load, props => props.volatile_
+  | .mlir__constant, _
+  | .mlir__poison, _
+  | .and, _ | .or, _ | .xor, _
+  | .add, _ | .sub, _ | .mul, _
+  | .sdiv, _ | .udiv, _ | .srem, _ | .urem, _
+  | .shl, _ | .lshr, _ | .ashr, _
+  | .intr__ctlz, _ | .intr__cttz, _ | .intr__ctpop, _
+  | .intr__bswap, _ | .intr__bitreverse, _
+  | .intr__fshl, _ | .intr__fshr, _
+  | .icmp, _ | .select, _
+  | .trunc, _ | .sext, _ | .zext, _
+  | .getelementptr, _
+  | .intr__smax, _ | .intr__smin, _ | .intr__umax, _ | .intr__umin, _
+  | .intr__abs, _
+  | .intr__sadd__sat, _ | .intr__uadd__sat, _
+  | .intr__ssub__sat, _ | .intr__usub__sat, _
+  | .intr__sshl__sat, _ | .intr__ushl__sat, _
+  | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _ => false
+  -- For everything else: be conservative!
+  | _, _ => true
+
 instance : HasDialectOpInfo Llvm where
   propertiesOf := Llvm.propertiesOf
+  hasSideEffects := Llvm.hasSideEffects
 
 end
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -23,5 +23,10 @@ match op with
 | .constant => ModArithConstantProperties
 | .add | .sub | .mul => Unit
 
+def Mod_Arith.hasSideEffects
+    (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : Bool :=
+  false
+
 instance : HasDialectOpInfo Mod_Arith where
   propertiesOf := Mod_Arith.propertiesOf
+  hasSideEffects := Mod_Arith.hasSideEffects

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -167,8 +167,52 @@ match op with
 | .sb => RISCVMemProperties
 | _ => Unit
 
+def Riscv.hasSideEffects (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
+  match op, props with
+  -- Volatile loads are definitionally side-effecting.
+  | .ld, props
+  | .lw, props
+  | .lwu, props
+  | .lh, props
+  | .lhu, props
+  | .lb, props
+  | .lbu, props => props.volatile_
+  | op, _ =>
+    match op with
+    | .li | .lui | .auipc
+    | .addi | .slti | .sltiu
+    | .andi | .ori | .xori
+    | .addiw | .slli | .srli | .srai
+    | .add | .sub | .sll | .slt | .sltu
+    | .xor | .srl | .sra | .or | .and
+    | .slliw | .srliw | .sraiw
+    | .addw | .subw | .sllw | .srlw | .sraw
+    | .rem | .remu | .remw | .remuw
+    | .mul | .mulh | .mulhu | .mulhsu | .mulw
+    | .div | .divw | .divu | .divuw
+    | .adduw | .sh1adduw | .sh2adduw | .sh3adduw
+    | .sh1add | .sh2add | .sh3add | .slliuw
+    | .andn | .orn | .xnor
+    | .max | .maxu | .min | .minu
+    | .rol | .ror | .rolw | .rorw
+    | .sextb | .sexth | .zexth
+    | .clz | .clzw | .ctz | .ctzw
+    | .cpop | .cpopw | .orcb | .rev8
+    | .rori | .roriw
+    | .bclr | .bext | .binv | .bset
+    | .bclri | .bexti | .binvi | .bseti
+    | .pack | .packh | .packw
+    | .czeroeqz | .czeronez
+    -- RISC-V pseudo-operations
+    | .mv | .not | .neg | .negw
+    | .sextw | .zextb | .zextw
+    | .seqz | .snez | .sltz | .sgtz => false
+    -- For everything else: be conservative!
+    | _ => true
+
 instance : HasDialectOpInfo Riscv where
   propertiesOf := Riscv.propertiesOf
+  hasSideEffects := Riscv.hasSideEffects
 
 end
 

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -35,8 +35,13 @@ match op with
 | .bnez => RISCVBrProperties
 | _ => Unit
 
+def Riscv_Cf.hasSideEffects
+    (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : Bool :=
+  true
+
 instance : HasDialectOpInfo Riscv_Cf where
   propertiesOf := Riscv_Cf.propertiesOf
+  hasSideEffects := Riscv_Cf.hasSideEffects
 
 end
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -19,8 +19,13 @@ def Riscv_Stack.propertiesOf (op : Riscv_Stack) : Type :=
 match op with
 | .alloca => RISCVStackAllocaProperties
 
+def Riscv_Stack.hasSideEffects
+    (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : Bool :=
+  true
+
 instance : HasDialectOpInfo Riscv_Stack where
   propertiesOf := Riscv_Stack.propertiesOf
+  hasSideEffects := Riscv_Stack.hasSideEffects
 
 end
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -18,8 +18,12 @@ def Rv64.propertiesOf (op : Rv64) : Type :=
 match op with
 | _ => Unit
 
+def Rv64.hasSideEffects (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
+  true
+
 instance : HasDialectOpInfo Rv64 where
   propertiesOf := Rv64.propertiesOf
+  hasSideEffects := Rv64.hasSideEffects
 
 end
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -17,8 +17,12 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 def Test.propertiesOf (_op : Test) : Type :=
   Unit
 
+def Test.hasSideEffects (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
+  true
+
 instance : HasDialectOpInfo Test where
   propertiesOf := Test.propertiesOf
+  hasSideEffects := Test.hasSideEffects
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -45,9 +45,6 @@ match opCode with
 | .datapath op => Datapath.propertiesOf op
 | .test op => Test.propertiesOf op
 
-instance : HasDialectOpInfo OpCode where
-  propertiesOf := _propertiesOf
-
 /--
   Does this OpCode count as an MLIR basic block terminator?
 -/
@@ -86,73 +83,25 @@ def OpCode.readsMemory (opCode : OpCode) : Bool :=
   https://mlir.llvm.org/docs/Rationale/SideEffectsAndSpeculation/
 -/
 def OpCode.hasSideEffects (opCode : OpCode) (props : _propertiesOf opCode) : Bool :=
-  if opCode.isTerminator then true else
   match opCode, props with
-  -- Volatile loads are definitionally side-effecting.
-  | .llvm .load, props => props.volatile_
-  | .riscv .ld, props
-  | .riscv .lw, props
-  | .riscv .lwu, props
-  | .riscv .lh, props
-  | .riscv .lhu, props
-  | .riscv .lb, props
-  | .riscv .lbu, props => props.volatile_
-  | opCode, _ =>
-    match opCode with
-    -- These dialects are pure
-    | .arith _ | .comb _ | .mod_arith _ | .datapath _ => false
-    | .builtin .unrealized_conversion_cast => false
-    | .hw .constant => false
-    -- Enumerate the pure subset of RISC-V
-    | .riscv .li | .riscv .lui | .riscv .auipc
-    | .riscv .addi | .riscv .slti | .riscv .sltiu
-    | .riscv .andi | .riscv .ori | .riscv .xori
-    | .riscv .addiw | .riscv .slli | .riscv .srli | .riscv .srai
-    | .riscv .add | .riscv .sub | .riscv .sll | .riscv .slt | .riscv .sltu
-    | .riscv .xor | .riscv .srl | .riscv .sra | .riscv .or | .riscv .and
-    | .riscv .slliw | .riscv .srliw | .riscv .sraiw
-    | .riscv .addw | .riscv .subw | .riscv .sllw | .riscv .srlw | .riscv .sraw
-    | .riscv .rem | .riscv .remu | .riscv .remw | .riscv .remuw
-    | .riscv .mul | .riscv .mulh | .riscv .mulhu | .riscv .mulhsu | .riscv .mulw
-    | .riscv .div | .riscv .divw | .riscv .divu | .riscv .divuw
-    | .riscv .adduw | .riscv .sh1adduw | .riscv .sh2adduw | .riscv .sh3adduw
-    | .riscv .sh1add | .riscv .sh2add | .riscv .sh3add | .riscv .slliuw
-    | .riscv .andn | .riscv .orn | .riscv .xnor
-    | .riscv .max | .riscv .maxu | .riscv .min | .riscv .minu
-    | .riscv .rol | .riscv .ror | .riscv .rolw | .riscv .rorw
-    | .riscv .sextb | .riscv .sexth | .riscv .zexth
-    | .riscv .clz | .riscv .clzw | .riscv .ctz | .riscv .ctzw
-    | .riscv .cpop | .riscv .cpopw | .riscv .orcb | .riscv .rev8
-    | .riscv .rori | .riscv .roriw
-    | .riscv .bclr | .riscv .bext | .riscv .binv | .riscv .bset
-    | .riscv .bclri | .riscv .bexti | .riscv .binvi | .riscv .bseti
-    | .riscv .pack | .riscv .packh | .riscv .packw
-    | .riscv .czeroeqz | .riscv .czeronez
-    -- RISC-V pseudo-operations
-    | .riscv .mv | .riscv .not | .riscv .neg | .riscv .negw
-    | .riscv .sextw | .riscv .zextb | .riscv .zextw
-    | .riscv .seqz | .riscv .snez | .riscv .sltz | .riscv .sgtz => false
-    -- For LLVM we enumerate the pure ops
-    | .llvm .mlir__constant
-    | .llvm .mlir__poison
-    | .llvm .and | .llvm .or | .llvm .xor
-    | .llvm .add | .llvm .sub | .llvm .mul
-    | .llvm .sdiv | .llvm .udiv | .llvm .srem | .llvm .urem
-    | .llvm .shl | .llvm .lshr | .llvm .ashr
-    | .llvm .intr__ctlz | .llvm .intr__cttz | .llvm .intr__ctpop
-    | .llvm .intr__bswap | .llvm .intr__bitreverse
-    | .llvm .intr__fshl | .llvm .intr__fshr
-    | .llvm .icmp | .llvm .select
-    | .llvm .trunc | .llvm .sext | .llvm .zext
-    | .llvm .getelementptr
-    | .llvm .intr__smax | .llvm .intr__smin | .llvm .intr__umax | .llvm .intr__umin
-    | .llvm .intr__abs
-    | .llvm .intr__sadd__sat | .llvm .intr__uadd__sat
-    | .llvm .intr__ssub__sat | .llvm .intr__usub__sat
-    | .llvm .intr__sshl__sat | .llvm .intr__ushl__sat
-    | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => false
-    -- For everything else: be conservative!
-    | _ => true
+  | .arith op, props => Arith.hasSideEffects op props
+  | .llvm op, props => Llvm.hasSideEffects op props
+  | .riscv op, props => Riscv.hasSideEffects op props
+  | .riscv_cf op, props => Riscv_Cf.hasSideEffects op props
+  | .riscv_stack op, props => Riscv_Stack.hasSideEffects op props
+  | .rv64 op, props => Rv64.hasSideEffects op props
+  | .mod_arith op, props => Mod_Arith.hasSideEffects op props
+  | .cf op, props => Cf.hasSideEffects op props
+  | .comb op, props => Comb.hasSideEffects op props
+  | .hw op, props => HW.hasSideEffects op props
+  | .builtin op, props => Builtin.hasSideEffects op props
+  | .func op, props => Func.hasSideEffects op props
+  | .datapath op, props => Datapath.hasSideEffects op props
+  | .test op, props => Test.hasSideEffects op props
+
+instance : HasDialectOpInfo OpCode where
+  propertiesOf := _propertiesOf
+  hasSideEffects := OpCode.hasSideEffects
 
 inductive RegionKind where
 | SSACFG
@@ -189,7 +138,6 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | _ => false
 
 instance : HasOpInfo OpCode where
-  hasSideEffects := OpCode.hasSideEffects
   readsMemory := OpCode.readsMemory
   isConstantLike := OpCode.isConstantLike
   hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -25,6 +25,14 @@ class HasDialectOpInfo (opCode: Type)
     ((try rename_i op; cases op) <;> infer_instance)
   decideEq : DecidableEq (opCode) := by
     intros opCode1 opCode2; cases opCode1 <;> cases opCode2 <;> infer_instance
+  /--
+  Whether an operation with this opcode and these properties may have
+  effects that make it ineligible for transformations that add /
+  remove / rearrange instructions (terminators count as having
+  effects). Defaults to `true` for every opcode, which conservatively
+  disables such transformations.
+  -/
+  hasSideEffects : (op : opCode) → propertiesOf op → Bool := fun _ _ => true
 
 instance [HasDialectOpInfo opCode] {op : opCode} : Hashable (HasDialectOpInfo.propertiesOf op) where
   hash := HasDialectOpInfo.propertiesHash.hash
@@ -48,14 +56,6 @@ opcodes and whether or not their regions have SSA dominance.
 -/
 class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
-  /--
-  Whether an operation with this opcode and these properties may have
-  effects that make it ineligible for transformations that add /
-  remove / rearrange instructions (terminators count as having
-  effects). Defaults to `true` for every opcode, which conservatively
-  disables such transformations.
-  -/
-  hasSideEffects : (op : opCode) → propertiesOf op → Bool := fun _ _ => true
   /--
   Whether an operation with this opcode reads memory.
 

--- a/Veir/Interfaces/SideEffectInterfaces.lean
+++ b/Veir/Interfaces/SideEffectInterfaces.lean
@@ -29,7 +29,7 @@ public section
 def OperationPtr.hasSideEffects {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
   let opType := op.getOpType! ctx
-  HasOpInfo.hasSideEffects opType (op.getProperties! ctx opType)
+  HasDialectOpInfo.hasSideEffects opType (op.getProperties! ctx opType)
 
 end
 

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -15,7 +15,7 @@ namespace Veir
 -/
 private def isFoldEvaluationCandidate
     (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode) : Bool :=
-  !HasOpInfo.hasSideEffects opCode properties && !HasOpInfo.readsMemory opCode
+  !HasDialectOpInfo.hasSideEffects opCode properties && !HasOpInfo.readsMemory opCode
 
 /--
   Evaluate an operation with the interpreter, given the runtime values of its


### PR DESCRIPTION
`HasOpInfo` should be merged with `HasDialectOpInfo` in the future, so its fields are moved to `HasDialectOpinfo`. Each dialect file now implements `hasSideEffects`, and they are merged in the end `OpCode`.