### PR TITLE
feat: Move `isConstantLike` to `HasDialectOpInfo`

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -68,10 +68,16 @@ def Arith.hasSideEffects (_op : Arith) (_props : Arith.propertiesOf _op) : Bool 
 def Arith.readsMemory (_op : Arith) : Bool :=
   false
 
+def Arith.isConstantLike (op : Arith) : Bool :=
+  match op with
+  | .constant => true
+  | _ => false
+
 instance : HasDialectOpInfo Arith where
   propertiesOf := Arith.propertiesOf
   hasSideEffects := Arith.hasSideEffects
   readsMemory := Arith.readsMemory
+  isConstantLike := Arith.isConstantLike
 
 end
 

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -30,10 +30,14 @@ def Builtin.hasSideEffects (op : Builtin) (_props : Builtin.propertiesOf op) : B
 def Builtin.readsMemory (_op : Builtin) : Bool :=
   false
 
+def Builtin.isConstantLike (_op : Builtin) : Bool :=
+  false
+
 instance : HasDialectOpInfo Builtin where
   propertiesOf := Builtin.propertiesOf
   hasSideEffects := Builtin.hasSideEffects
   readsMemory := Builtin.readsMemory
+  isConstantLike := Builtin.isConstantLike
 
 end
 

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -27,10 +27,14 @@ def Cf.hasSideEffects (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
 def Cf.readsMemory (_op : Cf) : Bool :=
   false
 
+def Cf.isConstantLike (_op : Cf) : Bool :=
+  false
+
 instance : HasDialectOpInfo Cf where
   propertiesOf := Cf.propertiesOf
   hasSideEffects := Cf.hasSideEffects
   readsMemory := Cf.readsMemory
+  isConstantLike := Cf.isConstantLike
 
 end
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -46,10 +46,14 @@ def Comb.hasSideEffects (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
 def Comb.readsMemory (_op : Comb) : Bool :=
   false
 
+def Comb.isConstantLike (_op : Comb) : Bool :=
+  false
+
 instance : HasDialectOpInfo Comb where
   propertiesOf := Comb.propertiesOf
   hasSideEffects := Comb.hasSideEffects
   readsMemory := Comb.readsMemory
+  isConstantLike := Comb.isConstantLike
 
 end
 

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -26,10 +26,14 @@ def Datapath.hasSideEffects
 def Datapath.readsMemory (_op : Datapath) : Bool :=
   false
 
+def Datapath.isConstantLike (_op : Datapath) : Bool :=
+  false
+
 instance : HasDialectOpInfo Datapath where
   propertiesOf := Datapath.propertiesOf
   hasSideEffects := Datapath.hasSideEffects
   readsMemory := Datapath.readsMemory
+  isConstantLike := Datapath.isConstantLike
 
 end
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -29,10 +29,14 @@ def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
 def Func.readsMemory (_op : Func) : Bool :=
   false
 
+def Func.isConstantLike (_op : Func) : Bool :=
+  false
+
 instance : HasDialectOpInfo Func where
   propertiesOf := Func.propertiesOf
   hasSideEffects := Func.hasSideEffects
   readsMemory := Func.readsMemory
+  isConstantLike := Func.isConstantLike
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -31,10 +31,16 @@ def HW.hasSideEffects (op : HW) (_props : HW.propertiesOf op) : Bool :=
 def HW.readsMemory (_op : HW) : Bool :=
   false
 
+def HW.isConstantLike (op : HW) : Bool :=
+  match op with
+  | .constant => true
+  | _ => false
+
 instance : HasDialectOpInfo HW where
   propertiesOf := HW.propertiesOf
   hasSideEffects := HW.hasSideEffects
   readsMemory := HW.readsMemory
+  isConstantLike := HW.isConstantLike
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -129,10 +129,16 @@ def Llvm.readsMemory (op : Llvm) : Bool :=
   | .load => true
   | _ => false
 
+def Llvm.isConstantLike (op : Llvm) : Bool :=
+  match op with
+  | .mlir__constant | .mlir__poison => true
+  | _ => false
+
 instance : HasDialectOpInfo Llvm where
   propertiesOf := Llvm.propertiesOf
   hasSideEffects := Llvm.hasSideEffects
   readsMemory := Llvm.readsMemory
+  isConstantLike := Llvm.isConstantLike
 
 end
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -30,7 +30,11 @@ def Mod_Arith.hasSideEffects
 def Mod_Arith.readsMemory (_op : Mod_Arith) : Bool :=
   false
 
+def Mod_Arith.isConstantLike (_op : Mod_Arith) : Bool :=
+  false
+
 instance : HasDialectOpInfo Mod_Arith where
   propertiesOf := Mod_Arith.propertiesOf
   hasSideEffects := Mod_Arith.hasSideEffects
   readsMemory := Mod_Arith.readsMemory
+  isConstantLike := Mod_Arith.isConstantLike

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -217,10 +217,16 @@ def Riscv.readsMemory (op : Riscv) : Bool :=
   | .lb | .lbu => true
   | _ => false
 
+def Riscv.isConstantLike (op : Riscv) : Bool :=
+  match op with
+  | .li => true
+  | _ => false
+
 instance : HasDialectOpInfo Riscv where
   propertiesOf := Riscv.propertiesOf
   hasSideEffects := Riscv.hasSideEffects
   readsMemory := Riscv.readsMemory
+  isConstantLike := Riscv.isConstantLike
 
 end
 

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -42,10 +42,14 @@ def Riscv_Cf.hasSideEffects
 def Riscv_Cf.readsMemory (_op : Riscv_Cf) : Bool :=
   false
 
+def Riscv_Cf.isConstantLike (_op : Riscv_Cf) : Bool :=
+  false
+
 instance : HasDialectOpInfo Riscv_Cf where
   propertiesOf := Riscv_Cf.propertiesOf
   hasSideEffects := Riscv_Cf.hasSideEffects
   readsMemory := Riscv_Cf.readsMemory
+  isConstantLike := Riscv_Cf.isConstantLike
 
 end
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -26,10 +26,14 @@ def Riscv_Stack.hasSideEffects
 def Riscv_Stack.readsMemory (_op : Riscv_Stack) : Bool :=
   false
 
+def Riscv_Stack.isConstantLike (_op : Riscv_Stack) : Bool :=
+  false
+
 instance : HasDialectOpInfo Riscv_Stack where
   propertiesOf := Riscv_Stack.propertiesOf
   hasSideEffects := Riscv_Stack.hasSideEffects
   readsMemory := Riscv_Stack.readsMemory
+  isConstantLike := Riscv_Stack.isConstantLike
 
 end
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -24,10 +24,14 @@ def Rv64.hasSideEffects (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
 def Rv64.readsMemory (_op : Rv64) : Bool :=
   false
 
+def Rv64.isConstantLike (_op : Rv64) : Bool :=
+  false
+
 instance : HasDialectOpInfo Rv64 where
   propertiesOf := Rv64.propertiesOf
   hasSideEffects := Rv64.hasSideEffects
   readsMemory := Rv64.readsMemory
+  isConstantLike := Rv64.isConstantLike
 
 end
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -23,10 +23,14 @@ def Test.hasSideEffects (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
 def Test.readsMemory (_op : Test) : Bool :=
   false
 
+def Test.isConstantLike (_op : Test) : Bool :=
+  false
+
 instance : HasDialectOpInfo Test where
   propertiesOf := Test.propertiesOf
   hasSideEffects := Test.hasSideEffects
   readsMemory := Test.readsMemory
+  isConstantLike := Test.isConstantLike
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -108,11 +108,6 @@ def OpCode.hasSideEffects (opCode : OpCode) (props : _propertiesOf opCode) : Boo
   | .datapath op, props => Datapath.hasSideEffects op props
   | .test op, props => Test.hasSideEffects op props
 
-instance : HasDialectOpInfo OpCode where
-  propertiesOf := _propertiesOf
-  hasSideEffects := OpCode.hasSideEffects
-  readsMemory := OpCode.readsMemory
-
 inductive RegionKind where
 | SSACFG
 | Graph
@@ -140,15 +135,28 @@ def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
 -/
 def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   match opCode with
-  | .arith .constant
-  | .llvm .mlir__constant
-  | .llvm .mlir__poison
-  | .hw .constant
-  | .riscv .li => true
-  | _ => false
+  | .arith op => Arith.isConstantLike op
+  | .llvm op => Llvm.isConstantLike op
+  | .riscv op => Riscv.isConstantLike op
+  | .riscv_cf op => Riscv_Cf.isConstantLike op
+  | .riscv_stack op => Riscv_Stack.isConstantLike op
+  | .rv64 op => Rv64.isConstantLike op
+  | .mod_arith op => Mod_Arith.isConstantLike op
+  | .cf op => Cf.isConstantLike op
+  | .comb op => Comb.isConstantLike op
+  | .hw op => HW.isConstantLike op
+  | .builtin op => Builtin.isConstantLike op
+  | .func op => Func.isConstantLike op
+  | .datapath op => Datapath.isConstantLike op
+  | .test op => Test.isConstantLike op
+
+instance : HasDialectOpInfo OpCode where
+  propertiesOf := _propertiesOf
+  hasSideEffects := OpCode.hasSideEffects
+  readsMemory := OpCode.readsMemory
+  isConstantLike := OpCode.isConstantLike
 
 instance : HasOpInfo OpCode where
-  isConstantLike := OpCode.isConstantLike
   hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG
 
 #generate_has_dialect_instances OpCode

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -46,6 +46,13 @@ class HasDialectOpInfo (opCode: Type)
   read.
   -/
   readsMemory : opCode → Bool := fun _ => true
+  /--
+  Whether an operation with this opcode materializes a literal constant
+  value: no operands, one result, no side effects, and a result that is
+  always determined by the operation's properties. Defaults to `false`
+  for every opcode, which conservatively treats nothing as constant.
+  -/
+  isConstantLike : opCode → Bool := fun _ => false
 
 instance [HasDialectOpInfo opCode] {op : opCode} : Hashable (HasDialectOpInfo.propertiesOf op) where
   hash := HasDialectOpInfo.propertiesHash.hash
@@ -69,13 +76,6 @@ opcodes and whether or not their regions have SSA dominance.
 -/
 class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
-  /--
-  Whether an operation with this opcode materializes a literal constant
-  value: no operands, one result, no side effects, and a result that is
-  always determined by the operation's properties. Defaults to `false`
-  for every opcode, which conservatively treats nothing as constant.
-  -/
-  isConstantLike : opCode → Bool := fun _ => false
   /--
   Whether definitions in the indexed region must dominate their uses. A false
   result denotes graph-style semantics, where only a single block can be in the

--- a/Veir/Interfaces/ConstantLikeInterfaces.lean
+++ b/Veir/Interfaces/ConstantLikeInterfaces.lean
@@ -16,7 +16,7 @@ public section
 
 def OperationPtr.isConstantLike {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
-  HasOpInfo.isConstantLike (op.getOpType! ctx)
+  HasDialectOpInfo.isConstantLike (op.getOpType! ctx)
 
 def ValuePtr.isConstantLike {OpInfo : Type} [HasOpInfo OpInfo]
     (val : ValuePtr) (ctx : IRContext OpInfo) : Bool :=


### PR DESCRIPTION
`HasOpInfo` should be merged with `HasDialectOpInfo` in the future, so its fields are moved to `HasDialectOpinfo`. Each dialect file now implements `isConstantLike`, and they are merged in the end `OpCode`.