### PR TITLE
test(PDL): cross-check the PDL round-trips against MLIR

### DIFF
--- a/Test/PDL/attribute.mlir
+++ b/Test/PDL/attribute.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
   // Define an attribute:

--- a/Test/PDL/type.mlir
+++ b/Test/PDL/type.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
   // Define a type:

--- a/Test/PDL/types.mlir
+++ b/Test/PDL/types.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 // The `pdl` handle types are nullary and round-trip as-is.
 "builtin.module"() ({


### PR DESCRIPTION
`MLIR_ROUNDTRIP` pipes the test through `mlir-opt --mlir-print-op-generic` before and after `veir-opt`, so the generic form VeIR accepts and prints is validated against real MLIR rather than only against VeIR itself.

Only these three tests qualify. `pdl.operand` carries `HasParent<pdl::PatternOp>` in MLIR, so `mlir-opt` rejects it outside a `pdl.pattern`:

    error: 'pdl.operand' op expects parent op 'pdl.pattern'

That rules out operand.mlir, and operation.mlir with it, since it sources its value handles from `pdl.operand`. Both can be enabled once `pdl.pattern` is modelled and the tests can be wrapped in one.