### PR TITLE
ci: only run Lean Action CI on pushes to main

### DIFF
--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -2,6 +2,7 @@ name: Lean Action CI
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
   merge_group:


### PR DESCRIPTION
`push` had no branch filter, so every commit on a pull request branch ran the
whole workflow twice: once for the push and once for the pull request. The same
applied to the merge queue, where `push` fires on the `gh-readonly-queue` branch
alongside `merge_group`.

Scoping `push` to `main` matches what `ci.yml` already does. The trade is that a
branch with no open pull request no longer gets CI.
