### PR TITLE
feat: Move `toAttrDict` and `fromAttrDict` to `HasDialectOpInfo`

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -62,6 +62,55 @@ match op with
 | .extui => NnegProperties
 | _ => Unit
 
+def Arith.fromAttrDict
+    (op : Arith) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Arith.propertiesOf op) := by
+  cases op
+  case constant => exact ArithConstantProperties.fromAttrDict attrDict
+  case addi | subi | muli | shli | trunci =>
+    exact ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict
+  case divsi | divui | shrsi | shrui =>
+    exact ExactProperties.fromAttrDict attrDict
+  case cmpi => exact IcmpProperties.fromAttrDictFor "arith.cmpi" attrDict
+  case ori => exact DisjointProperties.fromAttrDict attrDict
+  case extui => exact NnegProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Arith.toAttrDict
+    (op : Arith) (props : Arith.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .constant =>
+    (Std.HashMap.emptyWithCapacity 2).insert
+      "value".toUTF8 (Attribute.integerAttr props.value)
+  | .addi | .subi | .muli | .shli | .trunci => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 1
+    if props.attr.nsw || props.attr.nuw then
+      dict := dict.insert
+        "overflowFlags".toUTF8
+        (Attribute.arithIntegerOverflowFlagsAttr props.attr)
+    dict
+  | .cmpi =>
+    let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "predicate".toUTF8 (Attribute.integerAttr value)
+  | .divsi | .divui | .shrsi | .shrui => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    if props.exact then
+      dict := dict.insert "exact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+    dict
+  | .ori => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    if props.disjoint then
+      dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+    dict
+  | .extui => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 1
+    if props.nneg then
+      dict := dict.insert "nneg".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+    dict
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Arith.hasSideEffects (_op : Arith) (_props : Arith.propertiesOf _op) : Bool :=
   false
 
@@ -78,6 +127,8 @@ def Arith.hasSSADominance (_op : Arith) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Arith where
   propertiesOf := Arith.propertiesOf
+  fromAttrDict := Arith.fromAttrDict
+  toAttrDict := Arith.toAttrDict
   hasSideEffects := Arith.hasSideEffects
   readsMemory := Arith.readsMemory
   isConstantLike := Arith.isConstantLike

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -22,6 +22,20 @@ match op with
 | .unregistered => UnregisteredProperties
 | _ => Unit
 
+def Builtin.fromAttrDict
+    (op : Builtin) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Builtin.propertiesOf op) := by
+  cases op
+  case unregistered => exact UnregisteredProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Builtin.toAttrDict
+    (op : Builtin) (props : Builtin.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .unregistered => Std.HashMap.ofList props.properties.entries.toList
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Builtin.hasSideEffects (op : Builtin) (_props : Builtin.propertiesOf op) : Bool :=
   match op with
   | .unrealized_conversion_cast => false
@@ -40,6 +54,8 @@ def Builtin.hasSSADominance (op : Builtin) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Builtin where
   propertiesOf := Builtin.propertiesOf
+  fromAttrDict := Builtin.fromAttrDict
+  toAttrDict := Builtin.toAttrDict
   hasSideEffects := Builtin.hasSideEffects
   readsMemory := Builtin.readsMemory
   isConstantLike := Builtin.isConstantLike

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -21,6 +21,24 @@ match op with
 | .cond_br => CondBrProperties
 | _ => Unit
 
+def Cf.fromAttrDict
+    (op : Cf) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Cf.propertiesOf op) := by
+  cases op
+  case cond_br => exact CondBrProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Cf.toAttrDict
+    (op : Cf) (props : Cf.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .cond_br =>
+    let dict := (Std.HashMap.emptyWithCapacity 2).insert
+      "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
+    dict.insert "operandSegmentSizes".toUTF8
+      (Attribute.denseArrayAttr props.operandSegmentSizes)
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Cf.hasSideEffects (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
   true
 
@@ -35,6 +53,8 @@ def Cf.hasSSADominance (_op : Cf) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Cf where
   propertiesOf := Cf.propertiesOf
+  fromAttrDict := Cf.fromAttrDict
+  toAttrDict := Cf.toAttrDict
   hasSideEffects := Cf.hasSideEffects
   readsMemory := Cf.readsMemory
   isConstantLike := Cf.isConstantLike

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -40,6 +40,26 @@ match op with
 | .icmp => CombIcmpProperties
 | _ => Unit
 
+def Comb.fromAttrDict
+    (op : Comb) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Comb.propertiesOf op) := by
+  cases op
+  case extract => exact CombExtractProperties.fromAttrDict attrDict
+  case icmp => exact CombIcmpProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Comb.toAttrDict
+    (op : Comb) (props : Comb.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .extract =>
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
+  | .icmp =>
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "predicate".toUTF8 (Attribute.integerAttr props.predicate)
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Comb.hasSideEffects (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
   false
 
@@ -54,6 +74,8 @@ def Comb.hasSSADominance (_op : Comb) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Comb where
   propertiesOf := Comb.propertiesOf
+  fromAttrDict := Comb.fromAttrDict
+  toAttrDict := Comb.toAttrDict
   hasSideEffects := Comb.hasSideEffects
   readsMemory := Comb.readsMemory
   isConstantLike := Comb.isConstantLike

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -19,6 +19,16 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 def Datapath.propertiesOf (_op : Datapath) : Type :=
   Unit
 
+def Datapath.fromAttrDict
+    (_op : Datapath) (_attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Datapath.propertiesOf _op) :=
+  .ok ()
+
+def Datapath.toAttrDict
+    (_op : Datapath) (_props : Datapath.propertiesOf _op) :
+    Std.HashMap ByteArray Attribute :=
+  Std.HashMap.emptyWithCapacity 0
+
 def Datapath.hasSideEffects
     (_op : Datapath) (_props : Datapath.propertiesOf _op) : Bool :=
   false
@@ -34,6 +44,8 @@ def Datapath.hasSSADominance (_op : Datapath) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Datapath where
   propertiesOf := Datapath.propertiesOf
+  fromAttrDict := Datapath.fromAttrDict
+  toAttrDict := Datapath.toAttrDict
   hasSideEffects := Datapath.hasSideEffects
   readsMemory := Datapath.readsMemory
   isConstantLike := Datapath.isConstantLike

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -23,6 +23,31 @@ match op with
 | .call => FuncCallProperties
 | _ => Unit
 
+def Func.fromAttrDict
+    (op : Func) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Func.propertiesOf op) := by
+  cases op
+  case func => exact FuncFuncProperties.fromAttrDict attrDict
+  case call => exact FuncCallProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Func.toAttrDict
+    (op : Func) (props : Func.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .call => Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    dict := dict.insert "callee".toUTF8 (.flatSymbolRefAttr props.callee)
+    dict
+  | .func => Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    if let some sym_name := props.sym_name then
+      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
+    if let some function_type := props.function_type then
+      dict := dict.insert "function_type".toUTF8 function_type
+    dict
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
   true
 
@@ -37,6 +62,8 @@ def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Func where
   propertiesOf := Func.propertiesOf
+  fromAttrDict := Func.fromAttrDict
+  toAttrDict := Func.toAttrDict
   hasSideEffects := Func.hasSideEffects
   readsMemory := Func.readsMemory
   isConstantLike := Func.isConstantLike

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -23,6 +23,30 @@ match op with
 | .module => HWModuleProperties
 | _ => Unit
 
+def HW.fromAttrDict
+    (op : HW) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (HW.propertiesOf op) := by
+  cases op
+  case constant => exact HWConstantProperties.fromAttrDict attrDict
+  case module => exact HWModuleProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def HW.toAttrDict
+    (op : HW) (props : HW.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .constant =>
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "value".toUTF8 (Attribute.integerAttr props.value)
+  | .module => Id.run do
+    let dict := Std.HashMap.emptyWithCapacity 4
+    let dict := dict.insert "module_type".toUTF8 (.hwModuleType props.module_type)
+    let dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    let dict := dict.insert "per_port_attrs".toUTF8 (.arrayAttr props.per_port_attrs)
+    let dict := dict.insert "parameters".toUTF8 (.arrayAttr props.parameters)
+    dict
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def HW.hasSideEffects (op : HW) (_props : HW.propertiesOf op) : Bool :=
   match op with
   | .constant => false
@@ -41,6 +65,8 @@ def HW.hasSSADominance (_op : HW) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo HW where
   propertiesOf := HW.propertiesOf
+  fromAttrDict := HW.fromAttrDict
+  toAttrDict := HW.toAttrDict
   hasSideEffects := HW.hasSideEffects
   readsMemory := HW.readsMemory
   isConstantLike := HW.isConstantLike

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -99,6 +99,164 @@ match op with
 | .module_flags => LLVMModuleFlagsProperties
 | _ => Unit
 
+def Llvm.fromAttrDict
+    (op : Llvm) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Llvm.propertiesOf op) := by
+  cases op
+  case mlir__constant => exact LLVMConstantProperties.fromAttrDict attrDict
+  case add | sub | mul | shl | trunc =>
+    exact NswNuwProperties.fromAttrDict attrDict
+  case udiv | sdiv | lshr | ashr =>
+    exact ExactProperties.fromAttrDict attrDict
+  case intr__ctlz =>
+    exact ZeroPoisonProperties.fromAttrDictFor "llvm.intr.ctlz" attrDict
+  case intr__cttz =>
+    exact ZeroPoisonProperties.fromAttrDictFor "llvm.intr.cttz" attrDict
+  case intr__abs => exact IntMinPoisonProperties.fromAttrDict attrDict
+  case or => exact DisjointProperties.fromAttrDict attrDict
+  case zext => exact NnegProperties.fromAttrDict attrDict
+  case icmp => exact IcmpProperties.fromAttrDict attrDict
+  case cond_br => exact CondBrProperties.fromAttrDict attrDict
+  case alloca => exact AllocaProperties.fromAttrDict attrDict
+  case load => exact LoadProperties.fromAttrDict attrDict
+  case store => exact StoreProperties.fromAttrDict attrDict
+  case getelementptr => exact GetelementptrProperties.fromAttrDict attrDict
+  case fadd | fsub | fmul | fdiv | frem =>
+    exact FastMathFlagsProperties.fromAttrDict attrDict
+  case func => exact LLVMFuncProperties.fromAttrDict attrDict
+  case module_flags => exact LLVMModuleFlagsProperties.fromAttrDict attrDict
+  case call => exact LLVMCallProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Llvm.toAttrDict
+    (op : Llvm) (props : Llvm.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .mlir__constant =>
+    match props.value with
+    | .integer intAttr =>
+      (Std.HashMap.emptyWithCapacity 1).insert
+        "value".toUTF8 (Attribute.integerAttr intAttr)
+    | .float floatAttr =>
+      (Std.HashMap.emptyWithCapacity 1).insert
+        "value".toUTF8 (Attribute.floatAttr floatAttr)
+    | .dense denseAttr =>
+      (Std.HashMap.emptyWithCapacity 1).insert
+        "value".toUTF8 (Attribute.denseElementsAttr denseAttr)
+  | .add | .sub | .mul | .shl | .trunc => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 1
+    let mut val := 0
+    if props.nsw then
+      val := val + 1
+    if props.nuw then
+      val := val + 2
+    if val > 0 then
+      let attr := IntegerAttr.mk (Int.ofNat val) (IntegerType.mk 32)
+      dict := dict.insert "overflowFlags".toUTF8 (Attribute.integerAttr attr)
+    dict
+  | .fadd | .fsub | .fmul | .fdiv | .frem =>
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "fastmathFlags".toUTF8 (Attribute.fastMathFlagsAttr props.attr)
+  | .icmp =>
+    let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "predicate".toUTF8 (Attribute.integerAttr value)
+  | .cond_br =>
+    let dict := (Std.HashMap.emptyWithCapacity 2).insert
+      "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
+    dict.insert "operandSegmentSizes".toUTF8
+      (Attribute.denseArrayAttr props.operandSegmentSizes)
+  | .udiv | .sdiv | .lshr | .ashr => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    if props.exact then
+      dict := dict.insert "exact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+    dict
+  | .or => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    if props.disjoint then
+      dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+    dict
+  | .zext => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 1
+    if props.nneg then
+      dict := dict.insert "nneg".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+    dict
+  | .intr__ctlz | .intr__cttz =>
+    let value := if props.is_zero_poison then 1 else 0
+    let attr := IntegerAttr.mk value (IntegerType.mk 1)
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "is_zero_poison".toUTF8 (Attribute.integerAttr attr)
+  | .intr__abs =>
+    let value := if props.is_int_min_poison then 1 else 0
+    let attr := IntegerAttr.mk value (IntegerType.mk 1)
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "is_int_min_poison".toUTF8 (Attribute.integerAttr attr)
+  | .alloca => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 3
+    dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
+    dict := dict.insert "elem_type".toUTF8 props.elem_type
+    if props.inalloca then
+      dict := dict.insert "inalloca".toUTF8 (.unitAttr UnitAttr.mk)
+    dict
+  | .load => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 10
+    dict := dict.insert "alignment".toUTF8 (.integerAttr props.alignment)
+    if props.volatile_ then
+      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.nontemporal then
+      dict := dict.insert "nontemporal".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.invariant then
+      dict := dict.insert "invariant".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.invariantGroup then
+      dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
+    if let some syncscope := props.syncscope then
+      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
+    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
+    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
+    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
+    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
+    dict
+  | .store => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 9
+    dict := dict.insert "alignment".toUTF8 (.integerAttr props.alignment)
+    if props.volatile_ then
+      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.nontemporal then
+      dict := dict.insert "nontemporal".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.invariantGroup then
+      dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
+    if let some syncscope := props.syncscope then
+      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
+    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
+    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
+    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
+    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
+    dict
+  | .getelementptr => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 3
+    dict := dict.insert
+      "rawConstantIndices".toUTF8
+      (Attribute.denseArrayAttr props.rawConstantIndices)
+    dict := dict.insert "elem_type".toUTF8 props.elem_type
+    dict := dict.insert "noWrapFlags".toUTF8 (.integerAttr props.noWrapFlags)
+    dict
+  | .func => Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    if let some sym_name := props.sym_name then
+      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
+    if let some function_type := props.function_type then
+      dict := dict.insert "function_type".toUTF8 function_type
+    dict
+  | .module_flags =>
+    (Std.HashMap.emptyWithCapacity 3).insert
+      "flags".toUTF8 (Attribute.arrayAttr props.flags)
+  | .call => Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    if let some callee := props.callee then
+      dict := dict.insert "callee".toUTF8 (.flatSymbolRefAttr callee)
+    dict
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Llvm.hasSideEffects (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
   match op, props with
   -- Volatile loads are definitionally side-effecting.
@@ -139,6 +297,8 @@ def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Llvm where
   propertiesOf := Llvm.propertiesOf
+  fromAttrDict := Llvm.fromAttrDict
+  toAttrDict := Llvm.toAttrDict
   hasSideEffects := Llvm.hasSideEffects
   readsMemory := Llvm.readsMemory
   isConstantLike := Llvm.isConstantLike

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -23,6 +23,22 @@ match op with
 | .constant => ModArithConstantProperties
 | .add | .sub | .mul => Unit
 
+def Mod_Arith.fromAttrDict
+    (op : Mod_Arith) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Mod_Arith.propertiesOf op) := by
+  cases op
+  case constant => exact ModArithConstantProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Mod_Arith.toAttrDict
+    (op : Mod_Arith) (props : Mod_Arith.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .constant =>
+    (Std.HashMap.emptyWithCapacity 2).insert
+      "value".toUTF8 (Attribute.integerAttr props.value)
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Mod_Arith.hasSideEffects
     (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : Bool :=
   false
@@ -38,6 +54,8 @@ def Mod_Arith.hasSSADominance (_op : Mod_Arith) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Mod_Arith where
   propertiesOf := Mod_Arith.propertiesOf
+  fromAttrDict := Mod_Arith.fromAttrDict
+  toAttrDict := Mod_Arith.toAttrDict
   hasSideEffects := Mod_Arith.hasSideEffects
   readsMemory := Mod_Arith.readsMemory
   isConstantLike := Mod_Arith.isConstantLike

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -167,6 +167,38 @@ match op with
 | .sb => RISCVMemProperties
 | _ => Unit
 
+def Riscv.fromAttrDict
+    (op : Riscv) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Riscv.propertiesOf op) := by
+  cases op
+  case li | lui | auipc | andi | ori | xori | addi | slti | sltiu
+      | addiw | slli | srli | srai | slliw | srliw | sraiw | slliuw
+      | rori | roriw | bclri | bexti | binvi | bseti =>
+    exact RISCVImmediateProperties.fromAttrDict attrDict
+  case ld | lw | lwu | lh | lhu | lb | lbu | sd | sw | sh | sb =>
+    exact RISCVMemProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Riscv.toAttrDict
+    (op : Riscv) (props : Riscv.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .li | .lui | .auipc | .andi | .ori | .xori
+  | .addi | .slti | .sltiu | .addiw | .slli | .srli | .srai
+  | .slliw | .srliw | .sraiw | .rori | .roriw | .slliuw
+  | .bclri | .bexti | .binvi | .bseti =>
+    (Std.HashMap.emptyWithCapacity 2).insert
+      "value".toUTF8 (Attribute.integerAttr props.value)
+  -- The memory ops additionally carry a volatile flag, printed only when set.
+  | .ld | .lw | .lwu | .lh | .lhu | .lb | .lbu
+  | .sd | .sw | .sh | .sb => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "value".toUTF8 (Attribute.integerAttr props.value)
+    if props.volatile_ then
+      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
+    dict
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Riscv.hasSideEffects (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
   match op, props with
   -- Volatile loads are definitionally side-effecting.
@@ -227,6 +259,8 @@ def Riscv.hasSSADominance (_op : Riscv) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Riscv where
   propertiesOf := Riscv.propertiesOf
+  fromAttrDict := Riscv.fromAttrDict
+  toAttrDict := Riscv.toAttrDict
   hasSideEffects := Riscv.hasSideEffects
   readsMemory := Riscv.readsMemory
   isConstantLike := Riscv.isConstantLike

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -35,6 +35,24 @@ match op with
 | .bnez => RISCVBrProperties
 | _ => Unit
 
+def Riscv_Cf.fromAttrDict
+    (op : Riscv_Cf) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Riscv_Cf.propertiesOf op) := by
+  cases op
+  case beq | bne | blt | bge | bltu | bgeu | beqz | bnez =>
+    exact RISCVBrProperties.fromAttrDict attrDict
+  all_goals exact .ok ()
+
+def Riscv_Cf.toAttrDict
+    (op : Riscv_Cf) (props : Riscv_Cf.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .beq | .bne | .blt | .bge | .bltu | .bgeu | .beqz | .bnez =>
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "operandSegmentSizes".toUTF8
+      (Attribute.denseArrayAttr props.operandSegmentSizes)
+  | _ => Std.HashMap.emptyWithCapacity 0
+
 def Riscv_Cf.hasSideEffects
     (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : Bool :=
   true
@@ -50,6 +68,8 @@ def Riscv_Cf.hasSSADominance (_op : Riscv_Cf) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Riscv_Cf where
   propertiesOf := Riscv_Cf.propertiesOf
+  fromAttrDict := Riscv_Cf.fromAttrDict
+  toAttrDict := Riscv_Cf.toAttrDict
   hasSideEffects := Riscv_Cf.hasSideEffects
   readsMemory := Riscv_Cf.readsMemory
   isConstantLike := Riscv_Cf.isConstantLike

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -19,6 +19,21 @@ def Riscv_Stack.propertiesOf (op : Riscv_Stack) : Type :=
 match op with
 | .alloca => RISCVStackAllocaProperties
 
+def Riscv_Stack.fromAttrDict
+    (op : Riscv_Stack) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Riscv_Stack.propertiesOf op) := by
+  cases op
+  exact RISCVStackAllocaProperties.fromAttrDict attrDict
+
+def Riscv_Stack.toAttrDict
+    (op : Riscv_Stack) (props : Riscv_Stack.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .alloca => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "size".toUTF8 (Attribute.integerAttr props.size)
+    dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
+
 def Riscv_Stack.hasSideEffects
     (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : Bool :=
   true
@@ -34,6 +49,8 @@ def Riscv_Stack.hasSSADominance (_op : Riscv_Stack) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Riscv_Stack where
   propertiesOf := Riscv_Stack.propertiesOf
+  fromAttrDict := Riscv_Stack.fromAttrDict
+  toAttrDict := Riscv_Stack.toAttrDict
   hasSideEffects := Riscv_Stack.hasSideEffects
   readsMemory := Riscv_Stack.readsMemory
   isConstantLike := Riscv_Stack.isConstantLike

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -18,6 +18,17 @@ def Rv64.propertiesOf (op : Rv64) : Type :=
 match op with
 | _ => Unit
 
+def Rv64.fromAttrDict
+    (op : Rv64) (_attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Rv64.propertiesOf op) := by
+  cases op
+  exact .ok ()
+
+def Rv64.toAttrDict
+    (_op : Rv64) (_props : Rv64.propertiesOf _op) :
+    Std.HashMap ByteArray Attribute :=
+  Std.HashMap.emptyWithCapacity 0
+
 def Rv64.hasSideEffects (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
   true
 
@@ -32,6 +43,8 @@ def Rv64.hasSSADominance (_op : Rv64) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Rv64 where
   propertiesOf := Rv64.propertiesOf
+  fromAttrDict := Rv64.fromAttrDict
+  toAttrDict := Rv64.toAttrDict
   hasSideEffects := Rv64.hasSideEffects
   readsMemory := Rv64.readsMemory
   isConstantLike := Rv64.isConstantLike

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -17,6 +17,16 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 def Test.propertiesOf (_op : Test) : Type :=
   Unit
 
+def Test.fromAttrDict
+    (_op : Test) (_attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Test.propertiesOf _op) :=
+  .ok ()
+
+def Test.toAttrDict
+    (_op : Test) (_props : Test.propertiesOf _op) :
+    Std.HashMap ByteArray Attribute :=
+  Std.HashMap.emptyWithCapacity 0
+
 def Test.hasSideEffects (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
   true
 
@@ -31,6 +41,8 @@ def Test.hasSSADominance (_op : Test) (_index : Nat) : Bool :=
 
 instance : HasDialectOpInfo Test where
   propertiesOf := Test.propertiesOf
+  fromAttrDict := Test.fromAttrDict
+  toAttrDict := Test.toAttrDict
   hasSideEffects := Test.hasSideEffects
   readsMemory := Test.readsMemory
   isConstantLike := Test.isConstantLike

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -171,8 +171,50 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | .datapath op => Datapath.isConstantLike op
   | .test op => Test.isConstantLike op
 
+def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (_propertiesOf opCode) :=
+  match opCode with
+  | .arith op => Arith.fromAttrDict op attrDict
+  | .llvm op => Llvm.fromAttrDict op attrDict
+  | .riscv op => Riscv.fromAttrDict op attrDict
+  | .riscv_cf op => Riscv_Cf.fromAttrDict op attrDict
+  | .riscv_stack op => Riscv_Stack.fromAttrDict op attrDict
+  | .rv64 op => Rv64.fromAttrDict op attrDict
+  | .mod_arith op => Mod_Arith.fromAttrDict op attrDict
+  | .cf op => Cf.fromAttrDict op attrDict
+  | .comb op => Comb.fromAttrDict op attrDict
+  | .hw op => HW.fromAttrDict op attrDict
+  | .builtin op => Builtin.fromAttrDict op attrDict
+  | .func op => Func.fromAttrDict op attrDict
+  | .datapath op => Datapath.fromAttrDict op attrDict
+  | .test op => Test.fromAttrDict op attrDict
+
+/--
+  Converts the properties of an operation into a dictionary of attributes.
+-/
+def Properties.toAttrDict
+    (opCode : OpCode) (props : _propertiesOf opCode) :
+    Std.HashMap ByteArray Attribute :=
+  match opCode, props with
+  | .arith op, props => Arith.toAttrDict op props
+  | .llvm op, props => Llvm.toAttrDict op props
+  | .riscv op, props => Riscv.toAttrDict op props
+  | .riscv_cf op, props => Riscv_Cf.toAttrDict op props
+  | .riscv_stack op, props => Riscv_Stack.toAttrDict op props
+  | .rv64 op, props => Rv64.toAttrDict op props
+  | .mod_arith op, props => Mod_Arith.toAttrDict op props
+  | .cf op, props => Cf.toAttrDict op props
+  | .comb op, props => Comb.toAttrDict op props
+  | .hw op, props => HW.toAttrDict op props
+  | .builtin op, props => Builtin.toAttrDict op props
+  | .func op, props => Func.toAttrDict op props
+  | .datapath op, props => Datapath.toAttrDict op props
+  | .test op, props => Test.toAttrDict op props
+
 instance : HasDialectOpInfo OpCode where
   propertiesOf := _propertiesOf
+  fromAttrDict := Properties.fromAttrDict
+  toAttrDict := Properties.toAttrDict
   hasSideEffects := OpCode.hasSideEffects
   readsMemory := OpCode.readsMemory
   isConstantLike := OpCode.isConstantLike
@@ -183,329 +225,6 @@ instance : HasOpInfo OpCode where
 #generate_has_dialect_instances OpCode
 
 abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
-
-def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
-    Except String (propertiesOf opCode) := by
-  cases opCode
-  case test =>
-    all_goals exact (Except.ok ())
-  case datapath =>
-    all_goals exact (Except.ok ())
-  case mod_arith op =>
-    cases op
-    case constant => exact (ModArithConstantProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case riscv op =>
-    cases op
-    case li => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case lui => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case auipc => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case andi => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case ori => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case xori => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case addi => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case slti => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case sltiu => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case addiw => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case slli => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case srli => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case srai => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case slliw => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case srliw => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case sraiw => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case slliuw => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case rori => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case roriw => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case bclri => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case bexti => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case binvi => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case bseti => exact (RISCVImmediateProperties.fromAttrDict attrDict)
-    case ld => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case lw => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case lwu => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case lh => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case lhu => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case lb => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case lbu => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case sd => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case sw => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case sh => exact (RISCVMemProperties.fromAttrDict attrDict)
-    case sb => exact (RISCVMemProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case riscv_cf op =>
-    cases op
-    case beq => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case bne => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case blt => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case bge => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case bltu => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case bgeu => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case beqz => exact (RISCVBrProperties.fromAttrDict attrDict)
-    case bnez => exact (RISCVBrProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case riscv_stack op =>
-    cases op
-    case alloca => exact (RISCVStackAllocaProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case rv64 =>
-    exact Except.ok ()
-  case llvm op =>
-    cases op
-    case mlir__constant => exact (LLVMConstantProperties.fromAttrDict attrDict)
-    case add => exact (NswNuwProperties.fromAttrDict attrDict)
-    case sub => exact (NswNuwProperties.fromAttrDict attrDict)
-    case mul => exact (NswNuwProperties.fromAttrDict attrDict)
-    case udiv => exact (ExactProperties.fromAttrDict attrDict)
-    case sdiv => exact (ExactProperties.fromAttrDict attrDict)
-    case shl => exact (NswNuwProperties.fromAttrDict attrDict)
-    case lshr => exact (ExactProperties.fromAttrDict attrDict)
-    case ashr => exact (ExactProperties.fromAttrDict attrDict)
-    case intr__ctlz => exact (ZeroPoisonProperties.fromAttrDictFor "llvm.intr.ctlz" attrDict)
-    case intr__cttz => exact (ZeroPoisonProperties.fromAttrDictFor "llvm.intr.cttz" attrDict)
-    case intr__abs => exact (IntMinPoisonProperties.fromAttrDict attrDict)
-    case or => exact (DisjointProperties.fromAttrDict attrDict)
-    case trunc => exact (NswNuwProperties.fromAttrDict attrDict)
-    case zext => exact (NnegProperties.fromAttrDict attrDict)
-    case icmp => exact (IcmpProperties.fromAttrDict attrDict)
-    case cond_br => exact (CondBrProperties.fromAttrDict attrDict)
-    case alloca => exact (AllocaProperties.fromAttrDict attrDict)
-    case load => exact (LoadProperties.fromAttrDict attrDict)
-    case store => exact (StoreProperties.fromAttrDict attrDict)
-    case getelementptr => exact (GetelementptrProperties.fromAttrDict attrDict)
-    case fadd => exact (FastMathFlagsProperties.fromAttrDict attrDict)
-    case fsub => exact (FastMathFlagsProperties.fromAttrDict attrDict)
-    case fmul => exact (FastMathFlagsProperties.fromAttrDict attrDict)
-    case fdiv => exact (FastMathFlagsProperties.fromAttrDict attrDict)
-    case frem => exact (FastMathFlagsProperties.fromAttrDict attrDict)
-    case func => exact (LLVMFuncProperties.fromAttrDict attrDict)
-    case module_flags => exact (LLVMModuleFlagsProperties.fromAttrDict attrDict)
-    case call => exact (LLVMCallProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case func op =>
-    cases op
-    case func => exact (FuncFuncProperties.fromAttrDict attrDict)
-    case call => exact (FuncCallProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case cf op =>
-    cases op
-    case cond_br => exact (CondBrProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case builtin op =>
-    cases op
-    case unregistered => exact (UnregisteredProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case arith op =>
-    cases op
-    case constant => exact (ArithConstantProperties.fromAttrDict attrDict)
-    case addi => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
-    case subi => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
-    case muli => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
-    case divsi => exact (ExactProperties.fromAttrDict attrDict)
-    case divui => exact (ExactProperties.fromAttrDict attrDict)
-    case cmpi => exact (IcmpProperties.fromAttrDictFor "arith.cmpi" attrDict)
-    case shli => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
-    case shrsi => exact (ExactProperties.fromAttrDict attrDict)
-    case shrui => exact (ExactProperties.fromAttrDict attrDict)
-    case ori => exact (DisjointProperties.fromAttrDict attrDict)
-    case trunci => exact (ArithIntegerOverflowFlagsProperties.fromAttrDict attrDict)
-    case extui => exact (NnegProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case comb op =>
-    cases op
-    case extract => exact (CombExtractProperties.fromAttrDict attrDict)
-    case icmp => exact (CombIcmpProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-  case hw op =>
-    cases op
-    case constant => exact (HWConstantProperties.fromAttrDict attrDict)
-    case module => exact (HWModuleProperties.fromAttrDict attrDict)
-    all_goals exact (Except.ok ())
-
-/--
-  Converts the properties of an operation into a dictionary of attributes.
--/
-def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
-    Std.HashMap ByteArray Attribute :=
-  match opCode with
-  | .arith .constant =>
-    (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
-  | .llvm .mlir__constant =>
-    match props.value with
-    | .integer intAttr =>
-      (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr intAttr)
-    | .float floatAttr =>
-      (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.floatAttr floatAttr)
-    | .dense denseAttr =>
-      (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.denseElementsAttr denseAttr)
-  | .arith .addi | .arith .subi | .arith .muli | .arith .shli | .arith .trunci => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 1
-    if props.attr.nsw || props.attr.nuw then
-      dict := dict.insert "overflowFlags".toUTF8 (Attribute.arithIntegerOverflowFlagsAttr props.attr)
-    dict
-  | .llvm .add | .llvm .sub | .llvm .mul | .llvm .shl | .llvm .trunc => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 1
-
-    let mut val := 0
-    if props.nsw then
-      val := val + 1
-
-    if props.nuw then
-      val := val + 2
-
-    if val > 0 then
-      let attr := IntegerAttr.mk (Int.ofNat val) (IntegerType.mk 32)
-      dict := dict.insert "overflowFlags".toUTF8 (Attribute.integerAttr attr)
-
-    dict
-  | .llvm .fadd | .llvm .fsub | .llvm .fmul | .llvm .fdiv | .llvm .frem => Id.run do
-    (Std.HashMap.emptyWithCapacity 1).insert "fastmathFlags".toUTF8 (Attribute.fastMathFlagsAttr props.attr)
-  | .arith .cmpi | .llvm .icmp => Id.run do
-    let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
-    (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr value)
-  | .llvm .cond_br =>
-    let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
-    dict.insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
-  | .arith .divsi | .arith .divui | .arith .shrsi | .arith .shrui |
-    .llvm .udiv | .llvm .sdiv | .llvm .lshr | .llvm .ashr => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 2
-    if props.exact then
-      dict := dict.insert "exact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    dict
-  | .arith .ori | .llvm .or => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 2
-    if props.disjoint then
-      dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    dict
-  | .arith .extui | .llvm .zext => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 1
-    if props.nneg then
-      dict := dict.insert "nneg".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    dict
-  | .llvm .intr__ctlz | .llvm .intr__cttz =>
-    let value := if props.is_zero_poison then 1 else 0
-    let attr := IntegerAttr.mk value (IntegerType.mk 1)
-    (Std.HashMap.emptyWithCapacity 1).insert "is_zero_poison".toUTF8 (Attribute.integerAttr attr)
-  | .llvm .intr__abs =>
-    let value := if props.is_int_min_poison then 1 else 0
-    let attr := IntegerAttr.mk value (IntegerType.mk 1)
-    (Std.HashMap.emptyWithCapacity 1).insert "is_int_min_poison".toUTF8 (Attribute.integerAttr attr)
-  | .riscv .li  | .riscv .lui | .riscv .auipc | .riscv .andi | .riscv .ori | .riscv .xori
-  | .riscv .addi | .riscv .slti | .riscv .sltiu | .riscv .addiw | .riscv .slli | .riscv .srli | .riscv .srai
-  | .riscv .slliw | .riscv .srliw | .riscv .sraiw | .riscv .rori | .riscv .roriw | .riscv .slliuw
-  | .riscv .bclri | .riscv .bexti | .riscv .binvi | .riscv .bseti
-  | .mod_arith .constant =>
-    (Std.HashMap.emptyWithCapacity 2).insert "value".toUTF8 (Attribute.integerAttr props.value)
-  -- The memory ops additionally carry a volatile flag, printed (like the LLVM
-  -- dialect's `volatile_`) only when set, so ordinary accesses are unchanged.
-  | .riscv .ld | .riscv .lw | .riscv .lwu | .riscv .lh | .riscv .lhu
-  | .riscv .lb | .riscv .lbu
-  | .riscv .sd | .riscv .sw | .riscv .sh | .riscv .sb => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 2
-    dict := dict.insert "value".toUTF8 (Attribute.integerAttr props.value)
-    if props.volatile_ then
-      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
-    dict
-  | .riscv_stack .alloca => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 2
-    dict := dict.insert "size".toUTF8 (Attribute.integerAttr props.size)
-    dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
-  | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .blt | .riscv_cf .bge
-  | .riscv_cf .bltu | .riscv_cf .bgeu | .riscv_cf .beqz | .riscv_cf .bnez =>
-    (Std.HashMap.emptyWithCapacity 1).insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
-  | .cf .cond_br =>
-    let dict := (Std.HashMap.emptyWithCapacity 2).insert "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
-    dict.insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)
-  | .llvm .alloca => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 3
-    dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
-    dict := dict.insert "elem_type".toUTF8 props.elem_type
-    if props.inalloca then
-      dict := dict.insert "inalloca".toUTF8 (.unitAttr UnitAttr.mk)
-    dict
-  | .llvm .load => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 10
-    dict := dict.insert "alignment".toUTF8 (.integerAttr props.alignment)
-    if props.volatile_ then
-      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.nontemporal then
-      dict := dict.insert "nontemporal".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.invariant then
-      dict := dict.insert "invariant".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.invariantGroup then
-      dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
-    if let some syncscope := props.syncscope then
-      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
-    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
-    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
-    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
-    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
-    dict
-  | .llvm .store => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 9
-    dict := dict.insert "alignment".toUTF8 (.integerAttr props.alignment)
-    if props.volatile_ then
-      dict := dict.insert "volatile_".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.nontemporal then
-      dict := dict.insert "nontemporal".toUTF8 (.unitAttr UnitAttr.mk)
-    if props.invariantGroup then
-      dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
-    if let some syncscope := props.syncscope then
-      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
-    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
-    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
-    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
-    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
-    dict
-  | .llvm .getelementptr => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 3
-    dict := dict.insert "rawConstantIndices".toUTF8 (Attribute.denseArrayAttr props.rawConstantIndices)
-    dict := dict.insert "elem_type".toUTF8 props.elem_type
-    dict := dict.insert "noWrapFlags".toUTF8 (.integerAttr props.noWrapFlags)
-    dict
-  | .comb .extract =>
-    (Std.HashMap.emptyWithCapacity 1).insert "lowBit".toUTF8 (Attribute.integerAttr props.lowBit)
-  | .comb .icmp =>
-    (Std.HashMap.emptyWithCapacity 1).insert "predicate".toUTF8 (Attribute.integerAttr props.predicate)
-  | .hw .constant => Id.run do
-    (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (Attribute.integerAttr props.value)
-  | .llvm .func => Id.run do
-    let mut dict := Std.HashMap.ofList props.extra.entries.toList
-    if let some sym_name := props.sym_name then
-      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
-    if let some function_type := props.function_type then
-      dict := dict.insert "function_type".toUTF8 function_type
-    dict
-  | .llvm .module_flags => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 3
-    dict := dict.insert "flags".toUTF8 (Attribute.arrayAttr props.flags)
-    dict
-  | .func .call => Id.run do
-    let mut dict := Std.HashMap.ofList props.extra.entries.toList
-    dict := dict.insert "callee".toUTF8 (.flatSymbolRefAttr props.callee)
-    dict
-  | .llvm .call => Id.run do
-    let mut dict := Std.HashMap.ofList props.extra.entries.toList
-    if let some callee := props.callee then
-      dict := dict.insert "callee".toUTF8 (.flatSymbolRefAttr callee)
-    dict
-  | .func .func => Id.run do
-    let mut dict := Std.HashMap.ofList props.extra.entries.toList
-    if let some sym_name := props.sym_name then
-      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
-    if let some function_type := props.function_type then
-      dict := dict.insert "function_type".toUTF8  function_type
-    dict
-  | .builtin .unregistered =>
-    Std.HashMap.ofList props.properties.entries.toList
-  | .hw .module => Id.run do
-    let dict := Std.HashMap.emptyWithCapacity 4
-    let dict := dict.insert "module_type".toUTF8 (.hwModuleType props.module_type)
-    let dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
-    let dict := dict.insert "per_port_attrs".toUTF8 (.arrayAttr props.per_port_attrs)
-    let dict := dict.insert "parameters".toUTF8 (.arrayAttr props.parameters)
-    dict
-  | _ =>
-    Std.HashMap.emptyWithCapacity 0
 
 /--
   Is this `OpCode` commutative in its operands, i.e. `op x y` always

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -1,5 +1,8 @@
 module
 
+public import Veir.IR.Attribute
+public import Std.Data.HashMap
+
 namespace Veir
 
 public section
@@ -7,6 +10,11 @@ public section
 class HasDialectOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode where
   propertiesOf : opCode → Type
+  /-- Create an operation's properties from its attribute dictionary. -/
+  fromAttrDict : (op : opCode) → Std.HashMap ByteArray Attribute →
+    Except String (propertiesOf op)
+  /-- Convert an operation's properties into an attribute dictionary. -/
+  toAttrDict : (op : opCode) → propertiesOf op → Std.HashMap ByteArray Attribute
   propertiesHash {op : opCode} : Hashable (propertiesOf op) := by
     simp only [properties_of]
     intros opCode; cases opCode <;>


### PR DESCRIPTION
`HasOpInfo` should be merged with `HasDialectOpInfo` in the future, so its fields are moved to `HasDialectOpinfo`. Each dialect file now implements the two functions, and they are merged in the end `OpCode`.