### PR TITLE
ci: add a prebuilt image for the Namespace workflow

### DIFF
--- a/.github/docker/ci.Dockerfile
+++ b/.github/docker/ci.Dockerfile
@@ -1,0 +1,48 @@
+# Image for the Namespace CI workflow.
+#
+# The Namespace runner image ships neither `mlir-opt` nor a Python tool cache,
+# so the workflow installed both on every run. Baking them in removes the
+# install, which caching alone cannot do: a cache saves the download, not the
+# unpacking onto a fresh machine.
+#
+# `elan` is baked in, but the Lean toolchain it manages is not: the toolchain is
+# pinned by `lean-toolchain` and changes with the repository, so it belongs on
+# the cache volume rather than in an image that would go stale.
+
+FROM ubuntu:24.04
+
+# `noble` matches the LLVM apt suite below.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      git \
+      # leanc links through the system toolchain.
+      build-essential \
+      # ExArray's C code resolves GMP through pkg-config.
+      libgmp-dev \
+      pkg-config \
+ && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+      -o /etc/apt/trusted.gpg.d/llvm-snapshot.asc \
+ && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+      > /etc/apt/sources.list.d/llvm.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends mlir-22-tools \
+ && ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt \
+ && rm -rf /var/lib/apt/lists/*
+
+# `uv` provides both the Python interpreter and the `lit`/`filecheck`
+# dependencies, so no separate Python install is needed.
+COPY --from=ghcr.io/astral-sh/uv:0.9.7 /uv /usr/local/bin/uv
+
+# `elan` manages the Lean toolchain. `ELAN_HOME` is set away from `~/.elan` so
+# the path is explicit rather than tied to whichever user the job runs as; the
+# CI workflow caches this directory, which is also where elan puts the
+# toolchain it downloads.
+ENV ELAN_HOME=/usr/local/elan
+ENV PATH=/usr/local/elan/bin:$PATH
+RUN curl -fsSL https://elan.lean-lang.org/elan-init.sh \
+      | sh -s -- -y --default-toolchain none
+
+# Fail the build rather than the CI run if a tool is missing.
+RUN mlir-opt --version && uv --version && git --version && elan --version

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -1,0 +1,48 @@
+name: CI image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/docker/ci.Dockerfile
+      - .github/workflows/ci-image.yml
+  pull_request:
+    paths:
+      - .github/docker/ci.Dockerfile
+      - .github/workflows/ci-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      # Pull requests build the image to check the Dockerfile still works, but
+      # only pushes to `main` publish it.
+      - name: Log in to the container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .github/docker/ci.Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository }}-ci:latest
+            ghcr.io/${{ github.repository }}-ci:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,12 +14,13 @@ on:
 
 permissions:
   contents: read
-  # `nsc` authenticates through GitHub's OIDC token endpoint.
-  id-token: write
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # A Namespace runner is already authenticated with Namespace, so pushing to
+    # the workspace registry needs no OIDC token exchange, and so no Namespace
+    # GitHub App installation on the organisation.
+    runs-on: nscloud-ubuntu-24.04-amd64-4x8
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -14,7 +14,8 @@ on:
 
 permissions:
   contents: read
-  packages: write
+  # `nsc` authenticates through GitHub's OIDC token endpoint.
+  id-token: write
 
 jobs:
   build:
@@ -25,24 +26,21 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      # Pull requests build the image to check the Dockerfile still works, but
-      # only pushes to `main` publish it.
-      - name: Log in to the container registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+      # Also configures registry credentials, so no separate login step.
+      - name: Configure access to Namespace
+        id: nscloud
+        uses: namespacelabs/nscloud-setup@v0
 
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .
           file: .github/docker/ci.Dockerfile
+          # Pull requests build the image to check the Dockerfile still
+          # works, but only pushes to `main` publish it.
           push: ${{ github.event_name != 'pull_request' }}
           tags: |
-            ghcr.io/${{ github.repository }}-ci:latest
-            ghcr.io/${{ github.repository }}-ci:${{ github.sha }}
+            ${{ steps.nscloud.outputs.registry-address }}/veir-ci:latest
+            ${{ steps.nscloud.outputs.registry-address }}/veir-ci:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
The Namespace runner image ships neither `mlir-opt` nor a Python tool cache, so
the workflow installs both on every run: `setup-python` downloads and extracts a
full CPython tarball, and `apt-get update` refetches every repository index
before installing `mlir-22-tools`. Together that is roughly a quarter of a warm
run. Caching does not help, because it saves the download and not the unpacking
onto a fresh machine — baking the tools into an image does.

`elan` is baked in too, but the Lean toolchain it manages is not: the toolchain
is pinned by `lean-toolchain` and changes with the repository, so it belongs on
the cache volume. `ELAN_HOME` is `/usr/local/elan` rather than `~/.elan`,
because a containerised job runs as root and `~` would silently mean something
different from the non-container workflow; the workflow will need to cache that
path instead.

The image is published to the Namespace registry, which is what the runners pull
from. The build job runs on a Namespace runner because those are already
authenticated with Namespace: on a GitHub-hosted runner `nscloud-setup` has to
exchange a GitHub OIDC token, which fails with "Namespace Cloud App is not
installed for opencompl". Installing that App on the organisation would let the
job run anywhere, and is worth doing if this should not depend on Namespace.

Pull requests build the image without publishing, so a broken Dockerfile is
caught before it reaches the registry. Only pushes to `main` publish.

This lands on its own because the Namespace workflow cannot point at an image
that does not exist yet. Switching it over is the follow-up, and needs more than
a one-line change: a containerised job needs `/var/run/nsc/` mounted plus
`nscloud-setup`, and keeping the cache volume and git mirror working also needs
`NSC_CACHE_PATH` and `NSC_GIT_MIRROR` in `env:`, `/cache` and `/gitmirror`
mounted, and `--cap-add=SYS_ADMIN`.
