### PR TITLE
feat(PDL): add pdl.pattern and pdl.rewrite operations 

### DIFF
--- a/Test/PDL/pattern.mlir
+++ b/Test/PDL/pattern.mlir
@@ -1,0 +1,39 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  // A named pattern whose rewrite is given inline by the body region:
+  "pdl.pattern"() <{"benefit" = 2 : i16, "sym_name" = "named"}> ({
+    %0 = "pdl.type"() : () -> !pdl.type
+    %1 = "pdl.operand"() : () -> !pdl.value
+    %2 = "pdl.operation"(%1, %0) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.type) -> !pdl.operation
+    "pdl.rewrite"(%2) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+      %3 = "pdl.operation"(%0) <{"attributeValueNames" = [], "opName" = "bar.op", "operandSegmentSizes" = array<i32: 0, 0, 1>}> : (!pdl.type) -> !pdl.operation
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+  // An anonymous pattern delegating to an external rewrite function:
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "baz.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 2 : i16, "sym_name" = "named"}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %[[t:.*]] = "pdl.type"() : () -> !pdl.type
+// CHECK-NEXT:         %[[v:.*]] = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:         %[[root:.*]] = "pdl.operation"(%[[v]], %[[t]]) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.type) -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%[[root]]) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+// CHECK-NEXT:           ^{{.*}}():
+// CHECK-NEXT:             %{{.*}} = "pdl.operation"(%[[t]]) <{"attributeValueNames" = [], "opName" = "bar.op", "operandSegmentSizes" = array<i32: 0, 0, 1>}> : (!pdl.type) -> !pdl.operation
+// CHECK-NEXT:     }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %[[op:.*]] = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "baz.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%[[op]]) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({{.*}}) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/pattern_benefit_invalid.mlir
+++ b/Test/PDL/pattern_benefit_invalid.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The `benefit` of a `pdl.pattern` is a 16-bit attribute.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i32}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.pattern: Expected 'benefit' to be a 16-bit signless integer attribute

--- a/Test/PDL/pattern_benefit_negative_invalid.mlir
+++ b/Test/PDL/pattern_benefit_negative_invalid.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// MLIR confines `benefit` to non-negative values.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = -1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.pattern: Expected 'benefit' to be non-negative, but got -1

--- a/Test/PDL/pattern_terminator_invalid.mlir
+++ b/Test/PDL/pattern_terminator_invalid.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The body of a `pdl.pattern` must be terminated by a `pdl.rewrite`.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.pattern: Expected the body to terminate with a `pdl.rewrite`

--- a/Test/PDL/rewrite_external_body_invalid.mlir
+++ b/Test/PDL/rewrite_external_body_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// An external rewrite names a native function, so its region stays empty.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+      %1 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.rewrite: Expected the rewrite region to be empty when the rewrite is external

--- a/Test/PDL/rewrite_inline_empty_invalid.mlir
+++ b/Test/PDL/rewrite_inline_empty_invalid.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// An inline rewrite has no external name, so it must supply a body.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.rewrite: Expected the rewrite region to be non-empty when no external name is specified

--- a/Test/PDL/rewrite_parent_invalid.mlir
+++ b/Test/PDL/rewrite_parent_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A `pdl.rewrite` only ever terminates the body of a `pdl.pattern`.
+"builtin.module"() ({
+  "pdl.rewrite"() <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 0, 0>}> ({
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.rewrite: Expected the parent operation to be a `pdl.pattern`

--- a/Test/PDL/rewrite_root_type_invalid.mlir
+++ b/Test/PDL/rewrite_root_type_invalid.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The `root` operand of a `pdl.rewrite` is an `!pdl.operation` handle.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.type"() : () -> !pdl.type
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.type) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.rewrite: Expected the `root` operand to be of type '!pdl.operation'

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -15,7 +15,9 @@ inductive PDL where
 | attribute
 | operand
 | operation
+| pattern
 | result
+| rewrite
 | type
 deriving Inhabited, Repr, Hashable, DecidableEq
 
@@ -25,7 +27,9 @@ match op with
 | .attribute => PDLAttributeProperties
 | .operand => Unit
 | .operation => PDLOperationProperties
+| .pattern => PDLPatternProperties
 | .result => PDLResultProperties
+| .rewrite => PDLRewriteProperties
 | .type => PDLTypeProperties
 
 def PDL.fromAttrDict
@@ -40,7 +44,9 @@ def PDL.fromAttrDict
     else
       .ok ()
   | .operation => PDLOperationProperties.fromAttrDict attrDict
+  | .pattern => PDLPatternProperties.fromAttrDict attrDict
   | .result => PDLResultProperties.fromAttrDict attrDict
+  | .rewrite => PDLRewriteProperties.fromAttrDict attrDict
   | .type => PDLTypeProperties.fromAttrDict attrDict
 
 def PDL.toAttrDict
@@ -59,8 +65,19 @@ def PDL.toAttrDict
     dict := dict.insert "attributeValueNames".toUTF8 (.arrayAttr props.attributeValueNames)
     dict := dict.insert "operandSegmentSizes".toUTF8 (.denseArrayAttr props.operandSegmentSizes)
     dict
+  | .pattern => Id.run do
+    let mut dict : Std.HashMap ByteArray Attribute := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "benefit".toUTF8 (.integerAttr props.benefit)
+    if let some symName := props.sym_name then
+      dict := dict.insert "sym_name".toUTF8 (.stringAttr symName)
+    dict
   | .result =>
     (Std.HashMap.emptyWithCapacity 1).insert "index".toUTF8 (.integerAttr props.index)
+  | .rewrite => Id.run do
+    let mut dict : Std.HashMap ByteArray Attribute := Std.HashMap.emptyWithCapacity 2
+    if let some name := props.name then
+      dict := dict.insert "name".toUTF8 (.stringAttr name)
+    dict.insert "operandSegmentSizes".toUTF8 (.denseArrayAttr props.operandSegmentSizes)
   | .type =>
     match props.constantType with
     | some constantType =>
@@ -80,6 +97,13 @@ def PDL.isConstantLike (_op : PDL) : Bool :=
 def PDL.hasSSADominance (_op : PDL) (_index : Nat) : Bool :=
   true
 
+/-- MLIR marks the body of a `pdl.rewrite` `NoTerminator`; it is an ordinary
+    SSACFG region otherwise. -/
+def PDL.hasNoTerminator (op : PDL) (_index : Nat) : Bool :=
+  match op with
+  | .rewrite => true
+  | _ => false
+
 #generate_dialect PDL
 
 instance : HasDialectOpInfo PDL where
@@ -92,6 +116,7 @@ instance : HasDialectOpInfo PDL where
   readsMemory := PDL.readsMemory
   isConstantLike := PDL.isConstantLike
   hasSSADominance := PDL.hasSSADominance
+  hasNoTerminator := PDL.hasNoTerminator
 
 /--
 Verify the local invariants of a `pdl` operation in any operation-info type
@@ -179,6 +204,33 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
     for i in [valueCount + attributeCount:valueCount + attributeCount + typeCount] do
       if ((op.getOperand! ctx.raw i).getType! ctx.raw).val ≠ (PDL.TypeType.mk : TypeAttr).val then
         throw s!"Expected operand {i} to be of type '!pdl.type'"
+  | .pattern =>
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "Expected 1 region"
+    let props : PDL.propertiesOf .pattern :=
+      HasDialect.toDialectProperties (OpInfo := OpInfo) PDL.pattern
+        (op.getProperties! ctx.raw (ofDialect OpInfo PDL.pattern))
+    /- MLIR confines `benefit` to a non-negative 16-bit attribute. -/
+    if props.benefit.type.bitwidth ≠ 16 then
+      throw "Expected 'benefit' to be a 16-bit signless integer attribute"
+    if props.benefit.value < 0 then
+      throw s!"Expected 'benefit' to be non-negative, but got {props.benefit.value}"
+    /- The matcher body is a single block terminated by a `pdl.rewrite`. -/
+    let body := (op.getRegion! ctx.raw 0).get! ctx.raw
+    let some bodyBlock := body.firstBlock
+      | throw "Expected the body to contain exactly 1 block"
+    if body.lastBlock ≠ some bodyBlock then
+      throw "Expected the body to contain exactly 1 block"
+    let some terminator := (bodyBlock.get! ctx.raw).lastOp
+      | throw "Expected the body to terminate with a `pdl.rewrite`"
+    if toDialect? PDL (terminator.getOpType! ctx.raw) ≠ some PDL.rewrite then
+      throw "Expected the body to terminate with a `pdl.rewrite`"
   | .result =>
     op.verifyPlainOpCounts ctx opIn 1 1
     op.verifyResultTypeMatches ctx (PDL.ValueType.mk : TypeAttr)
@@ -193,6 +245,42 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
        count, so neither does this. -/
     if props.index.type.bitwidth ≠ 32 then
       throw "Expected 'index' to be a 32-bit signless integer attribute"
+  | .rewrite =>
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "Expected 1 region"
+    /- A `pdl.rewrite` only ever terminates the body of a `pdl.pattern`. -/
+    match op.getParentOp! ctx.raw with
+    | some parent =>
+      if toDialect? PDL (parent.getOpType! ctx.raw) ≠ some PDL.pattern then
+        throw "Expected the parent operation to be a `pdl.pattern`"
+    | none => throw "Expected the parent operation to be a `pdl.pattern`"
+    let props : PDL.propertiesOf .rewrite :=
+      HasDialect.toDialectProperties (OpInfo := OpInfo) PDL.rewrite
+        (op.getProperties! ctx.raw (ofDialect OpInfo PDL.rewrite))
+    /- The operands are the optional `root` followed by the `externalArgs`. -/
+    let segments ← op.verifyOperandSegmentSizes ctx opIn props.operandSegmentSizes 2
+    let rootCount := segments[0]!
+    if rootCount > 1 then
+      throw "Expected at most 1 `root` operand"
+    if rootCount = 1 then
+      if ((op.getOperand! ctx.raw 0).getType! ctx.raw).val
+          ≠ (PDL.OperationType.mk : TypeAttr).val then
+        throw "Expected the `root` operand to be of type '!pdl.operation'"
+    /- An external rewrite names a native function and leaves its region empty;
+       an inline rewrite supplies a body and takes no external arguments. -/
+    let body := (op.getRegion! ctx.raw 0).get! ctx.raw
+    if props.name.isSome then
+      if body.firstBlock.isSome then
+        throw "Expected the rewrite region to be empty when the rewrite is external"
+    else
+      if body.firstBlock.isNone then
+        throw "Expected the rewrite region to be non-empty when no external name is specified"
+      if segments[1]! ≠ 0 then
+        throw "Expected no external arguments when the rewrite is specified inline"
   | .type =>
     /- The optional `constantType` is a property, so `pdl.type` takes no
        operands. -/

--- a/Veir/Dialects/PDL/Properties.lean
+++ b/Veir/Dialects/PDL/Properties.lean
@@ -110,6 +110,64 @@ def PDLResultProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute
     throw s!"pdl.result: expected only the 'index' property, but got {attrDict.size} properties"
   return { index }
 
+/--
+  Properties of the `pdl.pattern` operation.
+
+  `benefit` is the pattern's benefit, mirroring the benefit of the
+  `RewritePattern` it stands for. MLIR constrains it to a non-negative 16-bit
+  attribute.
+
+  `sym_name` is optional: a pattern may, but need not, define a symbol.
+-/
+structure PDLPatternProperties where
+  benefit : IntegerAttr
+  sym_name : Option StringAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def PDLPatternProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String PDLPatternProperties := do
+  let some benefitAttr := attrDict["benefit".toUTF8]?
+    | throw "pdl.pattern: missing 'benefit' property"
+  let .integerAttr benefit := benefitAttr
+    | throw s!"pdl.pattern: expected 'benefit' to be an integer attribute, but got {benefitAttr}"
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr attr) => pure (some attr)
+    | some attr =>
+      throw s!"pdl.pattern: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => pure none
+  if attrDict.size > (if symName.isSome then 2 else 1) then
+    throw s!"pdl.pattern: expected only the 'benefit' and 'sym_name' properties, but got {attrDict.size} properties"
+  return { benefit, sym_name := symName }
+
+/--
+  Properties of the `pdl.rewrite` operation.
+
+  `name` names an external rewrite function. It is absent when the rewrite is
+  given inline by the body region instead.
+
+  `operandSegmentSizes` splits the operands into the optional `root` and the
+  variadic `externalArgs` groups, in that order.
+-/
+structure PDLRewriteProperties where
+  name : Option StringAttr
+  operandSegmentSizes : DenseArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def PDLRewriteProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String PDLRewriteProperties := do
+  let name ← match attrDict["name".toUTF8]? with
+    | some (.stringAttr attr) => pure (some attr)
+    | some attr =>
+      throw s!"pdl.rewrite: expected 'name' to be a string attribute, but got {attr}"
+    | none => pure none
+  let some sizesAttr := attrDict["operandSegmentSizes".toUTF8]?
+    | throw "pdl.rewrite: missing 'operandSegmentSizes' property"
+  let .denseArrayAttr operandSegmentSizes := sizesAttr
+    | throw s!"pdl.rewrite: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
+  if attrDict.size > (if name.isSome then 2 else 1) then
+    throw s!"pdl.rewrite: expected only the 'name' and 'operandSegmentSizes' properties, but got {attrDict.size} properties"
+  return { name, operandSegmentSizes }
+
 end
 
 end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -43,7 +43,8 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne
   | .riscv_cf .beqz | .riscv_cf .bnez
   | .riscv_cf .blt | .riscv_cf .bge | .riscv_cf .bltu | .riscv_cf .bgeu
-  | .hw .output => true
+  | .hw .output
+  | .pdl .rewrite => true
   | _ => false
 
 /--


### PR DESCRIPTION
`pdl.pattern` and `pdl.rewrite` arrive as a pair because `pdl.rewrite` is the
terminator of a `pdl.pattern` body and neither is well-formed without the
other. Together they are the first PDL operations to carry a region, and the
first container the entity operations can actually live in.

`pdl.pattern` holds a non-negative 16-bit `benefit` and an optional `sym_name`,
and its single-block body must end in a `pdl.rewrite`; a `pdl.rewrite` is
either external, naming a native function and leaving its region empty, or
inline, supplying a body and taking no external arguments. Its body sets the
`hasNoTerminator` hook from #1198, so it stays an ordinary SSACFG region as
MLIR models it, rather than being encoded as a graph region.

The whole-pattern invariants MLIR checks in `PatternOp::verifyRegions` — `pdl`
operations only, at least one `pdl.operation`, and a connected component — are
not modelled yet, and neither is `SingleBlock` on the rewrite body.
