### PR TITLE
feat(mod_arith): add variant of lowering that uses only power-of-two integer types.

### DIFF
--- a/Test/Passes/FunctionBoundaryCoercion/mod_arith_pow2_width.mlir
+++ b/Test/Passes/FunctionBoundaryCoercion/mod_arith_pow2_width.mlir
@@ -1,0 +1,23 @@
+// RUN: veir-opt %s -p=coerce-mod-arith-function-boundaries-pow2-width,reconcile-cast | filecheck %s
+
+"builtin.module"() ({
+
+  // With the pow2-width variant, `mod_arith` boundaries with a non-power-of-two storage
+  // type (i33) are coerced to the power-of-two-widened storage type (i64) — the same
+  // representation type the `mod-arith-to-arith-pow2-width` lowering uses. The boundary
+  // casts below (as that lowering would emit them) then form identity round trips and
+  // are reconciled away.
+    "func.func"() <{sym_name = "arith_add", function_type = (!mod_arith.int<7 : i33>, !mod_arith.int<7 : i33>) -> !mod_arith.int<7 : i33>}> ({
+    ^bb(%a: !mod_arith.int<7 : i33>, %b: !mod_arith.int<7 : i33>):
+      %ai = "builtin.unrealized_conversion_cast"(%a) : (!mod_arith.int<7 : i33>) -> i64
+      %bi = "builtin.unrealized_conversion_cast"(%b) : (!mod_arith.int<7 : i33>) -> i64
+      %sum = "arith.addi"(%ai, %bi) : (i64, i64) -> i64
+      %out = "builtin.unrealized_conversion_cast"(%sum) : (i64) -> !mod_arith.int<7 : i33>
+      "func.return"(%out) : (!mod_arith.int<7 : i33>) -> ()
+      // CHECK:      "func.func"() <{"function_type" = (i64, i64) -> i64, "sym_name" = "arith_add"}>
+      // CHECK-NEXT: ^{{.*}}([[A:%.*]] : i64, [[B:%.*]] : i64):
+      // CHECK-NEXT:   [[SUM:%.*]] = "arith.addi"([[A]], [[B]]) : (i64, i64) -> i64
+      // CHECK-NEXT:   "func.return"([[SUM]]) : (i64) -> ()
+    }) : () -> ()
+
+}) : () -> ()

--- a/Test/Passes/ModArithToArith/mul_pow2_width.mlir
+++ b/Test/Passes/ModArithToArith/mul_pow2_width.mlir
@@ -1,0 +1,26 @@
+// RUN: veir-opt %s -p=mod-arith-to-arith-pow2-width | filecheck %s
+
+// Width-normalized lowering of mod_arith.mul with a non-power-of-two storage type (i33).
+// The representation type crossing op boundaries is the normalized storage width (i64),
+// so no i33 arith value survives; the double-width intermediate (i66 -> i128) exists only
+// between the extui and trunci of this op's own cluster.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<7 : i33>, !mod_arith.int<7 : i33>) -> !mod_arith.int<7 : i33>, sym_name = "main"}> ({
+    ^bb0(%0 : !mod_arith.int<7 : i33>, %1 : !mod_arith.int<7 : i33>):
+      %r = "mod_arith.mul"(%0, %1) : (!mod_arith.int<7 : i33>, !mod_arith.int<7 : i33>) -> !mod_arith.int<7 : i33>
+      "func.return"(%r) : (!mod_arith.int<7 : i33>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      ^{{.*}}([[ARG0:%.*]] : !mod_arith.int<7 : i33>, [[ARG1:%.*]] : !mod_arith.int<7 : i33>):
+// CHECK-NEXT:   [[C0:%.*]] = "builtin.unrealized_conversion_cast"([[ARG0]]) : (!mod_arith.int<7 : i33>) -> i64
+// CHECK-NEXT:   [[E0:%.*]] = "arith.extui"([[C0]]) : (i64) -> i128
+// CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG1]]) : (!mod_arith.int<7 : i33>) -> i64
+// CHECK-NEXT:   [[E1:%.*]] = "arith.extui"([[C1]]) : (i64) -> i128
+// CHECK-NEXT:   [[Q:%.*]] = "arith.constant"() <{"value" = 7 : i128}> : () -> i128
+// CHECK-NEXT:   [[PROD:%.*]] = "arith.muli"([[E0]], [[E1]]) : (i128, i128) -> i128
+// CHECK-NEXT:   [[PRODR:%.*]] = "arith.remui"([[PROD]], [[Q]]) : (i128, i128) -> i128
+// CHECK-NEXT:   [[T:%.*]] = "arith.trunci"([[PRODR]]) <{"overflowFlags" = #arith.overflow<nuw>}> : (i128) -> i64
+// CHECK-NEXT:   [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[T]]) : (i64) -> !mod_arith.int<7 : i33>
+// CHECK-NEXT:   "func.return"([[RES]]) : (!mod_arith.int<7 : i33>) -> ()

--- a/Test/Passes/mod_arith_runner.mlir
+++ b/Test/Passes/mod_arith_runner.mlir
@@ -1,8 +1,15 @@
 // REQUIRES: clang, mlir-translate, mlir-opt
 // RUN: split-file %s %t
+
+// Standard pipeline, using i33/i42/etc
 // RUN: veir-opt %t/input.mlir -p=mod-arith,arith-to-llvm | mlir-opt --convert-func-to-llvm | mlir-translate --mlir-to-llvmir -o %t/kernel.ll
 // RUN: clang -Wno-override-module %t/driver.c %t/kernel.ll -o %t/test
 // RUN: %t/test | filecheck %s
+
+// Pow-2-width pipeline, using i32/i64/etc
+// RUN: veir-opt %t/input.mlir -p=mod-arith-pow2-width,arith-to-llvm | mlir-opt --convert-func-to-llvm | mlir-translate --mlir-to-llvmir -o %t/kernel_pow2.ll
+// RUN: clang -Wno-override-module %t/driver.c %t/kernel_pow2.ll -o %t/test_pow2
+// RUN: %t/test_pow2 | filecheck %s
 
 // CHECK: OK
 

--- a/Test/Passes/pass_group_mod_arith_pow2_width.mlir
+++ b/Test/Passes/pass_group_mod_arith_pow2_width.mlir
@@ -1,0 +1,31 @@
+// RUN: veir-opt %s -p=mod-arith-pow2-width | filecheck %s
+
+// The `mod-arith-pow2-width` pass group lowers `mod_arith` all the way to `arith` like
+// `mod-arith`, but rounds every integer width the lowering chooses up to a power of two.
+// The property under test: starting from a non-power-of-two storage type (i29), no
+// non-power-of-two integer type and no `unrealized_conversion_cast` survives the pipeline.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (!mod_arith.int<12289 : i29>, !mod_arith.int<12289 : i29>) -> !mod_arith.int<12289 : i29>, sym_name = "chain"}> ({
+  ^bb0(%a : !mod_arith.int<12289 : i29>, %b : !mod_arith.int<12289 : i29>):
+    %c5 = "mod_arith.constant"() <{"value" = 5 : i29}> : () -> !mod_arith.int<12289 : i29>
+    %s = "mod_arith.add"(%a, %b) : (!mod_arith.int<12289 : i29>, !mod_arith.int<12289 : i29>) -> !mod_arith.int<12289 : i29>
+    %d = "mod_arith.sub"(%a, %b) : (!mod_arith.int<12289 : i29>, !mod_arith.int<12289 : i29>) -> !mod_arith.int<12289 : i29>
+    %m = "mod_arith.mul"(%s, %d) : (!mod_arith.int<12289 : i29>, !mod_arith.int<12289 : i29>) -> !mod_arith.int<12289 : i29>
+    %r = "mod_arith.mul"(%m, %c5) : (!mod_arith.int<12289 : i29>, !mod_arith.int<12289 : i29>) -> !mod_arith.int<12289 : i29>
+    %out = "mod_arith.add"(%r, %a) : (!mod_arith.int<12289 : i29>, !mod_arith.int<12289 : i29>) -> !mod_arith.int<12289 : i29>
+    "func.return"(%out) : (!mod_arith.int<12289 : i29>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// The boundary is coerced to the power-of-two-widened storage type (i29 -> i32) ...
+// CHECK: "func.func"() <{"function_type" = (i32, i32) -> i32, "sym_name" = "chain"}> ({
+
+// ... and from here to the end of the output, nothing mod_arith-ish, no cast,
+// and no non-power-of-two width survives.
+// CHECK-NOT: mod_arith
+// CHECK-NOT: unrealized_conversion_cast
+// CHECK-NOT: i29
+// CHECK-NOT: i30
+// CHECK-NOT: i58
+// CHECK-NOT: i87

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -244,6 +244,10 @@ structure ModArithType where
   modulus : IntegerAttr
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/-- The bitwidth of the storage type of a `!mod_arith.int`. -/
+public def ModArithType.bitwidth (ty : ModArithType) : Nat :=
+  ty.modulus.type.bitwidth
+
 namespace LLVM
 
 structure VoidType

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -17,13 +17,13 @@ namespace Veir
   The coercion applied is selected by a `BoundaryCoercion` flag;
   each variant is  exposed as its own pass:
   - `.riscvReg`: i32-, i64-, and pointer-typed boundaries become `!riscv.reg`.
-  - `.modArithToInt`: `!mod_arith.int<q : iN>`-typed boundaries become `iN`.
+  - `.modArithToInt legalizeWidth`: `!mod_arith.int<q : iN>`-typed boundaries become `i(legalizeWidth N)`
 -/
 
 /-- Selects which boundary coercion the shared implementation applies. -/
 inductive BoundaryCoercion where
   | riscvReg
-  | modArithToInt
+  | modArithToInt (legalizeWidth : Nat → Nat)
 
 /-- The type a boundary value of type `t` is coerced to, or `none` to leave it alone. -/
 def BoundaryCoercion.target : BoundaryCoercion → TypeAttr → Option TypeAttr
@@ -33,9 +33,9 @@ def BoundaryCoercion.target : BoundaryCoercion → TypeAttr → Option TypeAttr
       if x.bitwidth == 64 || x.bitwidth == 32 then some (RegisterType.mk : TypeAttr) else none
     | .llvmPointerType _ => some (RegisterType.mk : TypeAttr)
     | _ => none
-  | .modArithToInt, t =>
+  | .modArithToInt legalizeWidth, t =>
     match t.val with
-    | .modArithType mt => some mt.modulus.type
+    | .modArithType mt => some (IntegerType.mk (legalizeWidth mt.bitwidth) : TypeAttr)
     | _ => none
 
 /-- The return-terminator opcode paired with a function op (`func.return` for
@@ -125,4 +125,9 @@ public def CoerceFunctionBoundariesToRiscvRegPass : Pass OpCode :=
 public def CoerceModArithFunctionBoundariesPass : Pass OpCode :=
   { name := "coerce-mod-arith-function-boundaries"
     description := "Coerce `!mod_arith.int` function boundaries to their storage integer type."
-    run := CoerceFunctionBoundariesPass.impl .modArithToInt }
+    run := CoerceFunctionBoundariesPass.impl (.modArithToInt id) }
+
+public def CoerceModArithFunctionBoundariesPassPow2Width : Pass OpCode :=
+  { name := "coerce-mod-arith-function-boundaries-pow2-width"
+    description := "Coerce `!mod_arith.int` function boundaries to their storage integer type, widened to a power of two."
+    run := CoerceFunctionBoundariesPass.impl (.modArithToInt Nat.nextPowerOfTwo) }

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -14,17 +14,17 @@ namespace Veir
   The current lowering is trivial, eagerly reducing at all times.
 
   Since Veir has no Dialect Conversion framework, this pass eagerly inserts `unrealized_conversion_casts`
-  to handle the type conversions between `!mod_arith.int<q : iN>` and `iN` that are needed.
+  to handle the type conversions between `!mod_arith.int<q : iN>` and `iM` that are needed.
 -/
 
 /-! ## Unrealized Conversion Casts -/
 
-/-- Emit `unrealized_conversion_cast v : !mod_arith.int<q:iN> → iN`. -/
-def castToStorage (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ip : InsertPoint) :
-    Option (PatternRewriter OpCode × ValuePtr) := do
+/-- Emit `unrealized_conversion_cast v : !mod_arith.int<q:iN> → i(legalizeWidth N)`. -/
+def castToStorage (legalizeWidth : Nat → Nat) (rewriter : PatternRewriter OpCode)
+    (v : ValuePtr) (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
   let .modArithType mt := (v.getType! rewriter.ctx.raw).val
     | none
-  let storageType : TypeAttr := mt.modulus.type
+  let storageType : TypeAttr := IntegerType.mk (legalizeWidth mt.bitwidth)
   let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
     #[storageType] #[v] #[] #[] () (some ip)
   return (rewriter, (castOp.getResult 0 : ValuePtr))
@@ -41,9 +41,10 @@ def castToModArith (rewriter : PatternRewriter OpCode) (x : ValuePtr) (ty : ModA
 /--
   Unpack a `!mod_arith.int<q:iN>` value `v` into the IntegerType `intermediateType`
 -/
-def unpackValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (intermediateType : IntegerType)
-    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
-  let (rewriter, stored) ← castToStorage rewriter v ip
+def unpackValue (legalizeWidth : Nat → Nat) (rewriter : PatternRewriter OpCode) (v : ValuePtr)
+    (intermediateType : IntegerType) (ip : InsertPoint) :
+    Option (PatternRewriter OpCode × ValuePtr) := do
+  let (rewriter, stored) ← castToStorage legalizeWidth rewriter v ip
   let .integerType storageType := (stored.getType! rewriter.ctx.raw).val
     | none
   if intermediateType.bitwidth > storageType.bitwidth then
@@ -56,11 +57,11 @@ def unpackValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (intermediate
 /--
   Pack an IntegerType value `v` of IntegerType `intermediateType` into a value of `!mod_arith.int<q:iN>` type `ty`.
 -/
-def packValue (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ty : ModArithType)
-    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+def packValue (legalizeWidth : Nat → Nat) (rewriter : PatternRewriter OpCode) (v : ValuePtr)
+    (ty : ModArithType) (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
   let .integerType intermediateType := (v.getType! rewriter.ctx.raw).val
     | none
-  let storageType := ty.modulus.type
+  let storageType := IntegerType.mk (legalizeWidth ty.bitwidth)
   if intermediateType.bitwidth > storageType.bitwidth then
     let (rewriter, narrowed) ← rewriter.createOp! (.arith .trunci)
       #[storageType] #[v] #[] #[] { attr := { nsw := false, nuw := true } }
@@ -107,12 +108,13 @@ def emitArithBinOp (rewriter : PatternRewriter OpCode) (arithOp : Arith)
     }
 -/
 
-def emitBarrettReduction (rewriter : PatternRewriter OpCode) (r : ValuePtr) (modulus : Int)
-    (width : Nat) (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+def emitBarrettReduction (legalizeWidth : Nat → Nat) (rewriter : PatternRewriter OpCode)
+    (r : ValuePtr) (modulus : Int) (width : Nat) (ip : InsertPoint) :
+    Option (PatternRewriter OpCode × ValuePtr) := do
   let k : Nat := (modulus - 1).toNat.log2 + 1     -- ceil(log2 modulus)
   let shift : Nat := 2 * k
   let mu : Int := (2 ^ shift) / modulus           -- floor(2^shift / modulus)
-  let bw := max width (3 * k)                     -- width required for r *
+  let bw := legalizeWidth (max width (3 * k))     -- width required for r * mu
   let ty : TypeAttr := IntegerType.mk bw
   let ty_i1 : TypeAttr := IntegerType.mk 1
 
@@ -173,10 +175,10 @@ abbrev Builder :=
   Option (PatternRewriter OpCode × ValuePtr)
 
 /-- Lower a binary `mod_arith` op `modOp`,
-    using intermediate Type iM given storage type iN, with M = `widen` N,
+    using intermediate Type iM given storage type iN, with M = `legalizeWidth` (`widen` N),
     and using Builder `build` to determine the exact `arith` operations to emit -/
-def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builder)
-    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (legalizeWidth : Nat → Nat)
+    (build : Builder) (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   -- match op and extract operands:
   let some (operands, _) := matchOp op rewriter.ctx (.mod_arith modOp) 2
@@ -186,16 +188,16 @@ def lowerModArithBinOp (modOp : Mod_Arith) (widen : Nat → Nat) (build : Builde
   -- type setup
   let .modArithType modArithType@⟨⟨modulus, storageType⟩⟩ := ((op.getResult 0 : ValuePtr).getType! rewriter.ctx.raw).val
     | return rewriter
-  let intermediateWidth := widen storageType.bitwidth
+  let intermediateWidth := legalizeWidth (widen storageType.bitwidth)
   let intermediateType  := IntegerType.mk intermediateWidth
   -- actual lowering:
   let ip := InsertPoint.before op
-  let (rewriter, a) ← unpackValue rewriter lhs intermediateType ip
-  let (rewriter, b) ← unpackValue rewriter rhs intermediateType ip
+  let (rewriter, a) ← unpackValue legalizeWidth rewriter lhs intermediateType ip
+  let (rewriter, b) ← unpackValue legalizeWidth rewriter rhs intermediateType ip
   let (rewriter, q) ← emitArithConstant rewriter modulus intermediateWidth ip
   let (rewriter, r) ← build rewriter a b q ip
   let (rewriter, r) ← emitArithBinOp rewriter .remui () r q ip
-  let (rewriter, r) ← packValue rewriter r modArithType ip
+  let (rewriter, r) ← packValue legalizeWidth rewriter r modArithType ip
   let rewriter := rewriter.replaceValue! (op.getResult 0) r
   return rewriter.eraseOp! op
 
@@ -205,13 +207,13 @@ def buildAdd : Builder :=
   fun rewriter a b _ ip =>
   emitArithBinOp rewriter .addi { attr := { nsw := false, nuw := false } } a b ip
 
-def lowerModArithAddOp := lowerModArithBinOp .add (· + 1) buildAdd
+def lowerModArithAddOp (legalizeWidth : Nat → Nat) := lowerModArithBinOp .add (· + 1) legalizeWidth buildAdd
 
 def buildMul : Builder :=
   fun rewriter a b _ ip =>
   emitArithBinOp rewriter .muli { attr := { nsw := false, nuw := false } } a b ip
 
-def lowerModArithMulOp := lowerModArithBinOp .mul (2 * ·) buildMul
+def lowerModArithMulOp (legalizeWidth : Nat → Nat) := lowerModArithBinOp .mul (2 * ·) legalizeWidth buildMul
 
 def buildSub : Builder :=
   fun (rewriter : PatternRewriter OpCode) (a b q : ValuePtr) (ip : InsertPoint) => do
@@ -220,13 +222,14 @@ def buildSub : Builder :=
       { attr := { nsw := false, nuw := false } } a q ip
     emitArithBinOp rewriter .subi { attr := { nsw := false, nuw := false } } aq b ip
 
-def lowerModArithSubOp := lowerModArithBinOp .sub (· + 1) buildSub
+def lowerModArithSubOp (legalizeWidth : Nat → Nat) := lowerModArithBinOp .sub (· + 1) legalizeWidth buildSub
 
 /-! ## Constant lowering Pattern -/
 
 /-- Lower `mod_arith.constant` to an `arith.constant`. -/
-def lowerModArithConstantOp (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+def lowerModArithConstantOp (legalizeWidth : Nat → Nat) (rewriter : PatternRewriter OpCode)
+    (op : OperationPtr) (_opInBounds : op.InBounds rewriter.ctx.raw) :
+    Option (PatternRewriter OpCode) := do
   -- match op and extract attribute:
   let some (_, props) := matchOp op rewriter.ctx (.mod_arith .constant) 0
     | return rewriter
@@ -236,7 +239,7 @@ def lowerModArithConstantOp (rewriter : PatternRewriter OpCode) (op : OperationP
     | return rewriter
   -- actual lowering:
   let ip := InsertPoint.before op
-  let (rewriter, r) ← emitArithConstant rewriter (c % q) storageType.bitwidth ip
+  let (rewriter, r) ← emitArithConstant rewriter (c % q) (legalizeWidth storageType.bitwidth) ip
   let (rewriter, out) ← castToModArith rewriter (r : ValuePtr) modArithType ip
   let rewriter := rewriter.replaceValue! (op.getResult 0) out
   return rewriter.eraseOp! op
@@ -244,7 +247,8 @@ def lowerModArithConstantOp (rewriter : PatternRewriter OpCode) (op : OperationP
 /-! ## arith.remui rewriting pattern -/
 
 /-- Rewrite `arith.remui r, q` to a Barrett reduction when `q` is a positive constant. -/
-def remuiToBarrettReduction (rewriter : PatternRewriter OpCode) (op : OperationPtr) (_opInBounds : op.InBounds rewriter.ctx.raw) :
+def remuiToBarrettReduction (legalizeWidth : Nat → Nat) (rewriter : PatternRewriter OpCode)
+    (op : OperationPtr) (_opInBounds : op.InBounds rewriter.ctx.raw) :
     Option (PatternRewriter OpCode) := do
   let some (r, q, _) := matchArithRemui op rewriter.ctx
     | return rewriter
@@ -262,8 +266,7 @@ def remuiToBarrettReduction (rewriter : PatternRewriter OpCode) (op : OperationP
 
   let ip := InsertPoint.before op
   let (rewriter, reduced) ←
-    emitBarrettReduction
-      rewriter r modulus resultType.bitwidth ip
+    emitBarrettReduction legalizeWidth rewriter r modulus resultType.bitwidth ip
 
   let rewriter :=
     rewriter.replaceValue! (op.getResult 0) reduced
@@ -271,13 +274,13 @@ def remuiToBarrettReduction (rewriter : PatternRewriter OpCode) (op : OperationP
 
 /-! ## Pass implementation -/
 
-def ModArithToArithPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
-    (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
+def ModArithToArithPass.impl (legalizeWidth : Nat → Nat) (ctx : WfIRContext OpCode)
+    (op : OperationPtr) (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[
-    lowerModArithConstantOp,
-    lowerModArithAddOp,
-    lowerModArithSubOp,
-    lowerModArithMulOp
+    lowerModArithConstantOp legalizeWidth,
+    lowerModArithAddOp legalizeWidth,
+    lowerModArithSubOp legalizeWidth,
+    lowerModArithMulOp legalizeWidth
   ]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying mod-arith-to-arith lowering"
@@ -286,12 +289,17 @@ def ModArithToArithPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
 public def ModArithToArithPass : Pass OpCode :=
   { name := "mod-arith-to-arith"
     description := "Lower mod_arith operations to the arith dialect."
-    run := ModArithToArithPass.impl }
+    run := ModArithToArithPass.impl id }
 
-def RemuiToBarrettReductionPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
-    (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
+public def ModArithToArithPassPow2Width : Pass OpCode :=
+  { name := "mod-arith-to-arith-pow2-width"
+    description := "Lower mod_arith operations to the arith dialect, using power-of-two bitwidths."
+    run := ModArithToArithPass.impl Nat.nextPowerOfTwo }
+
+def RemuiToBarrettReductionPass.impl (legalizeWidth : Nat → Nat) (ctx : WfIRContext OpCode)
+    (op : OperationPtr) (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
   let pattern := RewritePattern.GreedyRewritePattern #[
-    remuiToBarrettReduction
+    remuiToBarrettReduction legalizeWidth
   ]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying remui-to-barrett-reduction rewrite"
@@ -300,6 +308,10 @@ def RemuiToBarrettReductionPass.impl (ctx : WfIRContext OpCode) (op : OperationP
 public def RemuiToBarrettReductionPass : Pass OpCode :=
   { name := "remui-to-barrett-reduction"
     description := "Rewrite arith.remui operations to Barrett reduction."
-    run := RemuiToBarrettReductionPass.impl }
+    run := RemuiToBarrettReductionPass.impl id }
 
+public def RemuiToBarrettReductionPassPow2Width : Pass OpCode :=
+  { name := "remui-to-barrett-reduction-pow2-width"
+    description := "Rewrite arith.remui operations to Barrett reduction, using power-of-two bitwidths for intermediate types."
+    run := RemuiToBarrettReductionPass.impl Nat.nextPowerOfTwo }
 end Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -39,9 +39,12 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
     |>.insert CastReconcilePass.name CastReconcilePass
     |>.insert CoerceFunctionBoundariesToRiscvRegPass.name CoerceFunctionBoundariesToRiscvRegPass
     |>.insert CoerceModArithFunctionBoundariesPass.name CoerceModArithFunctionBoundariesPass
+    |>.insert CoerceModArithFunctionBoundariesPassPow2Width.name CoerceModArithFunctionBoundariesPassPow2Width
     |>.insert RISCV.Combine.name RISCV.Combine
     |>.insert ModArithToArithPass.name ModArithToArithPass
+    |>.insert ModArithToArithPassPow2Width.name ModArithToArithPassPow2Width
     |>.insert RemuiToBarrettReductionPass.name RemuiToBarrettReductionPass
+    |>.insert RemuiToBarrettReductionPassPow2Width.name RemuiToBarrettReductionPassPow2Width
     |>.insert ArithToLLVMPass.name ArithToLLVMPass
     |>.insert CanonicalizePass.name CanonicalizePass
 
@@ -55,6 +58,8 @@ def passGroups : Std.HashMap String String :=
     |>.insert "O" "canonicalize,instcombine,cse,dce"
     |>.insert "mod-arith"
         "mod-arith-to-arith,cse,coerce-mod-arith-function-boundaries,reconcile-cast,canonicalize,remui-to-barrett-reduction,canonicalize,cse,dce"
+    |>.insert "mod-arith-pow2-width"
+        "mod-arith-to-arith-pow2-width,cse,coerce-mod-arith-function-boundaries-pow2-width,reconcile-cast,canonicalize,remui-to-barrett-reduction-pow2-width,canonicalize,cse,dce"
     |>.insert "riscv"
         "isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,coerce-function-boundaries-to-riscv-reg,reconcile-cast,riscv-combine,dce"
 


### PR DESCRIPTION
Introduces the concept of `legalizeWidth: Nat -> Nat` to the mod-arith-to-arith lowering. The existing pass uses `id`, the new pass `Nat.nextPowerOfTwo`.

The same idea is also introduced to mod-arith function boundary coercion, and the new pass variants also get their own pass group.