### PR TITLE
feat(PDL): Add `!pdl.operation`, `!pdl.value`, and `!pdl.type`

### DIFF
--- a/Test/PDL/attribute.mlir
+++ b/Test/PDL/attribute.mlir
@@ -5,10 +5,16 @@
   %0 = "pdl.attribute"() : () -> !pdl.attribute
   // Define an attribute with an expected value:
   %1 = "pdl.attribute"() <{"value" = "hello"}> : () -> !pdl.attribute
+  // Define an attribute with an expected type. `test.test` stands in for
+  // `pdl.type`, which is not modelled yet:
+  %2 = "test.test"() : () -> !pdl.type
+  %3 = "pdl.attribute"(%2) : (!pdl.type) -> !pdl.attribute
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
 // CHECK-NEXT:     %{{.*}} = "pdl.attribute"() : () -> !pdl.attribute
 // CHECK-NEXT:     %{{.*}} = "pdl.attribute"() <{"value" = "hello"}> : () -> !pdl.attribute
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.type
+// CHECK-NEXT:     %{{.*}} = "pdl.attribute"(%{{.*}}) : (!pdl.type) -> !pdl.attribute
 // CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/attribute_invalid.mlir
+++ b/Test/PDL/attribute_invalid.mlir
@@ -1,11 +1,11 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 // A `pdl.attribute` is constrained either by an expected type or by a constant
-// value, but never by both. The `valueType` operand will be a `!pdl.type`
-// handle once `pdl.type` is modelled.
+// value, but never by both. `test.test` stands in for `pdl.type`, which is not
+// modelled yet.
 "builtin.module"() ({
-  %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
-  %1 = "pdl.attribute"(%0) <{"value" = "hello"}> : (i32) -> !pdl.attribute
+  %0 = "test.test"() : () -> !pdl.type
+  %1 = "pdl.attribute"(%0) <{"value" = "hello"}> : (!pdl.type) -> !pdl.attribute
 }) : () -> ()
 
 // CHECK: pdl.attribute: Expected only one of [`type`, `value`] to be set

--- a/Test/PDL/operand_type_invalid.mlir
+++ b/Test/PDL/operand_type_invalid.mlir
@@ -1,6 +1,6 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
-// The `valueType` operand of a `pdl.attribute` is an `!pdl.type` handle, not the
+// The `valueType` operand of a `pdl.attribute` is a `!pdl.type` handle, not the
 // type the attribute is constrained to.
 "builtin.module"() ({
   %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32

--- a/Test/PDL/operand_type_invalid.mlir
+++ b/Test/PDL/operand_type_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// The `valueType` operand of a `pdl.attribute` is an `!pdl.type` handle, not the
+// type the attribute is constrained to.
+"builtin.module"() ({
+  %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+  %1 = "pdl.attribute"(%0) : (i32) -> !pdl.attribute
+}) : () -> ()
+
+// CHECK: pdl.attribute: Expected the `valueType` operand to be of type '!pdl.type'

--- a/Test/PDL/types.mlir
+++ b/Test/PDL/types.mlir
@@ -1,0 +1,18 @@
+// RUN: VEIR_ROUNDTRIP
+
+// The `pdl` handle types are nullary and round-trip as-is. `test.test` stands in
+// for the `pdl` operations producing them, which are not modelled yet.
+"builtin.module"() ({
+  %0 = "test.test"() : () -> !pdl.attribute
+  %1 = "test.test"() : () -> !pdl.operation
+  %2 = "test.test"() : () -> !pdl.value
+  %3 = "test.test"() : () -> !pdl.type
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.attribute
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.operation
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.value
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.type
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -223,6 +223,15 @@ macro "#assert " e:term : command =>
 #assert expectSuccessType "!pdl.attribute" (PDL.AttributeType.mk)
 #assert expectSuccessAttr "!pdl.attribute" (PDL.AttributeType.mk)
 
+#assert expectSuccessType "!pdl.operation" (PDL.OperationType.mk)
+#assert expectSuccessAttr "!pdl.operation" (PDL.OperationType.mk)
+
+#assert expectSuccessType "!pdl.value" (PDL.ValueType.mk)
+#assert expectSuccessAttr "!pdl.value" (PDL.ValueType.mk)
+
+#assert expectSuccessType "!pdl.type" (PDL.TypeType.mk)
+#assert expectSuccessAttr "!pdl.type" (PDL.TypeType.mk)
+
 /-! ## LLVM Pointer type -/
 #assert expectSuccessType "!llvm.ptr" (LLVM.PointerType.mk)
 

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -64,9 +64,6 @@ instance : HasDialectOpInfo PDL where
 /--
 Verify the local invariants of a `pdl` operation in any operation-info type
 containing the `pdl` dialect.
-
-TODO: The optional `valueType` operand is a `!pdl.type` handle produced by
-`pdl.type`, which is not modelled yet, so the operand type is left unchecked.
 -/
 def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo PDL]
     (opType : PDL) (op : OperationPtr) (ctx : WfIRContext OpInfo)
@@ -85,6 +82,10 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
     let numOperands := op.getNumOperands ctx.raw opIn
     if numOperands > 1 then
       throw "Expected at most 1 operand"
+    if numOperands = 1 then
+      let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+      if operandType.val ≠ (PDL.TypeType.mk : TypeAttr).val then
+        throw "Expected the `valueType` operand to be of type '!pdl.type'"
     let props : PDL.propertiesOf .attribute :=
       HasDialect.toDialectProperties (OpInfo := OpInfo) PDL.attribute
         (op.getProperties! ctx.raw (ofDialect OpInfo PDL.attribute))

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -251,6 +251,24 @@ public def ModArithType.bitwidth (ty : ModArithType) : Nat :=
 namespace PDL
 
 /--
+  The `!pdl.operation` type, a handle to an `mlir::Operation` within a pattern.
+-/
+structure OperationType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  The `!pdl.value` type, a handle to an `mlir::Value` within a pattern.
+-/
+structure ValueType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  The `!pdl.type` type, a handle to an `mlir::Type` within a pattern.
+-/
+structure TypeType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   The `!pdl.attribute` type, a handle to an `mlir::Attribute` within a pattern.
 -/
 structure AttributeType
@@ -442,6 +460,12 @@ inductive Attribute
 | hwModuleType (type : HW.ModuleType)
 /-- PDL attribute handle type -/
 | pdlAttributeType (type : PDL.AttributeType)
+/-- PDL operation handle type -/
+| pdlOperationType (type : PDL.OperationType)
+/-- PDL value handle type -/
+| pdlValueType (type : PDL.ValueType)
+/-- PDL type handle type -/
+| pdlTypeType (type : PDL.TypeType)
 deriving Inhabited, Repr, Hashable
 
 end
@@ -686,6 +710,12 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
       | isFalse hEq => isFalse (by grind))
   case pdlAttributeType.pdlAttributeType type1 type2 =>
     exact (isTrue (by grind))
+  case pdlOperationType.pdlOperationType type1 type2 =>
+    exact (isTrue (by grind))
+  case pdlValueType.pdlValueType type1 type2 =>
+    exact (isTrue (by grind))
+  case pdlTypeType.pdlTypeType type1 type2 =>
+    exact (isTrue (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -820,6 +850,15 @@ instance : ToString ModArithType where
 
 instance : ToString PDL.AttributeType where
   toString _ := "!pdl.attribute"
+
+instance : ToString PDL.OperationType where
+  toString _ := "!pdl.operation"
+
+instance : ToString PDL.ValueType where
+  toString _ := "!pdl.value"
+
+instance : ToString PDL.TypeType where
+  toString _ := "!pdl.type"
 
 instance : ToString LLVM.VoidType where
   toString _ := "!llvm.void"
@@ -957,6 +996,9 @@ def Attribute.toString (attr : Attribute) : String :=
   | .cudaTilePointerType type => ToString.toString type
   | .hwModuleType type => ToString.toString type
   | .pdlAttributeType type => ToString.toString type
+  | .pdlOperationType type => ToString.toString type
+  | .pdlValueType type => ToString.toString type
+  | .pdlTypeType type => ToString.toString type
 termination_by sizeOf attr
 
 end
@@ -1077,6 +1119,15 @@ instance : Coe HW.ModuleType Attribute where
 instance : Coe PDL.AttributeType Attribute where
   coe type := .pdlAttributeType type
 
+instance : Coe PDL.OperationType Attribute where
+  coe type := .pdlOperationType type
+
+instance : Coe PDL.ValueType Attribute where
+  coe type := .pdlValueType type
+
+instance : Coe PDL.TypeType Attribute where
+  coe type := .pdlTypeType type
+
 /-!
   ## TypeAttr definition
 
@@ -1127,6 +1178,9 @@ def isType (attr : Attribute) : Bool :=
   | .cudaTilePointerType _ => true
   | .hwModuleType _ => true
   | .pdlAttributeType _ => true
+  | .pdlOperationType _ => true
+  | .pdlValueType _ => true
+  | .pdlTypeType _ => true
 
 /--
   Returns the size, in bits, that an LLVM type would use if stored to memory.
@@ -1196,6 +1250,12 @@ theorem isType_cudaTilePointerType type : (cudaTilePointerType type).isType = tr
 theorem isType_hwModuleType type : (hwModuleType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_pdlAttributeType type : (pdlAttributeType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_pdlOperationType type : (pdlOperationType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_pdlValueType type : (pdlValueType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_pdlTypeType type : (pdlTypeType type).isType = true := by rfl
 
 end Attribute
 
@@ -1271,6 +1331,15 @@ instance : Coe HW.ModuleType TypeAttr where
 
 instance : Coe PDL.AttributeType TypeAttr where
   coe type := ⟨.pdlAttributeType type, by rfl⟩
+
+instance : Coe PDL.OperationType TypeAttr where
+  coe type := ⟨.pdlOperationType type, by rfl⟩
+
+instance : Coe PDL.ValueType TypeAttr where
+  coe type := ⟨.pdlValueType type, by rfl⟩
+
+instance : Coe PDL.TypeType TypeAttr where
+  coe type := ⟨.pdlTypeType type, by rfl⟩
 
 end
 end Veir

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -473,6 +473,42 @@ partial def parseOptionalPDLAttributeType : AttrParserM (Option TypeAttr) := do
   return some PDL.AttributeType.mk
 
 /--
+  Parse a PDL operation handle type `!pdl.operation`, if present.
+-/
+partial def parseOptionalPDLOperationType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "pdl.operation".toByteArray then return none
+  let _ ← consumeToken
+  return some PDL.OperationType.mk
+
+/--
+  Parse a PDL value handle type `!pdl.value`, if present.
+-/
+partial def parseOptionalPDLValueType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "pdl.value".toByteArray then return none
+  let _ ← consumeToken
+  return some PDL.ValueType.mk
+
+/--
+  Parse a PDL type handle type `!pdl.type`, if present.
+-/
+partial def parseOptionalPDLTypeType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "pdl.type".toByteArray then return none
+  let _ ← consumeToken
+  return some PDL.TypeType.mk
+
+/--
   Parse an LLVM pointer type `!llvm.ptr`, if present.
 -/
 partial def parseOptionalLLVMPointerType : AttrParserM (Option TypeAttr) := do
@@ -748,6 +784,12 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some hwModuleType
   if let some pdlAttributeType ← parseOptionalPDLAttributeType then
     return some pdlAttributeType
+  if let some pdlOperationType ← parseOptionalPDLOperationType then
+    return some pdlOperationType
+  if let some pdlValueType ← parseOptionalPDLValueType then
+    return some pdlValueType
+  if let some pdlTypeType ← parseOptionalPDLTypeType then
+    return some pdlTypeType
   if let some dialectType ← parseOptionalDialectType then
     return some dialectType
   else if let some functionType := ← parseOptionalFunctionType then


### PR DESCRIPTION
Fills in these basic pdl types the same way `!pdl.attribute` was added in #1178. 
This PR does not include `!pdl.range<...>` which I assume will be slightly different because of its parameter.

(I'm also testing out this pull request stack feature)