### PR TITLE
feat(PDL): verify `pdl.pattern` body invariants

### DIFF
--- a/Test/PDL/operand.mlir
+++ b/Test/PDL/operand.mlir
@@ -1,16 +1,27 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
-  // Define an external operand:
-  %0 = "pdl.operand"() : () -> !pdl.value
-  // Define an external operand with an expected type:
-  %1 = "pdl.type"() <{"constantType" = i32}> : () -> !pdl.type
-  %2 = "pdl.operand"(%1) : (!pdl.type) -> !pdl.value
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    // Define an external operand:
+    %0 = "pdl.operand"() : () -> !pdl.value
+    // Define an external operand with an expected type:
+    %1 = "pdl.type"() <{"constantType" = i32}> : () -> !pdl.type
+    %2 = "pdl.operand"(%1) : (!pdl.type) -> !pdl.value
+    %3 = "pdl.operation"(%0, %2) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 0, 0>}> : (!pdl.value, !pdl.value) -> !pdl.operation
+    "pdl.rewrite"(%3) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %{{.*}} = "pdl.operand"() : () -> !pdl.value
-// CHECK-NEXT:     %{{.*}} = "pdl.type"() <{"constantType" = i32}> : () -> !pdl.type
-// CHECK-NEXT:     %{{.*}} = "pdl.operand"(%{{.*}}) : (!pdl.type) -> !pdl.value
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:         %{{.*}} = "pdl.type"() <{"constantType" = i32}> : () -> !pdl.type
+// CHECK-NEXT:         %{{.*}} = "pdl.operand"(%{{.*}}) : (!pdl.type) -> !pdl.value
+// CHECK-NEXT:         %{{.*}} = "pdl.operation"(%{{.*}}, %{{.*}}) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 0, 0>}> : (!pdl.value, !pdl.value) -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%{{.*}}) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({        }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/operation.mlir
+++ b/Test/PDL/operation.mlir
@@ -1,25 +1,50 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
   // Define an operation with no constraints:
-  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
   // Define an operation with a name:
-  %1 = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
   // Define an operation with operands, attributes and result types:
-  %2 = "pdl.operand"() : () -> !pdl.value
-  %3 = "pdl.operand"() : () -> !pdl.value
-  %4 = "pdl.attribute"() : () -> !pdl.attribute
-  %5 = "pdl.type"() : () -> !pdl.type
-  %6 = "pdl.operation"(%2, %3, %4, %5) <{"attributeValueNames" = ["attrA"], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 1, 1>}> : (!pdl.value, !pdl.value, !pdl.attribute, !pdl.type) -> !pdl.operation
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operand"() : () -> !pdl.value
+    %1 = "pdl.operand"() : () -> !pdl.value
+    %2 = "pdl.attribute"() : () -> !pdl.attribute
+    %3 = "pdl.type"() : () -> !pdl.type
+    %4 = "pdl.operation"(%0, %1, %2, %3) <{"attributeValueNames" = ["attrA"], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 1, 1>}> : (!pdl.value, !pdl.value, !pdl.attribute, !pdl.type) -> !pdl.operation
+    "pdl.rewrite"(%4) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
 }) : () -> ()
 
 // CHECK:      "builtin.module"() ({
 // CHECK-NEXT:   ^{{.*}}():
-// CHECK-NEXT:     %{{.*}} = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
-// CHECK-NEXT:     %{{.*}} = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
-// CHECK-NEXT:     %[[v0:.*]] = "pdl.operand"() : () -> !pdl.value
-// CHECK-NEXT:     %[[v1:.*]] = "pdl.operand"() : () -> !pdl.value
-// CHECK-NEXT:     %[[a0:.*]] = "pdl.attribute"() : () -> !pdl.attribute
-// CHECK-NEXT:     %[[t0:.*]] = "pdl.type"() : () -> !pdl.type
-// CHECK-NEXT:     %{{.*}} = "pdl.operation"(%[[v0]], %[[v1]], %[[a0]], %[[t0]]) <{"attributeValueNames" = ["attrA"], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 1, 1>}> : (!pdl.value, !pdl.value, !pdl.attribute, !pdl.type) -> !pdl.operation
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%{{.*}}) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({        }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%{{.*}}) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({        }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:         %{{.*}} = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:         %{{.*}} = "pdl.attribute"() : () -> !pdl.attribute
+// CHECK-NEXT:         %{{.*}} = "pdl.type"() : () -> !pdl.type
+// CHECK-NEXT:         %{{.*}} = "pdl.operation"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"attributeValueNames" = ["attrA"], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 2, 1, 1>}> : (!pdl.value, !pdl.value, !pdl.attribute, !pdl.type) -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%{{.*}}) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({        }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/pattern_no_operation_invalid.mlir
+++ b/Test/PDL/pattern_no_operation_invalid.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A pattern that matches no operation matches nothing.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.type"() : () -> !pdl.type
+    "pdl.rewrite"() <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 0, 0>}> ({
+    }) : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.pattern: the pattern must contain at least one `pdl.operation`

--- a/Test/PDL/pattern_non_pdl_op_invalid.mlir
+++ b/Test/PDL/pattern_non_pdl_op_invalid.mlir
@@ -1,0 +1,14 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A `pdl.pattern` body describes a pattern, so it holds only `pdl` operations.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+    %1 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%1) <{"name" = "rewriter", "operandSegmentSizes" = array<i32: 1, 0>}> ({
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.pattern: expected only `pdl` operations within the pattern body, but got 'arith.constant'

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -928,6 +928,34 @@ private def WfIRContext.verifyLLVMGlobalSymbols (ctx : WfIRContext OpCode) :
       if !globals.contains props.global_name.value.toUTF8 then
         throw s!"llvm.mlir.addressof: symbol '{props.global_name.value}' does not name an llvm.mlir.global"
 
+/--
+  Check the whole-pattern invariants that MLIR verifies in
+  `PatternOp::verifyRegions`: a `pdl.pattern` body holds only `pdl` operations,
+  and contains at least one `pdl.operation`.
+-/
+private def WfIRContext.verifyPDLPatternBodies (ctx : WfIRContext OpCode) :
+    Except String Unit := do
+  let mut patternHasOperation : Std.HashMap OperationPtr Bool := Std.HashMap.emptyWithCapacity
+  for op in ctx.raw.operations.keys do
+    if op.getOpType! ctx.raw = .pdl .pattern then
+      patternHasOperation := patternHasOperation.insert op false
+  for op in ctx.raw.operations.keys do
+    match op.getParentOp! ctx.raw with
+    | some parent =>
+      /- The body of a `pdl.pattern` and the body of the `pdl.rewrite` that
+         terminates it both belong to the pattern. -/
+      let parentType := parent.getOpType! ctx.raw
+      if parentType = .pdl .pattern || parentType = .pdl .rewrite then
+        let opType := op.getOpType! ctx.raw
+        let .pdl pdlOp := opType
+          | throw s!"pdl.pattern: expected only `pdl` operations within the pattern body, but got '{String.fromUTF8! opType.name}'"
+        if pdlOp = .operation && parentType = .pdl .pattern then
+          patternHasOperation := patternHasOperation.insert parent true
+    | none => pure ()
+  for (_, hasOperation) in patternHasOperation.toArray do
+    if !hasOperation then
+      throw "pdl.pattern: the pattern must contain at least one `pdl.operation`"
+
 public section
 
 /--
@@ -957,6 +985,7 @@ def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
         block.verifyTerminator ctx blockIn
     | none => pure ())
   ctx.verifyLLVMGlobalSymbols
+  ctx.verifyPDLPatternBodies
 
 /--
 Assert that the IR context satisfies its structural and local invariants.


### PR DESCRIPTION
A `pdl.pattern` body holds only `pdl` operations and must contain at least one
`pdl.operation`. They span a whole region, so they run as a module-wide pass
alongside the LLVM global symbol checks rather than as local invariants.

With those rules enforced, `operand.mlir` and `operation.mlir` can finally be
cross-checked against `mlir-opt` — they were the last two PDL round-trip tests
running only under `veir-opt`, since `pdl.operand` carries
`HasParent<pdl::PatternOp>` and is rejected outside a `pdl.pattern`. Wrapping
alone is not enough, which is why those two tests are reshaped rather than
merely indented: a pattern needs at least one `pdl.operation`, and every entity
in a matcher body needs a bindable user, so `operand.mlir` gains an operation
consuming both operands and `operation.mlir` becomes one pattern per shape.
