### PR TITLE
ci: drop the no-op `source .envrc` step

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Source environment variables
-        run: source .envrc
-
       - name: Add LLVM apt repository
         uses: gerlero/add-apt-repository@v1
         with:


### PR DESCRIPTION
Each `run:` block executes in its own shell, so the `LEAN_CC` and `LEAN_AR` exports never reached any later step. The build has always run without them.

Introduced in 188fc1754 ("Add ExArray to CI", #620), alongside the ExArray build and test steps it was presumably meant to configure.
