### PR TITLE
test(mod_arith): test that compiles to clang and runs

### DIFF
--- a/Test/Passes/mod_arith_runner.mlir
+++ b/Test/Passes/mod_arith_runner.mlir
@@ -1,0 +1,58 @@
+// REQUIRES: clang, mlir-translate, mlir-opt
+// RUN: split-file %s %t
+// RUN: veir-opt %t/input.mlir -p=mod-arith,arith-to-llvm | mlir-opt --convert-func-to-llvm | mlir-translate --mlir-to-llvmir -o %t/kernel.ll
+// RUN: clang -Wno-override-module %t/driver.c %t/kernel.ll -o %t/test
+// RUN: %t/test | filecheck %s
+
+// CHECK: OK
+
+//--- input.mlir
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<12289 : i32>, !mod_arith.int<12289 : i32>) -> !mod_arith.int<12289 : i32>, sym_name = "mod_arith_chain"}> ({
+  ^bb0(%a : !mod_arith.int<12289 : i32>, %b : !mod_arith.int<12289 : i32>):
+    %c5 = "mod_arith.constant"() <{"value" = 5 : i32}> : () -> !mod_arith.int<12289 : i32>
+    %s = "mod_arith.add"(%a, %b) : (!mod_arith.int<12289 : i32>, !mod_arith.int<12289 : i32>) -> !mod_arith.int<12289 : i32>
+    %d = "mod_arith.sub"(%a, %b) : (!mod_arith.int<12289 : i32>, !mod_arith.int<12289 : i32>) -> !mod_arith.int<12289 : i32>
+    %m = "mod_arith.mul"(%s, %d) : (!mod_arith.int<12289 : i32>, !mod_arith.int<12289 : i32>) -> !mod_arith.int<12289 : i32>
+    %r = "mod_arith.mul"(%m, %c5) : (!mod_arith.int<12289 : i32>, !mod_arith.int<12289 : i32>) -> !mod_arith.int<12289 : i32>
+    %out = "mod_arith.add"(%r, %a) : (!mod_arith.int<12289 : i32>, !mod_arith.int<12289 : i32>) -> !mod_arith.int<12289 : i32>
+    "func.return"(%out) : (!mod_arith.int<12289 : i32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+//--- driver.c
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+uint32_t mod_arith_chain(uint32_t, uint32_t);
+
+static uint32_t reference(uint32_t a, uint32_t b) {
+  const uint32_t q = 12289;
+  uint64_t sum = (a + b) % q;
+  uint64_t difference = (a + q - b) % q;
+  uint64_t product = sum * difference % q;
+  uint64_t scaled = product * 5 % q;
+  uint64_t result = (scaled + a) % q;
+  return (uint32_t)result;
+}
+
+int main(void) {
+  const uint32_t q = 12289;
+  const unsigned int seed = 0;
+  const uint32_t number_of_tests = 16384;
+  srand(seed);
+  for (uint32_t i = 0; i < number_of_tests; ++i) {
+    uint32_t a = (uint32_t)rand() % q;
+    uint32_t b = (uint32_t)rand() % q;
+    uint32_t got = mod_arith_chain(a, b);
+    uint32_t expected = reference(a, b);
+    if (got != expected) {
+      printf("FAIL mod_arith_chain(%u, %u) = %u, expected %u\n",
+             a, b, got, expected);
+      return 1;
+    }
+  }
+  printf("OK\n");
+  return 0;
+}

--- a/Test/Passes/mod_arith_runner.mlir
+++ b/Test/Passes/mod_arith_runner.mlir
@@ -29,8 +29,8 @@ uint32_t mod_arith_chain(uint32_t, uint32_t);
 
 static uint32_t reference(uint32_t a, uint32_t b) {
   const uint32_t q = 12289;
-  uint64_t sum = (a + b) % q;
-  uint64_t difference = (a + q - b) % q;
+  uint64_t sum = ((uint64_t)a + (uint64_t)b) % q;
+  uint64_t difference = ((uint64_t)a + q - (uint64_t)b) % q;
   uint64_t product = sum * difference % q;
   uint64_t scaled = product * 5 % q;
   uint64_t result = (scaled + a) % q;


### PR DESCRIPTION
After all the recent changes, we're now able to use veir to actually lower `mod_arith` to LLVM, compile it with clang and run it! 

Or, well, nearly: 
* we still need `mlir-opt --convert-func-to-llvm` since we don't have that pass (yet) and rewriting an operation with regions seems not-quite-fully-supported yet
* we also use `mlir-translate --mlir-to-llvmir`... we might eventually want that inside veir, but it seems less important than the prior one


The reference computes everything "naively" (explicit `%` everywhere), while the current lowering, though still far from optimal, at least uses Barrett reductions (though I haven't timed it to see if it's actually any faster).

Thanks to @Seonyoung-Cheon  and @regehr  for all their work on getting to this point! 