### PR TITLE
ci: install sudo in the CI image

### DIFF
--- a/.github/docker/ci.Dockerfile
+++ b/.github/docker/ci.Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get update \
       ca-certificates \
       curl \
       git \
+      # `nscloud-cache-action` shells out to `sudo` to bind-mount the volume.
+      sudo \
       # leanc links through the system toolchain.
       build-essential \
       # ExArray's C code resolves GMP through pkg-config.


### PR DESCRIPTION
`nscloud-cache-action` bind-mounts each cached path and shells out to `sudo` to
do it, which the minimal image did not have:

    mounting path "/usr/local/elan": binding from "/cache/usr/local/elan" to
    "/usr/local/elan": exec: "sudo": executable file not found in $PATH

Found on the first containerised run of the Namespace workflow, which is
blocked on this.
