### PR TITLE
feat: mirror more of MLIR's side effect system

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -13,3 +13,4 @@ import UnitTest.DataFlowFramework.DeadCodeAnalysis
 import UnitTest.ConstantValue
 import UnitTest.Evaluate
 import UnitTest.FoldDecision
+import UnitTest.SideEffectInterfaces

--- a/UnitTest/SideEffectInterfaces.lean
+++ b/UnitTest/SideEffectInterfaces.lean
@@ -1,0 +1,31 @@
+import Veir.GlobalOpInfo
+import Veir.Interfaces.SideEffectInterfaces
+import Veir.Rewriter.WfRewriter.Basic
+
+open Veir
+
+private def volatileLoadProperties : LoadProperties :=
+  { (default : LoadProperties) with volatile_ := true }
+
+private def volatileStoreProperties : StoreProperties :=
+  { (default : StoreProperties) with volatile_ := true }
+
+/- The memory-effect queries distinguish reads from writes and inspect properties. -/
+
+#guard OpCode.readsMemory (.llvm .load) (default : LoadProperties)
+#guard !(OpCode.writesMemory (.llvm .load) (default : LoadProperties))
+#guard OpCode.writesMemory (.llvm .load) volatileLoadProperties
+
+#guard OpCode.writesMemory (.llvm .store) (default : StoreProperties)
+#guard !(OpCode.readsMemory (.llvm .store) (default : StoreProperties))
+#guard OpCode.readsMemory (.llvm .store) volatileStoreProperties
+
+/- Operations carrying regions are conservatively treated as reading and writing. -/
+
+/-- A `builtin.module` op, which always carries a single region. -/
+private def moduleWithRegion : OperationPtr × IRContext OpCode :=
+  let (ctx, moduleOp) := WfIRContext.create! OpCode
+  (moduleOp, ctx.raw)
+
+#guard moduleWithRegion.1.readsMemory moduleWithRegion.2
+#guard moduleWithRegion.1.writesMemory moduleWithRegion.2

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -114,7 +114,10 @@ def Arith.toAttrDict
 def Arith.hasSideEffects (_op : Arith) (_props : Arith.propertiesOf _op) : Bool :=
   false
 
-def Arith.readsMemory (_op : Arith) : Bool :=
+def Arith.readsMemory (_op : Arith) (_props : Arith.propertiesOf _op) : Bool :=
+  false
+
+def Arith.writesMemory (_op : Arith) (_props : Arith.propertiesOf _op) : Bool :=
   false
 
 def Arith.isConstantLike (op : Arith) : Bool :=
@@ -135,6 +138,7 @@ instance : HasDialectOpInfo Arith where
   toAttrDict := Arith.toAttrDict
   hasSideEffects := Arith.hasSideEffects
   readsMemory := Arith.readsMemory
+  writesMemory := Arith.writesMemory
   isConstantLike := Arith.isConstantLike
   hasSSADominance := Arith.hasSSADominance
 

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -41,8 +41,17 @@ def Builtin.hasSideEffects (op : Builtin) (_props : Builtin.propertiesOf op) : B
   | .unrealized_conversion_cast => false
   | _ => true
 
-def Builtin.readsMemory (_op : Builtin) : Bool :=
-  false
+def Builtin.readsMemory
+    (op : Builtin) (_props : Builtin.propertiesOf op) : Bool :=
+  match op with
+  | .unrealized_conversion_cast => false
+  | _ => true
+
+def Builtin.writesMemory
+    (op : Builtin) (_props : Builtin.propertiesOf op) : Bool :=
+  match op with
+  | .unrealized_conversion_cast => false
+  | _ => true
 
 def Builtin.isConstantLike (_op : Builtin) : Bool :=
   false
@@ -69,6 +78,7 @@ instance : HasDialectOpInfo Builtin where
   toAttrDict := Builtin.toAttrDict
   hasSideEffects := Builtin.hasSideEffects
   readsMemory := Builtin.readsMemory
+  writesMemory := Builtin.writesMemory
   isConstantLike := Builtin.isConstantLike
   hasSSADominance := Builtin.hasSSADominance
   hasNoTerminator := Builtin.hasNoTerminator

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -43,7 +43,10 @@ def Cf.toAttrDict
 def Cf.hasSideEffects (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
   true
 
-def Cf.readsMemory (_op : Cf) : Bool :=
+def Cf.readsMemory (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
+  false
+
+def Cf.writesMemory (_op : Cf) (_props : Cf.propertiesOf _op) : Bool :=
   false
 
 def Cf.isConstantLike (_op : Cf) : Bool :=
@@ -62,6 +65,7 @@ instance : HasDialectOpInfo Cf where
   toAttrDict := Cf.toAttrDict
   hasSideEffects := Cf.hasSideEffects
   readsMemory := Cf.readsMemory
+  writesMemory := Cf.writesMemory
   isConstantLike := Cf.isConstantLike
   hasSSADominance := Cf.hasSSADominance
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -63,7 +63,10 @@ def Comb.toAttrDict
 def Comb.hasSideEffects (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
   false
 
-def Comb.readsMemory (_op : Comb) : Bool :=
+def Comb.readsMemory (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
+  false
+
+def Comb.writesMemory (_op : Comb) (_props : Comb.propertiesOf _op) : Bool :=
   false
 
 def Comb.isConstantLike (_op : Comb) : Bool :=
@@ -82,6 +85,7 @@ instance : HasDialectOpInfo Comb where
   toAttrDict := Comb.toAttrDict
   hasSideEffects := Comb.hasSideEffects
   readsMemory := Comb.readsMemory
+  writesMemory := Comb.writesMemory
   isConstantLike := Comb.isConstantLike
   hasSSADominance := Comb.hasSSADominance
 

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -33,7 +33,12 @@ def Datapath.hasSideEffects
     (_op : Datapath) (_props : Datapath.propertiesOf _op) : Bool :=
   false
 
-def Datapath.readsMemory (_op : Datapath) : Bool :=
+def Datapath.readsMemory
+    (_op : Datapath) (_props : Datapath.propertiesOf _op) : Bool :=
+  false
+
+def Datapath.writesMemory
+    (_op : Datapath) (_props : Datapath.propertiesOf _op) : Bool :=
   false
 
 def Datapath.isConstantLike (_op : Datapath) : Bool :=
@@ -52,6 +57,7 @@ instance : HasDialectOpInfo Datapath where
   toAttrDict := Datapath.toAttrDict
   hasSideEffects := Datapath.hasSideEffects
   readsMemory := Datapath.readsMemory
+  writesMemory := Datapath.writesMemory
   isConstantLike := Datapath.isConstantLike
   hasSSADominance := Datapath.hasSSADominance
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -51,8 +51,15 @@ def Func.toAttrDict
 def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
   true
 
-def Func.readsMemory (_op : Func) : Bool :=
-  false
+def Func.readsMemory (op : Func) (_props : Func.propertiesOf op) : Bool :=
+  match op with
+  | .call => true
+  | _ => false
+
+def Func.writesMemory (op : Func) (_props : Func.propertiesOf op) : Bool :=
+  match op with
+  | .call => true
+  | _ => false
 
 def Func.isConstantLike (_op : Func) : Bool :=
   false
@@ -70,6 +77,7 @@ instance : HasDialectOpInfo Func where
   toAttrDict := Func.toAttrDict
   hasSideEffects := Func.hasSideEffects
   readsMemory := Func.readsMemory
+  writesMemory := Func.writesMemory
   isConstantLike := Func.isConstantLike
   hasSSADominance := Func.hasSSADominance
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -54,12 +54,12 @@ def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
 def Func.readsMemory (op : Func) (_props : Func.propertiesOf op) : Bool :=
   match op with
   | .call => true
-  | _ => false
+  | .func | .return => false
 
 def Func.writesMemory (op : Func) (_props : Func.propertiesOf op) : Bool :=
   match op with
   | .call => true
-  | _ => false
+  | .func | .return => false
 
 def Func.isConstantLike (_op : Func) : Bool :=
   false

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -52,7 +52,10 @@ def HW.hasSideEffects (op : HW) (_props : HW.propertiesOf op) : Bool :=
   | .constant => false
   | _ => true
 
-def HW.readsMemory (_op : HW) : Bool :=
+def HW.readsMemory (_op : HW) (_props : HW.propertiesOf _op) : Bool :=
+  false
+
+def HW.writesMemory (_op : HW) (_props : HW.propertiesOf _op) : Bool :=
   false
 
 def HW.isConstantLike (op : HW) : Bool :=
@@ -73,6 +76,7 @@ instance : HasDialectOpInfo HW where
   toAttrDict := HW.toAttrDict
   hasSideEffects := HW.hasSideEffects
   readsMemory := HW.readsMemory
+  writesMemory := HW.writesMemory
   isConstantLike := HW.isConstantLike
   hasSSADominance := HW.hasSSADominance
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -309,10 +309,53 @@ def Llvm.hasSideEffects (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
   -- For everything else: be conservative!
   | _, _ => true
 
-def Llvm.readsMemory (op : Llvm) : Bool :=
-  match op with
-  | .load => true
-  | _ => false
+def Llvm.readsMemory (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
+  match op, props with
+  | .store, props => props.volatile_
+  | .mlir__constant, _ | .mlir__poison, _ | .mlir__addressof, _
+  | .and, _ | .or, _ | .xor, _
+  | .add, _ | .sub, _ | .mul, _
+  | .sdiv, _ | .udiv, _ | .srem, _ | .urem, _
+  | .shl, _ | .lshr, _ | .ashr, _
+  | .intr__ctlz, _ | .intr__cttz, _ | .intr__ctpop, _
+  | .intr__bswap, _ | .intr__bitreverse, _
+  | .intr__fshl, _ | .intr__fshr, _
+  | .icmp, _ | .select, _
+  | .trunc, _ | .sext, _ | .zext, _
+  | .getelementptr, _
+  | .br, _ | .cond_br, _ | .return, _
+  | .freeze, _ | .bitcast, _
+  | .intr__smax, _ | .intr__smin, _ | .intr__umax, _ | .intr__umin, _
+  | .intr__abs, _
+  | .intr__sadd__sat, _ | .intr__uadd__sat, _
+  | .intr__ssub__sat, _ | .intr__usub__sat, _
+  | .intr__sshl__sat, _ | .intr__ushl__sat, _
+  | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _ => false
+  | _, _ => true
+
+def Llvm.writesMemory (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
+  match op, props with
+  | .load, props => props.volatile_
+  | .mlir__constant, _ | .mlir__poison, _ | .mlir__addressof, _
+  | .and, _ | .or, _ | .xor, _
+  | .add, _ | .sub, _ | .mul, _
+  | .sdiv, _ | .udiv, _ | .srem, _ | .urem, _
+  | .shl, _ | .lshr, _ | .ashr, _
+  | .intr__ctlz, _ | .intr__cttz, _ | .intr__ctpop, _
+  | .intr__bswap, _ | .intr__bitreverse, _
+  | .intr__fshl, _ | .intr__fshr, _
+  | .icmp, _ | .select, _
+  | .trunc, _ | .sext, _ | .zext, _
+  | .getelementptr, _
+  | .br, _ | .cond_br, _ | .return, _
+  | .freeze, _ | .bitcast, _
+  | .intr__smax, _ | .intr__smin, _ | .intr__umax, _ | .intr__umin, _
+  | .intr__abs, _
+  | .intr__sadd__sat, _ | .intr__uadd__sat, _
+  | .intr__ssub__sat, _ | .intr__usub__sat, _
+  | .intr__sshl__sat, _ | .intr__ushl__sat, _
+  | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _ => false
+  | _, _ => true
 
 def Llvm.isConstantLike (op : Llvm) : Bool :=
   match op with
@@ -332,6 +375,7 @@ instance : HasDialectOpInfo Llvm where
   toAttrDict := Llvm.toAttrDict
   hasSideEffects := Llvm.hasSideEffects
   readsMemory := Llvm.readsMemory
+  writesMemory := Llvm.writesMemory
   isConstantLike := Llvm.isConstantLike
   hasSSADominance := Llvm.hasSSADominance
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -43,7 +43,12 @@ def Mod_Arith.hasSideEffects
     (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : Bool :=
   false
 
-def Mod_Arith.readsMemory (_op : Mod_Arith) : Bool :=
+def Mod_Arith.readsMemory
+    (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : Bool :=
+  false
+
+def Mod_Arith.writesMemory
+    (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : Bool :=
   false
 
 def Mod_Arith.isConstantLike (op : Mod_Arith) : Bool :=
@@ -64,5 +69,6 @@ instance : HasDialectOpInfo Mod_Arith where
   toAttrDict := Mod_Arith.toAttrDict
   hasSideEffects := Mod_Arith.hasSideEffects
   readsMemory := Mod_Arith.readsMemory
+  writesMemory := Mod_Arith.writesMemory
   isConstantLike := Mod_Arith.isConstantLike
   hasSSADominance := Mod_Arith.hasSSADominance

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -129,7 +129,10 @@ def PDL.hasSideEffects (op : PDL) (_props : PDL.propertiesOf op) : Bool :=
   | .range | .result | .results => false
   | _ => true
 
-def PDL.readsMemory (_op : PDL) : Bool :=
+def PDL.readsMemory (_op : PDL) (_props : PDL.propertiesOf _op) : Bool :=
+  false
+
+def PDL.writesMemory (_op : PDL) (_props : PDL.propertiesOf _op) : Bool :=
   false
 
 def PDL.isConstantLike (_op : PDL) : Bool :=
@@ -155,6 +158,7 @@ instance : HasDialectOpInfo PDL where
   toAttrDict := PDL.toAttrDict
   hasSideEffects := PDL.hasSideEffects
   readsMemory := PDL.readsMemory
+  writesMemory := PDL.writesMemory
   isConstantLike := PDL.isConstantLike
   hasSSADominance := PDL.hasSSADominance
   hasNoTerminator := PDL.hasNoTerminator

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -274,7 +274,7 @@ def Riscv.readsMemory (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
   | .mv, _ | .not, _ | .neg, _ | .negw, _
   | .sextw, _ | .zextb, _ | .zextw, _
   | .seqz, _ | .snez, _ | .sltz, _ | .sgtz, _ => false
-  -- For everything else: be conservative!
+  -- Conservative default
   | _, _ => true
 
 def Riscv.writesMemory (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
@@ -310,7 +310,7 @@ def Riscv.writesMemory (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
   | .mv, _ | .not, _ | .neg, _ | .negw, _
   | .sextw, _ | .zextb, _ | .zextw, _
   | .seqz, _ | .snez, _ | .sltz, _ | .sgtz, _ => false
-  -- For everything else: be conservative!
+  -- Conservative default
   | _, _ => true
 
 def Riscv.isConstantLike (op : Riscv) : Bool :=

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -242,12 +242,76 @@ def Riscv.hasSideEffects (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
     -- For everything else: be conservative!
     | _ => true
 
-def Riscv.readsMemory (op : Riscv) : Bool :=
-  match op with
-  | .ld | .lw | .lwu
-  | .lh | .lhu
-  | .lb | .lbu => true
-  | _ => false
+def Riscv.readsMemory (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
+  match op, props with
+  -- A volatile store also reads; ordinary loads reach the default below.
+  | .sd, props | .sw, props
+  | .sh, props | .sb, props => props.volatile_
+  | .li, _ | .lui, _ | .auipc, _
+  | .addi, _ | .slti, _ | .sltiu, _
+  | .andi, _ | .ori, _ | .xori, _
+  | .addiw, _ | .slli, _ | .srli, _ | .srai, _
+  | .add, _ | .sub, _ | .sll, _ | .slt, _ | .sltu, _
+  | .xor, _ | .srl, _ | .sra, _ | .or, _ | .and, _
+  | .slliw, _ | .srliw, _ | .sraiw, _
+  | .addw, _ | .subw, _ | .sllw, _ | .srlw, _ | .sraw, _
+  | .rem, _ | .remu, _ | .remw, _ | .remuw, _
+  | .mul, _ | .mulh, _ | .mulhu, _ | .mulhsu, _ | .mulw, _
+  | .div, _ | .divw, _ | .divu, _ | .divuw, _
+  | .adduw, _ | .sh1adduw, _ | .sh2adduw, _ | .sh3adduw, _
+  | .sh1add, _ | .sh2add, _ | .sh3add, _ | .slliuw, _
+  | .andn, _ | .orn, _ | .xnor, _
+  | .max, _ | .maxu, _ | .min, _ | .minu, _
+  | .rol, _ | .ror, _ | .rolw, _ | .rorw, _
+  | .sextb, _ | .sexth, _ | .zexth, _
+  | .clz, _ | .clzw, _ | .ctz, _ | .ctzw, _
+  | .cpop, _ | .cpopw, _ | .orcb, _ | .rev8, _
+  | .rori, _ | .roriw, _
+  | .bclr, _ | .bext, _ | .binv, _ | .bset, _
+  | .bclri, _ | .bexti, _ | .binvi, _ | .bseti, _
+  | .pack, _ | .packh, _ | .packw, _
+  | .czeroeqz, _ | .czeronez, _
+  | .mv, _ | .not, _ | .neg, _ | .negw, _
+  | .sextw, _ | .zextb, _ | .zextw, _
+  | .seqz, _ | .snez, _ | .sltz, _ | .sgtz, _ => false
+  -- For everything else: be conservative!
+  | _, _ => true
+
+def Riscv.writesMemory (op : Riscv) (props : Riscv.propertiesOf op) : Bool :=
+  match op, props with
+  -- A volatile load also writes; ordinary stores reach the default below.
+  | .ld, props | .lw, props | .lwu, props
+  | .lh, props | .lhu, props
+  | .lb, props | .lbu, props => props.volatile_
+  | .li, _ | .lui, _ | .auipc, _
+  | .addi, _ | .slti, _ | .sltiu, _
+  | .andi, _ | .ori, _ | .xori, _
+  | .addiw, _ | .slli, _ | .srli, _ | .srai, _
+  | .add, _ | .sub, _ | .sll, _ | .slt, _ | .sltu, _
+  | .xor, _ | .srl, _ | .sra, _ | .or, _ | .and, _
+  | .slliw, _ | .srliw, _ | .sraiw, _
+  | .addw, _ | .subw, _ | .sllw, _ | .srlw, _ | .sraw, _
+  | .rem, _ | .remu, _ | .remw, _ | .remuw, _
+  | .mul, _ | .mulh, _ | .mulhu, _ | .mulhsu, _ | .mulw, _
+  | .div, _ | .divw, _ | .divu, _ | .divuw, _
+  | .adduw, _ | .sh1adduw, _ | .sh2adduw, _ | .sh3adduw, _
+  | .sh1add, _ | .sh2add, _ | .sh3add, _ | .slliuw, _
+  | .andn, _ | .orn, _ | .xnor, _
+  | .max, _ | .maxu, _ | .min, _ | .minu, _
+  | .rol, _ | .ror, _ | .rolw, _ | .rorw, _
+  | .sextb, _ | .sexth, _ | .zexth, _
+  | .clz, _ | .clzw, _ | .ctz, _ | .ctzw, _
+  | .cpop, _ | .cpopw, _ | .orcb, _ | .rev8, _
+  | .rori, _ | .roriw, _
+  | .bclr, _ | .bext, _ | .binv, _ | .bset, _
+  | .bclri, _ | .bexti, _ | .binvi, _ | .bseti, _
+  | .pack, _ | .packh, _ | .packw, _
+  | .czeroeqz, _ | .czeronez, _
+  | .mv, _ | .not, _ | .neg, _ | .negw, _
+  | .sextw, _ | .zextb, _ | .zextw, _
+  | .seqz, _ | .snez, _ | .sltz, _ | .sgtz, _ => false
+  -- For everything else: be conservative!
+  | _, _ => true
 
 def Riscv.isConstantLike (op : Riscv) : Bool :=
   match op with
@@ -267,6 +331,7 @@ instance : HasDialectOpInfo Riscv where
   toAttrDict := Riscv.toAttrDict
   hasSideEffects := Riscv.hasSideEffects
   readsMemory := Riscv.readsMemory
+  writesMemory := Riscv.writesMemory
   isConstantLike := Riscv.isConstantLike
   hasSSADominance := Riscv.hasSSADominance
 

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -57,7 +57,12 @@ def Riscv_Cf.hasSideEffects
     (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : Bool :=
   true
 
-def Riscv_Cf.readsMemory (_op : Riscv_Cf) : Bool :=
+def Riscv_Cf.readsMemory
+    (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : Bool :=
+  false
+
+def Riscv_Cf.writesMemory
+    (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : Bool :=
   false
 
 def Riscv_Cf.isConstantLike (_op : Riscv_Cf) : Bool :=
@@ -76,6 +81,7 @@ instance : HasDialectOpInfo Riscv_Cf where
   toAttrDict := Riscv_Cf.toAttrDict
   hasSideEffects := Riscv_Cf.hasSideEffects
   readsMemory := Riscv_Cf.readsMemory
+  writesMemory := Riscv_Cf.writesMemory
   isConstantLike := Riscv_Cf.isConstantLike
   hasSSADominance := Riscv_Cf.hasSSADominance
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -38,7 +38,12 @@ def Riscv_Stack.hasSideEffects
     (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : Bool :=
   true
 
-def Riscv_Stack.readsMemory (_op : Riscv_Stack) : Bool :=
+def Riscv_Stack.readsMemory
+    (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : Bool :=
+  false
+
+def Riscv_Stack.writesMemory
+    (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : Bool :=
   false
 
 def Riscv_Stack.isConstantLike (_op : Riscv_Stack) : Bool :=
@@ -57,6 +62,7 @@ instance : HasDialectOpInfo Riscv_Stack where
   toAttrDict := Riscv_Stack.toAttrDict
   hasSideEffects := Riscv_Stack.hasSideEffects
   readsMemory := Riscv_Stack.readsMemory
+  writesMemory := Riscv_Stack.writesMemory
   isConstantLike := Riscv_Stack.isConstantLike
   hasSSADominance := Riscv_Stack.hasSSADominance
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -32,7 +32,10 @@ def Rv64.toAttrDict
 def Rv64.hasSideEffects (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
   true
 
-def Rv64.readsMemory (_op : Rv64) : Bool :=
+def Rv64.readsMemory (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
+  false
+
+def Rv64.writesMemory (_op : Rv64) (_props : Rv64.propertiesOf _op) : Bool :=
   false
 
 def Rv64.isConstantLike (_op : Rv64) : Bool :=
@@ -51,6 +54,7 @@ instance : HasDialectOpInfo Rv64 where
   toAttrDict := Rv64.toAttrDict
   hasSideEffects := Rv64.hasSideEffects
   readsMemory := Rv64.readsMemory
+  writesMemory := Rv64.writesMemory
   isConstantLike := Rv64.isConstantLike
   hasSSADominance := Rv64.hasSSADominance
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -30,8 +30,11 @@ def Test.toAttrDict
 def Test.hasSideEffects (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
   true
 
-def Test.readsMemory (_op : Test) : Bool :=
-  false
+def Test.readsMemory (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
+  true
+
+def Test.writesMemory (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
+  true
 
 def Test.isConstantLike (_op : Test) : Bool :=
   false
@@ -52,6 +55,7 @@ instance : HasDialectOpInfo Test where
   toAttrDict := Test.toAttrDict
   hasSideEffects := Test.hasSideEffects
   readsMemory := Test.readsMemory
+  writesMemory := Test.writesMemory
   isConstantLike := Test.isConstantLike
   hasSSADominance := Test.hasSSADominance
   hasNoTerminator := Test.hasNoTerminator

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -50,23 +50,47 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
 /--
   Does an operation with this opcode read memory?
 -/
-def OpCode.readsMemory (opCode : OpCode) : Bool :=
-  match opCode with
-  | .arith op => Arith.readsMemory op
-  | .llvm op => Llvm.readsMemory op
-  | .riscv op => Riscv.readsMemory op
-  | .riscv_cf op => Riscv_Cf.readsMemory op
-  | .riscv_stack op => Riscv_Stack.readsMemory op
-  | .rv64 op => Rv64.readsMemory op
-  | .mod_arith op => Mod_Arith.readsMemory op
-  | .cf op => Cf.readsMemory op
-  | .comb op => Comb.readsMemory op
-  | .hw op => HW.readsMemory op
-  | .builtin op => Builtin.readsMemory op
-  | .func op => Func.readsMemory op
-  | .datapath op => Datapath.readsMemory op
-  | .pdl op => PDL.readsMemory op
-  | .test op => Test.readsMemory op
+def OpCode.readsMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :=
+  match opCode, props with
+  | .arith op, props => Arith.readsMemory op props
+  | .llvm op, props => Llvm.readsMemory op props
+  | .riscv op, props => Riscv.readsMemory op props
+  | .riscv_cf op, props => Riscv_Cf.readsMemory op props
+  | .riscv_stack op, props => Riscv_Stack.readsMemory op props
+  | .rv64 op, props => Rv64.readsMemory op props
+  | .mod_arith op, props => Mod_Arith.readsMemory op props
+  | .cf op, props => Cf.readsMemory op props
+  | .comb op, props => Comb.readsMemory op props
+  | .hw op, props => HW.readsMemory op props
+  | .builtin op, props => Builtin.readsMemory op props
+  | .func op, props => Func.readsMemory op props
+  | .datapath op, props => Datapath.readsMemory op props
+  | .pdl op, props => PDL.readsMemory op props
+  | .test op, props => Test.readsMemory op props
+
+/--
+  Does an operation with this opcode and these properties write memory?
+
+  A `true` result says only that the operation may modify memory; it does not
+  establish a complete overwrite of any particular location.
+-/
+def OpCode.writesMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :=
+  match opCode, props with
+  | .arith op, props => Arith.writesMemory op props
+  | .llvm op, props => Llvm.writesMemory op props
+  | .riscv op, props => Riscv.writesMemory op props
+  | .riscv_cf op, props => Riscv_Cf.writesMemory op props
+  | .riscv_stack op, props => Riscv_Stack.writesMemory op props
+  | .rv64 op, props => Rv64.writesMemory op props
+  | .mod_arith op, props => Mod_Arith.writesMemory op props
+  | .cf op, props => Cf.writesMemory op props
+  | .comb op, props => Comb.writesMemory op props
+  | .hw op, props => HW.writesMemory op props
+  | .builtin op, props => Builtin.writesMemory op props
+  | .func op, props => Func.writesMemory op props
+  | .datapath op, props => Datapath.writesMemory op props
+  | .pdl op, props => PDL.writesMemory op props
+  | .test op, props => Test.writesMemory op props
 
 /--
   Does an operation with this opcode and these properties have effects that
@@ -236,6 +260,7 @@ instance : HasDialectOpInfo OpCode where
   toAttrDict := Properties.toAttrDict
   hasSideEffects := OpCode.hasSideEffects
   readsMemory := OpCode.readsMemory
+  writesMemory := OpCode.writesMemory
   isConstantLike := OpCode.isConstantLike
   hasSSADominance := OpCode.hasSSADominance
   hasNoTerminator := OpCode.hasNoTerminator

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -48,7 +48,7 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | _ => false
 
 /--
-  Does an operation with this opcode read memory?
+  Does an operation with this opcode and these properties read memory?
 -/
 def OpCode.readsMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :=
   match opCode, props with
@@ -70,9 +70,6 @@ def OpCode.readsMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :
 
 /--
   Does an operation with this opcode and these properties write memory?
-
-  A `true` result says only that the operation may modify memory; it does not
-  establish a complete overwrite of any particular location.
 -/
 def OpCode.writesMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :=
   match opCode, props with

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -54,10 +54,30 @@ class HasDialectOpInfo (opCode: Type)
   this as well before running an operation against memory that is not the
   program's.
 
+  This describes the operation itself and says nothing about operations nested
+  in its regions, which an opcode and its properties cannot see. Callers
+  holding an `OperationPtr` should use `OperationPtr.readsMemory`, which
+  accounts for regions.
+
   Defaults to `true` for every opcode, which conservatively assumes memory is
   read.
   -/
-  readsMemory : opCode → Bool := fun _ => true
+  readsMemory : (op : opCode) → propertiesOf op → Bool := fun _ _ => true
+  /--
+  Whether an operation with this opcode writes memory.
+
+  This reports only that memory may be modified. It does not imply that the
+  operation completely overwrites any particular location, so it is not by
+  itself sufficient to prove that an earlier write is dead.
+
+  As with `readsMemory`, this describes the operation itself and not the
+  operations nested in its regions; use `OperationPtr.writesMemory` when an
+  `OperationPtr` is available.
+
+  Defaults to `true` for every opcode, which conservatively assumes memory is
+  written.
+  -/
+  writesMemory : (op : opCode) → propertiesOf op → Bool := fun _ _ => true
   /--
   Whether an operation with this opcode materializes a literal constant
   value: no operands, one result, no side effects, and a result that is

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -54,11 +54,6 @@ class HasDialectOpInfo (opCode: Type)
   this as well before running an operation against memory that is not the
   program's.
 
-  This describes the operation itself and says nothing about operations nested
-  in its regions, which an opcode and its properties cannot see. Callers
-  holding an `OperationPtr` should use `OperationPtr.readsMemory`, which
-  accounts for regions.
-
   Defaults to `true` for every opcode, which conservatively assumes memory is
   read.
   -/
@@ -69,10 +64,6 @@ class HasDialectOpInfo (opCode: Type)
   This reports only that memory may be modified. It does not imply that the
   operation completely overwrites any particular location, so it is not by
   itself sufficient to prove that an earlier write is dead.
-
-  As with `readsMemory`, this describes the operation itself and not the
-  operations nested in its regions; use `OperationPtr.writesMemory` when an
-  `OperationPtr` is available.
 
   Defaults to `true` for every opcode, which conservatively assumes memory is
   written.

--- a/Veir/Interfaces/SideEffectInterfaces.lean
+++ b/Veir/Interfaces/SideEffectInterfaces.lean
@@ -33,6 +33,8 @@ def OperationPtr.hasSideEffects {OpInfo : Type} [HasOpInfo OpInfo]
 
 /--
   May this operation read memory?
+
+  TODO: recursively walk regions to get a less conservative answer
 -/
 def OperationPtr.readsMemory {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
@@ -42,6 +44,8 @@ def OperationPtr.readsMemory {OpInfo : Type} [HasOpInfo OpInfo]
 
 /--
   May this operation write memory?
+
+  TODO: recursively walk regions to get a less conservative answer
 -/
 def OperationPtr.writesMemory {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=

--- a/Veir/Interfaces/SideEffectInterfaces.lean
+++ b/Veir/Interfaces/SideEffectInterfaces.lean
@@ -31,6 +31,40 @@ def OperationPtr.hasSideEffects {OpInfo : Type} [HasOpInfo OpInfo]
   let opType := op.getOpType! ctx
   HasDialectOpInfo.hasSideEffects opType (op.getProperties! ctx opType)
 
+/--
+  Does this operation read memory?
+
+  An operation that carries regions reads memory whenever anything nested
+  inside it does, and `HasDialectOpInfo.readsMemory` sees only an opcode and
+  its properties, so it cannot answer for the nested operations. Such an
+  operation is therefore reported conservatively rather than being asked.
+
+  This mirrors MLIR's `isMemoryEffectFree`, which reports an operation as
+  having effects unless it either declares them through
+  `MemoryEffectOpInterface` or opts into a walk of its regions through
+  `HasRecursiveMemoryEffects`. No opcode opts into that walk here yet, so the
+  conservative answer is the only one available.
+-/
+def OperationPtr.readsMemory {OpInfo : Type} [HasOpInfo OpInfo]
+    (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
+  if op.getNumRegions! ctx != 0 then true else
+  let opType := op.getOpType! ctx
+  HasDialectOpInfo.readsMemory opType (op.getProperties! ctx opType)
+
+/--
+  Does this operation write memory?
+
+  This does not imply a complete overwrite of any particular location.
+
+  Operations carrying regions are reported conservatively, for the reason
+  given on `OperationPtr.readsMemory`.
+-/
+def OperationPtr.writesMemory {OpInfo : Type} [HasOpInfo OpInfo]
+    (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
+  if op.getNumRegions! ctx != 0 then true else
+  let opType := op.getOpType! ctx
+  HasDialectOpInfo.writesMemory opType (op.getProperties! ctx opType)
+
 end
 
 end Veir

--- a/Veir/Interfaces/SideEffectInterfaces.lean
+++ b/Veir/Interfaces/SideEffectInterfaces.lean
@@ -32,18 +32,7 @@ def OperationPtr.hasSideEffects {OpInfo : Type} [HasOpInfo OpInfo]
   HasDialectOpInfo.hasSideEffects opType (op.getProperties! ctx opType)
 
 /--
-  Does this operation read memory?
-
-  An operation that carries regions reads memory whenever anything nested
-  inside it does, and `HasDialectOpInfo.readsMemory` sees only an opcode and
-  its properties, so it cannot answer for the nested operations. Such an
-  operation is therefore reported conservatively rather than being asked.
-
-  This mirrors MLIR's `isMemoryEffectFree`, which reports an operation as
-  having effects unless it either declares them through
-  `MemoryEffectOpInterface` or opts into a walk of its regions through
-  `HasRecursiveMemoryEffects`. No opcode opts into that walk here yet, so the
-  conservative answer is the only one available.
+  May this operation read memory?
 -/
 def OperationPtr.readsMemory {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
@@ -52,12 +41,7 @@ def OperationPtr.readsMemory {OpInfo : Type} [HasOpInfo OpInfo]
   HasDialectOpInfo.readsMemory opType (op.getProperties! ctx opType)
 
 /--
-  Does this operation write memory?
-
-  This does not imply a complete overwrite of any particular location.
-
-  Operations carrying regions are reported conservatively, for the reason
-  given on `OperationPtr.readsMemory`.
+  May this operation write memory?
 -/
 def OperationPtr.writesMemory {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -15,7 +15,8 @@ namespace Veir
 -/
 private def isFoldEvaluationCandidate
     (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode) : Bool :=
-  !HasDialectOpInfo.hasSideEffects opCode properties && !HasDialectOpInfo.readsMemory opCode
+  !HasDialectOpInfo.hasSideEffects opCode properties &&
+    !HasDialectOpInfo.readsMemory opCode properties
 
 /--
   Evaluate an operation with the interpreter, given the runtime values of its


### PR DESCRIPTION
this is a shallow reimplementation of MLIR's side effect tracking:
https://mlir.llvm.org/docs/Rationale/SideEffectsAndSpeculation/

these have to be property-sensitive, otherwise we can't tell the difference between volatile and non-volatile memory operations

I'm not really sure about PDL, I've marked them as not reading or writing memory, which is true but it would be weird if DCE or CSE messed with PDL code.

this PR does not eliminate our existing, parallel infrastructure nor does it start to actually use the new infrastructure, that's for future PRs

this PR also leaves out a lot of machinery such as memory resources, recursive region checking, etc.