### PR TITLE
fix(PDL): only `pdl.range`, `pdl.result` and `pdl.results` are pure

### DIFF
--- a/Test/PDL/pattern_survives_canonicalize.mlir
+++ b/Test/PDL/pattern_survives_canonicalize.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-opt %s -p=canonicalize | filecheck %s
+
+// The rewrite actions in a pattern body produce no results, so treating them as
+// side-effect free would let dead-code elimination delete them. `mlir-opt
+// -canonicalize` leaves this pattern untouched.
+"builtin.module"() ({
+  "pdl.pattern"() <{benefit = 1 : i16}> ({
+    %0 = "pdl.operation"() <{attributeValueNames = [], opName = "foo.bar", operandSegmentSizes = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+    "pdl.rewrite"(%0) <{operandSegmentSizes = array<i32: 1, 0>}> ({
+      "pdl.erase"(%0) : (!pdl.operation) -> ()
+    }) : (!pdl.operation) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "pdl.pattern"() <{"benefit" = 1 : i16}> ({
+// CHECK-NEXT:       ^{{.*}}():
+// CHECK-NEXT:         %[[root:.*]] = "pdl.operation"() <{"attributeValueNames" = [], "opName" = "foo.bar", "operandSegmentSizes" = array<i32: 0, 0, 0>}> : () -> !pdl.operation
+// CHECK-NEXT:         "pdl.rewrite"(%[[root]]) <{"operandSegmentSizes" = array<i32: 1, 0>}> ({
+// CHECK-NEXT:           ^{{.*}}():
+// CHECK-NEXT:             "pdl.erase"(%[[root]]) : (!pdl.operation) -> ()
+// CHECK-NEXT:         }) : (!pdl.operation) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -121,9 +121,13 @@ def PDL.toAttrDict
       (Std.HashMap.emptyWithCapacity 1).insert "constantTypes".toUTF8 (.arrayAttr constantTypes)
     | none => Std.HashMap.emptyWithCapacity 0
 
-/-- The `pdl` operations are declarative pattern descriptions and are `Pure`. -/
-def PDL.hasSideEffects (_op : PDL) (_props : PDL.propertiesOf _op) : Bool :=
-  false
+/-- MLIR marks only `pdl.range`, `pdl.result` and `pdl.results` `Pure`. The rest
+    describe or perform rewrite actions, so treating them as side-effect free
+    lets dead-code elimination delete a pattern body. -/
+def PDL.hasSideEffects (op : PDL) (_props : PDL.propertiesOf op) : Bool :=
+  match op with
+  | .range | .result | .results => false
+  | _ => true
 
 def PDL.readsMemory (_op : PDL) : Bool :=
   false


### PR DESCRIPTION
`PDL.hasSideEffects` returned `false` for every operation in the dialect, so the greedy driver's trivially-dead check treated the result-less `pdl.erase` and `pdl.replace` as dead and `-p=canonicalize` alone was enough to delete the body of a pattern. This mirrors MLIR instead, marking only `pdl.range`, `pdl.result` and `pdl.results` pure. Checked against `mlir/include/mlir/Dialect/PDL/IR/PDLOps.td`, where `Pure` appears on exactly those three and the `PDL_Op` base class adds no traits of its own. `Test/PDL/pattern_survives_canonicalize.mlir` runs `-p=canonicalize` over a pattern and checks it comes back unchanged; it fails without the fix.