### PR TITLE
feat(PDL): add `pdl.operation` operation

### DIFF
--- a/Test/PDL/operation.mlir
+++ b/Test/PDL/operation.mlir
@@ -1,0 +1,25 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  // Define an operation with no constraints:
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  // Define an operation with a name:
+  %1 = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  // Define an operation with operands, attributes and result types:
+  %2 = "pdl.operand"() : () -> !pdl.value
+  %3 = "pdl.operand"() : () -> !pdl.value
+  %4 = "pdl.attribute"() : () -> !pdl.attribute
+  %5 = "pdl.type"() : () -> !pdl.type
+  %6 = "pdl.operation"(%2, %3, %4, %5) <{"attributeValueNames" = ["attrA"], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 1, 1>}> : (!pdl.value, !pdl.value, !pdl.attribute, !pdl.type) -> !pdl.operation
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     %{{.*}} = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+// CHECK-NEXT:     %{{.*}} = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+// CHECK-NEXT:     %[[v0:.*]] = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:     %[[v1:.*]] = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:     %[[a0:.*]] = "pdl.attribute"() : () -> !pdl.attribute
+// CHECK-NEXT:     %[[t0:.*]] = "pdl.type"() : () -> !pdl.type
+// CHECK-NEXT:     %{{.*}} = "pdl.operation"(%[[v0]], %[[v1]], %[[a0]], %[[t0]]) <{"attributeValueNames" = ["attrA"], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 1, 1>}> : (!pdl.value, !pdl.value, !pdl.attribute, !pdl.type) -> !pdl.operation
+// CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/operation_attribute_names_invalid.mlir
+++ b/Test/PDL/operation_attribute_names_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// `attributeValueNames` names the attribute operands positionally, so it must
+// hold exactly one name per attribute operand.
+"builtin.module"() ({
+  %0 = "pdl.attribute"() : () -> !pdl.attribute
+  %1 = "pdl.operation"(%0) <{"attributeValueNames" = ["attrA", "attrB"], "operandSegmentSizes" = array<i32: 0, 1, 0>}> : (!pdl.attribute) -> !pdl.operation
+}) : () -> ()
+
+// CHECK: pdl.operation: Expected the same number of attribute values and attribute names, got 1 values and 2 names

--- a/Test/PDL/operation_attribute_names_type_invalid.mlir
+++ b/Test/PDL/operation_attribute_names_type_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// `attributeValueNames` holds attribute names, which are strings.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [0 : i32], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+}) : () -> ()
+
+// CHECK: pdl.operation: expected 'attributeValueNames' to hold string attributes, but got 0 : i32

--- a/Test/PDL/operation_invalid.mlir
+++ b/Test/PDL/operation_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// A `pdl.operation` produces an `!pdl.operation` handle, not an arbitrary type.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> i32
+}) : () -> ()
+
+// CHECK: pdl.operation: Expected the result to be of type '!pdl.operation'

--- a/Test/PDL/operation_operand_type_invalid.mlir
+++ b/Test/PDL/operation_operand_type_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// The `operandValues` group of a `pdl.operation` holds `!pdl.value` handles, so
+// an `!pdl.attribute` handle in that group is rejected.
+"builtin.module"() ({
+  %0 = "pdl.attribute"() : () -> !pdl.attribute
+  %1 = "pdl.operation"(%0) <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!pdl.attribute) -> !pdl.operation
+}) : () -> ()
+
+// CHECK: pdl.operation: Expected operand 0 to be of type '!pdl.value'

--- a/Test/PDL/operation_property_invalid.mlir
+++ b/Test/PDL/operation_property_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// `attributeValueNames` is required on a `pdl.operation`.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+}) : () -> ()
+
+// CHECK: pdl.operation: missing 'attributeValueNames' property

--- a/Test/PDL/operation_segment_sizes_invalid.mlir
+++ b/Test/PDL/operation_segment_sizes_invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// `operandSegmentSizes` must account for every operand.
+"builtin.module"() ({
+  %0 = "pdl.operand"() : () -> !pdl.value
+  %1 = "pdl.operation"(%0) <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : (!pdl.value) -> !pdl.operation
+}) : () -> ()
+
+// CHECK: pdl.operation: operandSegmentSizes describes 0 operands, got 1

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -14,6 +14,7 @@ public section
 inductive PDL where
 | attribute
 | operand
+| operation
 | type
 deriving Inhabited, Repr, Hashable, DecidableEq
 
@@ -22,6 +23,7 @@ def PDL.propertiesOf (op : PDL) : Type :=
 match op with
 | .attribute => PDLAttributeProperties
 | .operand => Unit
+| .operation => PDLOperationProperties
 | .type => PDLTypeProperties
 
 def PDL.fromAttrDict
@@ -35,6 +37,7 @@ def PDL.fromAttrDict
       .error s!"pdl.operand: expected no properties, but got {attrDict.size} {plural}"
     else
       .ok ()
+  | .operation => PDLOperationProperties.fromAttrDict attrDict
   | .type => PDLTypeProperties.fromAttrDict attrDict
 
 def PDL.toAttrDict
@@ -46,6 +49,13 @@ def PDL.toAttrDict
     | some value => (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 value
     | none => Std.HashMap.emptyWithCapacity 0
   | .operand => Std.HashMap.emptyWithCapacity 0
+  | .operation => Id.run do
+    let mut dict : Std.HashMap ByteArray Attribute := Std.HashMap.emptyWithCapacity 3
+    if let some opName := props.opName then
+      dict := dict.insert "opName".toUTF8 (.stringAttr opName)
+    dict := dict.insert "attributeValueNames".toUTF8 (.arrayAttr props.attributeValueNames)
+    dict := dict.insert "operandSegmentSizes".toUTF8 (.denseArrayAttr props.operandSegmentSizes)
+    dict
   | .type =>
     match props.constantType with
     | some constantType =>
@@ -131,6 +141,39 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
       let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
       if operandType.val ≠ (PDL.TypeType.mk : TypeAttr).val then
         throw "Expected the `valueType` operand to be of type '!pdl.type'"
+  | .operation =>
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    op.verifyResultTypeMatches ctx (PDL.OperationType.mk : TypeAttr)
+      "Expected the result to be of type '!pdl.operation'"
+    let props : PDL.propertiesOf .operation :=
+      HasDialect.toDialectProperties (OpInfo := OpInfo) PDL.operation
+        (op.getProperties! ctx.raw (ofDialect OpInfo PDL.operation))
+    /- The operands are the `operandValues`, `attributeValues` and `typeValues`
+       groups, laid out consecutively in that order. -/
+    let segments ← op.verifyOperandSegmentSizes ctx opIn props.operandSegmentSizes 3
+    let valueCount := segments[0]!
+    let attributeCount := segments[1]!
+    let typeCount := segments[2]!
+    /- Every attribute operand is named positionally by `attributeValueNames`. -/
+    let nameCount := props.attributeValueNames.value.size
+    if nameCount ≠ attributeCount then
+      throw s!"Expected the same number of attribute values and attribute names, got {attributeCount} values and {nameCount} names"
+    /- TODO: `!pdl.range<...>` is not modelled yet, so the value and type groups
+       accept single handles only. -/
+    for i in [0:valueCount] do
+      if ((op.getOperand! ctx.raw i).getType! ctx.raw).val ≠ (PDL.ValueType.mk : TypeAttr).val then
+        throw s!"Expected operand {i} to be of type '!pdl.value'"
+    for i in [valueCount:valueCount + attributeCount] do
+      if ((op.getOperand! ctx.raw i).getType! ctx.raw).val ≠ (PDL.AttributeType.mk : TypeAttr).val then
+        throw s!"Expected operand {i} to be of type '!pdl.attribute'"
+    for i in [valueCount + attributeCount:valueCount + attributeCount + typeCount] do
+      if ((op.getOperand! ctx.raw i).getType! ctx.raw).val ≠ (PDL.TypeType.mk : TypeAttr).val then
+        throw s!"Expected operand {i} to be of type '!pdl.type'"
   | .type =>
     /- The optional `constantType` is a property, so `pdl.type` takes no
        operands. -/

--- a/Veir/Dialects/PDL/Properties.lean
+++ b/Veir/Dialects/PDL/Properties.lean
@@ -49,6 +49,46 @@ def PDLTypeProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) 
     throw s!"pdl.type: expected only the 'constantType' property, but got {attrDict.size} properties"
   return { constantType := constantType }
 
+/--
+  Properties of the `pdl.operation` operation.
+
+  `opName` is the optional name of the operation being matched or created; it is
+  absent when the pattern matches an operation of any name.
+
+  `attributeValueNames` names the `attributeValues` operands positionally, so it
+  holds one string attribute per attribute operand.
+
+  `operandSegmentSizes` splits the operands into the `operandValues`,
+  `attributeValues`, and `typeValues` groups, in that order.
+-/
+structure PDLOperationProperties where
+  opName : Option StringAttr
+  attributeValueNames : ArrayAttr
+  operandSegmentSizes : DenseArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def PDLOperationProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String PDLOperationProperties := do
+  let opName ← match attrDict["opName".toUTF8]? with
+    | some (.stringAttr attr) => pure (some attr)
+    | some attr =>
+      throw s!"pdl.operation: expected 'opName' to be a string attribute, but got {attr}"
+    | none => pure none
+  let some namesAttr := attrDict["attributeValueNames".toUTF8]?
+    | throw "pdl.operation: missing 'attributeValueNames' property"
+  let .arrayAttr attributeValueNames := namesAttr
+    | throw s!"pdl.operation: expected 'attributeValueNames' to be an array attribute, but got {namesAttr}"
+  for name in attributeValueNames.value do
+    let .stringAttr _ := name
+      | throw s!"pdl.operation: expected 'attributeValueNames' to hold string attributes, but got {name}"
+  let some sizesAttr := attrDict["operandSegmentSizes".toUTF8]?
+    | throw "pdl.operation: missing 'operandSegmentSizes' property"
+  let .denseArrayAttr operandSegmentSizes := sizesAttr
+    | throw s!"pdl.operation: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
+  if attrDict.size > (if opName.isSome then 3 else 2) then
+    throw s!"pdl.operation: expected only the 'opName', 'attributeValueNames' and 'operandSegmentSizes' properties, but got {attrDict.size} properties"
+  return { opName, attributeValueNames, operandSegmentSizes }
+
 end
 
 end Veir

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -81,6 +81,27 @@ def OperationPtr.verifyUnconditionalBranch (op : OperationPtr)
     throw s!"{instrName}: branch expected operand count {dest.getNumArguments! ctx.raw}, got {op.getNumOperands ctx.raw opIn}"
   op.verifyBranchSuccessorArgTypes ctx 0 dest s!"{instrName}: successor"
 
+/--
+  Validate an `operandSegmentSizes` property that splits an operation's operands
+  into `expectedSegments` consecutive groups, and return the group sizes.
+-/
+def OperationPtr.verifyOperandSegmentSizes
+    (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
+    (sizes : DenseArrayAttr) (expectedSegments : Nat) :
+    Except String (Array Nat) := do
+  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  if sizes.values.size ≠ expectedSegments then
+    throw s!"{instrName}: operandSegmentSizes expected {expectedSegments} entries, got {sizes.values.size}"
+  let mut segmentSizes : Array Nat := #[]
+  for size in sizes.values do
+    if size < 0 then
+      throw s!"{instrName}: operandSegmentSizes contains negative size {size}"
+    segmentSizes := segmentSizes.push size.toNat
+  let segmentSum := segmentSizes.foldl (init := 0) fun acc size => acc + size
+  if segmentSum ≠ op.getNumOperands ctx.raw opIn then
+    throw s!"{instrName}: operandSegmentSizes describes {segmentSum} operands, got {op.getNumOperands ctx.raw opIn}"
+  return segmentSizes
+
 def OperationPtr.verifyCondBranchOperandSegmentSizes
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (sizes : DenseArrayAttr) (fixedOperands : Nat) :


### PR DESCRIPTION
The hub of the dialect: it consumes `!pdl.value`, `!pdl.attribute` and `!pdl.type` handles and produces an `!pdl.operation` handle, which until now had no producer.

Its operands are split into the `operandValues`, `attributeValues` and `typeValues` groups by `operandSegmentSizes`, so this adds a general `verifyOperandSegmentSizes` helper alongside the branch-specific one.

`!pdl.range<...>` is not modelled yet, so the value and type groups accept single handles only.