### PR TITLE
feat(PDL): add `pdl.replace` operation

### DIFF
--- a/Test/PDL/replace.mlir
+++ b/Test/PDL/replace.mlir
@@ -1,0 +1,49 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  // Replace the matched operation with another operation:
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.type"() : () -> !pdl.type
+    %1 = "pdl.operand"() : () -> !pdl.value
+    %2 = "pdl.operation"(%1, %0) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.type) -> !pdl.operation
+    "pdl.rewrite"(%2) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+      %3 = "pdl.operation"(%0) <{"attributeValueNames" = [], "opName" = "bar.op", "operandSegmentSizes" = array<i32: 0, 0, 1>}> : (!pdl.type) -> !pdl.operation
+      "pdl.replace"(%2, %3) <{"operandSegmentSizes" = array<i32: 1, 1, 0>}> : (!pdl.operation, !pdl.operation) -> ()
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+  // Replace the matched operation with a list of values:
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.type"() : () -> !pdl.type
+    %1 = "pdl.operand"() : () -> !pdl.value
+    %2 = "pdl.operation"(%1, %0) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.type) -> !pdl.operation
+    "pdl.rewrite"(%2) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+      "pdl.replace"(%2, %1) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.operation, !pdl.value) -> ()
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "pdl.type"() : () -> !pdl.type
+// CHECK-NEXT:         %{{.*}} = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:         %{{.*}} = "pdl.operation"(%{{.*}}, %{{.*}}) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.type) -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%{{.*}}) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+// CHECK-NEXT:           ^{{.*}}():
+// CHECK-NEXT:             %{{.*}} = "pdl.operation"(%{{.*}}) <{"attributeValueNames" = [], "opName" = "bar.op", "operandSegmentSizes" = array<i32: 0, 0, 1>}> : (!pdl.type) -> !pdl.operation
+// CHECK-NEXT:             "pdl.replace"(%{{.*}}, %{{.*}}) <{"operandSegmentSizes" = array<i32: 1, 1, 0>}> : (!pdl.operation, !pdl.operation) -> ()
+// CHECK-NEXT:         }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %{{.*}} = "pdl.type"() : () -> !pdl.type
+// CHECK-NEXT:         %{{.*}} = "pdl.operand"() : () -> !pdl.value
+// CHECK-NEXT:         %{{.*}} = "pdl.operation"(%{{.*}}, %{{.*}}) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.type) -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%{{.*}}) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+// CHECK-NEXT:           ^{{.*}}():
+// CHECK-NEXT:             "pdl.replace"(%{{.*}}, %{{.*}}) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.operation, !pdl.value) -> ()
+// CHECK-NEXT:         }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/PDL/replace_both_invalid.mlir
+++ b/Test/PDL/replace_both_invalid.mlir
@@ -1,0 +1,16 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The replacement is either an operation or a list of values, never both.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operand"() : () -> !pdl.value
+    %1 = "pdl.operation"(%0) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!pdl.value) -> !pdl.operation
+    "pdl.rewrite"(%1) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+      %2 = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "bar.op", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+      "pdl.replace"(%1, %2, %0) <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (!pdl.operation, !pdl.operation, !pdl.value) -> ()
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.replace: Expected no replacement values when the replacement operation is present

--- a/Test/PDL/replace_op_type_invalid.mlir
+++ b/Test/PDL/replace_op_type_invalid.mlir
@@ -1,0 +1,15 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The replaced `opValue` is an `!pdl.operation` handle.
+"builtin.module"() ({
+  "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+    %0 = "pdl.operand"() : () -> !pdl.value
+    %1 = "pdl.operation"(%0) <{"attributeValueNames" = [], "opName" = "foo.op", "operandSegmentSizes" = array<i32: 1, 0, 0>}> : (!pdl.value) -> !pdl.operation
+    "pdl.rewrite"(%1) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+      "pdl.replace"(%0, %0) <{"operandSegmentSizes" = array<i32: 1, 0, 1>}> : (!pdl.value, !pdl.value) -> ()
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: pdl.replace: Expected the `opValue` operand to be of type '!pdl.operation'

--- a/Test/PDL/replace_parent_invalid.mlir
+++ b/Test/PDL/replace_parent_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A `pdl.replace` only appears inside the body of a `pdl.rewrite`.
+"builtin.module"() ({
+  %0 = "pdl.operation"() <{"attributeValueNames" = [], "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+  "pdl.replace"(%0, %0) <{"operandSegmentSizes" = array<i32: 1, 1, 0>}> : (!pdl.operation, !pdl.operation) -> ()
+}) : () -> ()
+
+// CHECK: pdl.replace: Expected the parent operation to be a `pdl.rewrite`

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -16,6 +16,7 @@ inductive PDL where
 | operand
 | operation
 | pattern
+| replace
 | result
 | rewrite
 | type
@@ -28,6 +29,7 @@ match op with
 | .operand => Unit
 | .operation => PDLOperationProperties
 | .pattern => PDLPatternProperties
+| .replace => PDLReplaceProperties
 | .result => PDLResultProperties
 | .rewrite => PDLRewriteProperties
 | .type => PDLTypeProperties
@@ -45,6 +47,7 @@ def PDL.fromAttrDict
       .ok ()
   | .operation => PDLOperationProperties.fromAttrDict attrDict
   | .pattern => PDLPatternProperties.fromAttrDict attrDict
+  | .replace => PDLReplaceProperties.fromAttrDict attrDict
   | .result => PDLResultProperties.fromAttrDict attrDict
   | .rewrite => PDLRewriteProperties.fromAttrDict attrDict
   | .type => PDLTypeProperties.fromAttrDict attrDict
@@ -71,6 +74,9 @@ def PDL.toAttrDict
     if let some symName := props.sym_name then
       dict := dict.insert "sym_name".toUTF8 (.stringAttr symName)
     dict
+  | .replace =>
+    (Std.HashMap.emptyWithCapacity 1).insert
+      "operandSegmentSizes".toUTF8 (.denseArrayAttr props.operandSegmentSizes)
   | .result =>
     (Std.HashMap.emptyWithCapacity 1).insert "index".toUTF8 (.integerAttr props.index)
   | .rewrite => Id.run do
@@ -231,6 +237,47 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
       | throw "Expected the body to terminate with a `pdl.rewrite`"
     if toDialect? PDL (terminator.getOpType! ctx.raw) ≠ some PDL.rewrite then
       throw "Expected the body to terminate with a `pdl.rewrite`"
+  | .replace =>
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    /- A `pdl.replace` only appears inside the body of a `pdl.rewrite`. -/
+    match op.getParentOp! ctx.raw with
+    | some parent =>
+      if toDialect? PDL (parent.getOpType! ctx.raw) ≠ some PDL.rewrite then
+        throw "Expected the parent operation to be a `pdl.rewrite`"
+    | none => throw "Expected the parent operation to be a `pdl.rewrite`"
+    let props : PDL.propertiesOf .replace :=
+      HasDialect.toDialectProperties (OpInfo := OpInfo) PDL.replace
+        (op.getProperties! ctx.raw (ofDialect OpInfo PDL.replace))
+    /- The operands are the replaced `opValue`, the optional `replOperation`,
+       and the `replValues`, in that order. -/
+    let segments ← op.verifyOperandSegmentSizes ctx opIn props.operandSegmentSizes 3
+    let replOperationCount := segments[1]!
+    let replValueCount := segments[2]!
+    if segments[0]! ≠ 1 then
+      throw "Expected exactly 1 replaced operation"
+    if replOperationCount > 1 then
+      throw "Expected at most 1 replacement operation"
+    if ((op.getOperand! ctx.raw 0).getType! ctx.raw).val
+        ≠ (PDL.OperationType.mk : TypeAttr).val then
+      throw "Expected the `opValue` operand to be of type '!pdl.operation'"
+    if replOperationCount = 1 then
+      if ((op.getOperand! ctx.raw 1).getType! ctx.raw).val
+          ≠ (PDL.OperationType.mk : TypeAttr).val then
+        throw "Expected the `replOperation` operand to be of type '!pdl.operation'"
+    /- TODO: `!pdl.range<...>` is not modelled yet, so `replValues` accepts
+       single handles only. -/
+    for i in [1 + replOperationCount : 1 + replOperationCount + replValueCount] do
+      if ((op.getOperand! ctx.raw i).getType! ctx.raw).val
+          ≠ (PDL.ValueType.mk : TypeAttr).val then
+        throw s!"Expected operand {i} to be of type '!pdl.value'"
+    /- The replacement is either an operation or a list of values, never both. -/
+    if replOperationCount = 1 && replValueCount ≠ 0 then
+      throw "Expected no replacement values when the replacement operation is present"
   | .result =>
     op.verifyPlainOpCounts ctx opIn 1 1
     op.verifyResultTypeMatches ctx (PDL.ValueType.mk : TypeAttr)

--- a/Veir/Dialects/PDL/Properties.lean
+++ b/Veir/Dialects/PDL/Properties.lean
@@ -168,6 +168,26 @@ def PDLRewriteProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribut
     throw s!"pdl.rewrite: expected only the 'name' and 'operandSegmentSizes' properties, but got {attrDict.size} properties"
   return { name, operandSegmentSizes }
 
+/--
+  Properties of the `pdl.replace` operation.
+
+  `operandSegmentSizes` splits the operands into the `opValue`, the optional
+  `replOperation`, and the variadic `replValues` groups, in that order.
+-/
+structure PDLReplaceProperties where
+  operandSegmentSizes : DenseArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def PDLReplaceProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String PDLReplaceProperties := do
+  let some sizesAttr := attrDict["operandSegmentSizes".toUTF8]?
+    | throw "pdl.replace: missing 'operandSegmentSizes' property"
+  let .denseArrayAttr operandSegmentSizes := sizesAttr
+    | throw s!"pdl.replace: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
+  if attrDict.size > 1 then
+    throw s!"pdl.replace: expected only the 'operandSegmentSizes' property, but got {attrDict.size} properties"
+  return { operandSegmentSizes }
+
 end
 
 end Veir


### PR DESCRIPTION
`pdl.replace` marks a matched operation as replaced, either by another
operation or by a list of values, never both. It lives inside the body of a
`pdl.rewrite`, which is the parent it checks for.

Its operands are the replaced `opValue`, the optional `replOperation`, and the
variadic `replValues`, split by `operandSegmentSizes`. `!pdl.range<...>` is not
modelled yet, so `replValues` accepts single handles only.
