### PR TITLE
chore: git ignore Vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ lean_packages/
 *~
 \#*
 .#*
+*.sw[a-p]
 build
 GPATH
 GRTAGS


### PR DESCRIPTION
The repository already ignores Emacs backup and auto-save files, but not the Vim equivalents, so an open buffer leaves a `.<name>.swp` in the working tree that `git add -A` happily stages.

`*.sw[a-p]` covers the whole rotation Vim uses: `.swp` first, then `.swo`, `.swn` and downwards.