### PR TITLE
feat(PDL): add `pdl.operand` operation

### DIFF
--- a/Test/PDL/operand.mlir
+++ b/Test/PDL/operand.mlir
@@ -1,0 +1,16 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  // Define an external operand:
+  %0 = "pdl.operand"() : () -> !pdl.value
+  // Define an external operand with an expected type:
+  %1 = "pdl.type"() <{"constantType" = i32}> : () -> !pdl.type
+  %2 = "pdl.operand"(%1) : (!pdl.type) -> !pdl.value
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     %{{.*}} = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:     %{{.*}} = "pdl.type"() <{"constantType" = i32}> : () -> !pdl.type
+// CHECK-NEXT:     %{{.*}} = "pdl.operand"(%{{.*}}) : (!pdl.type) -> !pdl.value
+// CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/operand_invalid.mlir
+++ b/Test/PDL/operand_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// A `pdl.operand` produces an `!pdl.value` handle, not an arbitrary type.
+"builtin.module"() ({
+  %0 = "pdl.operand"() : () -> i32
+}) : () -> ()
+
+// CHECK: pdl.operand: Expected the result to be of type '!pdl.value'

--- a/Test/PDL/operand_property_invalid.mlir
+++ b/Test/PDL/operand_property_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// A `pdl.operand` carries no properties.
+"builtin.module"() ({
+  %0 = "pdl.operand"() <{"constantType" = i32}> : () -> !pdl.value
+}) : () -> ()
+
+// CHECK: pdl.operand: expected no properties, but got 1 properties

--- a/Test/PDL/operand_property_invalid.mlir
+++ b/Test/PDL/operand_property_invalid.mlir
@@ -5,4 +5,4 @@
   %0 = "pdl.operand"() <{"constantType" = i32}> : () -> !pdl.value
 }) : () -> ()
 
-// CHECK: pdl.operand: expected no properties, but got 1 properties
+// CHECK: pdl.operand: expected no properties, but got 1 property.

--- a/Test/PDL/operand_property_invalid.mlir
+++ b/Test/PDL/operand_property_invalid.mlir
@@ -5,4 +5,4 @@
   %0 = "pdl.operand"() <{"constantType" = i32}> : () -> !pdl.value
 }) : () -> ()
 
-// CHECK: pdl.operand: expected no properties, but got 1 property.
+// CHECK: pdl.operand: expected no properties, but got 1 property

--- a/Test/PDL/operand_value_type_invalid.mlir
+++ b/Test/PDL/operand_value_type_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// The `valueType` operand of a `pdl.operand` is a `!pdl.type` handle, not the
+// type the operand is constrained to.
+"builtin.module"() ({
+  %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+  %1 = "pdl.operand"(%0) : (i32) -> !pdl.value
+}) : () -> ()
+
+// CHECK: pdl.operand: Expected the `valueType` operand to be of type '!pdl.type'

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -13,6 +13,7 @@ public section
 @[opcodes]
 inductive PDL where
 | attribute
+| operand
 | type
 deriving Inhabited, Repr, Hashable, DecidableEq
 
@@ -20,6 +21,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 def PDL.propertiesOf (op : PDL) : Type :=
 match op with
 | .attribute => PDLAttributeProperties
+| .operand => Unit
 | .type => PDLTypeProperties
 
 def PDL.fromAttrDict
@@ -27,6 +29,11 @@ def PDL.fromAttrDict
     Except String (PDL.propertiesOf op) :=
   match op with
   | .attribute => PDLAttributeProperties.fromAttrDict attrDict
+  | .operand =>
+    if attrDict.size > 0 then
+      .error s!"pdl.operand: expected no properties, but got {attrDict.size} properties"
+    else
+      .ok ()
   | .type => PDLTypeProperties.fromAttrDict attrDict
 
 def PDL.toAttrDict
@@ -37,6 +44,7 @@ def PDL.toAttrDict
     match props.value with
     | some value => (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 value
     | none => Std.HashMap.emptyWithCapacity 0
+  | .operand => Std.HashMap.emptyWithCapacity 0
   | .type =>
     match props.constantType with
     | some constantType =>
@@ -105,6 +113,23 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
        constant value, but never by both, as the constant provides its own type. -/
     if props.value.isSome && numOperands = 1 then
       throw "Expected only one of [`type`, `value`] to be set"
+  | .operand =>
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    op.verifyResultTypeMatches ctx (PDL.ValueType.mk : TypeAttr)
+      "Expected the result to be of type '!pdl.value'"
+    /- The `valueType` operand is optional. -/
+    let numOperands := op.getNumOperands ctx.raw opIn
+    if numOperands > 1 then
+      throw "Expected at most 1 operand"
+    if numOperands = 1 then
+      let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+      if operandType.val ≠ (PDL.TypeType.mk : TypeAttr).val then
+        throw "Expected the `valueType` operand to be of type '!pdl.type'"
   | .type =>
     /- The optional `constantType` is a property, so `pdl.type` takes no
        operands. -/

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -31,7 +31,8 @@ def PDL.fromAttrDict
   | .attribute => PDLAttributeProperties.fromAttrDict attrDict
   | .operand =>
     if attrDict.size > 0 then
-      .error s!"pdl.operand: expected no properties, but got {attrDict.size} properties"
+      let plural := if attrDict.size = 1 then "property" else "properties"
+      .error s!"pdl.operand: expected no properties, but got {attrDict.size} {plural}"
     else
       .ok ()
   | .type => PDLTypeProperties.fromAttrDict attrDict


### PR DESCRIPTION
Mirrors `pdl.attribute` and `pdl.type`: an optional `valueType` operand of type `!pdl.type`, a single `!pdl.value` result, and no properties.

This is the first operation producing an `!pdl.value` handle, which until now had to be conjured with `test.test` stand-ins in tests.