### PR TITLE
feat(PDL): add `pdl.result` operation

### DIFF
--- a/Test/PDL/result.mlir
+++ b/Test/PDL/result.mlir
@@ -1,0 +1,16 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  %0 = "pdl.type"() : () -> !pdl.type
+  %1 = "pdl.operation"(%0, %0) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 2>}> : (!pdl.type, !pdl.type) -> !pdl.operation
+  // Extract a result:
+  %2 = "pdl.result"(%1) <{"index" = 1 : i32}> : (!pdl.operation) -> !pdl.value
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     %[[t:.*]] = "pdl.type"() : () -> !pdl.type
+// CHECK-NEXT:     %[[op:.*]] = "pdl.operation"(%[[t]], %[[t]]) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 2>}> : (!pdl.type, !pdl.type) -> !pdl.operation
+// CHECK-NEXT:     %{{.*}} = "pdl.result"(%[[op]]) <{"index" = 1 : i32}> : (!pdl.operation) -> !pdl.value
+// CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/result_index_width_invalid.mlir
+++ b/Test/PDL/result_index_width_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The `index` of a `pdl.result` is a 32-bit integer attribute.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  %1 = "pdl.result"(%0) <{"index" = 0 : i64}> : (!pdl.operation) -> !pdl.value
+}) : () -> ()
+
+// CHECK: pdl.result: Expected 'index' to be a 32-bit signless integer attribute

--- a/Test/PDL/result_invalid.mlir
+++ b/Test/PDL/result_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A `pdl.result` produces an `!pdl.value` handle, not an arbitrary type.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  %1 = "pdl.result"(%0) <{"index" = 0 : i32}> : (!pdl.operation) -> i32
+}) : () -> ()
+
+// CHECK: pdl.result: Expected the result to be of type '!pdl.value'

--- a/Test/PDL/result_parent_type_invalid.mlir
+++ b/Test/PDL/result_parent_type_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The `parent` operand of a `pdl.result` is an `!pdl.operation` handle. The
+// handle fed in here comes from a `pdl.result` rather than a `pdl.operand`,
+// which would need a `pdl.pattern` parent to satisfy MLIR and so would make
+// `MLIR_INVALID` above pass for the wrong reason.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  %1 = "pdl.result"(%0) <{"index" = 0 : i32}> : (!pdl.operation) -> !pdl.value
+  %2 = "pdl.result"(%1) <{"index" = 0 : i32}> : (!pdl.value) -> !pdl.value
+}) : () -> ()
+
+// CHECK: pdl.result: Expected the `parent` operand to be of type '!pdl.operation'

--- a/Test/PDL/result_property_invalid.mlir
+++ b/Test/PDL/result_property_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// `index` is required on a `pdl.result`.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  %1 = "pdl.result"(%0) : (!pdl.operation) -> !pdl.value
+}) : () -> ()
+
+// CHECK: pdl.result: missing 'index' property

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -15,6 +15,7 @@ inductive PDL where
 | attribute
 | operand
 | operation
+| result
 | type
 deriving Inhabited, Repr, Hashable, DecidableEq
 
@@ -24,6 +25,7 @@ match op with
 | .attribute => PDLAttributeProperties
 | .operand => Unit
 | .operation => PDLOperationProperties
+| .result => PDLResultProperties
 | .type => PDLTypeProperties
 
 def PDL.fromAttrDict
@@ -38,6 +40,7 @@ def PDL.fromAttrDict
     else
       .ok ()
   | .operation => PDLOperationProperties.fromAttrDict attrDict
+  | .result => PDLResultProperties.fromAttrDict attrDict
   | .type => PDLTypeProperties.fromAttrDict attrDict
 
 def PDL.toAttrDict
@@ -56,6 +59,8 @@ def PDL.toAttrDict
     dict := dict.insert "attributeValueNames".toUTF8 (.arrayAttr props.attributeValueNames)
     dict := dict.insert "operandSegmentSizes".toUTF8 (.denseArrayAttr props.operandSegmentSizes)
     dict
+  | .result =>
+    (Std.HashMap.emptyWithCapacity 1).insert "index".toUTF8 (.integerAttr props.index)
   | .type =>
     match props.constantType with
     | some constantType =>
@@ -174,6 +179,20 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
     for i in [valueCount + attributeCount:valueCount + attributeCount + typeCount] do
       if ((op.getOperand! ctx.raw i).getType! ctx.raw).val ≠ (PDL.TypeType.mk : TypeAttr).val then
         throw s!"Expected operand {i} to be of type '!pdl.type'"
+  | .result =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    op.verifyResultTypeMatches ctx (PDL.ValueType.mk : TypeAttr)
+      "Expected the result to be of type '!pdl.value'"
+    if ((op.getOperand! ctx.raw 0).getType! ctx.raw).val ≠ (PDL.OperationType.mk : TypeAttr).val then
+      throw "Expected the `parent` operand to be of type '!pdl.operation'"
+    let props : PDL.propertiesOf .result :=
+      HasDialect.toDialectProperties (OpInfo := OpInfo) PDL.result
+        (op.getProperties! ctx.raw (ofDialect OpInfo PDL.result))
+    /- MLIR constrains `index` to a 32-bit signless integer attribute and
+       nothing more: it range-checks neither the sign nor the parent's result
+       count, so neither does this. -/
+    if props.index.type.bitwidth ≠ 32 then
+      throw "Expected 'index' to be a 32-bit signless integer attribute"
   | .type =>
     /- The optional `constantType` is a property, so `pdl.type` takes no
        operands. -/

--- a/Veir/Dialects/PDL/Properties.lean
+++ b/Veir/Dialects/PDL/Properties.lean
@@ -89,6 +89,27 @@ def PDLOperationProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attrib
     throw s!"pdl.operation: expected only the 'opName', 'attributeValueNames' and 'operandSegmentSizes' properties, but got {attrDict.size} properties"
   return { opName, attributeValueNames, operandSegmentSizes }
 
+/--
+  Properties of the `pdl.result` operation.
+
+  `index` is the zero-based index of the result to extract from the `parent`
+  operation handle. It counts concrete results, so it is not an index into the
+  range of results of a variadic result group.
+-/
+structure PDLResultProperties where
+  index : IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def PDLResultProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String PDLResultProperties := do
+  let some indexAttr := attrDict["index".toUTF8]?
+    | throw "pdl.result: missing 'index' property"
+  let .integerAttr index := indexAttr
+    | throw s!"pdl.result: expected 'index' to be an integer attribute, but got {indexAttr}"
+  if attrDict.size > 1 then
+    throw s!"pdl.result: expected only the 'index' property, but got {attrDict.size} properties"
+  return { index }
+
 end
 
 end Veir


### PR DESCRIPTION
Extracts a single result edge from an operation handle: one `!pdl.operation` operand, a zero-based `index` property, and an `!pdl.value` result.

The index counts concrete results, so it is not an index into the range of results of a variadic result group.