### PR TITLE
fix(mod_arith): fix shift factor and intermediate width in barret reduction

### DIFF
--- a/Test/Passes/ModArithToArith/barrett_reduction.mlir
+++ b/Test/Passes/ModArithToArith/barrett_reduction.mlir
@@ -23,12 +23,12 @@
 // CHECK-NEXT:     [[V1:%.*]] = "arith.extui"([[V0]]) : (i32) -> i64
 // CHECK-NEXT:     [[V2:%.*]] = "builtin.unrealized_conversion_cast"([[ARG1]]) : (!mod_arith.int<7 : i32>) -> i32
 // CHECK-NEXT:     [[V3:%.*]] = "arith.extui"([[V2]]) : (i32) -> i64
-// CHECK-NEXT:     [[C7:%.*]] = "arith.constant"() <{"value" = 7 : i64}> : () -> i64
 // CHECK-NEXT:     [[V4:%.*]] = "arith.muli"([[V1]], [[V3]]) : (i64, i64) -> i64
-// CHECK-NEXT:     [[C585:%.*]] = "arith.constant"() <{"value" = 585 : i64}> : () -> i64
-// CHECK-NEXT:     [[C12:%.*]] = "arith.constant"() <{"value" = 12 : i64}> : () -> i64
-// CHECK-NEXT:     [[V5:%.*]] = "arith.muli"([[V4]], [[C585]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i64, i64) -> i64
-// CHECK-NEXT:     [[V6:%.*]] = "arith.shrui"([[V5]], [[C12]]) : (i64, i64) -> i64
+// CHECK-NEXT:     [[C7:%.*]] = "arith.constant"() <{"value" = 7 : i64}> : () -> i64
+// CHECK-NEXT:     [[C9:%.*]] = "arith.constant"() <{"value" = 9 : i64}> : () -> i64
+// CHECK-NEXT:     [[C6:%.*]] = "arith.constant"() <{"value" = 6 : i64}> : () -> i64
+// CHECK-NEXT:     [[V5:%.*]] = "arith.muli"([[V4]], [[C9]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i64, i64) -> i64
+// CHECK-NEXT:     [[V6:%.*]] = "arith.shrui"([[V5]], [[C6]]) : (i64, i64) -> i64
 // CHECK-NEXT:     [[V7:%.*]] = "arith.muli"([[V6]], [[C7]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i64, i64) -> i64
 // CHECK-NEXT:     [[V8:%.*]] = "arith.subi"([[V4]], [[V7]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i64, i64) -> i64
 // CHECK-NEXT:     [[V9:%.*]] = "arith.cmpi"([[V8]], [[C7]]) <{"predicate" = 9 : i64}> : (i64, i64) -> i1

--- a/Test/Passes/ModArithToArith/barrett_reduction_wide.mlir
+++ b/Test/Passes/ModArithToArith/barrett_reduction_wide.mlir
@@ -1,0 +1,32 @@
+// RUN: veir-opt %s -p=remui-to-barrett-reduction | filecheck %s
+
+// q = 12289 (k = 14) on i32: r * mu needs 3k = 42 bits,
+// so the reduction is computed at i42 and wrapped in extui/trunci 
+
+"builtin.module"() ({
+  "func.func"() <{"function_type" = (i32, i32) -> i32, "sym_name" = "barrett_widened"}> ({
+  ^bb0(%arg0: i32, %arg1: i32):
+    %0 = "arith.constant"() <{"value" = 12289 : i32}> : () -> i32
+    %1 = "arith.muli"(%arg0, %arg1) : (i32, i32) -> i32
+    %2 = "arith.remui"(%1, %0) : (i32, i32) -> i32
+    "func.return"(%2) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      ^{{.*}}([[A0:%.*]] : i32, [[A1:%.*]] : i32):
+// CHECK-NEXT:     [[R:%.*]] = "arith.muli"([[A0]], [[A1]]) : (i32, i32) -> i32
+// CHECK-NEXT:     [[RW:%.*]] = "arith.extui"([[R]]) : (i32) -> i42
+// CHECK-NEXT:     [[Q:%.*]] = "arith.constant"() <{"value" = 12289 : i42}> : () -> i42
+// CHECK-NEXT:     [[MU:%.*]] = "arith.constant"() <{"value" = 21843 : i42}> : () -> i42
+// CHECK-NEXT:     [[SH:%.*]] = "arith.constant"() <{"value" = 28 : i42}> : () -> i42
+// CHECK-NEXT:     [[P:%.*]] = "arith.muli"([[RW]], [[MU]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i42, i42) -> i42
+// CHECK-NEXT:     [[E:%.*]] = "arith.shrui"([[P]], [[SH]]) : (i42, i42) -> i42
+// CHECK-NEXT:     [[EQ:%.*]] = "arith.muli"([[E]], [[Q]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i42, i42) -> i42
+// CHECK-NEXT:     [[REM:%.*]] = "arith.subi"([[RW]], [[EQ]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i42, i42) -> i42
+// CHECK-NEXT:     [[GE:%.*]] = "arith.cmpi"([[REM]], [[Q]]) <{"predicate" = 9 : i64}> : (i42, i42) -> i1
+// CHECK-NEXT:     [[REMQ:%.*]] = "arith.subi"([[REM]], [[Q]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i42, i42) -> i42
+// CHECK-NEXT:     [[RES:%.*]] = "arith.select"([[GE]], [[REMQ]], [[REM]]) : (i1, i42, i42) -> i42
+// CHECK-NEXT:     [[OUT:%.*]] = "arith.trunci"([[RES]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i42) -> i32
+// CHECK-NEXT:     "func.return"([[OUT]]) : (i32) -> ()
+// CHECK-NEXT:   }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -130,7 +130,7 @@ def emitBarrettReduction (rewriter : PatternRewriter OpCode) (r : ValuePtr) (mod
   let (rewriter, sh) ← emitArithConstant rewriter shift bw ip
 
 
-  -- reduced := (r * m) >> shift // (r * m) should be at most 2^(2*width) - 1, so we can safely truncate to width bits after the shift
+  -- reduced := (r * m) >> shift // (r * m) should be at most 2^(2*bw) - 1, so we can safely truncate to width bits after the shift
   let (rewriter, product) ← rewriter.createOp! (.arith .muli)
     #[ty] #[r, m] #[] #[] { attr := { nsw := false, nuw := true } } (some ip)
   let (rewriter, reduced) ← rewriter.createOp! (.arith .shrui)

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -93,13 +93,12 @@ def emitArithBinOp (rewriter : PatternRewriter OpCode) (arithOp : Arith)
 
 /-! ## Barrett Helper -/
 /-- Barrett reduction: approximate `⌊r / modulus⌋` with a precomputed reciprocal
-    `magic = ⌊2^width / modulus⌋` via widen → multiply → shift → truncate, instead of
-    emitting a runtime division. Note: this is the plain reciprocal-multiply approximation
+    `mu = ⌊2^(2*k) / modulus⌋` (`k = ceil(log2 modulus)`) via widen → multiply → shift → truncate,
+    instead of emitting a runtime division. Note: this is the plain reciprocal-multiply approximation
     with a single correction step.
 
     func reduce(r uint) uint {
-    -- m := magic
-    reduced := (r * m) >> k
+    reduced := (r * mu) >> k
     r := r - reduced * q
     if r >= q {
         r := r - q
@@ -108,16 +107,27 @@ def emitArithBinOp (rewriter : PatternRewriter OpCode) (arithOp : Arith)
     }
 -/
 
-def emitBarrettReduction (rewriter : PatternRewriter OpCode) (r q : ValuePtr) (modulus : Int)
+def emitBarrettReduction (rewriter : PatternRewriter OpCode) (r : ValuePtr) (modulus : Int)
     (width : Nat) (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
-  let ty : TypeAttr := IntegerType.mk width
-  let ty_i1 : TypeAttr := IntegerType.mk 1
   let k : Nat := (modulus - 1).toNat.log2 + 1     -- ceil(log2 modulus)
-  let shift : Nat := 4 * k                        -- 4k (2k if you want 2 * k)
+  let shift : Nat := 2 * k
   let mu : Int := (2 ^ shift) / modulus           -- floor(2^shift / modulus)
+  let bw := max width (3 * k)                     -- width required for r *
+  let ty : TypeAttr := IntegerType.mk bw
+  let ty_i1 : TypeAttr := IntegerType.mk 1
 
-  let (rewriter, m) ← emitArithConstant rewriter mu width ip
-  let (rewriter, sh) ← emitArithConstant rewriter shift width ip
+  -- extend if needed
+  let (rewriter, r) ←
+    if bw > width then
+      let (rewriter, ext) ← rewriter.createOp! (.arith .extui)
+        #[ty] #[r] #[] #[] { nneg := false } (some ip)
+      pure (rewriter, (ext.getResult 0 : ValuePtr))
+    else
+      pure (rewriter, r)
+
+  let (rewriter, q) ← emitArithConstant rewriter modulus bw ip
+  let (rewriter, m) ← emitArithConstant rewriter mu bw ip
+  let (rewriter, sh) ← emitArithConstant rewriter shift bw ip
 
 
   -- reduced := (r * m) >> shift // (r * m) should be at most 2^(2*width) - 1, so we can safely truncate to width bits after the shift
@@ -144,7 +154,15 @@ def emitBarrettReduction (rewriter : PatternRewriter OpCode) (r q : ValuePtr) (m
   let (rewriter, result) ← rewriter.createOp! (.arith .select)
     #[ty] #[corr.getResult 0, sub.getResult 0, remainder.getResult 0] #[] #[] ()
     (some ip)
-  return (rewriter, (result.getResult 0 : ValuePtr))
+
+  -- truncate if needed
+  if bw > width then
+    let (rewriter, narrowed) ← rewriter.createOp! (.arith .trunci)
+      #[IntegerType.mk width] #[result.getResult 0] #[] #[]
+      { attr := { nsw := false, nuw := true } } (some ip)
+    return (rewriter, (narrowed.getResult 0 : ValuePtr))
+  else
+    return (rewriter, (result.getResult 0 : ValuePtr))
 
 /-! ## Binary op lowering Template -/
 
@@ -247,7 +265,7 @@ def remuiToBarrettReduction (rewriter : PatternRewriter OpCode) (op : OperationP
   let ip := InsertPoint.before op
   let (rewriter, reduced) ←
     emitBarrettReduction
-      rewriter r q modulus resultType.bitwidth ip
+      rewriter r modulus resultType.bitwidth ip
 
   let rewriter :=
     rewriter.replaceValue! (op.getResult 0) reduced


### PR DESCRIPTION
While building some end-to-end test, I stumbled across a miscompilation it the modulus is large relative to the storage type.