### PR TITLE
fix: a few things should have been marked ConstantLike or not-side-effecting

### DIFF
--- a/UnitTest/ConstantValue.lean
+++ b/UnitTest/ConstantValue.lean
@@ -49,6 +49,20 @@ info: "ok"
 #guard_msgs in
 #eval! testRiscvLi
 
+private def testRiscvLui : String := Id.run do
+  let .ok (some (.reg value)) :=
+    constantValueOf r#"%x = "riscv.lui"() <{"value" = 5 : i20}> : () -> !riscv.reg"#
+    | return "failed to read riscv.lui"
+  if value.val ≠ (BitVec.ofInt 20 5 ++ (0 : BitVec 12)).signExtend 64 then
+    return "riscv.lui produced the wrong register value"
+  return "ok"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testRiscvLui
+
 private def testHwConstant : String := Id.run do
   let .ok (some (.int 32 (.val value))) :=
     constantValueOf r#"%x = "hw.constant"() <{"value" = 42 : i32}> : () -> i32"#

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -286,6 +286,7 @@ def Llvm.hasSideEffects (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
   | .load, props => props.volatile_
   | .mlir__constant, _
   | .mlir__poison, _
+  | .mlir__addressof, _
   | .and, _ | .or, _ | .xor, _
   | .add, _ | .sub, _ | .mul, _
   | .sdiv, _ | .udiv, _ | .srem, _ | .urem, _
@@ -312,7 +313,7 @@ def Llvm.readsMemory (op : Llvm) : Bool :=
 
 def Llvm.isConstantLike (op : Llvm) : Bool :=
   match op with
-  | .mlir__constant | .mlir__poison => true
+  | .mlir__constant | .mlir__poison | .mlir__addressof => true
   | _ => false
 
 def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -251,7 +251,7 @@ def Riscv.readsMemory (op : Riscv) : Bool :=
 
 def Riscv.isConstantLike (op : Riscv) : Bool :=
   match op with
-  | .li => true
+  | .li | .lui => true
   | _ => false
 
 def Riscv.hasSSADominance (_op : Riscv) (_index : Nat) : Bool :=


### PR DESCRIPTION
the introduction of ConstantLike missed a couple of things:
- riscv.lui (trivially constant-like)
- llvm.mlir.addressof (not as obvious, but it's constant-like in upstream MLIR so we can do it too)

here we also make llvm.mlir.addressof not side-effecting (I think trivially true)