### PR TITLE
feat(mod_arith): extend boundary coercion to `mod_arith`

### DIFF
--- a/Test/Passes/FunctionBoundaryCoercion/mod_arith.mlir
+++ b/Test/Passes/FunctionBoundaryCoercion/mod_arith.mlir
@@ -1,0 +1,22 @@
+// RUN: veir-opt %s -p=coerce-mod-arith-function-boundaries,reconcile-cast | filecheck %s
+
+"builtin.module"() ({
+
+  // `mod_arith` function boundaries can be coerced to their storage integer type.
+  // The pre-existing `i32 <-> !mod_arith.int<7 : i32>` boundary casts then form
+  // identity round trips and are reconciled away, so the `arith.addi` consumes the
+  // function arguments directly and the function returns the `arith.addi` result.
+    "func.func"() <{sym_name = "arith_add", function_type = (!mod_arith.int<7 : i32>, !mod_arith.int<7 : i32>) -> !mod_arith.int<7 : i32>}> ({
+    ^bb(%a: !mod_arith.int<7 : i32>, %b: !mod_arith.int<7 : i32>):
+      %ai = "builtin.unrealized_conversion_cast"(%a) : (!mod_arith.int<7 : i32>) -> i32
+      %bi = "builtin.unrealized_conversion_cast"(%b) : (!mod_arith.int<7 : i32>) -> i32
+      %sum = "arith.addi"(%ai, %bi) : (i32, i32) -> i32
+      %out = "builtin.unrealized_conversion_cast"(%sum) : (i32) -> !mod_arith.int<7 : i32>
+      "func.return"(%out) : (!mod_arith.int<7 : i32>) -> ()
+      // CHECK:      "func.func"() <{"function_type" = (i32, i32) -> i32, "sym_name" = "arith_add"}>
+      // CHECK-NEXT: ^{{.*}}([[A:%.*]] : i32, [[B:%.*]] : i32):
+      // CHECK-NEXT:   [[SUM:%.*]] = "arith.addi"([[A]], [[B]]) : (i32, i32) -> i32
+      // CHECK-NEXT:   "func.return"([[SUM]]) : (i32) -> ()
+    }) : () -> ()
+
+}) : () -> ()

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -9,19 +9,34 @@ import Veir.Interfaces.FunctionInterfaces
 
 namespace Veir
 
-/-! ## Coercing function boundaries to `!riscv.reg`
+/-! ## Coercing function boundaries
 
-  Before removing round-trip casts, we rewrite each `func.func` and
-  `llvm.func`'s i32- and i64- and pointer-typed arguments and return
-  values to `!riscv.reg`, inserting `unrealized_conversion_cast`s to
-  bridge to/from the original integer types.
+  Rewrite each `func.func`/`llvm.func`'s arguments and return values to a coerced type,
+  inserting`unrealized_conversion_cast`s to bridge to/from the original types.
+
+  The coercion applied is selected by a `BoundaryCoercion` flag;
+  each variant is  exposed as its own pass:
+  - `.riscvReg`: i32-, i64-, and pointer-typed boundaries become `!riscv.reg`.
+  - `.modArithToInt`: `!mod_arith.int<q : iN>`-typed boundaries become `iN`.
 -/
 
-def isRegCoercibleType (t : TypeAttr) : Bool :=
-  match t.val with
-  | .integerType x => x.bitwidth == 64 || x.bitwidth == 32
-  | .llvmPointerType _ => true
-  | _ => false
+/-- Selects which boundary coercion the shared implementation applies. -/
+inductive BoundaryCoercion where
+  | riscvReg
+  | modArithToInt
+
+/-- The type a boundary value of type `t` is coerced to, or `none` to leave it alone. -/
+def BoundaryCoercion.target : BoundaryCoercion → TypeAttr → Option TypeAttr
+  | .riscvReg, t =>
+    match t.val with
+    | .integerType x =>
+      if x.bitwidth == 64 || x.bitwidth == 32 then some (RegisterType.mk : TypeAttr) else none
+    | .llvmPointerType _ => some (RegisterType.mk : TypeAttr)
+    | _ => none
+  | .modArithToInt, t =>
+    match t.val with
+    | .modArithType mt => some mt.modulus.type
+    | _ => none
 
 /-- The return-terminator opcode paired with a function op (`func.return` for
     `func.func`, `llvm.return` for `llvm.func`). -/
@@ -30,18 +45,18 @@ def returnOpCodeFor : OpCode → OpCode
   | _ => .func .return
 
 set_option warn.sorry false in
-/-- Coerce one function's `i32`/`i64` arguments and return values to `!riscv.reg`,
+/-- Coerce one function's arguments and return values as dictated by `coercion`,
     inserting bridging casts and rewriting the `function_type` to match. Handles both
     `func.func` and `llvm.func`. -/
-def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
-    ExceptT String IO (WfIRContext OpCode) := do
+def coerceFunction (coercion : BoundaryCoercion) (ctx : WfIRContext OpCode)
+    (funcOp : OperationPtr) : ExceptT String IO (WfIRContext OpCode) := do
   -- Shadow the parameter: from here on `ctx` always names the latest version, with no
   -- separate old binding left around to second-guess.
   let mut ctx := ctx
   let some entry := FunctionOpInterface.getEntryBlock? funcOp ctx.raw | return ctx
   let returnCode := returnOpCodeFor (funcOp.getOpType! ctx.raw)
   -- Default the output types to the currently-declared ones, then flip coerced positions.
-  -- This preserves non-integer results and `llvm.func`'s `void` return.
+  -- This preserves uncoerced results and `llvm.func`'s `void` return.
   let mut outputs : Array Attribute := FunctionOpInterface.getResultTypes! funcOp ctx.raw
   -- (1) Coerce entry-block arguments (the function parameters). This mirrors the
   --     block-argument coercion in `isel-br-riscv64`, which skips entry blocks.
@@ -49,16 +64,17 @@ def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
   for i in List.range (entry.getNumArguments! ctx.raw) do
     let bap : BlockArgumentPtr := { block := entry, index := i }
     let origType := (ValuePtr.blockArgument bap).getType! ctx.raw
-    if isRegCoercibleType origType then
-      ctx := WfRewriter.setType ctx bap RegisterType.mk sorry
+    match coercion.target origType with
+    | some newType =>
+      ctx := WfRewriter.setType ctx bap newType sorry
       let ip := InsertPoint.atStart entry ctx.raw sorry
       let some (ctx', cast) := WfRewriter.createOp ctx
         (.builtin .unrealized_conversion_cast) #[origType] #[] #[] #[] default (some ip)
         sorry sorry sorry sorry | return ctx
       let ctx' := WfRewriter.replaceValue ctx' bap (cast.getResult 0) sorry sorry sorry
       ctx := WfRewriter.pushOperand ctx' cast bap sorry sorry
-      inputs := inputs.push (.registerType ⟨none⟩)
-    else
+      inputs := inputs.push newType.val
+    | none =>
       inputs := inputs.push origType.val
   -- (2) Coerce the operands of every return terminator in this function.
   let returnOps := ctx.raw.operations.keys.filter fun o =>
@@ -68,19 +84,21 @@ def coerceFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
     for j in List.range (retOp.getNumOperands! ctx.raw) do
       let opVal := retOp.getOperand! ctx.raw j
       let opType := opVal.getType! ctx.raw
-      if isRegCoercibleType opType then
+      match coercion.target opType with
+      | some newType =>
         let some (ctx', cast) := WfRewriter.createOp ctx
-          (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[opVal] #[] #[] default
+          (.builtin .unrealized_conversion_cast) #[newType] #[opVal] #[] #[] default
           (some (InsertPoint.before retOp)) sorry sorry sorry sorry | return ctx
         ctx := WfRewriter.replaceOperand ctx' ⟨retOp, j⟩ (cast.getResult 0) sorry sorry
         -- The `j`-th operand maps to the `j`-th declared result: the verifier guarantees
         -- a return's operand count equals the function's declared result count.
-        outputs := outputs.set! j (.registerType ⟨none⟩)
+        outputs := outputs.set! j newType.val
+      | none => pure ()
   -- (3) Rewrite the function_type to reflect the coerced boundary types.
   ctx := FunctionOpInterface.setFunctionType! ctx funcOp inputs outputs
   return ctx
 
-def coerceFunctionBoundaries (ctx : WfIRContext OpCode) :
+def coerceFunctionBoundaries (coercion : BoundaryCoercion) (ctx : WfIRContext OpCode) :
     ExceptT String IO (WfIRContext OpCode) := do
   let mut ctx := ctx
   let funcOps := ctx.raw.operations.keys.filter fun o =>
@@ -88,18 +106,23 @@ def coerceFunctionBoundaries (ctx : WfIRContext OpCode) :
     | .func .func | .llvm .func => true
     | _ => false
   for funcOp in funcOps do
-    ctx ← coerceFunction ctx funcOp
+    ctx ← coerceFunction coercion ctx funcOp
   return ctx
 
 
-def CoerceFunctionBoundariesToRiscvRegPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
-    ExceptT String IO (WfIRContext OpCode) := do
-  let ctx ← coerceFunctionBoundaries ctx
+def CoerceFunctionBoundariesPass.impl (coercion : BoundaryCoercion) (ctx : WfIRContext OpCode)
+    (op : OperationPtr) (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
+  let ctx ← coerceFunctionBoundaries coercion ctx
   match RewritePattern.applyInContext (RewritePattern.GreedyRewritePattern #[eliminateDeadOp]) ctx with
-  | none => throw "Error while applying DCE after cast reconciliation"
+  | none => throw "Error while applying DCE after function boundary coercion"
   | some ctx => pure ctx
 
 public def CoerceFunctionBoundariesToRiscvRegPass : Pass OpCode :=
   { name := "coerce-function-boundaries-to-riscv-reg"
-    description := "Coerce function boundaries to `!riscv.reg`."
-    run := CoerceFunctionBoundariesToRiscvRegPass.impl }
+    description := "Coerce i32/i64/pointer function boundaries to `!riscv.reg`."
+    run := CoerceFunctionBoundariesPass.impl .riscvReg }
+
+public def CoerceModArithFunctionBoundariesPass : Pass OpCode :=
+  { name := "coerce-mod-arith-function-boundaries"
+    description := "Coerce `!mod_arith.int` function boundaries to their storage integer type."
+    run := CoerceFunctionBoundariesPass.impl .modArithToInt }

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -43,7 +43,6 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
     |>.insert ModArithToArithPass.name ModArithToArithPass
     |>.insert RemuiToBarrettReductionPass.name RemuiToBarrettReductionPass
     |>.insert ArithToLLVMPass.name ArithToLLVMPass
-    |>.insert RemuiToBarrettReductionPass.name RemuiToBarrettReductionPass
     |>.insert CanonicalizePass.name CanonicalizePass
 
 /--

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -38,10 +38,12 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
     |>.insert DCEPass.name DCEPass
     |>.insert CastReconcilePass.name CastReconcilePass
     |>.insert CoerceFunctionBoundariesToRiscvRegPass.name CoerceFunctionBoundariesToRiscvRegPass
+    |>.insert CoerceModArithFunctionBoundariesPass.name CoerceModArithFunctionBoundariesPass
     |>.insert RISCV.Combine.name RISCV.Combine
     |>.insert ModArithToArithPass.name ModArithToArithPass
     |>.insert RemuiToBarrettReductionPass.name RemuiToBarrettReductionPass
     |>.insert ArithToLLVMPass.name ArithToLLVMPass
+    |>.insert RemuiToBarrettReductionPass.name RemuiToBarrettReductionPass
     |>.insert CanonicalizePass.name CanonicalizePass
 
 /--


### PR DESCRIPTION
Ports the boundary coercion part of Seonyoung's `seonyoung/reconcile-cast-arith` branch to the newly split-out boundary coercion and makes that more modular, now offering both a `riscv` and a `mod_arith` flavoured pass.