### PR TITLE
feat(IR): support dialect-local getProperties

### DIFF
--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -29,14 +29,6 @@ abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arit
 #guard Arith.from? (Arith.addi : OpCode) = some Arith.addi
 #guard Arith.from? (OpCode.builtin .module) = none
 
-/-! A future function for getting the properties of an operation, while getting the expected
-properties type based on the dialect, not the global opcode. -/
-def Veir.OperationPtr.getProperties!' {OpInfo Dialect : Type} [HasOpInfo OpInfo]
-    [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-    (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect) :
-    HasDialectOpInfo.propertiesOf opCode :=
-  op.getProperties! ctx opCode
-
 def Veir.OperationPtr.setProperties!' {OpInfo Dialect : Type} [HasOpInfo OpInfo]
     [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opCode : Dialect)
@@ -55,7 +47,7 @@ private def genericArithAwarePass {OpInfo : Type} [HasOpInfo OpInfo]
     /- Matching an `arith` operation, here an `addi`. -/
     let some .addi := Arith.from? (op.getOpType! ctx.raw) | return ctx
     /- Getting the property of an operation with a type based on the dialect. -/
-    let _a := op.getProperties!' ctx.raw Arith.addi
+    let _a := op.getProperties! ctx.raw Arith.addi
     /- Check that we automatically derive the correct properties type. -/
     let _b : ArithIntegerOverflowFlagsProperties := _a
     /- Create -/

--- a/Veir/Analysis/DataFlow/DeadCodeAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DeadCodeAnalysis.lean
@@ -40,7 +40,7 @@ def propagate (state : LivenessFact) (anchor : LatticeAnchor)
   | .CFGEdge edge =>
     for analysisKind in state.subscribers do
       dfCtx := dfCtx.enqueue (InsertPoint.atStart! edge.target irCtx, analysisKind)
-  | _ => 
+  | _ =>
     pure ()
   dfCtx
 
@@ -88,7 +88,7 @@ def markEntryBlocksLive
         (fact.setToLive, !fact.live)) irCtx
   dfCtx
 
-/-- 
+/--
 Return whether the given operation is a branch op.
 TODO: This function likely needs to be replaced with
 an interface much like what MLIR has.
@@ -114,7 +114,7 @@ private def getLiteralConstant?
     else
       match (result.op.get! irCtx).opType with
       | .arith .constant =>
-        let intAttr := (result.op.getProperties! irCtx (.arith .constant)).value
+        let intAttr := (result.op.getProperties! irCtx Arith.constant).value
         some (.constant ⟨intAttr.type.bitwidth, Data.LLVM.Int.constant intAttr.type.bitwidth intAttr.value⟩)
       | _ =>
         none

--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -112,8 +112,8 @@ def addIConstantFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_
     return rewriter
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! rewriter.ctx.raw (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! rewriter.ctx.raw (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! rewriter.ctx.raw Arith.constant).value.value
+  let rhsVal := (rhsOp.getProperties! rewriter.ctx.raw Arith.constant).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (rewriter, newOp) ← rewriter.createOp (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
   let mut rewriter ← rewriter.replaceOp op newOp sorry sorry sorry sorry sorry
@@ -148,8 +148,8 @@ def addIConstantFoldingLocal (ctx: WfIRContext OpCode) (op: OperationPtr) :
     | some (ctx, none)
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! ctx.raw (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! ctx.raw (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! ctx.raw Arith.constant).value.value
+  let rhsVal := (rhsOp.getProperties! ctx.raw Arith.constant).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry
   return (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -166,7 +166,7 @@ def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : o
   let rhsOpStruct := rhsOp.get rewriter.ctx.raw (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
-  if (rhsOp.getProperties! rewriter.ctx.raw (.arith .constant)).value.value ≠ 0 then
+  if (rhsOp.getProperties! rewriter.ctx.raw Arith.constant).value.value ≠ 0 then
     return rewriter
 
   -- Get the lhs value
@@ -192,7 +192,7 @@ def mulITwoReduce (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.
   let rhsOpStruct := rhsOp.get rewriter.ctx.raw (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return rewriter
-  if (rhsOp.getProperties! rewriter.ctx.raw (.arith .constant)).value.value ≠ 2 then
+  if (rhsOp.getProperties! rewriter.ctx.raw Arith.constant).value.value ≠ 2 then
     return rewriter
 
   -- Get the lhs value
@@ -237,8 +237,8 @@ def addIConstantFolding (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (W
     return ctx
 
   -- Sum both constant values
-  let lhsVal := (lhsOp.getProperties! ctx.raw (.arith .constant)).value.value
-  let rhsVal := (rhsOp.getProperties! ctx.raw (.arith .constant)).value.value
+  let lhsVal := (lhsOp.getProperties! ctx.raw Arith.constant).value.value
+  let rhsVal := (rhsOp.getProperties! ctx.raw Arith.constant).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
   let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
   let mut ctx ← WfRewriter.replaceOp? ctx op newOp sorry sorry sorry sorry sorry
@@ -261,7 +261,7 @@ def addIZeroFolding (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRC
   let rhsOpStruct := rhsOp.get ctx.raw (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
-  if (rhsOp.getProperties! ctx.raw (.arith .constant)).value.value ≠ 0 then
+  if (rhsOp.getProperties! ctx.raw Arith.constant).value.value ≠ 0 then
     return ctx
 
   -- Get the lhs value
@@ -287,7 +287,7 @@ def mulITwoReduce (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRCon
   let rhsOpStruct := rhsOp.get ctx.raw (by sorry)
   if rhsOpStruct.opType ≠ .arith .constant then
     return ctx
-  if (rhsOp.getProperties! ctx.raw (.arith .constant)).value.value ≠ 2 then
+  if (rhsOp.getProperties! ctx.raw Arith.constant).value.value ≠ 2 then
     return ctx
 
   -- Get the lhs value

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -180,6 +180,7 @@ structure Operation (OpInfo : Type) [HasOpInfo OpInfo] where
 deriving Inhabited, Repr, Hashable
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
 
 namespace Operation
 
@@ -1061,27 +1062,43 @@ theorem setAttributes!_eq_setAttributes {op : OperationPtr} (inBounds : op.InBou
     op.setAttributes! ctx newAttrs = op.setAttributes ctx newAttrs inBounds := by
   grind [setAttributes, setAttributes!]
 
+/--
+Get the properties of an operation of type `opCode`.
+The passed `opCode` can either be of the global `OpInfo` type, or the dialect-specific `Dialect`
+type, in order to get the dialect-specific properties which is often easier to use.
+-/
 @[inline]
-def getProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo)
+def getProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect)
     (inBounds : op.InBounds ctx := by grind)
-    (hprop : op.getOpType! ctx = opCode := by grind) : HasOpInfo.propertiesOf opCode :=
+    (hprop : op.getOpType! ctx = opCode := by grind) : HasDialectOpInfo.propertiesOf opCode :=
   have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
-  h ▸ (op.get ctx (by grind)).properties
+  let globalProperties := h ▸ (op.get ctx (by grind)).properties
+  HasDialect.toDialectProperties opCode globalProperties
 
+/--
+Get the properties of an operation of type `opCode`.
+The passed `opCode` can either be of the global `OpInfo` type, or the dialect-specific `Dialect`
+type, in order to get the dialect-specific properties which is often easier to use.
+
+This function returns the default properties if the operation is not in bounds, or if the
+operation's type does not match the passed `opCode`.
+-/
 @[inline]
-def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : OpInfo) : HasOpInfo.propertiesOf opCode :=
+def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo)
+    (opCode : Dialect) : HasDialectOpInfo.propertiesOf opCode :=
   if h : (op.get! ctx).opType = opCode then
-    h ▸ (op.get! ctx).properties
+    let globalProperties := h ▸ (op.get! ctx).properties
+    HasDialect.toDialectProperties opCode globalProperties
   else
     default
 
 @[grind =_, eq_bang ←]
 theorem getProperties!_eq_getProperties {op : OperationPtr} (inBounds : op.InBounds ctx)
-    (hprop : op.getOpType! ctx = opCode) :
+    {opCode : Dialect} (hprop : op.getOpType! ctx = opCode) :
     op.getProperties! ctx opCode = op.getProperties ctx opCode inBounds (by grind) := by
   grind [getProperties, getProperties!]
 
-theorem getProperties!_eq_of_OperationPtr_get!_eq {op : OperationPtr} :
+theorem getProperties!_eq_of_OperationPtr_get!_eq {op : OperationPtr} {opCode : Dialect} :
     op.get! ctx = op.get! ctx' →
     op.getProperties! ctx opCode = op.getProperties! ctx' opCode := by
   grind [OperationPtr.get!, getProperties!]

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -7,6 +7,8 @@ namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx ctx': IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode opCode' : Dialect}
 
 public section
 
@@ -100,11 +102,13 @@ theorem OpOperandPtr.get!_OperationPtr_allocEmpty  {opOperand : OpOperandPtr}
 @[simp, grind =>]
 theorem OperationPtr.getProperties!_OperationPtr_allocEmpty {operation : OperationPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
-    operation.getProperties! ctx' ty' =
+    operation.getProperties! ctx' opCode =
     if operation = op' then
-      if h : ty' = ty then h ▸ properties else default
+      if h : (opCode : OpInfo) = ty then
+        HasDialect.toDialectProperties opCode (h ▸ properties)
+      else default
     else
-      operation.getProperties! ctx ty' := by
+      operation.getProperties! ctx opCode := by
   grind
 
 @[grind =>]
@@ -1312,6 +1316,14 @@ theorem OpOperandPtrPtr.get!_OperationPtr_pushResult {opOperandPtr : OpOperandPt
 
 /- OperationPtr.setProperties -/
 
+section OperationPtr.setProperties
+
+variable {operation' : OperationPtr}
+variable {setterOpCode' : OpInfo}
+variable {newProperties : HasOpInfo.propertiesOf setterOpCode'}
+variable {inBounds : operation'.InBounds ctx}
+variable {hprop : operation'.getOpType! ctx = setterOpCode'}
+
 @[simp, grind =]
 theorem BlockPtr.get!_OperationPtr_setProperties {block : BlockPtr} :
     block.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
@@ -1322,17 +1334,19 @@ theorem BlockPtr.get!_OperationPtr_setProperties {block : BlockPtr} :
 theorem OperationPtr.get!_OperationPtr_setProperties {operation : OperationPtr} :
     operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
     if operation = operation' then
-      { operation.get! ctx with opType := operation'.getOpType! ctx, properties := newProperties }
+      { operation.get! ctx with
+        opType := operation'.getOpType! ctx
+        properties := hprop ▸ newProperties }
     else
       operation.get! ctx := by
   grind
 
 @[grind =]
 theorem OperationPtr.getProperties!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getProperties! (OperationPtr.setProperties (opCode := opCode') operation' ctx newProperties inBounds hprop) opCode =
+    operation.getProperties! (OperationPtr.setProperties (opCode := setterOpCode') operation' ctx newProperties inBounds hprop) opCode =
     if operation = operation' then
-      if h : opCode = opCode' then
-        h ▸ newProperties
+      if h : (opCode : OpInfo) = setterOpCode' then
+        HasDialect.toDialectProperties opCode (h ▸ newProperties)
       else
         default
     else
@@ -1343,10 +1357,13 @@ theorem OperationPtr.getProperties!_OperationPtr_setProperties {operation : Oper
   TODO: make a decision about this
 -/
 @[grind =]
-theorem OperationPtr.getProperties!_OperationPtr_setProperties_same_opCode {operation : OperationPtr} :
-    operation.getProperties! (OperationPtr.setProperties (opCode := opCode) operation' ctx newProperties inBounds hprop) opCode =
+theorem OperationPtr.getProperties!_OperationPtr_setProperties_same_opCode
+    {operation : OperationPtr} (h : (opCode : OpInfo) = setterOpCode') :
+    operation.getProperties!
+      (OperationPtr.setProperties (opCode := setterOpCode') operation' ctx
+        newProperties inBounds hprop) opCode =
     if operation = operation' then
-      newProperties
+      HasDialect.toDialectProperties opCode (h ▸ newProperties)
     else
       operation.getProperties! ctx opCode := by
   grind
@@ -1476,6 +1493,8 @@ theorem OpOperandPtrPtr.get!_OperationPtr_setProperties {opOperandPtr : OpOperan
     opOperandPtr.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
     opOperandPtr.get! ctx := by
   grind
+
+end OperationPtr.setProperties
 
 /- OperationPtr.setAttributes -/
 

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -135,6 +135,22 @@ def ofDialect {Dialect : Type} (OpInfo : Type) [HasOpInfo OpInfo] [HasDialectOpI
     OpInfo :=
   HasDialect.inject op
 
+/--
+We can always treat a global opcode type as a dialect of itself.
+This simplifies quite a lot of the API, since we can use a single generic function for both
+dialect-local and global opcodes.
+-/
+instance hasDialectRefl (OpInfo : Type) [HasOpInfo OpInfo] : HasDialect OpInfo OpInfo where
+  inject := id
+  project := some
+  project_eq_some_iff _ _ := by grind
+  properties_eq _ := rfl
+
+/-- Casting an opcode to itself is the identity. -/
+@[simp, grind =]
+theorem ofDialect_hasDialectRefl (OpInfo : Type) [HasOpInfo OpInfo] (op : OpInfo) :
+    ofDialect OpInfo op = op := by rfl
+
 /-- Coercion from a dialect opcode to the global opcode type. -/
 instance {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
     [HasDialect OpInfo Dialect] (op : Dialect) :

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -24,9 +24,9 @@ namespace FunctionOpInterface
 def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr :=
   match funcOp.getOpType! raw with
   | .func .func =>
-    (funcOp.getProperties! raw (.func .func) : FuncFuncProperties).sym_name
+    (funcOp.getProperties! raw Func.func : FuncFuncProperties).sym_name
   | .llvm .func =>
-    (funcOp.getProperties! raw (.llvm .func) : LLVMFuncProperties).sym_name
+    (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).sym_name
   | _ => none
 
 /-- Returns the type of the function. -/
@@ -34,12 +34,12 @@ def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
     Option FunctionType := do
   match funcOp.getOpType! raw with
   | .func .func =>
-    let ta ← (funcOp.getProperties! raw (.func .func) : FuncFuncProperties).function_type
+    let ta ← (funcOp.getProperties! raw Func.func : FuncFuncProperties).function_type
     match ta.val with
     | .functionType ft => some ft
     | _ => none
   | .llvm .func =>
-    let ta ← (funcOp.getProperties! raw (.llvm .func) : LLVMFuncProperties).function_type
+    let ta ← (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).function_type
     match ta.val with
     | .llvmFunctionType ft => some ft
     | _ => none
@@ -91,12 +91,12 @@ def setFunctionType (wfCtx : WfIRContext OpCode) (funcOp : OperationPtr)
   match h : funcOp.getOpType wfCtx.raw opInBounds with
   | .func .func =>
     let ftType : TypeAttr := ⟨.functionType { inputs, outputs }, by simp⟩
-    let props : FuncFuncProperties := funcOp.getProperties! wfCtx.raw (.func .func)
+    let props : FuncFuncProperties := funcOp.getProperties! wfCtx.raw Func.func
     let newProps : FuncFuncProperties := { props with function_type := some ftType }
     WfRewriter.setProperties (opCode := .func .func) wfCtx funcOp newProps opInBounds
   | .llvm .func =>
     let ftType : TypeAttr := ⟨.llvmFunctionType { inputs, outputs }, by simp⟩
-    let props : LLVMFuncProperties := funcOp.getProperties! wfCtx.raw (.llvm .func)
+    let props : LLVMFuncProperties := funcOp.getProperties! wfCtx.raw Llvm.func
     let newProps : LLVMFuncProperties := { props with function_type := some ftType }
     WfRewriter.setProperties (opCode := .llvm .func) wfCtx funcOp newProps opInBounds
   | _ => wfCtx

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -134,7 +134,7 @@ operation whose parent operation is `moduleOp`.
 structure OperationPtr.IsTopLevelFuncWithName (op : OperationPtr) (moduleOp : OperationPtr)
     (ctx : IRContext OpCode) (name : StringAttr) : Prop where
   isFunc : op.getOpType! ctx = .func .func
-  hasName : name = (op.getProperties! ctx (.func .func)).sym_name
+  hasName : name = (op.getProperties! ctx Func.func).sym_name
   isTopLevel : op.getParentOp! ctx = some moduleOp
 
 /--

--- a/Veir/Passes/CSE.lean
+++ b/Veir/Passes/CSE.lean
@@ -123,10 +123,10 @@ def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key := do
       return commutativeBinopKey ctx op kind
   | .llvm .icmp =>
       return icmpKey ctx op (fun props => ⟨.llvm .icmp, props⟩)
-        (op.getProperties! ctx (.llvm .icmp))
+        (op.getProperties! ctx Llvm.icmp)
   | .arith .cmpi =>
       return icmpKey ctx op (fun props => ⟨.arith .cmpi, props⟩)
-        (op.getProperties! ctx (.arith .cmpi))
+        (op.getProperties! ctx Arith.cmpi)
   | .llvm .sub | .llvm .mlir__constant
   | .llvm .shl | .llvm .lshr | .llvm .ashr
   | .llvm .intr__ctlz | .llvm .intr__cttz | .llvm .intr__ctpop

--- a/Veir/Passes/InstructionSelection/RISCV64Branches.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Branches.lean
@@ -33,7 +33,7 @@ def convertBranch (ctx : WfIRContext OpCode) (op : OperationPtr)
     c := c'
 
   if op.getOpType! c = OpCode.llvm .cond_br then do
-    let condProps : CondBrProperties := op.getProperties! c
+    let condProps : CondBrProperties := op.getProperties! c.raw
       (OpCode.llvm .cond_br)
     let props : RISCVBrProperties := ⟨condProps.operandSegmentSizes⟩
 

--- a/Veir/Passes/Matching/Arith/Basic.lean
+++ b/Veir/Passes/Matching/Arith/Basic.lean
@@ -11,7 +11,7 @@ namespace Veir
 def matchArithConstantIntVal (val : ValuePtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .opResult result := val | none
   let .arith .constant := result.op.getOpType! ctx | none
-  let properties := result.op.getProperties! ctx (.arith .constant)
+  let properties := result.op.getProperties! ctx Arith.constant
   return properties.value
 
 def matchArithRemui (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.arith .remui)) := do

--- a/Veir/Passes/Matching/LLVM/Basic.lean
+++ b/Veir/Passes/Matching/LLVM/Basic.lean
@@ -43,7 +43,7 @@ def matchXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
 
 def matchConstantIntOp (op : OperationPtr) (ctx : IRContext OpCode) : Option IntegerAttr := do
   let .llvm .mlir__constant := op.getOpType! ctx | none
-  let properties := op.getProperties! ctx (.llvm .mlir__constant)
+  let properties := op.getProperties! ctx (OpCode.llvm Llvm.mlir__constant)
   let .integer intAttr := properties.value | none
   return intAttr
 
@@ -252,7 +252,7 @@ def matchStore (op : OperationPtr) (ctx : IRContext OpCode) :
   guard (op.getOpType! ctx = .llvm .store)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
-  let properties := op.getProperties! ctx (.llvm .store)
+  let properties := op.getProperties! ctx (OpCode.llvm Llvm.store)
   return (operands[0]!, operands[1]!, properties)
 
 def matchFreeze (op : OperationPtr) (ctx : IRContext OpCode) : Option ValuePtr := do

--- a/Veir/Passes/Matching/LLVM/Lemmas.lean
+++ b/Veir/Passes/Matching/LLVM/Lemmas.lean
@@ -17,7 +17,7 @@ theorem matchAddi_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .add ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .add) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.add) := by
   intro hmatch
   simp only [matchAddi, bind, Option.bind, pure] at hmatch
   grind
@@ -28,7 +28,7 @@ theorem matchAdd_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .add ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .add) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.add) := by
   intro hmatch
   simp only [matchAdd, bind, Option.bind, pure] at hmatch
   grind
@@ -39,7 +39,7 @@ theorem matchSubi_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .sub ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .sub) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.sub) := by
   intro hmatch
   simp only [matchSubi, bind, Option.bind, pure] at hmatch
   grind
@@ -50,7 +50,7 @@ theorem matchMuli_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .mul ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .mul) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.mul) := by
   intro hmatch
   simp only [matchMuli, bind, Option.bind, pure] at hmatch
   grind
@@ -71,7 +71,7 @@ theorem matchAnd_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .and ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .and) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.and) := by
   intro hmatch
   simp only [matchAnd, bind, Option.bind, pure] at hmatch
   grind
@@ -82,7 +82,7 @@ theorem matchOri_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .or ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .or) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.or) := by
   intro hmatch
   simp only [matchOri, bind, Option.bind, pure] at hmatch
   grind
@@ -101,7 +101,7 @@ theorem matchXori_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs}
 theorem matchConstantIntOp_implies {op : OperationPtr} {ctx : IRContext OpCode} {intAttr} :
     matchConstantIntOp op ctx = some intAttr →
     op.getOpType! ctx = .llvm .mlir__constant ∧
-    (op.getProperties! ctx (.llvm .mlir__constant)).value = .integer intAttr := by
+    (op.getProperties! ctx (OpCode.llvm Llvm.mlir__constant)).value = .integer intAttr := by
   intro hmatch
   simp only [matchConstantIntOp, pure] at hmatch
   grind
@@ -147,7 +147,7 @@ theorem matchAshr_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .ashr ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .ashr) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.ashr) := by
   intro hmatch
   simp only [matchAshr, bind, Option.bind, pure] at hmatch
   grind
@@ -158,7 +158,7 @@ theorem matchIcmp_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .icmp ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .icmp) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.icmp) := by
   intro hmatch
   simp only [matchIcmp, bind, Option.bind, pure] at hmatch
   grind
@@ -169,7 +169,7 @@ theorem matchOr_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs pr
     op.getOpType! ctx = .llvm .or ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .or) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.or) := by
   intro hmatch
   simp only [matchOr, bind, Option.bind, pure] at hmatch
   grind
@@ -190,7 +190,7 @@ theorem matchXor_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .xor ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .xor) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.xor) := by
   intro hmatch
   simp only [matchXor, bind, Option.bind, pure] at hmatch
   grind
@@ -333,7 +333,7 @@ theorem matchMul_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .mul ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .mul) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.mul) := by
   intro hmatch
   simp only [matchMul, bind, Option.bind, pure] at hmatch
   grind
@@ -344,7 +344,7 @@ theorem matchSdiv_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .sdiv ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .sdiv) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.sdiv) := by
   intro hmatch
   simp only [matchSdiv, bind, Option.bind, pure] at hmatch
   grind
@@ -355,7 +355,7 @@ theorem matchUdiv_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .udiv ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .udiv) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.udiv) := by
   intro hmatch
   simp only [matchUdiv, bind, Option.bind, pure] at hmatch
   grind
@@ -366,7 +366,7 @@ theorem matchSrem_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .srem ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .srem) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.srem) := by
   intro hmatch
   simp only [matchSrem, bind, Option.bind, pure] at hmatch
   grind
@@ -377,7 +377,7 @@ theorem matchUrem_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .urem ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .urem) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.urem) := by
   intro hmatch
   simp only [matchUrem, bind, Option.bind, pure] at hmatch
   grind
@@ -388,7 +388,7 @@ theorem matchSext_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand 
     op.getOpType! ctx = .llvm .sext ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .sext) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.sext) := by
   intro hmatch
   simp only [matchSext, bind, Option.bind, pure] at hmatch
   grind
@@ -399,7 +399,7 @@ theorem matchTrunc_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand
     op.getOpType! ctx = .llvm .trunc ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .trunc) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.trunc) := by
   intro hmatch
   simp only [matchTrunc, bind, Option.bind, pure] at hmatch
   grind
@@ -410,7 +410,7 @@ theorem matchBitcast_implies {op : OperationPtr} {ctx : IRContext OpCode} {opera
     op.getOpType! ctx = .llvm .bitcast ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .bitcast) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.bitcast) := by
   intro hmatch
   simp only [matchBitcast, bind, Option.bind, pure] at hmatch
   grind
@@ -421,7 +421,7 @@ theorem matchZext_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand 
     op.getOpType! ctx = .llvm .zext ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .zext) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.zext) := by
   intro hmatch
   simp only [matchZext, bind, Option.bind, pure] at hmatch
   grind
@@ -432,7 +432,7 @@ theorem matchShl_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .shl ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .shl) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.shl) := by
   intro hmatch
   simp only [matchShl, bind, Option.bind, pure] at hmatch
   grind
@@ -443,7 +443,7 @@ theorem matchLshr_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs 
     op.getOpType! ctx = .llvm .lshr ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .lshr) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.lshr) := by
   intro hmatch
   simp only [matchLshr, bind, Option.bind, pure] at hmatch
   grind
@@ -454,7 +454,7 @@ theorem matchSub_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs p
     op.getOpType! ctx = .llvm .sub ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[lhs, rhs] ∧
-    props = op.getProperties! ctx (.llvm .sub) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.sub) := by
   intro hmatch
   simp only [matchSub, bind, Option.bind, pure] at hmatch
   grind
@@ -465,7 +465,7 @@ theorem matchLoad_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand 
     op.getOpType! ctx = .llvm .load ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .load) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.load) := by
   intro hmatch
   simp only [matchLoad, bind, Option.bind, pure] at hmatch
   grind
@@ -476,7 +476,7 @@ theorem matchCtlz_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand 
     op.getOpType! ctx = .llvm .intr__ctlz ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .intr__ctlz) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.intr__ctlz) := by
   intro hmatch
   simp only [matchCtlz, bind, Option.bind, pure] at hmatch
   grind
@@ -487,7 +487,7 @@ theorem matchCttz_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand 
     op.getOpType! ctx = .llvm .intr__cttz ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .intr__cttz) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.intr__cttz) := by
   intro hmatch
   simp only [matchCttz, bind, Option.bind, pure] at hmatch
   grind
@@ -498,7 +498,7 @@ theorem matchCtpop_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand
     op.getOpType! ctx = .llvm .intr__ctpop ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[operand] ∧
-    props = op.getProperties! ctx (.llvm .intr__ctpop) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.intr__ctpop) := by
   intro hmatch
   simp only [matchCtpop, bind, Option.bind, pure] at hmatch
   grind
@@ -539,7 +539,7 @@ theorem matchGetelementptr_implies {op : OperationPtr} {ctx : IRContext OpCode} 
     op.getOpType! ctx = .llvm .getelementptr ∧
     op.getNumResults! ctx = 1 ∧
     op.getOperands! ctx = #[base, idx] ∧
-    props = op.getProperties! ctx (.llvm .getelementptr) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.getelementptr) := by
   intro hmatch
   simp only [matchGetelementptr, bind, Option.bind, pure] at hmatch
   grind
@@ -559,7 +559,7 @@ theorem matchStore_implies {op : OperationPtr} {ctx : IRContext OpCode} {value p
     matchStore op ctx = some (value, ptr, props) →
     op.getOpType! ctx = .llvm .store ∧
     op.getOperands! ctx = #[value, ptr] ∧
-    props = op.getProperties! ctx (.llvm .store) := by
+    props = op.getProperties! ctx (OpCode.llvm Llvm.store) := by
   intro hmatch
   simp only [matchStore, bind, pure, Option.bind, guard, failure] at hmatch
   grind

--- a/Veir/Passes/Matching/RISCV/Basic.lean
+++ b/Veir/Passes/Matching/RISCV/Basic.lean
@@ -396,28 +396,28 @@ def matchRVSd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
   guard (op.getOpType! ctx = .riscv .sd)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
-  let properties := op.getProperties! ctx (.riscv .sd)
+  let properties := op.getProperties! ctx Riscv.sd
   return (operands[0]!, operands[1]!, properties)
 
 def matchRVSw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sw)) := do
   guard (op.getOpType! ctx = .riscv .sw)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
-  let properties := op.getProperties! ctx (.riscv .sw)
+  let properties := op.getProperties! ctx Riscv.sw
   return (operands[0]!, operands[1]!, properties)
 
 def matchRVSh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh)) := do
   guard (op.getOpType! ctx = .riscv .sh)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
-  let properties := op.getProperties! ctx (.riscv .sh)
+  let properties := op.getProperties! ctx Riscv.sh
   return (operands[0]!, operands[1]!, properties)
 
 def matchRVSb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sb)) := do
   guard (op.getOpType! ctx = .riscv .sb)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
-  let properties := op.getProperties! ctx (.riscv .sb)
+  let properties := op.getProperties! ctx Riscv.sb
   return (operands[0]!, operands[1]!, properties)
 
 def matchRVMv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .mv)) := do

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -1761,7 +1761,7 @@ private def matchRiscvStore (store : Riscv) (op : OperationPtr) (ctx : IRContext
   guard (op.getOpType! ctx = .riscv store)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
-  let properties := op.getProperties! ctx (.riscv store)
+  let properties := op.getProperties! ctx store
   return (operands[0]!, operands[1]!, properties)
 
 /-- Drop a `riscv.<ext>` from the value operand of a `riscv.<store>` whose width

--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -178,7 +178,7 @@ partial def printOperation (ctx: IRContext OpCode) (op: OperationPtr) (indent: N
   let nameBytes : ByteArray :=
     match opStruct.opType with
     | .builtin .unregistered =>
-      (op.getProperties! ctx (.builtin .unregistered)).opName
+      (op.getProperties! ctx Builtin.unregistered).opName
     | _ => opStruct.opType.name
   IO.print s!"\"{String.fromUTF8! nameBytes}\""
   printOpOperands ctx op

--- a/Veir/Rewriter/GetSet/BlockArguments.lean
+++ b/Veir/Rewriter/GetSet/BlockArguments.lean
@@ -49,6 +49,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 
 /-! ## `Rewriter.pushBlockArgument` -/
 

--- a/Veir/Rewriter/GetSet/BlockOperands.lean
+++ b/Veir/Rewriter/GetSet/BlockOperands.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 
 /-! ## `Rewriter.pushBlockOperand` -/
 

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -55,6 +55,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {dialectOpType : Dialect}
 section Rewriter.createEmptyOp
 
 variable {op : OperationPtr}
@@ -162,15 +164,18 @@ grind_pattern OperationPtr.attrs!_createEmptyOp =>
 
 theorem OperationPtr.getProperties!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
-    operation.getProperties! ctx' opType' =
+    operation.getProperties! ctx' dialectOpType =
     if operation = op then
-      if h : opType = opType' then h ▸ properties else default
+      if h : (dialectOpType : OpInfo) = opType then
+        HasDialect.toDialectProperties dialectOpType (h ▸ properties)
+      else default
     else
-      operation.getProperties! ctx opType' := by
+      operation.getProperties! ctx dialectOpType := by
   grind [Operation.empty]
 
 grind_pattern OperationPtr.getProperties!_createEmptyOp =>
-  Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getProperties! ctx' opType'
+  Rewriter.createEmptyOp ctx opType properties, some (ctx', op),
+    operation.getProperties! ctx' dialectOpType
 
 theorem OperationPtr.getNumResults!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
@@ -482,11 +487,13 @@ theorem OperationPtr.attrs!_createOp {operation : OperationPtr} :
 theorem OperationPtr.getProperties!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
-    operation.getProperties! ctx' opType' =
+    operation.getProperties! ctx' dialectOpType =
     if operation = newOp then
-      if h : opType = opType' then h ▸ properties else default
+      if h : (dialectOpType : OpInfo) = opType then
+        HasDialect.toDialectProperties dialectOpType (h ▸ properties)
+      else default
     else
-      operation.getProperties! ctx opType' := by
+      operation.getProperties! ctx dialectOpType := by
   simp only [Rewriter.createOp]
   grind (gen := 20)
 

--- a/Veir/Rewriter/GetSet/CreateRegion.lean
+++ b/Veir/Rewriter/GetSet/CreateRegion.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 
 section Rewriter.createRegion
 

--- a/Veir/Rewriter/GetSet/DetachBlockOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachBlockOperands.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 section Rewriter.detachBlockOperands.loop
 
 variable {op : OperationPtr}

--- a/Veir/Rewriter/GetSet/DetachOp.lean
+++ b/Veir/Rewriter/GetSet/DetachOp.lean
@@ -52,6 +52,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 section Rewriter.unsetParentAndNeighbors
 
 attribute [local grind] Rewriter.unsetParentAndNeighbors

--- a/Veir/Rewriter/GetSet/DetachOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachOperands.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 section Rewriter.detachOperands.loop
 
 variable {op : OperationPtr}

--- a/Veir/Rewriter/GetSet/InsertOp.lean
+++ b/Veir/Rewriter/GetSet/InsertOp.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 section Rewriter.insertOp
 
 unseal Rewriter.insertOp

--- a/Veir/Rewriter/GetSet/Operands.lean
+++ b/Veir/Rewriter/GetSet/Operands.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 /-! ## `Rewriter.pushOperand` -/
 
 section Rewriter.pushOperand

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -48,6 +48,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 /-! ## `Rewriter.setAttributes` -/
 
 section Rewriter.setAttributes
@@ -139,8 +141,8 @@ theorem OperationPtr.attrs!_setAttributes {op' : OperationPtr} :
 
 @[simp, grind =]
 theorem OperationPtr.getProperties!_setAttributes {op' : OperationPtr} :
-    op'.getProperties! (Rewriter.setAttributes ctx op newAttrs opIn) =
-    op'.getProperties! ctx := by
+    op'.getProperties! (Rewriter.setAttributes ctx op newAttrs opIn) opCode =
+    op'.getProperties! ctx opCode := by
   grind
 
 @[simp, grind =]
@@ -361,12 +363,15 @@ theorem OperationPtr.attrs!_setProperties {op' : OperationPtr} :
   grind
 
 @[grind =]
-theorem OperationPtr.getProperties!_setProperties {op' : OperationPtr} {opCode' : OpInfo}:
-    op'.getProperties! (Rewriter.setProperties ctx op newProps opIn hprop) opCode' =
+theorem OperationPtr.getProperties!_setProperties
+    {op' : OperationPtr} {getterOpCode : Dialect} :
+    op'.getProperties! (Rewriter.setProperties ctx op newProps opIn hprop) getterOpCode =
     if op' = op then
-      if h: opCode' = opCode then h ▸ newProps else default
+      if h : (getterOpCode : OpInfo) = opCode then
+        HasDialect.toDialectProperties getterOpCode (h ▸ newProps)
+      else default
     else
-      op'.getProperties! ctx opCode' := by
+      op'.getProperties! ctx getterOpCode := by
   grind
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/Regions.lean
+++ b/Veir/Rewriter/GetSet/Regions.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 /-! ## `Rewriter.pushRegion` -/
 
 section Rewriter.pushRegion

--- a/Veir/Rewriter/GetSet/ReplaceUse.lean
+++ b/Veir/Rewriter/GetSet/ReplaceUse.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 section Rewriter.replaceUse
 
 @[simp, grind .]
@@ -133,8 +135,8 @@ theorem OperationPtr.attrs!_replaceUse {op : OperationPtr} :
 
 @[simp, grind =]
 theorem OperationPtr.getProperties!_replaceUse {op : OperationPtr} :
-    op.getProperties! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) opType =
-    op.getProperties! ctx opType := by
+    op.getProperties! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) opCode =
+    op.getProperties! ctx opCode := by
   grind [Rewriter.replaceUse]
 
 @[simp, grind =]

--- a/Veir/Rewriter/GetSet/Results.lean
+++ b/Veir/Rewriter/GetSet/Results.lean
@@ -50,6 +50,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 /-! ## `Rewriter.pushResult` -/
 
 section Rewriter.pushResult

--- a/Veir/Rewriter/GetSet/Value.lean
+++ b/Veir/Rewriter/GetSet/Value.lean
@@ -49,6 +49,8 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
 /-! ## `Rewriter.setType` -/
 
 section Rewriter.setType

--- a/Veir/Rewriter/LinkedList/GetSet.lean
+++ b/Veir/Rewriter/LinkedList/GetSet.lean
@@ -53,6 +53,8 @@ variable {blockOperand blockOperand' : BlockOperandPtr}
 variable {value value' : ValuePtr}
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx ctx' : IRContext OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode propT : Dialect}
 
 /- OpOperandPtr.removeFromCurrent -/
 attribute [local grind] OpOperandPtr.removeFromCurrent

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -45,6 +45,9 @@ namespace Veir
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx ctx' : WfIRContext OpInfo}
 variable {operation : OperationPtr} {region : RegionPtr} {block : BlockPtr} {value : ValuePtr}
+variable {opType : OpInfo}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {dialectOpType : Dialect}
 
 /-! ## `WfRewriter.createOp` -/
 
@@ -169,8 +172,12 @@ theorem OperationPtr.attrs!_WfRewriter_createOp :
 theorem OperationPtr.getProperties!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
-    operation.getProperties! ctx'.raw opType =
-    if operation = newOp then properties else operation.getProperties! ctx.raw opType := by
+    operation.getProperties! ctx'.raw dialectOpType =
+    if operation = newOp then
+      if h : (dialectOpType : OpInfo) = opType then
+        HasDialect.toDialectProperties dialectOpType (h ▸ properties)
+      else default
+    else operation.getProperties! ctx.raw dialectOpType := by
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
@@ -391,7 +398,8 @@ theorem OperationPtr.attrs!_wfRewriter_insertOp :
 @[simp, grind =>, simp_getset]
 theorem OperationPtr.getProperties!_wfRewriter_insertOp :
     WfRewriter.insertOp ctx newOp insertionPoint newOpIn insIn = some ctx' →
-    operation.getProperties! ctx'.raw opType = operation.getProperties! ctx.raw opType := by
+    operation.getProperties! ctx'.raw dialectOpType =
+      operation.getProperties! ctx.raw dialectOpType := by
   grind
 
 @[simp, grind =>, simp_getset]
@@ -582,8 +590,9 @@ theorem OperationPtr.attrs!_wfRewriter_eraseOp :
 @[simp, grind =]
 theorem OperationPtr.getProperties!_wfRewriter_eraseOp :
     operation.InBounds (WfRewriter.eraseOp ctx op opRegions opUses hOp).raw →
-    operation.getProperties! (WfRewriter.eraseOp ctx op opRegions opUses hOp).raw opType =
-    operation.getProperties! ctx.raw opType := by
+    operation.getProperties!
+      (WfRewriter.eraseOp ctx op opRegions opUses hOp).raw dialectOpType =
+    operation.getProperties! ctx.raw dialectOpType := by
   grind
 
 @[simp, grind =]
@@ -764,8 +773,9 @@ theorem OperationPtr.attrs!_WfRewriter_replaceValue :
 
 @[simp, grind =]
 theorem OperationPtr.getProperties!_WfRewriter_replaceValue :
-    operation.getProperties! (WfRewriter.replaceValue ctx oldValue newValue ne oldIn newIn).raw opType =
-    operation.getProperties! ctx.raw opType := by
+    operation.getProperties!
+      (WfRewriter.replaceValue ctx oldValue newValue ne oldIn newIn).raw dialectOpType =
+    operation.getProperties! ctx.raw dialectOpType := by
   fun_induction WfRewriter.replaceValue <;> grind
 
 @[simp, grind =]
@@ -947,8 +957,8 @@ theorem OperationPtr.attrs!_wfRewriter_setAttributes {op' : OperationPtr} :
 
 @[simp, grind =]
 theorem OperationPtr.getProperties!_wfRewriter_setAttributes {op' : OperationPtr} :
-    op'.getProperties! (WfRewriter.setAttributes ctx op newAttrs opIn).raw =
-    op'.getProperties! ctx.raw := by
+    op'.getProperties! (WfRewriter.setAttributes ctx op newAttrs opIn).raw dialectOpType =
+    op'.getProperties! ctx.raw dialectOpType := by
   grind
 
 @[simp, grind =]
@@ -1119,12 +1129,15 @@ theorem OperationPtr.attrs!_wfRewriter_setProperties {op' : OperationPtr} :
   grind
 
 @[grind =]
-theorem OperationPtr.getProperties!_wfRewriter_setProperties {op' : OperationPtr} {opCode' : OpInfo}:
-    op'.getProperties! (WfRewriter.setProperties ctx op newProps opIn hprop).raw opCode' =
+theorem OperationPtr.getProperties!_wfRewriter_setProperties
+    {op' : OperationPtr} {getterOpCode : Dialect} :
+    op'.getProperties! (WfRewriter.setProperties ctx op newProps opIn hprop).raw getterOpCode =
     if op' = op then
-      if h: opCode' = opCode then h ▸ newProps else default
+      if h : (getterOpCode : OpInfo) = opCode then
+        HasDialect.toDialectProperties getterOpCode (h ▸ newProps)
+      else default
     else
-      op'.getProperties! ctx.raw opCode' := by
+      op'.getProperties! ctx.raw getterOpCode := by
   grind
 
 @[simp, grind =]
@@ -1295,8 +1308,8 @@ theorem OperationPtr.attrs!_wfRewriter_setType :
 
 @[simp, grind =]
 theorem OperationPtr.getProperties!_wfRewriter_setType :
-    operation.getProperties! (WfRewriter.setType ctx setValue newType hValue).raw opType =
-    operation.getProperties! ctx.raw opType := by
+    operation.getProperties! (WfRewriter.setType ctx setValue newType hValue).raw dialectOpType =
+    operation.getProperties! ctx.raw dialectOpType := by
   grind
 
 @[simp, grind =]

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -69,7 +69,7 @@ def OperationPtr.verifyLLVMFuncReturnTypes (op : OperationPtr) (ctx : WfIRContex
 def OperationPtr.verifyLLVMGlobalReturnTypes (op : OperationPtr) (ctx : WfIRContext OpCode)
     (opIn : op.InBounds ctx.raw) (globalOp : OperationPtr) : Except String PUnit := do
   let globalType :=
-    (globalOp.getProperties! ctx.raw (.llvm .mlir__global)).global_type
+    (globalOp.getProperties! ctx.raw Llvm.mlir__global).global_type
   if op.getNumOperands ctx.raw opIn ≠ 1 then
     throw "Expected llvm.return in llvm.mlir.global to have 1 operand"
   let opTypes := op.getOperandTypes! ctx.raw
@@ -223,7 +223,7 @@ def OperationPtr.verifyModArithConstantOp (op : OperationPtr) (ctx: WfIRContext 
     op.verifyPlainOpCounts ctx opIn 0 1
     let instrName := String.fromUTF8! (op.getOpType ctx.raw opIn).name
     let mat ← ((op.getResult 0).get! ctx.raw).type.verifyModArithType s!"{instrName}: Expected result to have ModArithType"
-    let value := (op.getProperties! ctx.raw (.mod_arith .constant)).value.value
+    let value := (op.getProperties! ctx.raw Mod_Arith.constant).value.value
     let bw := mat.modulus.type.bitwidth
     -- slightly odd range because the storage type is signless
     if value < -(2 ^ (bw - 1) : Int) ∨ (2 ^ bw : Int) ≤ value then
@@ -272,7 +272,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 0 regions"
     else if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    else if (op.getProperties! ctx.raw (.arith .constant)).value.type ≠
+    else if (op.getProperties! ctx.raw Arith.constant).value.type ≠
           ((op.getResult 0).get ctx.raw).type.val then
         throw "Expected result type to be equal to the constant's type"
     pure ()
@@ -366,7 +366,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     -- a same-width float result, or a same-width integer result (the workaround
     -- for builtin MLIR float types without an LLVM equivalent).
     let resultType := ((op.getResult 0).get! ctx.raw).type.val
-    match (op.getProperties! ctx.raw (.llvm .mlir__constant)).value with
+    match (op.getProperties! ctx.raw Llvm.mlir__constant).value with
     | .integer _ =>
       match resultType with
       | .integerType _ => pure ()
@@ -405,7 +405,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
       throw "Expected 1 region"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    let properties := op.getProperties! ctx.raw (.llvm .mlir__global)
+    let properties := op.getProperties! ctx.raw Llvm.mlir__global
     if let some alignment := properties.alignment then
       if alignment.type.bitwidth ≠ 64 then
         throw "'alignment' must be a 64-bit signless integer attribute"
@@ -494,15 +494,15 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .llvm .cond_br => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyTerminatorCounts ctx opIn 2
-    let weights := (op.getProperties! ctx.raw (.llvm .cond_br)).branch_weights
+    let weights := (op.getProperties! ctx.raw Llvm.cond_br).branch_weights
     if weights.values.size ≠ 2 && weights.values.size ≠ 0 then
       throw "Expected 0 or 2 branch weights"
-    let sizes := (op.getProperties! ctx.raw (.llvm .cond_br)).operandSegmentSizes
+    let sizes := (op.getProperties! ctx.raw Llvm.cond_br).operandSegmentSizes
     op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 1
   | .llvm .alloca => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 1 1
-    let properties := (op.getProperties! ctx.raw (.llvm .alloca))
+    let properties := (op.getProperties! ctx.raw Llvm.alloca)
     if properties.alignment.type.bitwidth ≠ 64 then
       throw "'llvm.alloca' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
 
@@ -510,7 +510,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .llvm .load => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 1 1
-    let properties := (op.getProperties! ctx.raw (.llvm .load))
+    let properties := (op.getProperties! ctx.raw Llvm.load)
     if properties.alignment.type.bitwidth ≠ 64 then
       throw "'llvm.load' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
 
@@ -518,13 +518,13 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .llvm .store => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 2 0
-    let properties := (op.getProperties! ctx.raw (.llvm .store))
+    let properties := (op.getProperties! ctx.raw Llvm.store)
     if properties.alignment.type.bitwidth ≠ 64 then
       throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
     pure ()
   | .llvm .getelementptr => do
     op.checkIsNonNullIntegerType ctx opIn
-    let props := op.getProperties! ctx.raw (.llvm .getelementptr)
+    let props := op.getProperties! ctx.raw Llvm.getelementptr
     let dynamicCount := props.rawConstantIndices.values.filter (· == -2147483648) |>.size
     if op.getNumOperands ctx.raw opIn ≠ 1 + dynamicCount then
       throw s!"Expected {1 + dynamicCount} operands"
@@ -591,53 +591,53 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     op.verifyPlainOpCounts ctx opIn 0 1
     pure ()
   | .riscv .lui => do
-    op.verifyRISCVneg ctx opIn 0 1 (op.getProperties! ctx.raw (.riscv .lui)).value.value
+    op.verifyRISCVneg ctx opIn 0 1 (op.getProperties! ctx.raw Riscv.lui).value.value
     pure ()
   | .riscv .auipc => do
-    op.verifyRISCVneg ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .auipc)).value.value
+    op.verifyRISCVneg ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.auipc).value.value
     pure ()
   | .riscv .addi => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .addi)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.addi).value.value
     pure ()
   | .riscv .slti => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .slti)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.slti).value.value
     pure ()
   | .riscv .sltiu => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .sltiu)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.sltiu).value.value
     pure ()
   | .riscv .andi => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .andi)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.andi).value.value
     pure ()
   | .riscv .ori => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .ori)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.ori).value.value
     pure ()
   | .riscv .xori => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .xori)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.xori).value.value
     pure ()
   | .riscv .addiw => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .addiw)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.addiw).value.value
     pure ()
   | .riscv .slli => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .slli)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.slli).value.value
     pure ()
   | .riscv .srli => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .srli)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.srli).value.value
     pure ()
   | .riscv .srai => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .srai)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.srai).value.value
     pure ()
   | .riscv .add | .riscv .sub | .riscv .sll | .riscv .slt | .riscv .sltu
   | .riscv .xor | .riscv .srl | .riscv .sra | .riscv .or | .riscv .and => do
     op.verifyPlainOpCounts ctx opIn 2 1
     pure ()
   | .riscv .slliw => do
-    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .slliw)).value.value
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw Riscv.slliw).value.value
     pure ()
   | .riscv .srliw => do
-    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .srliw)).value.value
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw Riscv.srliw).value.value
     pure ()
   | .riscv .sraiw => do
-    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .sraiw)).value.value
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw Riscv.sraiw).value.value
     pure ()
   | .riscv .addw | .riscv .subw | .riscv .sllw | .riscv .srlw | .riscv .sraw
   | .riscv .rem | .riscv .remu | .riscv .remw | .riscv .remuw
@@ -648,7 +648,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     op.verifyPlainOpCounts ctx opIn 2 1
     pure ()
   | .riscv .slliuw => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .slliuw)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.slliuw).value.value
     pure ()
   | .riscv .andn | .riscv .orn | .riscv .xnor
   | .riscv .max | .riscv .maxu | .riscv .min | .riscv .minu
@@ -661,62 +661,62 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
     op.verifyPlainOpCounts ctx opIn 1 1
     pure ()
   | .riscv .roriw => do
-    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw (.riscv .roriw)).value.value
+    op.verifyRISCVuimm5 ctx opIn (op.getProperties! ctx.raw Riscv.roriw).value.value
     pure ()
   | .riscv .rori => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .rori)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.rori).value.value
     pure ()
   | .riscv .bclr | .riscv .bext | .riscv .binv | .riscv .bset => do
     op.verifyPlainOpCounts ctx opIn 2 1
     pure ()
   | .riscv .bclri => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .bclri)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.bclri).value.value
     pure ()
   | .riscv .bexti => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .bexti)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.bexti).value.value
     pure ()
   | .riscv .binvi => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .binvi)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.binvi).value.value
     pure ()
   | .riscv .bseti => do
-    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw (.riscv .bseti)).value.value
+    op.verifyRISCVuimm6 ctx opIn (op.getProperties! ctx.raw Riscv.bseti).value.value
     pure ()
   | .riscv .pack | .riscv .packh | .riscv .packw
   | .riscv .czeroeqz | .riscv .czeronez => do
     op.verifyPlainOpCounts ctx opIn 2 1
     pure ()
   | .riscv .ld => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .ld)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.ld).value.value
     pure ()
   | .riscv .lw => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .lw)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.lw).value.value
     pure ()
   | .riscv .lwu => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .lwu)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.lwu).value.value
     pure ()
   | .riscv .lh => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .lh)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.lh).value.value
     pure ()
   | .riscv .lhu => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .lhu)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.lhu).value.value
     pure ()
   | .riscv .lb => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .lb)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.lb).value.value
     pure ()
   | .riscv .lbu => do
-    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw (.riscv .lbu)).value.value
+    op.verifyRISCVimm12 ctx opIn 1 1 (op.getProperties! ctx.raw Riscv.lbu).value.value
     pure ()
   | .riscv .sd => do
-    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw (.riscv .sd)).value.value
+    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw Riscv.sd).value.value
     pure ()
   | .riscv .sw => do
-    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw (.riscv .sw)).value.value
+    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw Riscv.sw).value.value
     pure ()
   | .riscv .sh => do
-    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw (.riscv .sh)).value.value
+    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw Riscv.sh).value.value
     pure ()
   | .riscv .sb => do
-    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw (.riscv .sb)).value.value
+    op.verifyRISCVimm12 ctx opIn 2 0 (op.getProperties! ctx.raw Riscv.sb).value.value
     pure ()
   | .riscv .mv | .riscv .not | .riscv .neg | .riscv .negw | .riscv .sextw
   | .riscv .zextb | .riscv .zextw | .riscv .seqz | .riscv .snez
@@ -770,7 +770,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .riscv_stack .alloca => do
     op.verifyPlainOpCounts ctx opIn 0 1
     op.verifyRISCVRegisterTypes ctx opIn
-    let properties := op.getProperties! ctx.raw (.riscv_stack .alloca)
+    let properties := op.getProperties! ctx.raw Riscv_Stack.alloca
     if properties.size.type.bitwidth ≠ 64 then
       throw "attribute 'size' must be a 64-bit signless integer attribute"
     if properties.size.value < 0 then
@@ -897,7 +897,7 @@ private def WfIRContext.verifyLLVMGlobalSymbols (ctx : WfIRContext OpCode) :
   let mut globals : Std.HashMap ByteArray OperationPtr := Std.HashMap.emptyWithCapacity
   for op in ctx.raw.operations.keys do
     if op.getOpType! ctx.raw = .llvm .mlir__global then
-      let props := op.getProperties! ctx.raw (.llvm .mlir__global)
+      let props := op.getProperties! ctx.raw Llvm.mlir__global
       let symbolName := "@".toUTF8 ++ props.sym_name.value
       if globals.contains symbolName then
         let displayName := String.fromUTF8? symbolName |>.getD "<non-UTF8 global symbol>"
@@ -905,7 +905,7 @@ private def WfIRContext.verifyLLVMGlobalSymbols (ctx : WfIRContext OpCode) :
       globals := globals.insert symbolName op
   for op in ctx.raw.operations.keys do
     if op.getOpType! ctx.raw = .llvm .mlir__addressof then
-      let props := op.getProperties! ctx.raw (.llvm .mlir__addressof)
+      let props := op.getProperties! ctx.raw Llvm.mlir__addressof
       if !globals.contains props.global_name.value.toUTF8 then
         throw s!"llvm.mlir.addressof: symbol '{props.global_name.value}' does not name an llvm.mlir.global"
 
@@ -1037,7 +1037,7 @@ theorem OperationPtr.Verified.arith_constant {op : OperationPtr} {opInBounds}
     op.getNumSuccessors! ctx.raw = 0 ∧
     op.getNumRegions! ctx.raw = 0 ∧
     ((op.getResult 0).get! ctx.raw).type =
-      ⟨(op.getProperties! ctx.raw (.arith .constant)).value.type, (by grind)⟩ := by
+      ⟨(op.getProperties! ctx.raw Arith.constant).value.type, (by grind)⟩ := by
   simp only [Verified, verifyLocalInvariants, ← getOpType!_eq_getOpType, opType, ne_eq,
     bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure, Except.pure, dite_not,
     ite_not] at opVerify
@@ -1049,7 +1049,7 @@ theorem OperationPtr.Verified.llvm_mlir__constant_resultType {op : OperationPtr}
     {intAttr : IntegerAttr}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .mlir__constant)
-    (hProp : (op.getProperties! ctx.raw (.llvm .mlir__constant)).value = .integer intAttr) :
+    (hProp : (op.getProperties! ctx.raw Llvm.mlir__constant).value = .integer intAttr) :
     ∃ intTy : IntegerType, ((op.getResult 0).get! ctx.raw).type.val = .integerType intTy := by
   rw [Verified] at opVerify
   simp only [verifyLocalInvariants, ← getOpType!_eq_getOpType, opType] at opVerify
@@ -1644,8 +1644,8 @@ def OperationPtr.IsVerifiedModArithConstant (op : OperationPtr) (ctx : WfIRConte
     modArithType.modulus.value > 0 ∧
     modArithType.modulus.value < 2 ^ modArithType.modulus.type.bitwidth ∧
     -(2 ^ (modArithType.modulus.type.bitwidth - 1) : Int)
-        ≤ (op.getProperties! ctx.raw (.mod_arith .constant)).value.value ∧
-    (op.getProperties! ctx.raw (.mod_arith .constant)).value.value
+        ≤ (op.getProperties! ctx.raw Mod_Arith.constant).value.value ∧
+    (op.getProperties! ctx.raw Mod_Arith.constant).value.value
         < 2 ^ modArithType.modulus.type.bitwidth
 
 theorem OperationPtr.Verified.mod_arith_constant {op : OperationPtr} {opInBounds}


### PR DESCRIPTION
With this change, we can now write `getProperties ctx Arith.addi` instead of `getProperties ctx (.arith .addi)`, and get a `propertiesOf (Arith.addi)` instead of a `propertiesOf (.arith .addi)`. This is quite important since the new version is definitionally equal to the property structure, while the second one will not be definitionally equal when we have a generic `OpInfo` rather than `OpCode`.