### PR TITLE
feat(verifier): add a `NoTerminator` hook to `HasDialectOpInfo`

### DIFF
--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -52,6 +52,13 @@ def Builtin.hasSSADominance (op : Builtin) (_index : Nat) : Bool :=
   | .module | .unregistered => false
   | _ => true
 
+/-- A `builtin.module` body holds no terminator, and an unregistered operation
+    makes no promise about its regions. -/
+def Builtin.hasNoTerminator (op : Builtin) (_index : Nat) : Bool :=
+  match op with
+  | .module | .unregistered => true
+  | _ => false
+
 #generate_dialect Builtin
 
 instance : HasDialectOpInfo Builtin where
@@ -64,6 +71,7 @@ instance : HasDialectOpInfo Builtin where
   readsMemory := Builtin.readsMemory
   isConstantLike := Builtin.isConstantLike
   hasSSADominance := Builtin.hasSSADominance
+  hasNoTerminator := Builtin.hasNoTerminator
 
 end
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -39,6 +39,9 @@ def Test.isConstantLike (_op : Test) : Bool :=
 def Test.hasSSADominance (_op : Test) (_index : Nat) : Bool :=
   false
 
+def Test.hasNoTerminator (_op : Test) (_index : Nat) : Bool :=
+  true
+
 #generate_dialect Test
 
 instance : HasDialectOpInfo Test where
@@ -51,6 +54,7 @@ instance : HasDialectOpInfo Test where
   readsMemory := Test.readsMemory
   isConstantLike := Test.isConstantLike
   hasSSADominance := Test.hasSSADominance
+  hasNoTerminator := Test.hasNoTerminator
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -137,6 +137,29 @@ def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
   | .test op => Test.hasSSADominance op index
 
 /--
+  Whether the indexed region of this opcode is exempt from the requirement
+  that each of its blocks ends in a terminator. Dialects that do not say
+  otherwise inherit the `HasDialectOpInfo` default of `false`.
+-/
+def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
+  match opCode with
+  | .arith op => HasDialectOpInfo.hasNoTerminator op index
+  | .llvm op => HasDialectOpInfo.hasNoTerminator op index
+  | .riscv op => HasDialectOpInfo.hasNoTerminator op index
+  | .riscv_cf op => HasDialectOpInfo.hasNoTerminator op index
+  | .riscv_stack op => HasDialectOpInfo.hasNoTerminator op index
+  | .rv64 op => HasDialectOpInfo.hasNoTerminator op index
+  | .mod_arith op => HasDialectOpInfo.hasNoTerminator op index
+  | .cf op => HasDialectOpInfo.hasNoTerminator op index
+  | .comb op => HasDialectOpInfo.hasNoTerminator op index
+  | .hw op => HasDialectOpInfo.hasNoTerminator op index
+  | .builtin op => HasDialectOpInfo.hasNoTerminator op index
+  | .func op => HasDialectOpInfo.hasNoTerminator op index
+  | .datapath op => HasDialectOpInfo.hasNoTerminator op index
+  | .pdl op => HasDialectOpInfo.hasNoTerminator op index
+  | .test op => HasDialectOpInfo.hasNoTerminator op index
+
+/--
   Does this `OpCode` materialize a literal constant value, i.e. an op
   whose single result is a compile-time constant taken from its
   properties, with no SSA operands and no side effects?
@@ -214,6 +237,7 @@ instance : HasDialectOpInfo OpCode where
   readsMemory := OpCode.readsMemory
   isConstantLike := OpCode.isConstantLike
   hasSSADominance := OpCode.hasSSADominance
+  hasNoTerminator := OpCode.hasNoTerminator
 
 instance : HasOpInfo OpCode where
 

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -71,6 +71,20 @@ class HasDialectOpInfo (opCode: Type)
   region, and operation order does not impose SSA dominance.
   -/
   hasSSADominance : opCode → Nat → Bool
+  /--
+  Whether the indexed region is exempt from the requirement that each of its
+  blocks ends in a terminator, mirroring MLIR's `NoTerminator` trait.
+
+  This is deliberately separate from the region kind. A graph region implies
+  no terminator, but the converse does not hold: MLIR gives `pdl.rewrite` a
+  body that is an ordinary SSACFG region and yet carries `NoTerminator`.
+  Encoding such a region as a graph region would silently drop SSA dominance
+  from the model in order to relax an unrelated requirement.
+
+  Defaults to `false` for every opcode, which conservatively keeps the
+  terminator requirement.
+  -/
+  hasNoTerminator : opCode → Nat → Bool := fun _ _ => false
 
 instance [HasDialectOpInfo opCode] {op : opCode} : Hashable (HasDialectOpInfo.propertiesOf op) where
   hash := HasDialectOpInfo.propertiesHash.hash

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -853,6 +853,17 @@ public def RegionPtr.getRegionKind (region : RegionPtr) (ctx : WfIRContext OpCod
   | none => .SSACFG
 
 /--
+  Whether this region is exempt from the requirement that each of its blocks
+  ends in a terminator.
+-/
+public def RegionPtr.hasNoTerminator (region : RegionPtr) (ctx : WfIRContext OpCode) : Bool :=
+  match (region.get! ctx.raw).parent with
+  | some parentOp =>
+    let parent := parentOp.get! ctx.raw
+    parent.opType.hasNoTerminator (parent.regions.idxOf region)
+  | none => false
+
+/--
   Verify that a terminator only ever appears as the last operation of its block:
   an operation that is a terminator must not be followed by another operation.
 -/
@@ -942,7 +953,7 @@ def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
   ctx.raw.forBlocksDepM (fun block blockIn => do
     match (block.get ctx.raw blockIn).parent with
     | some region =>
-      if region.getRegionKind ctx = .SSACFG then
+      if !region.hasNoTerminator ctx then
         block.verifyTerminator ctx blockIn
     | none => pure ())
   ctx.verifyLLVMGlobalSymbols


### PR DESCRIPTION
VeIR tied the "every block ends in a terminator" requirement to the region
kind, which conflates two independent properties: a graph region implies no
terminator, but the converse does not hold. MLIR gives `pdl.rewrite` a body
that is an ordinary SSACFG region and yet carries `NoTerminator`, so modelling
it as a graph region relaxes the terminator rule only by also dropping SSA
dominance.

`HasDialectOpInfo` gains a `hasNoTerminator` hook, and the verifier's block
check now depends on it alone rather than on the region kind. This is not a
pure deletion: `builtin.module`, `builtin.unregistered` and `test.test` were
relying on their graph region kind to skip the check and now say so directly.
The hook defaults to `false`, so no other dialect changes behaviour or needs
updating, and `getRegionKind` is left governing only SSA dominance and the
at-most-one-block rule.

The hook has no user on `main` yet — the first is `pdl.rewrite` in #1197, which
currently works around this with a graph region and can then keep an SSACFG
body.
