### PR TITLE
feat: Move `fromName` and `toName` to `HasDialectOpInfo`

### DIFF
--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -10,6 +10,16 @@ open Veir
 example : HasDialect OpCode Arith := inferInstance
 example : HasDialect OpCode Builtin := inferInstance
 
+/-! Dialect-local and global operation name lookup is generated. -/
+#guard Arith.fromName "arith.addi".toUTF8 = some .addi
+#guard Arith.fromName "llvm.add".toUTF8 = none
+#guard Arith.name .addi = "arith.addi".toUTF8
+#guard OpCode.fromName "arith.addi".toUTF8 = some (.arith .addi)
+#guard OpCode.fromName "unknown.op".toUTF8 = none
+#guard OpCode.name (.arith .addi) = "arith.addi".toUTF8
+#guard HasDialectOpInfo.fromName (opCode := Arith) "arith.addi".toUTF8 = some .addi
+#guard HasDialectOpInfo.name (opCode := Arith) .addi = "arith.addi".toUTF8
+
 /-! Dialects can define conversion functions to and from the global opcode type. -/
 abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arith]
     : Option Arith :=

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -4,7 +4,7 @@ public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Arith.Properties
 public import Veir.Dialects.LLVM.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -125,7 +125,11 @@ def Arith.isConstantLike (op : Arith) : Bool :=
 def Arith.hasSSADominance (_op : Arith) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Arith
+
 instance : HasDialectOpInfo Arith where
+  fromName := Arith.fromName
+  name := Arith.name
   propertiesOf := Arith.propertiesOf
   fromAttrDict := Arith.fromAttrDict
   toAttrDict := Arith.toAttrDict

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Builtin.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -52,7 +52,11 @@ def Builtin.hasSSADominance (op : Builtin) (_index : Nat) : Bool :=
   | .module | .unregistered => false
   | _ => true
 
+#generate_dialect Builtin
+
 instance : HasDialectOpInfo Builtin where
+  fromName := Builtin.fromName
+  name := Builtin.name
   propertiesOf := Builtin.propertiesOf
   fromAttrDict := Builtin.fromAttrDict
   toAttrDict := Builtin.toAttrDict

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Cf.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -51,7 +51,11 @@ def Cf.isConstantLike (_op : Cf) : Bool :=
 def Cf.hasSSADominance (_op : Cf) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Cf
+
 instance : HasDialectOpInfo Cf where
+  fromName := Cf.fromName
+  name := Cf.name
   propertiesOf := Cf.propertiesOf
   fromAttrDict := Cf.fromAttrDict
   toAttrDict := Cf.toAttrDict

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Comb.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -72,7 +72,11 @@ def Comb.isConstantLike (_op : Comb) : Bool :=
 def Comb.hasSSADominance (_op : Comb) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Comb
+
 instance : HasDialectOpInfo Comb where
+  fromName := Comb.fromName
+  name := Comb.name
   propertiesOf := Comb.propertiesOf
   fromAttrDict := Comb.fromAttrDict
   toAttrDict := Comb.toAttrDict

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -2,7 +2,7 @@ module
 
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -42,7 +42,11 @@ def Datapath.isConstantLike (_op : Datapath) : Bool :=
 def Datapath.hasSSADominance (_op : Datapath) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Datapath
+
 instance : HasDialectOpInfo Datapath where
+  fromName := Datapath.fromName
+  name := Datapath.name
   propertiesOf := Datapath.propertiesOf
   fromAttrDict := Datapath.fromAttrDict
   toAttrDict := Datapath.toAttrDict

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Func.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -60,7 +60,11 @@ def Func.isConstantLike (_op : Func) : Bool :=
 def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Func
+
 instance : HasDialectOpInfo Func where
+  fromName := Func.fromName
+  name := Func.name
   propertiesOf := Func.propertiesOf
   fromAttrDict := Func.fromAttrDict
   toAttrDict := Func.toAttrDict

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.HW.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -63,7 +63,11 @@ def HW.isConstantLike (op : HW) : Bool :=
 def HW.hasSSADominance (_op : HW) (_index : Nat) : Bool :=
   true
 
+#generate_dialect HW
+
 instance : HasDialectOpInfo HW where
+  fromName := HW.fromName
+  name := HW.name
   propertiesOf := HW.propertiesOf
   fromAttrDict := HW.fromAttrDict
   toAttrDict := HW.toAttrDict

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -4,7 +4,7 @@ public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.LLVM.Properties
 public import Veir.Dialects.Cf.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -295,7 +295,11 @@ def Llvm.isConstantLike (op : Llvm) : Bool :=
 def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Llvm
+
 instance : HasDialectOpInfo Llvm where
+  fromName := Llvm.fromName
+  name := Llvm.name
   propertiesOf := Llvm.propertiesOf
   fromAttrDict := Llvm.fromAttrDict
   toAttrDict := Llvm.toAttrDict

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.ModArith.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -52,7 +52,11 @@ def Mod_Arith.isConstantLike (_op : Mod_Arith) : Bool :=
 def Mod_Arith.hasSSADominance (_op : Mod_Arith) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Mod_Arith
+
 instance : HasDialectOpInfo Mod_Arith where
+  fromName := Mod_Arith.fromName
+  name := Mod_Arith.name
   propertiesOf := Mod_Arith.propertiesOf
   fromAttrDict := Mod_Arith.fromAttrDict
   toAttrDict := Mod_Arith.toAttrDict

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.RISCV.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -257,7 +257,11 @@ def Riscv.isConstantLike (op : Riscv) : Bool :=
 def Riscv.hasSSADominance (_op : Riscv) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Riscv
+
 instance : HasDialectOpInfo Riscv where
+  fromName := Riscv.fromName
+  name := Riscv.name
   propertiesOf := Riscv.propertiesOf
   fromAttrDict := Riscv.fromAttrDict
   toAttrDict := Riscv.toAttrDict

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.RISCV_Cf.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -66,7 +66,11 @@ def Riscv_Cf.isConstantLike (_op : Riscv_Cf) : Bool :=
 def Riscv_Cf.hasSSADominance (_op : Riscv_Cf) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Riscv_Cf
+
 instance : HasDialectOpInfo Riscv_Cf where
+  fromName := Riscv_Cf.fromName
+  name := Riscv_Cf.name
   propertiesOf := Riscv_Cf.propertiesOf
   fromAttrDict := Riscv_Cf.fromAttrDict
   toAttrDict := Riscv_Cf.toAttrDict

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -3,7 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.RISCV_Stack.Properties
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -47,7 +47,11 @@ def Riscv_Stack.isConstantLike (_op : Riscv_Stack) : Bool :=
 def Riscv_Stack.hasSSADominance (_op : Riscv_Stack) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Riscv_Stack
+
 instance : HasDialectOpInfo Riscv_Stack where
+  fromName := Riscv_Stack.fromName
+  name := Riscv_Stack.name
   propertiesOf := Riscv_Stack.propertiesOf
   fromAttrDict := Riscv_Stack.fromAttrDict
   toAttrDict := Riscv_Stack.toAttrDict

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -2,7 +2,7 @@ module
 
 public import Veir.IR.OpInfo
 public import Veir.IR.Simp
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -41,7 +41,11 @@ def Rv64.isConstantLike (_op : Rv64) : Bool :=
 def Rv64.hasSSADominance (_op : Rv64) (_index : Nat) : Bool :=
   true
 
+#generate_dialect Rv64
+
 instance : HasDialectOpInfo Rv64 where
+  fromName := Rv64.fromName
+  name := Rv64.name
   propertiesOf := Rv64.propertiesOf
   fromAttrDict := Rv64.fromAttrDict
   toAttrDict := Rv64.toAttrDict

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -2,7 +2,7 @@ module
 
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
-meta import Veir.Meta.Attrs
+meta import Veir.Meta.OpCode
 
 namespace Veir
 
@@ -39,7 +39,11 @@ def Test.isConstantLike (_op : Test) : Bool :=
 def Test.hasSSADominance (_op : Test) (_index : Nat) : Bool :=
   false
 
+#generate_dialect Test
+
 instance : HasDialectOpInfo Test where
+  fromName := Test.fromName
+  name := Test.name
   propertiesOf := Test.propertiesOf
   fromAttrDict := Test.fromAttrDict
   toAttrDict := Test.toAttrDict

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -212,6 +212,8 @@ def Properties.toAttrDict
   | .test op, props => Test.toAttrDict op props
 
 instance : HasDialectOpInfo OpCode where
+  fromName := OpCode.fromName
+  name := OpCode.name
   propertiesOf := _propertiesOf
   fromAttrDict := Properties.fromAttrDict
   toAttrDict := Properties.toAttrDict

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -9,6 +9,10 @@ public section
 
 class HasDialectOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode where
+  /-- Look up an operation by its fully qualified MLIR name. -/
+  fromName : ByteArray → Option opCode
+  /-- Return an operation's fully qualified MLIR name. -/
+  name : opCode → ByteArray
   propertiesOf : opCode → Type
   /-- Create an operation's properties from its attribute dictionary. -/
   fromAttrDict : (op : opCode) → Std.HashMap ByteArray Attribute →

--- a/Veir/Meta/OpCode.lean
+++ b/Veir/Meta/OpCode.lean
@@ -70,25 +70,67 @@ meta def mkOpCodeInductive (ds : Array Dialect) : TermElabM Syntax := do
   `(inductive $(mkIdent `OpCode) where $ctors*
     deriving Inhabited, Repr, Hashable, DecidableEq)
 
-meta def emitFromName (ds : Array Dialect) : TermElabM Command := do
-  let unreg : TSyntax `term := (mkIdent `Builtin.unregistered)
-  let builtin : TSyntax `term := (mkIdent `OpCode.builtin)
-  let mut res : TSyntax `term ← `($builtin $unreg)
-  for d in ds do
-    for op in d.operations do
-      let op := op.replace "." "__" -- we replace "." with "__" to avoid issues with '.' in constructor names
-      if d.getName = "builtin" ∧ op = "unregistered" then continue
-      res ← `(if name = $(Syntax.mkStrLit (d.mkOpName op)).toByteArray then ($(mkIdent d.mkDialectCode) $(mkIdent (.mkStr2 d.name op))) else $res)
-  `(def $(mkIdent `OpCode.fromName) (name : $(mkIdent ``ByteArray)) : $(mkIdent `OpCode) := $res)
+/--
+Generate `Dialect.fromName : ByteArray → Option Dialect` from a given
+inductive representing the operation opcodes of a dialect.
+-/
+meta def emitDialectFromName (d : Dialect) : TermElabM Command := do
+  let mut res : TSyntax `term ← `(none)
+  for op in d.operations do
+    res ←
+      `(if name = $(Syntax.mkStrLit (d.mkOpName op)).toByteArray then
+          some $(mkIdent (.mkStr2 d.name op))
+        else
+          $res)
+  `(def $(mkIdent (.mkStr2 d.name "fromName"))
+      (name : $(mkIdent ``ByteArray)) : Option $(mkIdent d.mkDialectCodeSimple) := $res)
 
-meta def emitName (ds : Array Dialect) : TermElabM Command := do
+/--
+Generate `Dialect.name : Dialect → ByteArray` from a given
+inductive representing the operation opcodes of a dialect.
+-/
+meta def emitDialectName (d : Dialect) : TermElabM Command := do
+  let mut alts := #[]
+  for op in d.operations do
+    alts := alts.push <| ←
+      `(Lean.Parser.Term.matchAltExpr |
+         | $(mkIdent (.mkStr2 d.name op)) => $(Syntax.mkStrLit (d.mkOpName op)).toByteArray)
+  `(def $(mkIdent (.mkStr2 d.name "name"))
+      (op : $(mkIdent d.mkDialectCodeSimple)) : ByteArray := match op with $alts:matchAlt* )
+
+/-- Generate `OpCode.fromName : ByteArray → Option OpCode` from a given array of dialects. -/
+meta def emitGlobalFromName (ds : Array Dialect) : TermElabM Command := do
+  let mut res : TSyntax `term ← `(none)
+  for d in ds do
+    res ←
+      `(match ($(mkIdent (.mkStr2 d.name "fromName")) name) with
+        | some op => some ($(mkIdent d.mkDialectCode) op)
+        | none => $res)
+  `(def $(mkIdent `OpCode.fromName)
+      (name : $(mkIdent ``ByteArray)) : Option $(mkIdent `OpCode) := $res)
+
+/-- Generate `OpCode.name : OpCode → ByteArray` from a given array of dialects. -/
+meta def emitGlobalName (ds : Array Dialect) : TermElabM Command := do
   let mut alts := #[]
   for d in ds do
-    for op in d.operations do
-      alts := alts.push <| ←
-        `(Lean.Parser.Term.matchAltExpr |
-           | $(mkIdent d.mkDialectCode) $(mkIdent (.mkStr2 d.name op)) => $(Syntax.mkStrLit (d.mkOpName op)).toByteArray)
-  `(def $(mkIdent `OpCode.name) (op : $(mkIdent `OpCode)) : ByteArray := match op with $alts:matchAlt* )
+    alts := alts.push <| ←
+      `(Lean.Parser.Term.matchAltExpr |
+         | $(mkIdent d.mkDialectCode) op => $(mkIdent (.mkStr2 d.name "name")) op)
+  `(def $(mkIdent `OpCode.name)
+      (op : $(mkIdent `OpCode)) : ByteArray := match op with $alts:matchAlt* )
+
+/--
+Generate the necessary boilerplate for a dialect inductive type.
+For now, this only include generating `Dialect.fromName` and `Dialect.name`.
+-/
+elab "#generate_dialect" dialect:ident : command => do
+  let dialectName ← resolveGlobalConstNoOverload dialect
+  let env ← getEnv
+  let some (.inductInfo info) := env.find? dialectName
+    | throwError m!"Type {dialectName} is not defined or not an inductive."
+  let d := mkDialect dialectName.getString! info
+  elabCommand <| ← Command.liftTermElabM <| emitDialectFromName d
+  elabCommand <| ← Command.liftTermElabM <| emitDialectName d
 
 /--
 Generate a `HasDialect OpInfo Dialect` instance for the inductive `opInfo` with
@@ -150,8 +192,8 @@ elab "#generate_op_codes" : command => do
     dialects := dialects.push <| mkDialect t.getString! info
 
   elabCommand <| ← Command.liftTermElabM <| mkOpCodeInductive dialects
-  elabCommand <| ← Command.liftTermElabM <| emitFromName dialects
-  elabCommand <| ← Command.liftTermElabM <| emitName dialects
+  elabCommand <| ← Command.liftTermElabM <| emitGlobalFromName dialects
+  elabCommand <| ← Command.liftTermElabM <| emitGlobalName dialects
   pure ()
 
 /--

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -648,7 +648,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) : MlirParserM (Option Oper
   let blockOperands ← parseBlockOperands
 
   /- Get the operation opcode. -/
-  let opId := OpCode.fromName opName
+  let opId := (OpCode.fromName opName).getD (.builtin .unregistered)
 
   if let .builtin .unregistered := opId then
     if !(← get).allowUnregisteredDialect then


### PR DESCRIPTION
These two functions should be part of `HasOpInfo` at least. Since we can already define them on `HasDialectOpInfo`, I feel it should be moved there instead.