### PR TITLE
feat: Move `readsMemory` to `HasDialectOpInfo`

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -65,9 +65,13 @@ match op with
 def Arith.hasSideEffects (_op : Arith) (_props : Arith.propertiesOf _op) : Bool :=
   false
 
+def Arith.readsMemory (_op : Arith) : Bool :=
+  false
+
 instance : HasDialectOpInfo Arith where
   propertiesOf := Arith.propertiesOf
   hasSideEffects := Arith.hasSideEffects
+  readsMemory := Arith.readsMemory
 
 end
 

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -27,9 +27,13 @@ def Builtin.hasSideEffects (op : Builtin) (_props : Builtin.propertiesOf op) : B
   | .unrealized_conversion_cast => false
   | _ => true
 
+def Builtin.readsMemory (_op : Builtin) : Bool :=
+  false
+
 instance : HasDialectOpInfo Builtin where
   propertiesOf := Builtin.propertiesOf
   hasSideEffects := Builtin.hasSideEffects
+  readsMemory := Builtin.readsMemory
 
 end
 

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -24,9 +24,13 @@ match op with
 def Cf.hasSideEffects (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
   true
 
+def Cf.readsMemory (_op : Cf) : Bool :=
+  false
+
 instance : HasDialectOpInfo Cf where
   propertiesOf := Cf.propertiesOf
   hasSideEffects := Cf.hasSideEffects
+  readsMemory := Cf.readsMemory
 
 end
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -43,9 +43,13 @@ match op with
 def Comb.hasSideEffects (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
   false
 
+def Comb.readsMemory (_op : Comb) : Bool :=
+  false
+
 instance : HasDialectOpInfo Comb where
   propertiesOf := Comb.propertiesOf
   hasSideEffects := Comb.hasSideEffects
+  readsMemory := Comb.readsMemory
 
 end
 

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -23,9 +23,13 @@ def Datapath.hasSideEffects
     (_op : Datapath) (_props : Datapath.propertiesOf _op) : Bool :=
   false
 
+def Datapath.readsMemory (_op : Datapath) : Bool :=
+  false
+
 instance : HasDialectOpInfo Datapath where
   propertiesOf := Datapath.propertiesOf
   hasSideEffects := Datapath.hasSideEffects
+  readsMemory := Datapath.readsMemory
 
 end
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -26,9 +26,13 @@ match op with
 def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
   true
 
+def Func.readsMemory (_op : Func) : Bool :=
+  false
+
 instance : HasDialectOpInfo Func where
   propertiesOf := Func.propertiesOf
   hasSideEffects := Func.hasSideEffects
+  readsMemory := Func.readsMemory
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -28,9 +28,13 @@ def HW.hasSideEffects (op : HW) (_props : HW.propertiesOf op) : Bool :=
   | .constant => false
   | _ => true
 
+def HW.readsMemory (_op : HW) : Bool :=
+  false
+
 instance : HasDialectOpInfo HW where
   propertiesOf := HW.propertiesOf
   hasSideEffects := HW.hasSideEffects
+  readsMemory := HW.readsMemory
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -124,9 +124,15 @@ def Llvm.hasSideEffects (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
   -- For everything else: be conservative!
   | _, _ => true
 
+def Llvm.readsMemory (op : Llvm) : Bool :=
+  match op with
+  | .load => true
+  | _ => false
+
 instance : HasDialectOpInfo Llvm where
   propertiesOf := Llvm.propertiesOf
   hasSideEffects := Llvm.hasSideEffects
+  readsMemory := Llvm.readsMemory
 
 end
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -27,6 +27,10 @@ def Mod_Arith.hasSideEffects
     (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : Bool :=
   false
 
+def Mod_Arith.readsMemory (_op : Mod_Arith) : Bool :=
+  false
+
 instance : HasDialectOpInfo Mod_Arith where
   propertiesOf := Mod_Arith.propertiesOf
   hasSideEffects := Mod_Arith.hasSideEffects
+  readsMemory := Mod_Arith.readsMemory

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -210,9 +210,17 @@ def Riscv.hasSideEffects (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
     -- For everything else: be conservative!
     | _ => true
 
+def Riscv.readsMemory (op : Riscv) : Bool :=
+  match op with
+  | .ld | .lw | .lwu
+  | .lh | .lhu
+  | .lb | .lbu => true
+  | _ => false
+
 instance : HasDialectOpInfo Riscv where
   propertiesOf := Riscv.propertiesOf
   hasSideEffects := Riscv.hasSideEffects
+  readsMemory := Riscv.readsMemory
 
 end
 

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -39,9 +39,13 @@ def Riscv_Cf.hasSideEffects
     (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : Bool :=
   true
 
+def Riscv_Cf.readsMemory (_op : Riscv_Cf) : Bool :=
+  false
+
 instance : HasDialectOpInfo Riscv_Cf where
   propertiesOf := Riscv_Cf.propertiesOf
   hasSideEffects := Riscv_Cf.hasSideEffects
+  readsMemory := Riscv_Cf.readsMemory
 
 end
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -23,9 +23,13 @@ def Riscv_Stack.hasSideEffects
     (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : Bool :=
   true
 
+def Riscv_Stack.readsMemory (_op : Riscv_Stack) : Bool :=
+  false
+
 instance : HasDialectOpInfo Riscv_Stack where
   propertiesOf := Riscv_Stack.propertiesOf
   hasSideEffects := Riscv_Stack.hasSideEffects
+  readsMemory := Riscv_Stack.readsMemory
 
 end
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -21,9 +21,13 @@ match op with
 def Rv64.hasSideEffects (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
   true
 
+def Rv64.readsMemory (_op : Rv64) : Bool :=
+  false
+
 instance : HasDialectOpInfo Rv64 where
   propertiesOf := Rv64.propertiesOf
   hasSideEffects := Rv64.hasSideEffects
+  readsMemory := Rv64.readsMemory
 
 end
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -20,9 +20,13 @@ def Test.propertiesOf (_op : Test) : Type :=
 def Test.hasSideEffects (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
   true
 
+def Test.readsMemory (_op : Test) : Bool :=
+  false
+
 instance : HasDialectOpInfo Test where
   propertiesOf := Test.propertiesOf
   hasSideEffects := Test.hasSideEffects
+  readsMemory := Test.readsMemory
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -64,11 +64,20 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
 -/
 def OpCode.readsMemory (opCode : OpCode) : Bool :=
   match opCode with
-  | .llvm .load
-  | .riscv .ld | .riscv .lw | .riscv .lwu
-  | .riscv .lh | .riscv .lhu
-  | .riscv .lb | .riscv .lbu => true
-  | _ => false
+  | .arith op => Arith.readsMemory op
+  | .llvm op => Llvm.readsMemory op
+  | .riscv op => Riscv.readsMemory op
+  | .riscv_cf op => Riscv_Cf.readsMemory op
+  | .riscv_stack op => Riscv_Stack.readsMemory op
+  | .rv64 op => Rv64.readsMemory op
+  | .mod_arith op => Mod_Arith.readsMemory op
+  | .cf op => Cf.readsMemory op
+  | .comb op => Comb.readsMemory op
+  | .hw op => HW.readsMemory op
+  | .builtin op => Builtin.readsMemory op
+  | .func op => Func.readsMemory op
+  | .datapath op => Datapath.readsMemory op
+  | .test op => Test.readsMemory op
 
 /--
   Does an operation with this opcode and these properties have effects that
@@ -102,6 +111,7 @@ def OpCode.hasSideEffects (opCode : OpCode) (props : _propertiesOf opCode) : Boo
 instance : HasDialectOpInfo OpCode where
   propertiesOf := _propertiesOf
   hasSideEffects := OpCode.hasSideEffects
+  readsMemory := OpCode.readsMemory
 
 inductive RegionKind where
 | SSACFG
@@ -138,7 +148,6 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | _ => false
 
 instance : HasOpInfo OpCode where
-  readsMemory := OpCode.readsMemory
   isConstantLike := OpCode.isConstantLike
   hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG
 

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -33,6 +33,19 @@ class HasDialectOpInfo (opCode: Type)
   disables such transformations.
   -/
   hasSideEffects : (op : opCode) → propertiesOf op → Bool := fun _ _ => true
+  /--
+  Whether an operation with this opcode reads memory.
+
+  This is deliberately separate from `hasSideEffects`: a non-volatile load
+  reads memory and yet is eligible for removal when its result is unused, so
+  `hasSideEffects` reports `false` for it. Fold-time evaluation must consult
+  this as well before running an operation against memory that is not the
+  program's.
+
+  Defaults to `true` for every opcode, which conservatively assumes memory is
+  read.
+  -/
+  readsMemory : opCode → Bool := fun _ => true
 
 instance [HasDialectOpInfo opCode] {op : opCode} : Hashable (HasDialectOpInfo.propertiesOf op) where
   hash := HasDialectOpInfo.propertiesHash.hash
@@ -56,19 +69,6 @@ opcodes and whether or not their regions have SSA dominance.
 -/
 class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
-  /--
-  Whether an operation with this opcode reads memory.
-
-  This is deliberately separate from `hasSideEffects`: a non-volatile load
-  reads memory and yet is eligible for removal when its result is unused, so
-  `hasSideEffects` reports `false` for it. Fold-time evaluation must consult
-  this as well before running an operation against memory that is not the
-  program's.
-
-  Defaults to `true` for every opcode, which conservatively assumes memory is
-  read.
-  -/
-  readsMemory : opCode → Bool := fun _ => true
   /--
   Whether an operation with this opcode materializes a literal constant
   value: no operands, one result, no side effects, and a result that is

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -15,7 +15,7 @@ namespace Veir
 -/
 private def isFoldEvaluationCandidate
     (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode) : Bool :=
-  !HasDialectOpInfo.hasSideEffects opCode properties && !HasOpInfo.readsMemory opCode
+  !HasDialectOpInfo.hasSideEffects opCode properties && !HasDialectOpInfo.readsMemory opCode
 
 /--
   Evaluate an operation with the interpreter, given the runtime values of its


### PR DESCRIPTION
`HasOpInfo` should be merged with `HasDialectOpInfo` in the future, so its fields are moved to `HasDialectOpinfo`. Each dialect file now implements `readsMemory`, and they are merged in the end `OpCode`.