### PR TITLE
feat(PDL): enforce `SingleBlock` on a `pdl.rewrite` body

### DIFF
--- a/Test/PDL/rewrite_multi_block_invalid.mlir
+++ b/Test/PDL/rewrite_multi_block_invalid.mlir
@@ -1,0 +1,17 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// MLIR gives `pdl.rewrite` `SingleBlock`, so its body holds at most one block.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+      ^bb0():
+        %1 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+      ^bb1():
+        %2 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.rewrite: Expected the rewrite region to contain at most 1 block

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -273,6 +273,10 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
     /- An external rewrite names a native function and leaves its region empty;
        an inline rewrite supplies a body and takes no external arguments. -/
     let body := (op.getRegion! ctx.raw 0).get! ctx.raw
+    /- MLIR gives `pdl.rewrite` `SingleBlock`, so the body holds no more than
+       one block. -/
+    if body.firstBlock ≠ body.lastBlock then
+      throw "Expected the rewrite region to contain at most 1 block"
     if props.name.isSome then
       if body.firstBlock.isSome then
         throw "Expected the rewrite region to be empty when the rewrite is external"


### PR DESCRIPTION
MLIR gives `pdl.rewrite` the `SingleBlock` trait, and rejects a body with more than one block. VeIR accepted it: the check had been an incidental consequence of modelling the body as a graph region, and was lost when the body became an ordinary SSACFG region carrying `hasNoTerminator` instead.