### PR TITLE
feat: Move `hasSSADominance` to `HasDialectOpInfo`

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -73,11 +73,15 @@ def Arith.isConstantLike (op : Arith) : Bool :=
   | .constant => true
   | _ => false
 
+def Arith.hasSSADominance (_op : Arith) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Arith where
   propertiesOf := Arith.propertiesOf
   hasSideEffects := Arith.hasSideEffects
   readsMemory := Arith.readsMemory
   isConstantLike := Arith.isConstantLike
+  hasSSADominance := Arith.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -33,11 +33,17 @@ def Builtin.readsMemory (_op : Builtin) : Bool :=
 def Builtin.isConstantLike (_op : Builtin) : Bool :=
   false
 
+def Builtin.hasSSADominance (op : Builtin) (_index : Nat) : Bool :=
+  match op with
+  | .module | .unregistered => false
+  | _ => true
+
 instance : HasDialectOpInfo Builtin where
   propertiesOf := Builtin.propertiesOf
   hasSideEffects := Builtin.hasSideEffects
   readsMemory := Builtin.readsMemory
   isConstantLike := Builtin.isConstantLike
+  hasSSADominance := Builtin.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -30,11 +30,15 @@ def Cf.readsMemory (_op : Cf) : Bool :=
 def Cf.isConstantLike (_op : Cf) : Bool :=
   false
 
+def Cf.hasSSADominance (_op : Cf) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Cf where
   propertiesOf := Cf.propertiesOf
   hasSideEffects := Cf.hasSideEffects
   readsMemory := Cf.readsMemory
   isConstantLike := Cf.isConstantLike
+  hasSSADominance := Cf.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -49,11 +49,15 @@ def Comb.readsMemory (_op : Comb) : Bool :=
 def Comb.isConstantLike (_op : Comb) : Bool :=
   false
 
+def Comb.hasSSADominance (_op : Comb) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Comb where
   propertiesOf := Comb.propertiesOf
   hasSideEffects := Comb.hasSideEffects
   readsMemory := Comb.readsMemory
   isConstantLike := Comb.isConstantLike
+  hasSSADominance := Comb.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -29,11 +29,15 @@ def Datapath.readsMemory (_op : Datapath) : Bool :=
 def Datapath.isConstantLike (_op : Datapath) : Bool :=
   false
 
+def Datapath.hasSSADominance (_op : Datapath) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Datapath where
   propertiesOf := Datapath.propertiesOf
   hasSideEffects := Datapath.hasSideEffects
   readsMemory := Datapath.readsMemory
   isConstantLike := Datapath.isConstantLike
+  hasSSADominance := Datapath.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -32,11 +32,15 @@ def Func.readsMemory (_op : Func) : Bool :=
 def Func.isConstantLike (_op : Func) : Bool :=
   false
 
+def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Func where
   propertiesOf := Func.propertiesOf
   hasSideEffects := Func.hasSideEffects
   readsMemory := Func.readsMemory
   isConstantLike := Func.isConstantLike
+  hasSSADominance := Func.hasSSADominance
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -36,11 +36,15 @@ def HW.isConstantLike (op : HW) : Bool :=
   | .constant => true
   | _ => false
 
+def HW.hasSSADominance (_op : HW) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo HW where
   propertiesOf := HW.propertiesOf
   hasSideEffects := HW.hasSideEffects
   readsMemory := HW.readsMemory
   isConstantLike := HW.isConstantLike
+  hasSSADominance := HW.hasSSADominance
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -134,11 +134,15 @@ def Llvm.isConstantLike (op : Llvm) : Bool :=
   | .mlir__constant | .mlir__poison => true
   | _ => false
 
+def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Llvm where
   propertiesOf := Llvm.propertiesOf
   hasSideEffects := Llvm.hasSideEffects
   readsMemory := Llvm.readsMemory
   isConstantLike := Llvm.isConstantLike
+  hasSSADominance := Llvm.hasSSADominance
 
 end
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -33,8 +33,12 @@ def Mod_Arith.readsMemory (_op : Mod_Arith) : Bool :=
 def Mod_Arith.isConstantLike (_op : Mod_Arith) : Bool :=
   false
 
+def Mod_Arith.hasSSADominance (_op : Mod_Arith) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Mod_Arith where
   propertiesOf := Mod_Arith.propertiesOf
   hasSideEffects := Mod_Arith.hasSideEffects
   readsMemory := Mod_Arith.readsMemory
   isConstantLike := Mod_Arith.isConstantLike
+  hasSSADominance := Mod_Arith.hasSSADominance

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -222,11 +222,15 @@ def Riscv.isConstantLike (op : Riscv) : Bool :=
   | .li => true
   | _ => false
 
+def Riscv.hasSSADominance (_op : Riscv) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Riscv where
   propertiesOf := Riscv.propertiesOf
   hasSideEffects := Riscv.hasSideEffects
   readsMemory := Riscv.readsMemory
   isConstantLike := Riscv.isConstantLike
+  hasSSADominance := Riscv.hasSSADominance
 
 end
 

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -45,11 +45,15 @@ def Riscv_Cf.readsMemory (_op : Riscv_Cf) : Bool :=
 def Riscv_Cf.isConstantLike (_op : Riscv_Cf) : Bool :=
   false
 
+def Riscv_Cf.hasSSADominance (_op : Riscv_Cf) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Riscv_Cf where
   propertiesOf := Riscv_Cf.propertiesOf
   hasSideEffects := Riscv_Cf.hasSideEffects
   readsMemory := Riscv_Cf.readsMemory
   isConstantLike := Riscv_Cf.isConstantLike
+  hasSSADominance := Riscv_Cf.hasSSADominance
 
 end
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -29,11 +29,15 @@ def Riscv_Stack.readsMemory (_op : Riscv_Stack) : Bool :=
 def Riscv_Stack.isConstantLike (_op : Riscv_Stack) : Bool :=
   false
 
+def Riscv_Stack.hasSSADominance (_op : Riscv_Stack) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Riscv_Stack where
   propertiesOf := Riscv_Stack.propertiesOf
   hasSideEffects := Riscv_Stack.hasSideEffects
   readsMemory := Riscv_Stack.readsMemory
   isConstantLike := Riscv_Stack.isConstantLike
+  hasSSADominance := Riscv_Stack.hasSSADominance
 
 end
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -27,11 +27,15 @@ def Rv64.readsMemory (_op : Rv64) : Bool :=
 def Rv64.isConstantLike (_op : Rv64) : Bool :=
   false
 
+def Rv64.hasSSADominance (_op : Rv64) (_index : Nat) : Bool :=
+  true
+
 instance : HasDialectOpInfo Rv64 where
   propertiesOf := Rv64.propertiesOf
   hasSideEffects := Rv64.hasSideEffects
   readsMemory := Rv64.readsMemory
   isConstantLike := Rv64.isConstantLike
+  hasSSADominance := Rv64.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -26,11 +26,15 @@ def Test.readsMemory (_op : Test) : Bool :=
 def Test.isConstantLike (_op : Test) : Bool :=
   false
 
+def Test.hasSSADominance (_op : Test) (_index : Nat) : Bool :=
+  false
+
 instance : HasDialectOpInfo Test where
   propertiesOf := Test.propertiesOf
   hasSideEffects := Test.hasSideEffects
   readsMemory := Test.readsMemory
   isConstantLike := Test.isConstantLike
+  hasSSADominance := Test.hasSSADominance
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -126,6 +126,27 @@ def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
   | _ => .SSACFG
 
 /--
+  Whether definitions in the indexed region of this opcode must dominate
+  their uses.
+-/
+def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
+  match opCode with
+  | .arith op => Arith.hasSSADominance op index
+  | .llvm op => Llvm.hasSSADominance op index
+  | .riscv op => Riscv.hasSSADominance op index
+  | .riscv_cf op => Riscv_Cf.hasSSADominance op index
+  | .riscv_stack op => Riscv_Stack.hasSSADominance op index
+  | .rv64 op => Rv64.hasSSADominance op index
+  | .mod_arith op => Mod_Arith.hasSSADominance op index
+  | .cf op => Cf.hasSSADominance op index
+  | .comb op => Comb.hasSSADominance op index
+  | .hw op => HW.hasSSADominance op index
+  | .builtin op => Builtin.hasSSADominance op index
+  | .func op => Func.hasSSADominance op index
+  | .datapath op => Datapath.hasSSADominance op index
+  | .test op => Test.hasSSADominance op index
+
+/--
   Does this `OpCode` materialize a literal constant value, i.e. an op
   whose single result is a compile-time constant taken from its
   properties, with no SSA operands and no side effects?
@@ -155,9 +176,9 @@ instance : HasDialectOpInfo OpCode where
   hasSideEffects := OpCode.hasSideEffects
   readsMemory := OpCode.readsMemory
   isConstantLike := OpCode.isConstantLike
+  hasSSADominance := OpCode.hasSSADominance
 
 instance : HasOpInfo OpCode where
-  hasSSADominance opCode index := opCode.getRegionKind index == .SSACFG
 
 #generate_has_dialect_instances OpCode
 

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -53,6 +53,12 @@ class HasDialectOpInfo (opCode: Type)
   for every opcode, which conservatively treats nothing as constant.
   -/
   isConstantLike : opCode → Bool := fun _ => false
+  /--
+  Whether definitions in the indexed region must dominate their uses. A false
+  result denotes graph-style semantics, where only a single block can be in the
+  region, and operation order does not impose SSA dominance.
+  -/
+  hasSSADominance : opCode → Nat → Bool
 
 instance [HasDialectOpInfo opCode] {op : opCode} : Hashable (HasDialectOpInfo.propertiesOf op) where
   hash := HasDialectOpInfo.propertiesHash.hash
@@ -70,18 +76,11 @@ instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
   HasDialectOpInfo.decideEq
 
 /--
-The `HasOpInfo` type class provides information about opcodes and their properties
-and how to hash, represent, and compare them for equality. It also contains the mapping between
-opcodes and whether or not their regions have SSA dominance.
+The `HasOpInfo` type class provides the combined operation information for a
+global opcode type.
 -/
 class HasOpInfo (opCode: Type)
-    extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode where
-  /--
-  Whether definitions in the indexed region must dominate their uses. A false
-  result denotes graph-style semantics, where only a single block can be in the
-  region, and operation order does not impose SSA dominance.
-  -/
-  hasSSADominance : opCode → Nat → Bool
+    extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode
 
 /--
 `HasDialect OpInfo Dialect` states that `OpInfo` contains the operations from

--- a/Veir/Interfaces/RegionKindInterfaces.lean
+++ b/Veir/Interfaces/RegionKindInterfaces.lean
@@ -26,7 +26,7 @@ def RegionPtr.hasSSADominance (region : RegionPtr)
   match (region.get! ctx.raw).parent with
   | none => true
   | some parent =>
-      HasOpInfo.hasSSADominance (parent.getOpType! ctx.raw)
+      HasDialectOpInfo.hasSSADominance (parent.getOpType! ctx.raw)
         ((parent.get! ctx.raw).regions.idxOf region)
 
 end Veir


### PR DESCRIPTION
`HasOpInfo` should be merged with `HasDialectOpInfo` in the future, so its fields are moved to `HasDialectOpinfo`. Each dialect file now implements `hasSSADominance`, and they are merged in the end `OpCode`.