### PR TITLE
ci: bake Python and the lit/filecheck dependencies into the image

### DIFF
--- a/.github/docker/ci.Dockerfile
+++ b/.github/docker/ci.Dockerfile
@@ -46,5 +46,16 @@ ENV PATH=/usr/local/elan/bin:$PATH
 RUN curl -fsSL https://elan.lean-lang.org/elan-init.sh \
       | sh -s -- -y --default-toolchain none
 
+# Python and the `lit`/`filecheck` dependencies, resolved from the repository's
+# own lockfile so the image cannot drift from it. `uv.lock` pins `filecheck`,
+# whose versions differ enough to change test outcomes, so this must stay in
+# step: the `CI image` workflow rebuilds when either file changes.
+COPY pyproject.toml uv.lock /opt/veir-python/
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv-python
+ENV PATH=/opt/veir-python/.venv/bin:$PATH
+RUN cd /opt/veir-python \
+ && uv sync --frozen --no-install-project
+
 # Fail the build rather than the CI run if a tool is missing.
-RUN mlir-opt --version && uv --version && git --version && elan --version
+RUN mlir-opt --version && uv --version && git --version && elan --version \
+ && lit --version && filecheck --version

--- a/.github/workflows/ci-image.yml
+++ b/.github/workflows/ci-image.yml
@@ -6,10 +6,14 @@ on:
     paths:
       - .github/docker/ci.Dockerfile
       - .github/workflows/ci-image.yml
+      - pyproject.toml
+      - uv.lock
   pull_request:
     paths:
       - .github/docker/ci.Dockerfile
       - .github/workflows/ci-image.yml
+      - pyproject.toml
+      - uv.lock
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removes the `uv sync` step from the Namespace workflow, and with it a runtime
dependency on the network.

The dependencies are resolved from the repository's own `uv.lock` rather than
installed loose, so the image cannot drift from it. That matters more than it
sounds: `uv.lock` pins `filecheck`, and versions of it differ enough to change
which tests pass — an older one on this machine failed 220 tests that the pinned
one passes. The `CI image` workflow now also rebuilds when `pyproject.toml` or
`uv.lock` change, so the two stay in step.

The saving is small: `uv sync` takes about a second once the uv cache is warm.
The point is one fewer step and one fewer thing that can fail mid-run.

Dropping `uv sync` from the workflow itself is the follow-up, once this image is
published.
