### PR TITLE
feat(PDL): add the `!pdl.range<...>` type

### DIFF
--- a/Test/PDL/range_nested_invalid.mlir
+++ b/Test/PDL/range_nested_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// A `!pdl.range` element is one of the four handle types, so ranges never nest.
+"builtin.module"() ({
+  %0 = "test.test"() : () -> !pdl.range<range<value>>
+}) : () -> ()
+
+// CHECK: expected the element of a '!pdl.range' to be one of 'attribute', 'operation', 'type' or 'value'

--- a/Test/PDL/range_types.mlir
+++ b/Test/PDL/range_types.mlir
@@ -1,0 +1,17 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  %0 = "test.test"() : () -> !pdl.range<attribute>
+  %1 = "test.test"() : () -> !pdl.range<operation>
+  %2 = "test.test"() : () -> !pdl.range<type>
+  %3 = "test.test"() : () -> !pdl.range<value>
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.range<attribute>
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.range<operation>
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.range<type>
+// CHECK-NEXT:     %{{.*}} = "test.test"() : () -> !pdl.range<value>
+// CHECK-NEXT: }) : () -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -221,6 +221,8 @@ macro "#assert " e:term : command =>
 
 /-! ## PDL handle types -/
 #assert expectSuccessType "!pdl.attribute" (PDL.AttributeType.mk)
+#assert expectSuccessType "!pdl.range<value>" (PDL.RangeType.mk .value)
+#assert expectSuccessType "!pdl.range<attribute>" (PDL.RangeType.mk .attribute)
 #assert expectSuccessAttr "!pdl.attribute" (PDL.AttributeType.mk)
 
 #assert expectSuccessType "!pdl.operation" (PDL.OperationType.mk)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -274,6 +274,24 @@ deriving Inhabited, Repr, DecidableEq, Hashable
 structure AttributeType
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/--
+  The element of a `!pdl.range<...>`. MLIR restricts it to the four handle
+  types, so a range never nests.
+-/
+inductive RangeElement
+| attribute
+| operation
+| type
+| value
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
+  The `!pdl.range<...>` type, a handle to a range of PDL entities.
+-/
+structure RangeType where
+  element : RangeElement
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 end PDL
 
 namespace LLVM
@@ -458,6 +476,8 @@ inductive Attribute
 | cudaTilePointerType (type : CudaTile.PointerType)
 /-- CIRCT hw module type -/
 | hwModuleType (type : HW.ModuleType)
+/-- PDL range handle type -/
+| pdlRangeType (type : PDL.RangeType)
 /-- PDL attribute handle type -/
 | pdlAttributeType (type : PDL.AttributeType)
 /-- PDL operation handle type -/
@@ -708,6 +728,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case pdlRangeType.pdlRangeType type1 type2 =>
+    exact (match decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case pdlAttributeType.pdlAttributeType type1 type2 =>
     exact (isTrue (by grind))
   case pdlOperationType.pdlOperationType type1 type2 =>
@@ -847,6 +871,17 @@ instance : ToString FlatSymbolRefAttr where
 
 instance : ToString ModArithType where
   toString type := s!"!mod_arith.int<{type.modulus}>"
+
+instance : ToString PDL.RangeElement where
+  toString element :=
+    match element with
+    | .attribute => "attribute"
+    | .operation => "operation"
+    | .type => "type"
+    | .value => "value"
+
+instance : ToString PDL.RangeType where
+  toString type := s!"!pdl.range<{type.element}>"
 
 instance : ToString PDL.AttributeType where
   toString _ := "!pdl.attribute"
@@ -995,6 +1030,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .llvmFunctionType type => type.toLLVMString
   | .cudaTilePointerType type => ToString.toString type
   | .hwModuleType type => ToString.toString type
+  | .pdlRangeType type => ToString.toString type
   | .pdlAttributeType type => ToString.toString type
   | .pdlOperationType type => ToString.toString type
   | .pdlValueType type => ToString.toString type
@@ -1116,6 +1152,9 @@ instance : Coe CudaTile.PointerType Attribute where
 instance : Coe HW.ModuleType Attribute where
   coe type := .hwModuleType type
 
+instance : Coe PDL.RangeType Attribute where
+  coe type := .pdlRangeType type
+
 instance : Coe PDL.AttributeType Attribute where
   coe type := .pdlAttributeType type
 
@@ -1177,6 +1216,7 @@ def isType (attr : Attribute) : Bool :=
   | .llvmFunctionType _ => true
   | .cudaTilePointerType _ => true
   | .hwModuleType _ => true
+  | .pdlRangeType _ => true
   | .pdlAttributeType _ => true
   | .pdlOperationType _ => true
   | .pdlValueType _ => true
@@ -1250,6 +1290,8 @@ theorem isType_cudaTilePointerType type : (cudaTilePointerType type).isType = tr
 theorem isType_hwModuleType type : (hwModuleType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_pdlAttributeType type : (pdlAttributeType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_pdlRangeType type : (pdlRangeType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_pdlOperationType type : (pdlOperationType type).isType = true := by rfl
 @[simp, grind =]
@@ -1328,6 +1370,9 @@ instance : Coe CudaTile.PointerType TypeAttr where
 
 instance : Coe HW.ModuleType TypeAttr where
   coe type := ⟨.hwModuleType type, by rfl⟩
+
+instance : Coe PDL.RangeType TypeAttr where
+  coe type := ⟨.pdlRangeType type, by rfl⟩
 
 instance : Coe PDL.AttributeType TypeAttr where
   coe type := ⟨.pdlAttributeType type, by rfl⟩

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -461,6 +461,32 @@ partial def parseOptionalLLVMVoidType : AttrParserM (Option TypeAttr) := do
   return some LLVM.VoidType.mk
 
 /--
+  Parse a PDL range handle type `!pdl.range<...>`, if present. MLIR restricts
+  the element to the four handle types, so a range never nests.
+-/
+partial def parseOptionalPDLRangeType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "pdl.range".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let element ←
+    if ← parseOptionalKeyword "attribute".toByteArray then
+      pure PDL.RangeElement.attribute
+    else if ← parseOptionalKeyword "operation".toByteArray then
+      pure PDL.RangeElement.operation
+    else if ← parseOptionalKeyword "type".toByteArray then
+      pure PDL.RangeElement.type
+    else if ← parseOptionalKeyword "value".toByteArray then
+      pure PDL.RangeElement.value
+    else
+      throwAtCurrentPos "expected the element of a '!pdl.range' to be one of 'attribute', 'operation', 'type' or 'value'"
+  parsePunctuation ">"
+  return some (PDL.RangeType.mk element)
+
+/--
   Parse a PDL attribute handle type `!pdl.attribute`, if present.
 -/
 partial def parseOptionalPDLAttributeType : AttrParserM (Option TypeAttr) := do
@@ -782,6 +808,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some cudaTilePointerType
   if let some hwModuleType ← parseOptionalHWModuleType then
     return some hwModuleType
+  if let some pdlRangeType ← parseOptionalPDLRangeType then
+    return some pdlRangeType
   if let some pdlAttributeType ← parseOptionalPDLAttributeType then
     return some pdlAttributeType
   if let some pdlOperationType ← parseOptionalPDLOperationType then


### PR DESCRIPTION
`!pdl.range<...>` is the last PDL type left unmodelled, and the one #1179
deferred because it takes a parameter rather than being nullary like the four
handle types.

MLIR restricts the element to those four handle types, so it is modelled as an
enumeration rather than a nested `Attribute`. That makes the "a range is never
another range" rule hold by construction instead of needing a verifier.

This unblocks `pdl.operands`, `pdl.results`, `pdl.types` and `pdl.range`, none
of which can be expressed without it.
