### PR TITLE
feat(riscv): alloca improvements

### DIFF
--- a/Test/Interpreter/RISCV_Stack/mem.mlir
+++ b/Test/Interpreter/RISCV_Stack/mem.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> (!riscv.reg)}> ({
     %2 = "riscv.li"() <{ "value" = 8 : i64 }> : () -> !riscv.reg
-    %4 = "riscv_stack.alloca"() <{ "value_type" = i64 }> : () -> !riscv.reg
+    %4 = "riscv_stack.alloca"() <{ "size" = 8 : i64, "alignment" = 8 : i64 }> : () -> !riscv.reg
     "riscv.sd"(%2, %4) <{ "value" = 0 : i64 }> : (!riscv.reg, !riscv.reg) -> ()
     %6 = "riscv.ld"(%4) <{ "value" = 0 : i64 }> : (!riscv.reg) -> !riscv.reg
     "func.return"(%6) : (!riscv.reg) -> ()

--- a/Test/RISCV_Stack/identity.mlir
+++ b/Test/RISCV_Stack/identity.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
   "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
     ^bb0():
-      %1 = "riscv_stack.alloca"() <{"value_type" = i64, "alignment" = 8 : i64}> : () -> !riscv.reg
+      %1 = "riscv_stack.alloca"() <{"size" = 8 : i64, "alignment" = 8 : i64}> : () -> !riscv.reg
       "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
@@ -12,7 +12,7 @@
 // CHECK-NEXT:   ^{{.*}}():
 // CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
 // CHECK-NEXT:       ^{{.*}}():
-// CHECK-NEXT:         %{{.*}} = "riscv_stack.alloca"() <{"alignment" = 8 : i64, "value_type" = i64}> : () -> !riscv.reg
+// CHECK-NEXT:         %{{.*}} = "riscv_stack.alloca"() <{"alignment" = 8 : i64, "size" = 8 : i64}> : () -> !riscv.reg
 // CHECK-NEXT:         "func.return"() : () -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Verifier/riscv_stack_alloca_invalid_alignment.mlir
+++ b/Test/Verifier/riscv_stack_alloca_invalid_alignment.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    %slot = "riscv_stack.alloca"() <{size = 8 : i64, alignment = 3 : i64}> : () -> !riscv.reg
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: riscv_stack.alloca: alignment must be a positive power of two

--- a/Veir/Dialects/RISCV_Stack/Properties.lean
+++ b/Veir/Dialects/RISCV_Stack/Properties.lean
@@ -7,21 +7,27 @@ namespace Veir
 
 public section
 
+/--
+  Properties of a fixed-size function-local stack object. `size` and
+  `alignment` are expressed in bytes; assignment of the object's final frame
+  offset is left to the backend.
+-/
 structure RISCVStackAllocaProperties where
+  size : IntegerAttr
   alignment : IntegerAttr
-  value_type : TypeAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def RISCVStackAllocaProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String RISCVStackAllocaProperties := do
+  let sizeAttr ← match attrDict["size".toUTF8]? with
+    | some (.integerAttr sizeAttr) => .ok sizeAttr
+    | some attr => .error s!"expected 'size' to be an integer attribute, but got {attr}"
+    | none => .error "alloca: missing 'size' property"
   let alignAttr ← match attrDict["alignment".toUTF8]? with
     | some (.integerAttr alignAttr) => .ok alignAttr
-    | some attr => .error s!"expected 'alignment' to be an optional integer attribute, but got {attr}"
-    | none => .ok { value := 0, type := { bitwidth := 64 } }
-  let some typeAttr := attrDict["value_type".toUTF8]?
-    | throw "alloca: missing 'value_type' property"
-  if _ : typeAttr.isType = false then throw "alloca: expected 'value_type' to be a type attribute" else
-  return { alignment := alignAttr, value_type := typeAttr.asType }
+    | some attr => .error s!"expected 'alignment' to be an integer attribute, but got {attr}"
+    | none => .error "alloca: missing 'alignment' property"
+  return { size := sizeAttr, alignment := alignAttr }
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -421,8 +421,8 @@ def Properties.toAttrDict (opCode : OpCode) (props : propertiesOf opCode) :
     dict
   | .riscv_stack .alloca => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
-    dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
-    dict.insert "value_type".toUTF8 props.value_type
+    dict := dict.insert "size".toUTF8 (Attribute.integerAttr props.size)
+    dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
   | .riscv_cf .beq | .riscv_cf .bne | .riscv_cf .blt | .riscv_cf .bge
   | .riscv_cf .bltu | .riscv_cf .bgeu | .riscv_cf .beqz | .riscv_cf .bnez =>
     (Std.HashMap.emptyWithCapacity 1).insert "operandSegmentSizes".toUTF8 (Attribute.denseArrayAttr props.operandSegmentSizes)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1448,11 +1448,7 @@ def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : HasDialec
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
   match opType with
   | .alloca => do
-    let size ← match properties.value_type.val with
-    | Attribute.integerType ⟨bw⟩ => some (.ok (bw / 8))
-    | Attribute.llvmPointerType _ => some (.ok 8)
-    | _ => none
-    let (mem, addr) := mem.alloc size.toUInt64
+    let (mem, addr) := mem.alloc properties.size.value.toNat.toUInt64
     return (#[.reg ⟨.ofNat 64 addr.toNat⟩], mem, none)
 
 def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInfo.propertiesOf opType)

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1002,6 +1002,19 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   /- RISCV Stack -/
   | .riscv_stack .alloca => do
     op.verifyPlainOpCounts ctx opIn 0 1
+    op.verifyRISCVRegisterTypes ctx opIn
+    let properties := op.getProperties! ctx.raw (.riscv_stack .alloca)
+    if properties.size.type.bitwidth ≠ 64 then
+      throw "attribute 'size' must be a 64-bit signless integer attribute"
+    if properties.size.value < 0 then
+      throw "size must be nonnegative"
+    if properties.alignment.type.bitwidth ≠ 64 then
+      throw "attribute 'alignment' must be a 64-bit signless integer attribute"
+    if properties.alignment.value ≤ 0 then
+      throw "alignment must be a positive power of two"
+    let alignment := properties.alignment.value.toNat
+    if alignment &&& (alignment - 1) ≠ 0 then
+      throw "alignment must be a positive power of two"
     pure ()
   /- RISCV 64-bit -/
   | .rv64 .get_register => do


### PR DESCRIPTION
at the RISC-V level allocas should just be bags of bytes at some alignment-- no types are wanted, this PR moves in that direction

after this we can lower LLVM allocas to RISC-V allocas, and then also start to turn RISC-V allocas into stack pointer math