### PR TITLE
ci: add speed-optimized Namespace CI workflow

### DIFF
--- a/.github/docker/namespace-base-image.Dockerfile
+++ b/.github/docker/namespace-base-image.Dockerfile
@@ -34,9 +34,6 @@ RUN apt-get update \
       mlir-22-tools \
       # leanc links through the system toolchain.
       build-essential \
-      # ExArray's C code resolves GMP through pkg-config.
-      libgmp-dev \
-      pkg-config \
  && ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt \
  && rm -rf /var/lib/apt/lists/*
 

--- a/.github/docker/namespace-base-image.Dockerfile
+++ b/.github/docker/namespace-base-image.Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
 
 # `uv` provides both the Python interpreter and the test dependencies, so no
 # separate Python install is needed.
-COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.2 /uv /usr/local/bin/uv
 
 USER runner
 

--- a/.github/docker/namespace-base-image.Dockerfile
+++ b/.github/docker/namespace-base-image.Dockerfile
@@ -1,0 +1,79 @@
+# Custom base image for the Namespace runner profile used by
+# `lean_action_ci_namespace.yml`.
+#
+# This file is not built by CI. Namespace builds it from the Dockerfile field of
+# the runner profile in the dashboard, so the copy here is the source of truth
+# to edit and paste back. A profile build has no build context: nothing can be
+# `COPY`ed from the repository, which is why the Python tool versions below are
+# spelled out rather than resolved from `uv.lock`.
+#
+# The Namespace runner image ships neither `mlir-opt` nor a Python tool cache,
+# so the workflow installed both on every run. Baking them in removes the
+# install, which caching alone cannot do: a cache saves the download, not the
+# unpacking onto a fresh machine.
+
+ARG NAMESPACE_BASE_IMAGE_REF=""
+
+# Your image must build FROM NAMESPACE_BASE_IMAGE_REF
+FROM ${NAMESPACE_BASE_IMAGE_REF} AS base
+
+# Installing needs root; the image switches back to `runner` below, which the
+# GitHub runner software requires.
+USER root
+
+# `noble` matches the Ubuntu 24.04 base image. On a different base image, change
+# the LLVM apt suite to match.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+      -o /etc/apt/trusted.gpg.d/llvm-snapshot.asc \
+ && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+      > /etc/apt/sources.list.d/llvm.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      mlir-22-tools \
+      # leanc links through the system toolchain.
+      build-essential \
+      # ExArray's C code resolves GMP through pkg-config.
+      libgmp-dev \
+      pkg-config \
+ && ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt \
+ && rm -rf /var/lib/apt/lists/*
+
+# `uv` provides both the Python interpreter and the test dependencies, so no
+# separate Python install is needed.
+COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /usr/local/bin/uv
+
+USER runner
+
+# Everything below installs into `runner`'s home at its default location. Doing
+# it as root instead puts the interpreter and the tool virtualenvs under
+# `/root`, and no amount of `chmod` on the target makes them usable: `/root` is
+# mode 0700, so `runner` cannot traverse it to reach them.
+#
+# `HOME` is set explicitly because `USER` alone does not reliably set it during
+# a build, and every default path below is derived from it.
+ENV HOME=/home/runner
+ENV PATH=/home/runner/.local/bin:/home/runner/.elan/bin:$PATH
+
+# Pinned to the versions `uv.lock` resolves. Keep them in step by hand: the
+# lockfile cannot be read here, and `filecheck` versions differ enough to change
+# which tests pass.
+RUN uv python install 3.13 \
+ && uv tool install --python 3.13 lit==18.1.8 \
+ && uv tool install --python 3.13 filecheck==1.0.3
+
+# `elan` manages the Lean toolchain; the toolchain itself is not baked in, since
+# `lean-toolchain` pins it and it belongs on the cache volume. Installing as
+# `runner` puts elan in `$HOME/.elan`, which is where `lean-action` looks.
+RUN curl -fsSL https://elan.lean-lang.org/elan-init.sh \
+      | sh -s -- -y --default-toolchain none
+
+# Fail the image build rather than a CI run if a tool is missing or is not
+# reachable as `runner`. If a run reports `command not found` for one of these,
+# the image did not build and the profile fell back to the stock base image.
+RUN mlir-opt --version \
+ && uv --version \
+ && lit --version \
+ && filecheck --version \
+ && elan --version

--- a/.github/workflows/lean_action_ci_namespace.yml
+++ b/.github/workflows/lean_action_ci_namespace.yml
@@ -1,0 +1,52 @@
+name: Lean Action CI (Namespace)
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  merge_group:
+
+jobs:
+  build:
+    # The runner profile pins the machine shape (32 vCPU, eight times what the
+    # GitHub-hosted runner in the sibling `Lean Action CI` workflow gets, so
+    # Lake builds with `-j32` instead of `-j4`), the cache volume and the git
+    # mirror. It also carries the custom base image that provides `mlir-opt`,
+    # `uv`, `lit`, `filecheck` and `elan`; its Dockerfile is kept in
+    # `.github/docker/namespace-base-image.Dockerfile`.
+    runs-on: namespace-profile-veir
+
+    steps:
+      - uses: namespacelabs/nscloud-checkout-action@v9
+
+      # The checkout wipes the workspace, so `.lake` does not exist when the
+      # cache action runs and it has nothing to bind the volume onto. It skips
+      # the path with "Some cache paths missing" and still reports success, so
+      # the directory has to be created first.
+      - name: Create the build directory
+        run: mkdir -p ${{ github.workspace }}/.lake
+
+      # `~/.elan` holds the Lean toolchain and `.lake` the build tree; together
+      # they dominate the run.
+      - name: Set up caches
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          path: |
+            ~/.elan
+            ${{ github.workspace }}/.lake
+
+      # One invocation: `lean-action` runs `lake build` and then `lake test`,
+      # so a second one only repeated the build as a no-op.
+      - name: Build and test the project
+        uses: leanprover/lean-action@v1
+        with:
+          build-args: "--iofail"
+          test-args: "--iofail"
+          test: true
+          use-github-cache: false
+
+      # `lit` and `filecheck` come from the image, so there is nothing to
+      # install and no virtualenv to activate.
+      - name: Run filecheck tests
+        run: lit Test/ -v


### PR DESCRIPTION
This second workflow runs the same build, unit tests and filecheck tests as `Lean Action CI` using a Namespace runner with 32 cores and high-performance caching. As a result, the build time for warm runs reduces from 160s to 16s (GitHub vs. Namespace).

The Namespace CI and the GitHub runners have the same test coverage, with the exception of the
ExArray steps, which we leave out as they rarely change. However, the Namespace CI workflow uses a custom docker base image with `mlir-opt`, `uv`, `lit`, `filecheck` and `elan` included. Namespace caches these in base docker image, such that we spend no time installing these tools at each CI run,. The  namespace runner also uses a cache volume to cache the lean compiler, temporary build artifacts (e.g., the .lake folder), and offers a local git mirror that caches the git checkout.
 
Namespace builds the image for its runner from a profile in the Namespace dashboard, so the Dockerfile we add is a copy to edit and paste back. A profile build has no build context, so`lit` and `filecheck` are pinned by hand rather than resolved from `uv.lock`.