### PR TITLE
feat: Add `simp_getset` to all `Rewriter` operations

### DIFF
--- a/Veir/Rewriter/GetSet/BlockArguments.lean
+++ b/Veir/Rewriter/GetSet/BlockArguments.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 public section
 
@@ -60,133 +61,133 @@ variable {block : BlockPtr}
 
 attribute [local grind] Rewriter.pushBlockArgument
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     (block'.get! (Rewriter.pushBlockArgument ctx block type hblock)).firstUse =
     (block'.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     (block'.get! (Rewriter.pushBlockArgument ctx block type hblock)).prev =
     (block'.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     (block'.get! (Rewriter.pushBlockArgument ctx block type hblock)).next =
     (block'.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     (block'.get! (Rewriter.pushBlockArgument ctx block type hblock)).parent =
     (block'.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     (block'.get! (Rewriter.pushBlockArgument ctx block type hblock)).firstOp =
     (block'.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     (block'.get! (Rewriter.pushBlockArgument ctx block type hblock)).lastOp =
     (block'.get! ctx).lastOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.get!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getOpType! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getProperties! (Rewriter.pushBlockArgument ctx block type hblock) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_Rewriter_pushBlockArgument {opResult : OpResultPtr} :
     opResult.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_Rewriter_pushBlockArgument {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getOperands! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_Rewriter_pushBlockArgument {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.pushBlockArgument ctx block type hblock) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.pushBlockArgument ctx block type hblock) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_Rewriter_pushBlockArgument {operation : OperationPtr} :
     operation.getRegion! (Rewriter.pushBlockArgument ctx block type hblock) idx =
     operation.getRegion! ctx idx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_Rewriter_pushBlockArgument {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_Rewriter_pushBlockArgument {block' : BlockPtr} :
     block'.getNumArguments! (Rewriter.pushBlockArgument ctx block type hblock) =
     if block = block' then
@@ -195,7 +196,7 @@ theorem BlockPtr.getNumArguments!_Rewriter_pushBlockArgument {block' : BlockPtr}
       block'.getNumArguments! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockArgumentPtr.get!_Rewriter_pushBlockArgument {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     if blockArg = block.nextArgument ctx then
@@ -204,13 +205,13 @@ theorem BlockArgumentPtr.get!_Rewriter_pushBlockArgument {blockArg : BlockArgume
       blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_Rewriter_pushBlockArgument {region : RegionPtr} :
     region.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     region.get! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_Rewriter_pushBlockArgument {value : ValuePtr} :
     value.getFirstUse! (Rewriter.pushBlockArgument ctx block type hblock) =
     if value = block.nextArgument ctx then
@@ -219,7 +220,7 @@ theorem ValuePtr.getFirstUse!_Rewriter_pushBlockArgument {value : ValuePtr} :
       value.getFirstUse! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getType!_Rewriter_pushBlockArgument {value : ValuePtr} :
     value.getType! (Rewriter.pushBlockArgument ctx block type hblock) =
     if value = block.nextArgument ctx then
@@ -228,7 +229,7 @@ theorem ValuePtr.getType!_Rewriter_pushBlockArgument {value : ValuePtr} :
       value.getType! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_Rewriter_pushBlockArgument {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.pushBlockArgument ctx block type hblock) =
     if opOperandPtr = OpOperandPtrPtr.valueFirstUse (block.nextArgument ctx) then
@@ -247,132 +248,132 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.initBlockArguments
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_initBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂)).firstUse =
     (block'.get! ctx).firstUse := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_initBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂)).prev =
     (block'.get! ctx).prev := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_initBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂)).next =
     (block'.get! ctx).next := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_initBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂)).parent =
     (block'.get! ctx).parent := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_initBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂)).firstOp =
     (block'.get! ctx).firstOp := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_initBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂)).lastOp =
     (block'.get! ctx).lastOp := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.get!_initBlockArguments {operation : OperationPtr} :
     operation.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_initBlockArguments {operation : OperationPtr} :
     operation.getOpType! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.getOpType! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_initBlockArguments {operation : OperationPtr} :
     operation.getProperties! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) opCode =
     operation.getProperties! ctx opCode := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_initBlockArguments {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.getNumResults! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_initBlockArguments {opResult : OpResultPtr} :
     opResult.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     opResult.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind [cases OpResultPtr]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_initBlockArguments {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.getNumOperands! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_initBlockArguments {opOperand : OpOperandPtr}:
     opOperand.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) = opOperand.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_initBlockArguments {operation : OperationPtr} :
     operation.getOperands! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) = operation.getOperands! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_initBlockArguments {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.getNumSuccessors! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_initBlockArguments {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     blockOperand.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_initBlockArguments {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) i =
     operation.getSuccessor! ctx i := by
   fun_induction Rewriter.initBlockArguments <;> grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_initBlockArguments {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_initBlockArguments,
     OperationPtr.getNumSuccessors!_initBlockArguments]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_initBlockArguments {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     operation.getNumRegions! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_initBlockArguments {operation : OperationPtr} :
     operation.getRegion! (Rewriter.initBlockArguments ctx block types index h₁ h₂) idx =
     operation.getRegion! ctx idx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_initBlockArguments {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     blockOperandPtr.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_initBlockArguments {block' : BlockPtr} :
     block'.getNumArguments! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     if block = block' then
@@ -381,7 +382,7 @@ theorem BlockPtr.getNumArguments!_initBlockArguments {block' : BlockPtr} :
       block'.getNumArguments! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockArgumentPtr.get!_initBlockArguments {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.initBlockArguments ctx bl types idx h₁ h₂) =
     if h : blockArg.block = bl ∧ blockArg.index < types.size ∧ bl.getNumArguments! ctx ≤ blockArg.index then
@@ -389,13 +390,13 @@ theorem BlockArgumentPtr.get!_initBlockArguments {blockArg : BlockArgumentPtr} :
     else blockArg.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind [BlockPtr.getArgument_def, cases BlockArgumentPtr]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_initBlockArguments {region : RegionPtr} :
     region.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     region.get! ctx := by
   fun_induction Rewriter.initBlockArguments <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_initBlockArguments {value : ValuePtr} :
     value.getFirstUse! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     match value with
@@ -407,7 +408,7 @@ theorem ValuePtr.getFirstUse!_initBlockArguments {value : ValuePtr} :
   fun_induction Rewriter.initBlockArguments <;>
     grind [cases BlockArgumentPtr, cases ValuePtr, BlockPtr.getArgument_def]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getType!_initBlockArguments {value : ValuePtr} :
     value.getType! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     match value with
@@ -419,7 +420,7 @@ theorem ValuePtr.getType!_initBlockArguments {value : ValuePtr} :
   fun_induction Rewriter.initBlockArguments <;>
     grind [cases BlockArgumentPtr, cases ValuePtr, BlockPtr.getArgument_def]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_initBlockArguments {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.initBlockArguments ctx block types idx h₁ h₂) =
     match opOperandPtr with
@@ -441,134 +442,134 @@ section Rewriter.setBlockArguments
 variable {op : OperationPtr}
 attribute [local grind] Rewriter.setBlockArguments
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_Rewriter_setBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).firstUse =
     (block'.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_Rewriter_setBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).prev =
     (block'.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_Rewriter_setBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).next =
     (block'.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_Rewriter_setBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).parent =
     (block'.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_Rewriter_setBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).firstOp =
     (block'.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_Rewriter_setBlockArguments {block' : BlockPtr} :
     (block'.get! (Rewriter.setBlockArguments ctx blockPtr types hblock)).lastOp =
     (block'.get! ctx).lastOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.get!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getOpType! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getProperties! (Rewriter.setBlockArguments ctx blockPtr types hblock) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_Rewriter_setBlockArguments {opResult : OpResultPtr} :
     opResult.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     opResult.get! ctx := by
   grind [cases OpResultPtr]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_Rewriter_setBlockArguments {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getOperands! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_Rewriter_setBlockArguments {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.setBlockArguments ctx blockPtr types hblock) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_Rewriter_setBlockArguments,
     OperationPtr.getNumSuccessors!_Rewriter_setBlockArguments]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_Rewriter_setBlockArguments {operation : OperationPtr} :
     operation.getRegion! (Rewriter.setBlockArguments ctx blockPtr types hblock) idx =
     operation.getRegion! ctx idx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_Rewriter_setBlockArguments {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_Rewriter_setBlockArguments {block' : BlockPtr} :
     block'.getNumArguments! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     if blockPtr = block' then
@@ -577,7 +578,7 @@ theorem BlockPtr.getNumArguments!_Rewriter_setBlockArguments {block' : BlockPtr}
       block'.getNumArguments! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockArgumentPtr.get!_Rewriter_setBlockArguments {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     if blockArg.block = blockPtr then
@@ -589,13 +590,13 @@ theorem BlockArgumentPtr.get!_Rewriter_setBlockArguments {blockArg : BlockArgume
       blockArg.get! ctx := by
   grind [BlockArgumentPtr.inBounds_def, BlockArgumentPtr.get!_of_not_inBounds]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_Rewriter_setBlockArguments {region : RegionPtr} :
     region.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     region.get! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_Rewriter_setBlockArguments {value : ValuePtr} :
     value.getFirstUse! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     match value with
@@ -608,7 +609,7 @@ theorem ValuePtr.getFirstUse!_Rewriter_setBlockArguments {value : ValuePtr} :
     grind [BlockArgumentPtr.inBounds_def, BlockArgumentPtr.get!_of_not_inBounds,
       BlockArgument.default_firstUse_eq]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getType!_Rewriter_setBlockArguments {value : ValuePtr} :
     value.getType! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     match value with
@@ -625,7 +626,7 @@ theorem ValuePtr.getType!_Rewriter_setBlockArguments {value : ValuePtr} :
     grind [BlockArgumentPtr.inBounds_def, BlockArgumentPtr.get!_of_not_inBounds,
       BlockArgument.default_type_eq]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_Rewriter_setBlockArguments {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.setBlockArguments ctx blockPtr types hblock) =
     match opOperandPtr with

--- a/Veir/Rewriter/GetSet/BlockOperands.lean
+++ b/Veir/Rewriter/GetSet/BlockOperands.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -61,109 +62,109 @@ variable {opPtr : OperationPtr} {blockPtr : BlockPtr}
 
 attribute [local grind] Rewriter.pushBlockOperand
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstUse!_pushBlockOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).firstUse =
     if block = blockPtr then some (opPtr.nextBlockOperand! ctx) else (block.get! ctx).firstUse := by
   grind [OperationPtr.getBlockOperand_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_pushBlockOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).prev =
     (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_pushBlockOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).next =
     (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_pushBlockOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).parent =
     (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_pushBlockOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_pushBlockOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_pushBlockOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_pushBlockOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_pushBlockOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_pushBlockOperand {operation : OperationPtr} :
     operation.getOpType! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_pushBlockOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_pushBlockOperand {operation : OperationPtr} :
     operation.getProperties! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_pushBlockOperand {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_pushBlockOperand {opResult : OpResultPtr} :
     opResult.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_pushBlockOperand {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_pushBlockOperand {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_pushBlockOperand {operation : OperationPtr} :
     operation.getOperands! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     operation.getOperands! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_pushBlockOperand {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     if operation = opPtr then
@@ -172,7 +173,7 @@ theorem OperationPtr.getNumSuccessors!_pushBlockOperand {operation : OperationPt
       operation.getNumSuccessors! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockOperandPtr.get!_pushBlockOperand {operand : BlockOperandPtr} :
     operand.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     if operand = opPtr.nextBlockOperand ctx then
@@ -207,27 +208,27 @@ theorem BlockOperandPtr.get!_pushBlockOperand' {operandPtr : BlockOperandPtr} :
         operandPtr.get! ctx := by
   apply BlockOperand.ext <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_pushBlockOperand {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) index =
     if operation = opPtr ∧ index = operation.getNumSuccessors! ctx then blockPtr
     else operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def, OperationPtr.getBlockOperand_def]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_pushBlockOperand {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     if operation = opPtr then (operation.getSuccessors! ctx).push blockPtr
     else operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessor!_def, OperationPtr.getBlockOperand_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_pushBlockOperand {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_pushBlockOperand {operation : OperationPtr} :
     operation.getRegion! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) idx =
     operation.getRegion! ctx idx := by
@@ -238,49 +239,49 @@ BlockOperandPtrPtr.get!_pushBlockOperand should not be needed
 in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_pushBlockOperand {block : BlockPtr} :
     block.getNumArguments! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_pushBlockOperand {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_pushBlockOperand {region : RegionPtr} :
     (region.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).firstBlock =
     (region.get! ctx).firstBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_pushBlockOperand {region : RegionPtr} :
     (region.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).lastBlock =
     (region.get! ctx).lastBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_pushBlockOperand {region : RegionPtr} :
     (region.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃)).parent =
     (region.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_pushBlockOperand {value : ValuePtr} :
     value.getFirstUse! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_pushBlockOperand {value : ValuePtr} :
     value.getType! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_pushBlockOperand {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.pushBlockOperand ctx opPtr blockPtr h₁ h₂ h₃) =
     opOperandPtr.get! ctx := by
@@ -295,109 +296,109 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.initBlockOperands
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_initBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).prev =
     (block.get! ctx).prev := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_initBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).next =
     (block.get! ctx).next := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_initBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).parent =
     (block.get! ctx).parent := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_initBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).firstOp =
     (block.get! ctx).firstOp := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_initBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).lastOp =
     (block.get! ctx).lastOp := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_initBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).prev =
     (operation.get! ctx).prev := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_initBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).next =
     (operation.get! ctx).next := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_initBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).parent =
     (operation.get! ctx).parent := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_initBlockOperands {operation : OperationPtr} :
     operation.getOpType! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     operation.getOpType! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_initBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).attrs =
     (operation.get! ctx).attrs := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_initBlockOperands {operation : OperationPtr} :
     operation.getProperties! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) opCode =
     operation.getProperties! ctx opCode := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_initBlockOperands {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     operation.getNumResults! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_initBlockOperands {opResult : OpResultPtr} :
     opResult.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     opResult.get! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_initBlockOperands {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     operation.getNumOperands! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_initBlockOperands {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     opOperand.get! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_initBlockOperands {operation : OperationPtr} :
     operation.getOperands! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     operation.getOperands! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_initBlockOperands {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     operation.getNumRegions! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_initBlockOperands {operation : OperationPtr} :
     operation.getRegion! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) idx =
     operation.getRegion! ctx idx := by
@@ -408,7 +409,7 @@ BlockOperandPtrPtr.get!_initBlockOperands is too complex to be expressed, and sh
 be needed in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_initBlockOperands {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) index =
     if operation = op ∧ index ≥ operation.getNumSuccessors! ctx then
@@ -418,7 +419,7 @@ theorem OperationPtr.getSuccessor!_initBlockOperands {operation : OperationPtr} 
   simp only [← OperationPtr.getSuccessors!.getElem!_eq_getSuccessor!]
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_initBlockOperands {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     if operation = op then
@@ -427,7 +428,7 @@ theorem OperationPtr.getNumSuccessors!_initBlockOperands {operation : OperationP
       operation.getNumSuccessors! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_initBlockOperands {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     if operation = op then
@@ -437,55 +438,55 @@ theorem OperationPtr.getSuccessors!_initBlockOperands {operation : OperationPtr}
   simp only [OperationPtr.getSuccessors!_def]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_initBlockOperands {block : BlockPtr} :
     block.getNumArguments! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     block.getNumArguments! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_initBlockOperands {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     blockArg.get! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_initBlockOperands {region : RegionPtr} :
     (region.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).firstBlock =
     (region.get! ctx).firstBlock := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_initBlockOperands {region : RegionPtr} :
     (region.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).lastBlock =
     (region.get! ctx).lastBlock := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_initBlockOperands {region : RegionPtr} :
     (region.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn)).parent =
     (region.get! ctx).parent := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_initBlockOperands {value : ValuePtr} :
     value.getFirstUse! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     value.getFirstUse! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_initBlockOperands {value : ValuePtr} :
     value.getType! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     value.getType! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_initBlockOperands {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.initBlockOperands ctx op operands n h₁ h₂ h₃ hn) =
     opOperandPtr.get! ctx := by
   fun_induction Rewriter.initBlockOperands <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem Rewriter.initBlockOperands_inBounds (ptr : GenericPtr) :
     ptr.InBounds (initBlockOperands ctx op operands n h₁ h₂ h₃ hn) ↔
     match ptr with

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 import Veir.Rewriter.GetSet.Operands
 import Veir.Rewriter.GetSet.BlockOperands
@@ -67,7 +68,7 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.createEmptyOp
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.firstUse!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (block.get! ctx').firstUse = (block.get! ctx).firstUse := by
@@ -76,7 +77,7 @@ theorem BlockPtr.firstUse!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.firstUse!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (block.get! ctx').firstUse
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.prev!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (block.get! ctx').prev = (block.get! ctx).prev := by
@@ -85,7 +86,7 @@ theorem BlockPtr.prev!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.prev!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (block.get! ctx').prev
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.next!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (block.get! ctx').next = (block.get! ctx).next := by
@@ -94,7 +95,7 @@ theorem BlockPtr.next!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.next!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (block.get! ctx').next
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.parent!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (block.get! ctx').parent = (block.get! ctx).parent := by
@@ -103,7 +104,7 @@ theorem BlockPtr.parent!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.parent!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (block.get! ctx').parent
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.firstOp!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (block.get! ctx').firstOp = (block.get! ctx).firstOp := by
@@ -112,7 +113,7 @@ theorem BlockPtr.firstOp!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.firstOp!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (block.get! ctx').firstOp
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.lastOp!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (block.get! ctx').lastOp = (block.get! ctx).lastOp := by
@@ -121,6 +122,7 @@ theorem BlockPtr.lastOp!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.lastOp!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (block.get! ctx').lastOp
 
+@[simp_getset]
 theorem OperationPtr.prev!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (operation.get! ctx').prev =
@@ -130,6 +132,7 @@ theorem OperationPtr.prev!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.prev!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (operation.get! ctx').prev
 
+@[simp_getset]
 theorem OperationPtr.next!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (operation.get! ctx').next =
@@ -139,6 +142,7 @@ theorem OperationPtr.next!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.next!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (operation.get! ctx').next
 
+@[simp_getset]
 theorem OperationPtr.parent!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (operation.get! ctx').parent =
@@ -148,6 +152,7 @@ theorem OperationPtr.parent!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.parent!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (operation.get! ctx').parent
 
+@[simp_getset]
 theorem OperationPtr.getOpType!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getOpType! ctx' =
@@ -157,6 +162,7 @@ theorem OperationPtr.getOpType!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getOpType!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getOpType! ctx'
 
+@[simp_getset]
 theorem OperationPtr.attrs!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (operation.get! ctx').attrs =
@@ -166,6 +172,7 @@ theorem OperationPtr.attrs!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.attrs!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (operation.get! ctx').attrs
 
+@[simp_getset]
 theorem OperationPtr.getProperties!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getProperties! ctx' dialectOpType =
@@ -181,6 +188,7 @@ grind_pattern OperationPtr.getProperties!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op),
     operation.getProperties! ctx' dialectOpType
 
+@[simp_getset]
 theorem OperationPtr.getNumResults!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getNumResults! ctx' =
@@ -190,7 +198,7 @@ theorem OperationPtr.getNumResults!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumResults!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getNumResults! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem OpResultPtr.get!_createEmptyOp {opResult : OpResultPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     opResult.get! ctx' = opResult.get! ctx := by
@@ -199,6 +207,7 @@ theorem OpResultPtr.get!_createEmptyOp {opResult : OpResultPtr} :
 grind_pattern OpResultPtr.get!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), opResult.get! ctx'
 
+@[simp_getset]
 theorem OperationPtr.getNumOperands!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getNumOperands! ctx' =
@@ -208,7 +217,7 @@ theorem OperationPtr.getNumOperands!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumOperands!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getNumOperands! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem OpOperandPtr.get!_createEmptyOp {operand : OpOperandPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operand.get! ctx' = operand.get! ctx := by
@@ -217,6 +226,7 @@ theorem OpOperandPtr.get!_createEmptyOp {operand : OpOperandPtr} :
 grind_pattern OpOperandPtr.get!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operand.get! ctx'
 
+@[simp_getset]
 theorem OperationPtr.getOperands!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getOperands! ctx' =
@@ -226,6 +236,7 @@ theorem OperationPtr.getOperands!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getOperands!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getOperands! ctx'
 
+@[simp_getset]
 theorem OperationPtr.getNumSuccessors!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getNumSuccessors! ctx' =
@@ -235,7 +246,7 @@ theorem OperationPtr.getNumSuccessors!_createEmptyOp {operation : OperationPtr} 
 grind_pattern OperationPtr.getNumSuccessors!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getNumSuccessors! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockOperandPtr.get!_createEmptyOp {operand : BlockOperandPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operand.get! ctx' = operand.get! ctx := by
@@ -244,7 +255,7 @@ theorem BlockOperandPtr.get!_createEmptyOp {operand : BlockOperandPtr} :
 grind_pattern BlockOperandPtr.get!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operand.get! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getSuccessor!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getSuccessor! ctx' index = operation.getSuccessor! ctx index := by
@@ -253,6 +264,7 @@ theorem OperationPtr.getSuccessor!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getSuccessor!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getSuccessor! ctx' index
 
+@[simp_getset]
 theorem OperationPtr.getSuccessors!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getSuccessors! ctx' =
@@ -265,6 +277,7 @@ theorem OperationPtr.getSuccessors!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getSuccessors!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getSuccessors! ctx'
 
+@[simp_getset]
 theorem OperationPtr.getNumRegions!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getNumRegions! ctx' =
@@ -274,7 +287,7 @@ theorem OperationPtr.getNumRegions!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumRegions!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getNumRegions! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getRegion!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getRegion! ctx' idx = operation.getRegion! ctx idx := by
@@ -283,7 +296,7 @@ theorem OperationPtr.getRegion!_createEmptyOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getRegion!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operation.getRegion! ctx' idx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockOperandPtrPtr.get!_createEmptyOp {operandPtr : BlockOperandPtrPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operandPtr.get! ctx' = operandPtr.get! ctx := by
@@ -292,7 +305,7 @@ theorem BlockOperandPtrPtr.get!_createEmptyOp {operandPtr : BlockOperandPtrPtr} 
 grind_pattern BlockOperandPtrPtr.get!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), operandPtr.get! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.getNumArguments!_createEmptyOp {block : BlockPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     block.getNumArguments! ctx' = block.getNumArguments! ctx := by
@@ -301,7 +314,7 @@ theorem BlockPtr.getNumArguments!_createEmptyOp {block : BlockPtr} :
 grind_pattern BlockPtr.getNumArguments!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), block.getNumArguments! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockArgumentPtr.get!_createEmptyOp {blockArg : BlockArgumentPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     blockArg.get! ctx' = blockArg.get! ctx := by
@@ -310,7 +323,7 @@ theorem BlockArgumentPtr.get!_createEmptyOp {blockArg : BlockArgumentPtr} :
 grind_pattern BlockArgumentPtr.get!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), blockArg.get! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem RegionPtr.firstBlock!_createEmptyOp {region : RegionPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (region.get! ctx').firstBlock = (region.get! ctx).firstBlock := by
@@ -319,7 +332,7 @@ theorem RegionPtr.firstBlock!_createEmptyOp {region : RegionPtr} :
 grind_pattern RegionPtr.firstBlock!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (region.get! ctx').firstBlock
 
-@[simp]
+@[simp, simp_getset]
 theorem RegionPtr.lastBlock!_createEmptyOp {region : RegionPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (region.get! ctx').lastBlock = (region.get! ctx).lastBlock := by
@@ -328,7 +341,7 @@ theorem RegionPtr.lastBlock!_createEmptyOp {region : RegionPtr} :
 grind_pattern RegionPtr.lastBlock!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (region.get! ctx').lastBlock
 
-@[simp]
+@[simp, simp_getset]
 theorem RegionPtr.parent!_createEmptyOp {region : RegionPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     (region.get! ctx').parent = (region.get! ctx).parent := by
@@ -337,7 +350,7 @@ theorem RegionPtr.parent!_createEmptyOp {region : RegionPtr} :
 grind_pattern RegionPtr.parent!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), (region.get! ctx').parent
 
-@[simp]
+@[simp, simp_getset]
 theorem ValuePtr.getFirstUse!_createEmptyOp {value : ValuePtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     value.getFirstUse! ctx' = value.getFirstUse! ctx := by
@@ -346,7 +359,7 @@ theorem ValuePtr.getFirstUse!_createEmptyOp {value : ValuePtr} :
 grind_pattern ValuePtr.getFirstUse!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), value.getFirstUse! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem ValuePtr.getType!_createEmptyOp {value : ValuePtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     value.getType! ctx' = value.getType! ctx := by
@@ -355,7 +368,7 @@ theorem ValuePtr.getType!_createEmptyOp {value : ValuePtr} :
 grind_pattern ValuePtr.getType!_createEmptyOp =>
   Rewriter.createEmptyOp ctx opType properties, some (ctx', op), value.getType! ctx'
 
-@[simp]
+@[simp, simp_getset]
 theorem OpOperandPtrPtr.get!_createEmptyOp {opOperandPtr : OpOperandPtrPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     opOperandPtr.get! ctx' = opOperandPtr.get! ctx := by
@@ -379,28 +392,28 @@ BlockPtr.firstUse!_createOp is too complex to be expressed, and should not be ne
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.prev!_createOp {block : BlockPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     (block.get! ctx').prev = (block.get! ctx).prev := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.next!_createOp {block : BlockPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     (block.get! ctx').next = (block.get! ctx).next := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.parent!_createOp {block : BlockPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     (block.get! ctx').parent = (block.get! ctx).parent := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem BlockPtr.firstOp!_createOp {block : BlockPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -413,7 +426,7 @@ theorem BlockPtr.firstOp!_createOp {block : BlockPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20) (instances := 2000) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem BlockPtr.lastOp!_createOp {block : BlockPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -426,7 +439,7 @@ theorem BlockPtr.lastOp!_createOp {block : BlockPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.prev!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -441,7 +454,7 @@ theorem OperationPtr.prev!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.next!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -456,7 +469,7 @@ theorem OperationPtr.next!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20) (splits := 20) (instances := 2000) [cases InsertPoint]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.parent!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -469,7 +482,7 @@ theorem OperationPtr.parent!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20) [cases InsertPoint, Operation.empty]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getOpType!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -478,7 +491,7 @@ theorem OperationPtr.getOpType!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.attrs!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -487,7 +500,7 @@ theorem OperationPtr.attrs!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getProperties!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -501,7 +514,7 @@ theorem OperationPtr.getProperties!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumResults!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -515,7 +528,7 @@ OpResultPtr.get!_createOp is too complex to be expressed, and should not be need
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumOperands!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -529,7 +542,7 @@ OpOperandPtr.get!_createOp is too complex to be expressed, and should not be nee
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getOperands!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -538,7 +551,7 @@ theorem OperationPtr.getOperands!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumSuccessors!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -551,7 +564,7 @@ BlockOperandPtr.get!_createOp is too complex to be expressed, and should not be 
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getSuccessor!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -561,7 +574,7 @@ theorem OperationPtr.getSuccessor!_createOp {operation : OperationPtr} :
   simp only [Rewriter.createOp]
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getSuccessors!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -569,7 +582,7 @@ theorem OperationPtr.getSuccessors!_createOp {operation : OperationPtr} :
     if operation = newOp then blockOperands else operation.getSuccessors! ctx := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumRegions!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -577,7 +590,7 @@ theorem OperationPtr.getNumRegions!_createOp {operation : OperationPtr} :
     if operation = newOp then regions.size else operation.getNumRegions! ctx := by
   grind (gen := 20)
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getRegion!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -591,7 +604,7 @@ BlockOperandPtrPtr.get!_createOp is too complex to be expressed, and should not 
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.getNumArguments!_createOp {block : BlockPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -603,21 +616,21 @@ BlockArgumentPtr.get!_createOp is too complex to be expressed, and should not be
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.firstBlock!_createOp {region : RegionPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     (region.get! ctx').firstBlock = (region.get! ctx).firstBlock := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.lastBlock!_createOp {region : RegionPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     (region.get! ctx').lastBlock = (region.get! ctx).lastBlock := by
   grind (gen := 20)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.parent!_createOp {region : RegionPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -630,7 +643,7 @@ ValuePtr.getFirstUse!_createOp is too complex to be expressed, and should not be
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem ValuePtr.getType!_createOp {value : ValuePtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
@@ -652,7 +665,7 @@ end Rewriter.createOp
 
 /- replaceValue? -/
 
-@[simp, grind .]
+@[simp, grind ., simp_getset]
 theorem OperationPtr.getNumOperands_iff_replaceValue?
     (hctx' : Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some ctx') :
     OperationPtr.getNumOperands op ctx' h_op =
@@ -664,7 +677,7 @@ theorem OperationPtr.getNumOperands_iff_replaceValue?
 only new pointers that are in bounds in the new context and not in the old one are the operation
 itself, its results, its operands, its block operands, and the links to them.
 -/
-@[grind =>]
+@[grind =>, simp_getset]
 theorem Rewriter.createOp_inBounds (ptr : GenericPtr)
     (h : createOp ctx opType resultTypes operands blockOperands regions props ip h₁ h₂ h₃ h₄ h₅ = some (newCtx, newOp)) :
     ptr.InBounds newCtx ↔

--- a/Veir/Rewriter/GetSet/CreateRegion.lean
+++ b/Veir/Rewriter/GetSet/CreateRegion.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -59,79 +60,79 @@ variable {reg : RegionPtr}
 
 attribute [local grind] Rewriter.createRegion
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.get!_createRegion {block : BlockPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     block.get! ctx' = block.get! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.get!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.get! ctx' = operation.get! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getOpType!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getOpType! ctx' = operation.getOpType! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getProperties!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getProperties! ctx' opCode = operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumResults!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getNumResults! ctx' = operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpResultPtr.get!_createRegion {opResult : OpResultPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     opResult.get! ctx' = opResult.get! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumOperands!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getNumOperands! ctx' = operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpOperandPtr.get!_createRegion {operand : OpOperandPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operand.get! ctx' = operand.get! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getOperands!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getOperands! ctx' = operation.getOperands! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumSuccessors!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getNumSuccessors! ctx' = operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockOperandPtr.get!_createRegion {operand : BlockOperandPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operand.get! ctx' = operand.get! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getSuccessor!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getSuccessor! ctx' index = operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getSuccessors!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getSuccessors! ctx' = operation.getSuccessors! ctx := by
@@ -139,70 +140,70 @@ theorem OperationPtr.getSuccessors!_createRegion {operation : OperationPtr} :
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_createRegion h,
     OperationPtr.getNumSuccessors!_createRegion h]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumRegions!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getNumRegions! ctx' = operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getRegion!_createRegion {operation : OperationPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operation.getRegion! ctx' idx = operation.getRegion! ctx idx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockOperandPtrPtr.get!_createRegion {operandPtr : BlockOperandPtrPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     operandPtr.get! ctx' = operandPtr.get! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.getNumArguments!_createRegion {block : BlockPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     block.getNumArguments! ctx' = block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockArgumentPtr.get!_createRegion {blockArg : BlockArgumentPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     blockArg.get! ctx' = blockArg.get! ctx := by
   grind
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem RegionPtr.firstBlock!_createRegion {region : RegionPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     (region.get! ctx').firstBlock =
     if region = reg then none else (region.get! ctx).firstBlock := by
   grind [Region.empty]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem RegionPtr.lastBlock!_createRegion {region : RegionPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     (region.get! ctx').lastBlock =
     if region = reg then none else (region.get! ctx).lastBlock := by
   grind [Region.empty]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem RegionPtr.parent!_createRegion {region : RegionPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     (region.get! ctx').parent =
     if region = reg then none else (region.get! ctx).parent := by
   grind [Region.empty]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem ValuePtr.getFirstUse!_createRegion {value : ValuePtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     value.getFirstUse! ctx' = value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem ValuePtr.getType!_createRegion {value : ValuePtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     value.getType! ctx' = value.getType! ctx := by
   grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpOperandPtrPtr.get!_createRegion {opOperandPtr : OpOperandPtrPtr} :
     Rewriter.createRegion ctx = some (ctx', reg) →
     opOperandPtr.get! ctx' = opOperandPtr.get! ctx := by

--- a/Veir/Rewriter/GetSet/DetachBlockOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachBlockOperands.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -62,7 +63,7 @@ attribute [local grind] Rewriter.detachBlockOperands.loop
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_detachBlockOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).prev = (block.get! ctx).prev := by
   induction index generalizing ctx
@@ -70,7 +71,7 @@ theorem BlockPtr.prev!_detachBlockOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_detachBlockOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).next = (block.get! ctx).next := by
   induction index generalizing ctx
@@ -78,7 +79,7 @@ theorem BlockPtr.next!_detachBlockOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_detachBlockOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).parent = (block.get! ctx).parent := by
   induction index generalizing ctx
@@ -86,7 +87,7 @@ theorem BlockPtr.parent!_detachBlockOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstOp!_detachBlockOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).firstOp =
     (block.get! ctx).firstOp := by
@@ -95,7 +96,7 @@ theorem BlockPtr.firstOp!_detachBlockOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.lastOp!_detachBlockOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).lastOp =
     (block.get! ctx).lastOp := by
@@ -104,7 +105,7 @@ theorem BlockPtr.lastOp!_detachBlockOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.prev!_detachBlockOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).prev =
     (operation.get! ctx).prev := by
@@ -113,7 +114,7 @@ theorem OperationPtr.prev!_detachBlockOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.next!_detachBlockOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).next =
     (operation.get! ctx).next := by
@@ -122,7 +123,7 @@ theorem OperationPtr.next!_detachBlockOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.parent!_detachBlockOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).parent =
     (operation.get! ctx).parent := by
@@ -131,7 +132,7 @@ theorem OperationPtr.parent!_detachBlockOperands_loop {operation : OperationPtr}
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getOpType! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getOpType! ctx := by
@@ -140,7 +141,7 @@ theorem OperationPtr.getOpType!_detachBlockOperands_loop {operation : OperationP
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_detachBlockOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex)).attrs =
     (operation.get! ctx).attrs := by
@@ -149,7 +150,7 @@ theorem OperationPtr.attrs!_detachBlockOperands_loop {operation : OperationPtr} 
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getProperties! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) opCode =
     operation.getProperties! ctx opCode := by
@@ -158,7 +159,7 @@ theorem OperationPtr.getProperties!_detachBlockOperands_loop {operation : Operat
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getNumResults! ctx := by
@@ -167,7 +168,7 @@ theorem OperationPtr.getNumResults!_detachBlockOperands_loop {operation : Operat
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_detachBlockOperands_loop {opResult : OpResultPtr} :
     opResult.get! (Rewriter.detachBlockOperands.loop ctx op' idx hCtx hOp hIdx) =
     opResult.get! ctx := by
@@ -176,7 +177,7 @@ theorem OpResultPtr.get!_detachBlockOperands_loop {opResult : OpResultPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) = operation.getNumOperands! ctx := by
   induction index generalizing ctx
@@ -184,7 +185,7 @@ theorem OperationPtr.getNumOperands!_detachBlockOperands_loop {operation : Opera
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_detachBlockOperands_loop {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.detachBlockOperands.loop ctx op' idx hCtx hOp hIdx) =
     opOperand.get! ctx := by
@@ -193,7 +194,7 @@ theorem OpOperandPtr.get!_detachBlockOperands_loop {opOperand : OpOperandPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getOperands! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getOperands! ctx := by
@@ -202,7 +203,7 @@ theorem OperationPtr.getOperands!_detachBlockOperands_loop {operation : Operatio
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getNumSuccessors! ctx := by
@@ -215,7 +216,7 @@ theorem OperationPtr.getNumSuccessors!_detachBlockOperands_loop {operation : Ope
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) i =
     operation.getSuccessor! ctx i := by
@@ -224,14 +225,14 @@ theorem OperationPtr.getSuccessor!_detachBlockOperands_loop {operation : Operati
   · simp only [Rewriter.detachBlockOperands.loop]
     grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_detachBlockOperands_loop,
     OperationPtr.getNumSuccessors!_detachBlockOperands_loop]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getNumRegions! ctx := by
@@ -240,7 +241,7 @@ theorem OperationPtr.getNumRegions!_detachBlockOperands_loop {operation : Operat
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_detachBlockOperands_loop {operation : OperationPtr} :
     operation.getRegion! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) i =
     operation.getRegion! ctx i := by
@@ -253,7 +254,7 @@ theorem OperationPtr.getRegion!_detachBlockOperands_loop {operation : OperationP
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_detachBlockOperands_loop {block : BlockPtr} :
     block.getNumArguments! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     block.getNumArguments! ctx := by
@@ -262,7 +263,7 @@ theorem BlockPtr.getNumArguments!_detachBlockOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_detachBlockOperands_loop {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.detachBlockOperands.loop ctx op' idx hCtx hOp hIdx) =
     blockArg.get! ctx := by
@@ -271,7 +272,7 @@ theorem BlockArgumentPtr.get!_detachBlockOperands_loop {blockArg : BlockArgument
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_detachBlockOperands_loop {region : RegionPtr} :
     region.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     region.get! ctx := by
@@ -280,7 +281,7 @@ theorem RegionPtr.get!_detachBlockOperands_loop {region : RegionPtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_detachBlockOperands_loop {value : ValuePtr} :
     value.getFirstUse! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     value.getFirstUse! ctx := by
@@ -289,7 +290,7 @@ theorem ValuePtr.getFirstUse!_detachBlockOperands_loop {value : ValuePtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_detachBlockOperands_loop {value : ValuePtr} :
     value.getType! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     value.getType! ctx := by
@@ -298,7 +299,7 @@ theorem ValuePtr.getType!_detachBlockOperands_loop {value : ValuePtr} :
   · simp only [Rewriter.detachBlockOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_detachBlockOperands_loop {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.detachBlockOperands.loop ctx op' index hCtx hOp hIndex) =
     opOperandPtr.get! ctx := by
@@ -318,99 +319,99 @@ attribute [local grind] Rewriter.detachBlockOperands
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_detachBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).prev = (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_detachBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).next = (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_detachBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).parent = (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_detachBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_detachBlockOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_detachBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_detachBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_detachBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_detachBlockOperands {operation : OperationPtr} :
     operation.getOpType! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_detachBlockOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_detachBlockOperands {operation : OperationPtr} :
     operation.getProperties! (Rewriter.detachBlockOperands ctx op' hCtx hOp) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_detachBlockOperands {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_detachBlockOperands {opResult : OpResultPtr} :
     opResult.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_detachBlockOperands {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.detachBlockOperands ctx op' hCtx hOp) = operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_detachBlockOperands {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_detachBlockOperands {operation : OperationPtr} :
     operation.getOperands! (Rewriter.detachBlockOperands ctx op' hCtx hOp) = operation.getOperands! ctx := by
   simp only [Rewriter.detachBlockOperands]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_detachBlockOperands {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     operation.getNumSuccessors! ctx := by
@@ -420,13 +421,13 @@ theorem OperationPtr.getNumSuccessors!_detachBlockOperands {operation : Operatio
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_detachBlockOperands {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_detachBlockOperands {operation : OperationPtr} :
     operation.getRegion! (Rewriter.detachBlockOperands ctx op' hCtx hOp) i =
     operation.getRegion! ctx i := by
@@ -436,44 +437,44 @@ theorem OperationPtr.getRegion!_detachBlockOperands {operation : OperationPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_detachBlockOperands {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.detachBlockOperands ctx op' hCtx hOp) i =
     operation.getSuccessor! ctx i := by
   grind [OperationPtr.getSuccessor!_def, Rewriter.detachBlockOperands]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_detachBlockOperands {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_detachBlockOperands,
     OperationPtr.getNumSuccessors!_detachBlockOperands]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_detachBlockOperands {block : BlockPtr} :
     block.getNumArguments! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_detachBlockOperands {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_detachBlockOperands {region : RegionPtr} :
     region.get! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_detachBlockOperands {value : ValuePtr} :
     value.getFirstUse! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_detachBlockOperands {value : ValuePtr} :
     value.getType! (Rewriter.detachBlockOperands ctx op' hCtx hOp) =
     value.getType! ctx := by

--- a/Veir/Rewriter/GetSet/DetachOp.lean
+++ b/Veir/Rewriter/GetSet/DetachOp.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 import Veir.Rewriter.GetSet.DetachOperands
 import Veir.Rewriter.GetSet.DetachBlockOperands
@@ -58,39 +59,39 @@ section Rewriter.unsetParentAndNeighbors
 
 attribute [local grind] Rewriter.unsetParentAndNeighbors
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_unsetParentAndNeighbors {block : BlockPtr} :
     (block.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).firstUse = (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_unsetParentAndNeighbors {block : BlockPtr} :
     (block.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).prev = (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_unsetParentAndNeighbors {block : BlockPtr} :
     (block.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).next = (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_unsetParentAndNeighbors {block : BlockPtr} :
     (block.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).parent = (block.get! ctx).parent := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstOp!_unsetParentAndNeighbors {block : BlockPtr} :
     (block.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.lastOp!_unsetParentAndNeighbors {block : BlockPtr} :
     (block.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.prev!_unsetParentAndNeighbors {operation : OperationPtr} :
     (operation.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).prev =
     if operation = op' then
@@ -99,7 +100,7 @@ theorem OperationPtr.prev!_unsetParentAndNeighbors {operation : OperationPtr} :
       (operation.get! ctx).prev := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.next!_unsetParentAndNeighbors {operation : OperationPtr} :
     (operation.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).next =
     if operation = op' then
@@ -108,131 +109,131 @@ theorem OperationPtr.next!_unsetParentAndNeighbors {operation : OperationPtr} :
       (operation.get! ctx).next := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.parent!_unsetParentAndNeighbors {operation : OperationPtr} :
     (operation.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).parent =
     if operation = op' then none else (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getOpType! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_unsetParentAndNeighbors {operation : OperationPtr} :
     (operation.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getProperties! (Rewriter.unsetParentAndNeighbors ctx op' hIn) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_unsetParentAndNeighbors {opResult : OpResultPtr} :
     opResult.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.unsetParentAndNeighbors ctx op' hIn) = operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_unsetParentAndNeighbors {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) = opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getOperands! (Rewriter.unsetParentAndNeighbors ctx op' hIn) = operation.getOperands! ctx := by
   simp only [Rewriter.unsetParentAndNeighbors]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_unsetParentAndNeighbors {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.unsetParentAndNeighbors ctx op' hIn) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_unsetParentAndNeighbors {operation : OperationPtr} :
     operation.getRegion! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     operation.getRegion! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_unsetParentAndNeighbors {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_unsetParentAndNeighbors {block : BlockPtr} :
     block.getNumArguments! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_unsetParentAndNeighbors {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_unsetParentAndNeighbors {region : RegionPtr} :
     region.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_unsetParentAndNeighbors {value : ValuePtr} :
     value.getFirstUse! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_unsetParentAndNeighbors {value : ValuePtr} :
     value.getType! (Rewriter.unsetParentAndNeighbors ctx op' hIn) =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_unsetParentAndNeighbors {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.unsetParentAndNeighbors ctx op' hIn) = opOperandPtr.get! ctx := by
   grind
@@ -244,27 +245,27 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.detachOp
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_detachOp {block : BlockPtr} :
     (block.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).firstUse = (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_detachOp {block : BlockPtr} :
     (block.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).prev = (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_detachOp {block : BlockPtr} :
     (block.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).next = (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_detachOp {block : BlockPtr} :
     (block.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).parent = (block.get! ctx).parent := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstOp!_detachOp {block : BlockPtr} :
     (block.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).firstOp =
     if (op'.get! ctx).prev = none ∧ block = (op'.get! ctx).parent then
@@ -273,7 +274,7 @@ theorem BlockPtr.firstOp!_detachOp {block : BlockPtr} :
       (block.get! ctx).firstOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.lastOp!_detachOp {block : BlockPtr} :
     (block.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).lastOp =
     if (op'.get! ctx).next = none ∧ block = (op'.get! ctx).parent then
@@ -282,7 +283,7 @@ theorem BlockPtr.lastOp!_detachOp {block : BlockPtr} :
       (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.prev!_detachOp {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).prev =
     if operation = (op'.get! ctx).next then
@@ -293,7 +294,7 @@ theorem OperationPtr.prev!_detachOp {operation : OperationPtr} :
       (operation.get! ctx).prev := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.next!_detachOp {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).next =
     if operation = (op'.get! ctx).prev then
@@ -304,131 +305,131 @@ theorem OperationPtr.next!_detachOp {operation : OperationPtr} :
       (operation.get! ctx).next := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.parent!_detachOp {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).parent =
     if operation = op' then none else (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_detachOp {operation : OperationPtr} :
     operation.getOpType! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_detachOp {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_detachOp {operation : OperationPtr} :
     operation.getProperties! (Rewriter.detachOp ctx op' h₁ h₂ h₃) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_detachOp {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_detachOp {opResult : OpResultPtr} :
     opResult.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_detachOp {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.detachOp ctx op' h₁ h₂ h₃) = operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_detachOp {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) = opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_detachOp {operation : OperationPtr} :
     operation.getOperands! (Rewriter.detachOp ctx op' h₁ h₂ h₃) = operation.getOperands! ctx := by
   simp only [Rewriter.detachOp]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_detachOp {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_detachOp {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_detachOp {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.detachOp ctx op' h₁ h₂ h₃) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_detachOp {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_detachOp {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_detachOp {operation : OperationPtr} :
     operation.getRegion! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     operation.getRegion! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_detachOp {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_detachOp {block : BlockPtr} :
     block.getNumArguments! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_detachOp {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_detachOp {region : RegionPtr} :
     region.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_detachOp {value : ValuePtr} :
     value.getFirstUse! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_detachOp {value : ValuePtr} :
     value.getType! (Rewriter.detachOp ctx op' h₁ h₂ h₃) =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_detachOp {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.detachOp ctx op' h₁ h₂ h₃) = opOperandPtr.get! ctx := by
   grind
@@ -440,27 +441,27 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.detachOpIfAttached
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_detachOpIfAttached {block : BlockPtr} :
     (block.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).firstUse = (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_detachOpIfAttached {block : BlockPtr} :
     (block.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).prev = (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_detachOpIfAttached {block : BlockPtr} :
     (block.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).next = (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_detachOpIfAttached {block : BlockPtr} :
     (block.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).parent = (block.get! ctx).parent := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstOp!_detachOpIfAttached {block : BlockPtr} :
     (block.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).firstOp =
     if (op'.get! ctx).prev = none ∧ block = (op'.get! ctx).parent then
@@ -469,7 +470,7 @@ theorem BlockPtr.firstOp!_detachOpIfAttached {block : BlockPtr} :
       (block.get! ctx).firstOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.lastOp!_detachOpIfAttached {block : BlockPtr} :
     (block.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).lastOp =
     if (op'.get! ctx).next = none ∧ block = (op'.get! ctx).parent then
@@ -478,7 +479,7 @@ theorem BlockPtr.lastOp!_detachOpIfAttached {block : BlockPtr} :
       (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.prev!_detachOpIfAttached {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).prev =
     if (op'.get! ctx).parent ≠ none ∧ operation = (op'.get! ctx).next then
@@ -489,7 +490,7 @@ theorem OperationPtr.prev!_detachOpIfAttached {operation : OperationPtr} :
       (operation.get! ctx).prev := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.next!_detachOpIfAttached {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).next =
     if (op'.get! ctx).parent ≠ none ∧ operation = (op'.get! ctx).prev then
@@ -500,131 +501,131 @@ theorem OperationPtr.next!_detachOpIfAttached {operation : OperationPtr} :
       (operation.get! ctx).next := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.parent!_detachOpIfAttached {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).parent =
     if operation = op' then none else (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_detachOpIfAttached {operation : OperationPtr} :
     operation.getOpType! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_detachOpIfAttached {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_detachOpIfAttached {operation : OperationPtr} :
     operation.getProperties! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_detachOpIfAttached {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_detachOpIfAttached {opResult : OpResultPtr} :
     opResult.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_detachOpIfAttached {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) = operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_detachOpIfAttached {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) = opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_detachOpIfAttached {operation : OperationPtr} :
     operation.getOperands! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) = operation.getOperands! ctx := by
   simp only [Rewriter.detachOpIfAttached]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_detachOpIfAttached {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_detachOpIfAttached {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_detachOpIfAttached {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_detachOpIfAttached {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_detachOpIfAttached {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_detachOpIfAttached {operation : OperationPtr} :
     operation.getRegion! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     operation.getRegion! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_detachOpIfAttached {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_detachOpIfAttached {block : BlockPtr} :
     block.getNumArguments! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_detachOpIfAttached {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_detachOpIfAttached {region : RegionPtr} :
     region.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_detachOpIfAttached {value : ValuePtr} :
     value.getFirstUse! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_detachOpIfAttached {value : ValuePtr} :
     value.getType! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_detachOpIfAttached {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.detachOpIfAttached ctx op' hCtx hOp) = opOperandPtr.get! ctx := by
   grind
@@ -640,22 +641,22 @@ attribute [local grind] Rewriter.eraseOp
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_eraseOp {block : BlockPtr} :
     (block.get! (Rewriter.eraseOp ctx op hCtx hOp)).prev = (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_eraseOp {block : BlockPtr} :
     (block.get! (Rewriter.eraseOp ctx op hCtx hOp)).next = (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_eraseOp {block : BlockPtr} :
     (block.get! (Rewriter.eraseOp ctx op hCtx hOp)).parent = (block.get! ctx).parent := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstOp!_eraseOp {block : BlockPtr} :
     (block.get! (Rewriter.eraseOp ctx op hCtx hOp)).firstOp =
     if (op.get! ctx).prev = none ∧ block = (op.get! ctx).parent then
@@ -664,7 +665,7 @@ theorem BlockPtr.firstOp!_eraseOp {block : BlockPtr} :
       (block.get! ctx).firstOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.lastOp!_eraseOp {block : BlockPtr} :
     (block.get! (Rewriter.eraseOp ctx op hCtx hOp)).lastOp =
     if (op.get! ctx).next = none ∧ block = (op.get! ctx).parent then
@@ -673,7 +674,7 @@ theorem BlockPtr.lastOp!_eraseOp {block : BlockPtr} :
       (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.prev!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     (operation.get! (Rewriter.eraseOp ctx op hCtx hOp)).prev =
@@ -685,7 +686,7 @@ theorem OperationPtr.prev!_eraseOp {operation : OperationPtr} :
       (operation.get! ctx).prev := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.next!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     (operation.get! (Rewriter.eraseOp ctx op hCtx hOp)).next =
@@ -697,42 +698,42 @@ theorem OperationPtr.next!_eraseOp {operation : OperationPtr} :
       (operation.get! ctx).next := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.parent!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     (operation.get! (Rewriter.eraseOp ctx op hCtx hOp)).parent =
     if operation = op then none else (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getOpType! (Rewriter.eraseOp ctx op hCtx hOp) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     (operation.get! (Rewriter.eraseOp ctx op hCtx hOp)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getProperties! (Rewriter.eraseOp ctx op hCtx hOp) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getNumResults! (Rewriter.eraseOp ctx op hCtx hOp) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getNumOperands! (Rewriter.eraseOp ctx op hCtx hOp) =
@@ -747,13 +748,13 @@ theorem OperationPtr.getNumOperands!_eraseOp {operation : OperationPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getOperands! (Rewriter.eraseOp ctx op hCtx hOp) = operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getNumSuccessors! (Rewriter.eraseOp ctx op hCtx hOp) =
@@ -764,28 +765,28 @@ theorem OperationPtr.getNumSuccessors!_eraseOp {operation : OperationPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getSuccessor! (Rewriter.eraseOp ctx op hCtx hOp) index =
     operation.getSuccessor! ctx index := by
   grind [_=_ OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getSuccessors! (Rewriter.eraseOp ctx op hCtx hOp) =
     operation.getSuccessors! ctx := by
   grind [_=_ OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getNumRegions! (Rewriter.eraseOp ctx op hCtx hOp) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_eraseOp {operation : OperationPtr} :
     operation.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     operation.getRegion! (Rewriter.eraseOp ctx op hCtx hOp) idx =
@@ -796,7 +797,7 @@ theorem OperationPtr.getRegion!_eraseOp {operation : OperationPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_eraseOp {block : BlockPtr} :
     block.getNumArguments! (Rewriter.eraseOp ctx op hCtx hOp) =
     block.getNumArguments! ctx := by
@@ -806,19 +807,19 @@ theorem BlockPtr.getNumArguments!_eraseOp {block : BlockPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_eraseOp {region : RegionPtr} :
     (region.get! (Rewriter.eraseOp ctx op hCtx hOp)).firstBlock =
     (region.get! ctx).firstBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_eraseOp {region : RegionPtr} :
     (region.get! (Rewriter.eraseOp ctx op hCtx hOp)).lastBlock =
     (region.get! ctx).lastBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_eraseOp {region : RegionPtr} :
     (region.get! (Rewriter.eraseOp ctx op hCtx hOp)).parent =
     (region.get! ctx).parent := by
@@ -828,7 +829,7 @@ theorem RegionPtr.parent!_eraseOp {region : RegionPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.DefUse` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_eraseOp {value : ValuePtr} :
     value.InBounds (Rewriter.eraseOp ctx op hCtx hOp) →
     value.getType! (Rewriter.eraseOp ctx op hCtx hOp) =

--- a/Veir/Rewriter/GetSet/DetachOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachOperands.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -58,7 +59,7 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.detachOperands.loop
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_detachOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).firstUse = (block.get! ctx).firstUse := by
   induction index generalizing ctx
@@ -66,7 +67,7 @@ theorem BlockPtr.firstUse!_detachOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_detachOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).prev = (block.get! ctx).prev := by
   induction index generalizing ctx
@@ -74,7 +75,7 @@ theorem BlockPtr.prev!_detachOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_detachOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).next = (block.get! ctx).next := by
   induction index generalizing ctx
@@ -82,7 +83,7 @@ theorem BlockPtr.next!_detachOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_detachOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).parent = (block.get! ctx).parent := by
   induction index generalizing ctx
@@ -90,7 +91,7 @@ theorem BlockPtr.parent!_detachOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.firstOp!_detachOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).firstOp =
     (block.get! ctx).firstOp := by
@@ -99,7 +100,7 @@ theorem BlockPtr.firstOp!_detachOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.lastOp!_detachOperands_loop {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).lastOp =
     (block.get! ctx).lastOp := by
@@ -108,7 +109,7 @@ theorem BlockPtr.lastOp!_detachOperands_loop {block : BlockPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.prev!_detachOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).prev =
     (operation.get! ctx).prev := by
@@ -117,7 +118,7 @@ theorem OperationPtr.prev!_detachOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.next!_detachOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).next =
     (operation.get! ctx).next := by
@@ -126,7 +127,7 @@ theorem OperationPtr.next!_detachOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.parent!_detachOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).parent =
     (operation.get! ctx).parent := by
@@ -135,7 +136,7 @@ theorem OperationPtr.parent!_detachOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_detachOperands_loop {operation : OperationPtr} :
     operation.getOpType! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getOpType! ctx := by
@@ -144,7 +145,7 @@ theorem OperationPtr.getOpType!_detachOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_detachOperands_loop {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex)).attrs =
     (operation.get! ctx).attrs := by
@@ -153,7 +154,7 @@ theorem OperationPtr.attrs!_detachOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_detachOperands_loop {operation : OperationPtr} :
     operation.getProperties! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) opCode =
     operation.getProperties! ctx opCode := by
@@ -162,7 +163,7 @@ theorem OperationPtr.getProperties!_detachOperands_loop {operation : OperationPt
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_detachOperands_loop {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getNumResults! ctx := by
@@ -175,7 +176,7 @@ theorem OperationPtr.getNumResults!_detachOperands_loop {operation : OperationPt
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_detachOperands_loop {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) = operation.getNumOperands! ctx := by
   induction index generalizing ctx
@@ -187,7 +188,7 @@ theorem OperationPtr.getNumOperands!_detachOperands_loop {operation : OperationP
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_detachOperands_loop {operation : OperationPtr} :
     operation.getOperands! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getOperands! ctx := by
@@ -196,7 +197,7 @@ theorem OperationPtr.getOperands!_detachOperands_loop {operation : OperationPtr}
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_detachOperands_loop {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getNumSuccessors! ctx := by
@@ -205,7 +206,7 @@ theorem OperationPtr.getNumSuccessors!_detachOperands_loop {operation : Operatio
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_detachOperands_loop {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.detachOperands.loop ctx op' index' hCtx hOp hIndex) =
     blockOperand.get! ctx := by
@@ -214,7 +215,7 @@ theorem BlockOperandPtr.get!_detachOperands_loop {blockOperand : BlockOperandPtr
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_detachOperands_loop {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) i =
     operation.getSuccessor! ctx i := by
@@ -223,14 +224,14 @@ theorem OperationPtr.getSuccessor!_detachOperands_loop {operation : OperationPtr
   · simp only [Rewriter.detachOperands.loop]
     grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_detachOperands_loop {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_detachOperands_loop,
     OperationPtr.getNumSuccessors!_detachOperands_loop]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_detachOperands_loop {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     operation.getNumRegions! ctx := by
@@ -239,7 +240,7 @@ theorem OperationPtr.getNumRegions!_detachOperands_loop {operation : OperationPt
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_detachOperands_loop {operation : OperationPtr} :
     operation.getRegion! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) i =
     operation.getRegion! ctx i := by
@@ -248,7 +249,7 @@ theorem OperationPtr.getRegion!_detachOperands_loop {operation : OperationPtr} :
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_detachOperands_loop {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     blockOperandPtr.get! ctx := by
@@ -257,7 +258,7 @@ theorem BlockOperandPtrPtr.get!_detachOperands_loop {blockOperandPtr : BlockOper
   · simp only [Rewriter.detachOperands.loop]
     grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_detachOperands_loop {block : BlockPtr} :
     block.getNumArguments! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     block.getNumArguments! ctx := by
@@ -270,7 +271,7 @@ theorem BlockPtr.getNumArguments!_detachOperands_loop {block : BlockPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_detachOperands_loop {region : RegionPtr} :
     region.get! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     region.get! ctx := by
@@ -283,7 +284,7 @@ theorem RegionPtr.get!_detachOperands_loop {region : RegionPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_detachOperands_loop {value : ValuePtr} :
     value.getType! (Rewriter.detachOperands.loop ctx op' index hCtx hOp hIndex) =
     value.getType! ctx := by
@@ -303,75 +304,75 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.detachOperands
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_detachOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands ctx op' hCtx hOp)).firstUse = (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_detachOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands ctx op' hCtx hOp)).prev = (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_detachOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands ctx op' hCtx hOp)).next = (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_detachOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands ctx op' hCtx hOp)).parent = (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_detachOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands ctx op' hCtx hOp)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_detachOperands {block : BlockPtr} :
     (block.get! (Rewriter.detachOperands ctx op' hCtx hOp)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_detachOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands ctx op' hCtx hOp)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_detachOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands ctx op' hCtx hOp)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_detachOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands ctx op' hCtx hOp)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_detachOperands {operation : OperationPtr} :
     operation.getOpType! (Rewriter.detachOperands ctx op' hCtx hOp) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_detachOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.detachOperands ctx op' hCtx hOp)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_detachOperands {operation : OperationPtr} :
     operation.getProperties! (Rewriter.detachOperands ctx op' hCtx hOp) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_detachOperands {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.detachOperands ctx op' hCtx hOp) =
     operation.getNumResults! ctx := by
@@ -381,7 +382,7 @@ theorem OperationPtr.getNumResults!_detachOperands {operation : OperationPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_detachOperands {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.detachOperands ctx op' hCtx hOp) = operation.getNumOperands! ctx := by
   grind
@@ -390,55 +391,55 @@ theorem OperationPtr.getNumOperands!_detachOperands {operation : OperationPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_detachOperands {operation : OperationPtr} :
     operation.getOperands! (Rewriter.detachOperands ctx op' hCtx hOp) = operation.getOperands! ctx := by
   simp only [Rewriter.detachOperands]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_detachOperands {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.detachOperands ctx op' hCtx hOp) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_detachOperands {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.detachOperands ctx op' hCtx hOp) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_detachOperands {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.detachOperands ctx op' hCtx hOp) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_detachOperands {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.detachOperands ctx op' hCtx hOp) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_detachOperands {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.detachOperands ctx op' hCtx hOp) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_detachOperands {operation : OperationPtr} :
     operation.getRegion! (Rewriter.detachOperands ctx op' hCtx hOp) i =
     operation.getRegion! ctx i := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_detachOperands {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.detachOperands ctx op' hCtx hOp) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_detachOperands {block : BlockPtr} :
     block.getNumArguments! (Rewriter.detachOperands ctx op' hCtx hOp) =
     block.getNumArguments! ctx := by
@@ -448,7 +449,7 @@ theorem BlockPtr.getNumArguments!_detachOperands {block : BlockPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_detachOperands {region : RegionPtr} :
     region.get! (Rewriter.detachOperands ctx op' hCtx hOp) =
     region.get! ctx := by
@@ -458,7 +459,7 @@ theorem RegionPtr.get!_detachOperands {region : RegionPtr} :
 -- In any case, we shouldn't need it in practice, as we should reason at a higher-level abstraction at
 -- this point, likely on `BlockPtr.OpChain` directly.
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_detachOperands {value : ValuePtr} :
     value.getType! (Rewriter.detachOperands ctx op' hCtx hOp) =
     value.getType! ctx := by

--- a/Veir/Rewriter/GetSet/InsertBlock.lean
+++ b/Veir/Rewriter/GetSet/InsertBlock.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -56,7 +57,7 @@ unseal Rewriter.insertBlock
 
 attribute [local grind] Rewriter.insertBlock
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.firstUse!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstUse = (block.get! ctx).firstUse := by
@@ -66,6 +67,7 @@ theorem BlockPtr.firstUse!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.firstUse!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstUse
 
+@[simp_getset]
 theorem BlockPtr.prev!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).prev =
@@ -81,6 +83,7 @@ theorem BlockPtr.prev!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.prev!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).prev
 
+@[simp_getset]
 theorem BlockPtr.next!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).next =
@@ -96,6 +99,7 @@ theorem BlockPtr.next!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.next!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).next
 
+@[simp_getset]
 theorem BlockPtr.parent!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).parent =
@@ -109,7 +113,7 @@ theorem BlockPtr.parent!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.parent!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).parent
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.firstOp!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstOp = (block.get! ctx).firstOp := by
@@ -119,7 +123,7 @@ theorem BlockPtr.firstOp!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.firstOp!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstOp
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.lastOp!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).lastOp = (block.get! ctx).lastOp := by
@@ -129,7 +133,7 @@ theorem BlockPtr.lastOp!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.lastOp!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.get!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.get! newCtx = operation.get! ctx := by
@@ -139,7 +143,7 @@ theorem OperationPtr.get!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.get!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getOpType!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getOpType! newCtx = operation.getOpType! ctx := by
@@ -149,7 +153,7 @@ theorem OperationPtr.getOpType!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getOpType!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumResults!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumResults! newCtx = operation.getNumResults! ctx := by
@@ -159,7 +163,7 @@ theorem OperationPtr.getNumResults!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumResults!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumResults! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OpResultPtr.get!_insertBlock {opResult : OpResultPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     opResult.get! newCtx = opResult.get! ctx := by
@@ -169,7 +173,7 @@ theorem OpResultPtr.get!_insertBlock {opResult : OpResultPtr} :
 grind_pattern OpResultPtr.get!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, opResult.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumOperands!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumOperands! newCtx = operation.getNumOperands! ctx := by
@@ -179,7 +183,7 @@ theorem OperationPtr.getNumOperands!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumOperands!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumOperands! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OpOperandPtr.get!_insertBlock {operand : OpOperandPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
@@ -189,7 +193,7 @@ theorem OpOperandPtr.get!_insertBlock {operand : OpOperandPtr} :
 grind_pattern OpOperandPtr.get!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getOperands!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getOperands! newCtx = operation.getOperands! ctx := by
@@ -199,7 +203,7 @@ theorem OperationPtr.getOperands!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getOperands!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getOperands! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumSuccessors!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumSuccessors! newCtx = operation.getNumSuccessors! ctx := by
@@ -209,7 +213,7 @@ theorem OperationPtr.getNumSuccessors!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumSuccessors!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumSuccessors! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockOperandPtr.get!_insertBlock {operand : BlockOperandPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
@@ -219,7 +223,7 @@ theorem BlockOperandPtr.get!_insertBlock {operand : BlockOperandPtr} :
 grind_pattern BlockOperandPtr.get!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getSuccessor!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessor! newCtx index = operation.getSuccessor! ctx index := by
@@ -228,7 +232,7 @@ theorem OperationPtr.getSuccessor!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getSuccessor!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getSuccessor! newCtx index
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getSuccessors!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessors! newCtx = operation.getSuccessors! ctx := by
@@ -237,7 +241,7 @@ theorem OperationPtr.getSuccessors!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getSuccessors!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getSuccessors! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumRegions!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getNumRegions! newCtx = operation.getNumRegions! ctx := by
@@ -247,7 +251,7 @@ theorem OperationPtr.getNumRegions!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumRegions!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getNumRegions! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getRegion!_insertBlock {operation : OperationPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operation.getRegion! newCtx = operation.getRegion! ctx := by
@@ -257,7 +261,7 @@ theorem OperationPtr.getRegion!_insertBlock {operation : OperationPtr} :
 grind_pattern OperationPtr.getRegion!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operation.getRegion! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockOperandPtrPtr.get!_insertBlock {operandPtr : BlockOperandPtrPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     operandPtr.get! newCtx = operandPtr.get! ctx := by
@@ -267,7 +271,7 @@ theorem BlockOperandPtrPtr.get!_insertBlock {operandPtr : BlockOperandPtrPtr} :
 grind_pattern BlockOperandPtrPtr.get!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, operandPtr.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.getNumArguments!_insertBlock {block : BlockPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     block.getNumArguments! newCtx = block.getNumArguments! ctx := by
@@ -277,7 +281,7 @@ theorem BlockPtr.getNumArguments!_insertBlock {block : BlockPtr} :
 grind_pattern BlockPtr.getNumArguments!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, block.getNumArguments! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockArgumentPtr.get!_insertBlock {blockArg : BlockArgumentPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     blockArg.get! newCtx = blockArg.get! ctx := by
@@ -287,6 +291,7 @@ theorem BlockArgumentPtr.get!_insertBlock {blockArg : BlockArgumentPtr} :
 grind_pattern BlockArgumentPtr.get!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, blockArg.get! newCtx
 
+@[simp_getset]
 theorem RegionPtr.firstBlock!_insertBlock {region : RegionPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (region.get! newCtx).firstBlock =
@@ -300,6 +305,7 @@ theorem RegionPtr.firstBlock!_insertBlock {region : RegionPtr} :
 grind_pattern RegionPtr.firstBlock!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).firstBlock
 
+@[simp_getset]
 theorem RegionPtr.lastBlock!_insertBlock {region : RegionPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (region.get! newCtx).lastBlock =
@@ -313,7 +319,7 @@ theorem RegionPtr.lastBlock!_insertBlock {region : RegionPtr} :
 grind_pattern RegionPtr.lastBlock!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).lastBlock
 
-@[simp]
+@[simp, simp_getset]
 theorem RegionPtr.parent!_insertBlock {region : RegionPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     (region.get! newCtx).parent = (region.get! ctx).parent := by
@@ -323,7 +329,7 @@ theorem RegionPtr.parent!_insertBlock {region : RegionPtr} :
 grind_pattern RegionPtr.parent!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, (region.get! newCtx).parent
 
-@[simp]
+@[simp, simp_getset]
 theorem ValuePtr.getFirstUse!_insertBlock {value : ValuePtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     value.getFirstUse! newCtx = value.getFirstUse! ctx := by
@@ -333,7 +339,7 @@ theorem ValuePtr.getFirstUse!_insertBlock {value : ValuePtr} :
 grind_pattern ValuePtr.getFirstUse!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, value.getFirstUse! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem ValuePtr.getType!_insertBlock {value : ValuePtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     value.getType! newCtx = value.getType! ctx := by
@@ -343,7 +349,7 @@ theorem ValuePtr.getType!_insertBlock {value : ValuePtr} :
 grind_pattern ValuePtr.getType!_insertBlock =>
   Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃, some newCtx, value.getType! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OpOperandPtrPtr.get!_insertBlock {opOperandPtr : OpOperandPtrPtr} :
     Rewriter.insertBlock ctx newBlock ip h₁ h₂ h₃ = some newCtx →
     opOperandPtr.get! newCtx = opOperandPtr.get! ctx := by

--- a/Veir/Rewriter/GetSet/InsertOp.lean
+++ b/Veir/Rewriter/GetSet/InsertOp.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -58,7 +59,7 @@ unseal Rewriter.insertOp
 
 attribute [local grind] Rewriter.insertOp
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.firstUse!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstUse = (block.get! ctx).firstUse := by
@@ -68,7 +69,7 @@ theorem BlockPtr.firstUse!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.firstUse!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstUse
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.prev!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).prev = (block.get! ctx).prev := by
@@ -78,7 +79,7 @@ theorem BlockPtr.prev!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.prev!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).prev
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.next!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).next = (block.get! ctx).next := by
@@ -88,7 +89,7 @@ theorem BlockPtr.next!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.next!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).next
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.parent!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).parent = (block.get! ctx).parent := by
@@ -98,6 +99,7 @@ theorem BlockPtr.parent!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.parent!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).parent
 
+@[simp_getset]
 theorem BlockPtr.firstOp!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).firstOp =
@@ -111,6 +113,7 @@ theorem BlockPtr.firstOp!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.firstOp!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).firstOp
 
+@[simp_getset]
 theorem BlockPtr.lastOp!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (block.get! newCtx).lastOp =
@@ -124,6 +127,7 @@ theorem BlockPtr.lastOp!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.lastOp!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (block.get! newCtx).lastOp
 
+@[simp_getset]
 theorem OperationPtr.prev!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).prev =
@@ -139,6 +143,7 @@ theorem OperationPtr.prev!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.prev!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).prev
 
+@[simp_getset]
 theorem OperationPtr.next!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).next =
@@ -154,6 +159,7 @@ theorem OperationPtr.next!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.next!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).next
 
+@[simp_getset]
 theorem OperationPtr.parent!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).parent =
@@ -167,7 +173,7 @@ theorem OperationPtr.parent!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.parent!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).parent
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getOpType!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getOpType! newCtx = operation.getOpType! ctx := by
@@ -177,7 +183,7 @@ theorem OperationPtr.getOpType!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getOpType!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOpType! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.attrs!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     (operation.get! newCtx).attrs = (operation.get! ctx).attrs := by
@@ -186,7 +192,7 @@ theorem OperationPtr.attrs!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.attrs!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, (operation.get! newCtx).attrs
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getProperties!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getProperties! newCtx opCode = operation.getProperties! ctx opCode := by
@@ -196,7 +202,7 @@ theorem OperationPtr.getProperties!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getProperties!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getProperties! newCtx opCode
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumResults!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumResults! newCtx = operation.getNumResults! ctx := by
@@ -206,7 +212,7 @@ theorem OperationPtr.getNumResults!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumResults!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumResults! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OpResultPtr.get!_insertOp {opResult : OpResultPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     opResult.get! newCtx = opResult.get! ctx := by
@@ -216,7 +222,7 @@ theorem OpResultPtr.get!_insertOp {opResult : OpResultPtr} :
 grind_pattern OpResultPtr.get!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, opResult.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumOperands!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumOperands! newCtx = operation.getNumOperands! ctx := by
@@ -226,7 +232,7 @@ theorem OperationPtr.getNumOperands!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumOperands!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumOperands! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OpOperandPtr.get!_insertOp {operand : OpOperandPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
@@ -236,7 +242,7 @@ theorem OpOperandPtr.get!_insertOp {operand : OpOperandPtr} :
 grind_pattern OpOperandPtr.get!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getOperands!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getOperands! newCtx = operation.getOperands! ctx := by
@@ -246,7 +252,7 @@ theorem OperationPtr.getOperands!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getOperands!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getOperands! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumSuccessors!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumSuccessors! newCtx = operation.getNumSuccessors! ctx := by
@@ -256,7 +262,7 @@ theorem OperationPtr.getNumSuccessors!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumSuccessors!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumSuccessors! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockOperandPtr.get!_insertOp {operand : BlockOperandPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operand.get! newCtx = operand.get! ctx := by
@@ -266,7 +272,7 @@ theorem BlockOperandPtr.get!_insertOp {operand : BlockOperandPtr} :
 grind_pattern BlockOperandPtr.get!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operand.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getSuccessor!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessor! newCtx index = operation.getSuccessor! ctx index := by
@@ -275,7 +281,7 @@ theorem OperationPtr.getSuccessor!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getSuccessor!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getSuccessor! newCtx index
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getSuccessors!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getSuccessors! newCtx = operation.getSuccessors! ctx := by
@@ -284,7 +290,7 @@ theorem OperationPtr.getSuccessors!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getSuccessors!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getSuccessors! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getNumRegions!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getNumRegions! newCtx = operation.getNumRegions! ctx := by
@@ -294,7 +300,7 @@ theorem OperationPtr.getNumRegions!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getNumRegions!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getNumRegions! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OperationPtr.getRegion!_insertOp {operation : OperationPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operation.getRegion! newCtx idx = operation.getRegion! ctx idx := by
@@ -304,7 +310,7 @@ theorem OperationPtr.getRegion!_insertOp {operation : OperationPtr} :
 grind_pattern OperationPtr.getRegion!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operation.getRegion! newCtx idx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockOperandPtrPtr.get!_insertOp {operandPtr : BlockOperandPtrPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     operandPtr.get! newCtx = operandPtr.get! ctx := by
@@ -314,7 +320,7 @@ theorem BlockOperandPtrPtr.get!_insertOp {operandPtr : BlockOperandPtrPtr} :
 grind_pattern BlockOperandPtrPtr.get!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, operandPtr.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockPtr.getNumArguments!_insertOp {block : BlockPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     block.getNumArguments! newCtx = block.getNumArguments! ctx := by
@@ -324,7 +330,7 @@ theorem BlockPtr.getNumArguments!_insertOp {block : BlockPtr} :
 grind_pattern BlockPtr.getNumArguments!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, block.getNumArguments! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem BlockArgumentPtr.get!_insertOp {blockArg : BlockArgumentPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     blockArg.get! newCtx = blockArg.get! ctx := by
@@ -334,7 +340,7 @@ theorem BlockArgumentPtr.get!_insertOp {blockArg : BlockArgumentPtr} :
 grind_pattern BlockArgumentPtr.get!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, blockArg.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem RegionPtr.get!_insertOp {region : RegionPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     region.get! newCtx = region.get! ctx := by
@@ -344,7 +350,7 @@ theorem RegionPtr.get!_insertOp {region : RegionPtr} :
 grind_pattern RegionPtr.get!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, region.get! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem ValuePtr.getFirstUse!_insertOp {value : ValuePtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     value.getFirstUse! newCtx = value.getFirstUse! ctx := by
@@ -354,6 +360,7 @@ theorem ValuePtr.getFirstUse!_insertOp {value : ValuePtr} :
 grind_pattern ValuePtr.getFirstUse!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, value.getFirstUse! newCtx
 
+@[simp_getset]
 theorem ValuePtr.getType!_insertOp {value : ValuePtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     value.getType! newCtx = value.getType! ctx := by
@@ -362,7 +369,7 @@ theorem ValuePtr.getType!_insertOp {value : ValuePtr} :
 grind_pattern ValuePtr.getType!_insertOp =>
   Rewriter.insertOp ctx newOp ip h₁ h₂ h₃, some newCtx, value.getType! newCtx
 
-@[simp]
+@[simp, simp_getset]
 theorem OpOperandPtrPtr.get!_insertOp {opOperandPtr : OpOperandPtrPtr} :
     Rewriter.insertOp ctx newOp ip h₁ h₂ h₃ = some newCtx →
     opOperandPtr.get! newCtx = opOperandPtr.get! ctx := by

--- a/Veir/Rewriter/GetSet/Operands.lean
+++ b/Veir/Rewriter/GetSet/Operands.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -60,85 +61,85 @@ variable {opPtr : OperationPtr} {valuePtr : ValuePtr}
 
 attribute [local grind] Rewriter.pushOperand
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_pushOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).firstUse =
     (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_pushOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).prev =
     (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_pushOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).next =
     (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_pushOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).parent =
     (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_pushOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_pushOperand {block : BlockPtr} :
     (block.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_pushOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_pushOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_pushOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_pushOperand {operation : OperationPtr} :
     operation.getOpType! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_pushOperand {operation : OperationPtr} :
     (operation.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_pushOperand {operation : OperationPtr} :
     operation.getProperties! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_pushOperand {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     operation.getNumResults! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpResultPtr.get!_pushOperand {opResult : OpResultPtr} :
     opResult.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if valuePtr = opResult then
@@ -147,7 +148,7 @@ theorem OpResultPtr.get!_pushOperand {opResult : OpResultPtr} :
       opResult.get! ctx := by
   grind [OperationPtr.getOpOperand_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_pushOperand {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if operation = opPtr then
@@ -156,7 +157,7 @@ theorem OperationPtr.getNumOperands!_pushOperand {operation : OperationPtr} :
       operation.getNumOperands! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpOperandPtr.get!_pushOperand {operand : OpOperandPtr} :
     operand.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if operand = opPtr.nextOperand ctx then
@@ -195,7 +196,7 @@ theorem OpOperandPtr.get!_pushOperand'
         operandPtr.get! ctx := by
   apply OpOperand.ext <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_pushOperand {operation : OperationPtr} :
     operation.getOperands! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if operation = opPtr then
@@ -204,56 +205,56 @@ theorem OperationPtr.getOperands!_pushOperand {operation : OperationPtr} :
       operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_pushOperand {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_pushOperand {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_pushOperand {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_pushOperand {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_pushOperand,
     OperationPtr.getNumSuccessors!_pushOperand]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_pushOperand {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_pushOperand {operation : OperationPtr} :
     operation.getRegion! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) idx =
     operation.getRegion! ctx idx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_pushOperand {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_pushOperand {block : BlockPtr} :
     block.getNumArguments! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_pushOperand {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if valuePtr = blockArg then
@@ -262,37 +263,37 @@ theorem BlockArgumentPtr.get!_pushOperand {blockArg : BlockArgumentPtr} :
       blockArg.get! ctx := by
   grind [OperationPtr.getOpOperand_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_pushOperand {region : RegionPtr} :
     (region.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).firstBlock =
     (region.get! ctx).firstBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_pushOperand {region : RegionPtr} :
     (region.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).lastBlock =
     (region.get! ctx).lastBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_pushOperand {region : RegionPtr} :
     (region.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃)).parent =
     (region.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_pushOperand {value : ValuePtr} :
     value.getType! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_pushOperand {value : ValuePtr} :
     value.getFirstUse! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if value = valuePtr then some (opPtr.nextOperand! ctx) else value.getFirstUse! ctx := by
   grind [OperationPtr.getOpOperand_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_pushOperand {operandPtr : OpOperandPtrPtr} :
     operandPtr.get! (Rewriter.pushOperand ctx opPtr valuePtr h₁ h₂ h₃) =
     if operandPtr = .operandNextUse (opPtr.nextOperand ctx) then
@@ -312,79 +313,79 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.initOpOperands
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_initOpOperands {block : BlockPtr} :
     (block.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).firstUse =
     (block.get! ctx).firstUse := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_initOpOperands {block : BlockPtr} :
     (block.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).prev =
     (block.get! ctx).prev := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_initOpOperands {block : BlockPtr} :
     (block.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).next =
     (block.get! ctx).next := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_initOpOperands {block : BlockPtr} :
     (block.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).parent =
     (block.get! ctx).parent := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_initOpOperands {block : BlockPtr} :
     (block.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).firstOp =
     (block.get! ctx).firstOp := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_initOpOperands {block : BlockPtr} :
     (block.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).lastOp =
     (block.get! ctx).lastOp := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_initOpOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).prev =
     (operation.get! ctx).prev := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_initOpOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).next =
     (operation.get! ctx).next := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_initOpOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).parent =
     (operation.get! ctx).parent := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_initOpOperands {operation : OperationPtr} :
     operation.getOpType! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     operation.getOpType! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_initOpOperands {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).attrs =
     (operation.get! ctx).attrs := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_initOpOperands {operation : OperationPtr} :
     operation.getProperties! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) opCode =
     operation.getProperties! ctx opCode := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_initOpOperands {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     operation.getNumResults! ctx := by
@@ -395,32 +396,32 @@ OpResultPtr.get!_initOpOperands is too complex to be expressed, and should not b
 as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_initOpOperands {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     operation.getNumSuccessors! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_initOpOperands {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     blockOperand.get! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_initOpOperands {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) i =
     operation.getSuccessor! ctx i := by
   fun_induction Rewriter.initOpOperands <;> grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_initOpOperands {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_initOpOperands,
     OperationPtr.getNumSuccessors!_initOpOperands]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumOperands!_initOpOperands {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     if operation = op then
@@ -433,7 +434,7 @@ theorem OperationPtr.getNumOperands!_initOpOperands {operation : OperationPtr} :
 OpOperandPtr.get!_initOpOperands is too complex to be expressed, and should not be needed in practice,
 as we should reason at a higher-level abstraction at this point.
 -/
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getOperands!_initOpOperands {operation : OperationPtr} :
     operation.getOperands! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     if operation = op then
@@ -442,25 +443,25 @@ theorem OperationPtr.getOperands!_initOpOperands {operation : OperationPtr} :
       operation.getOperands! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_initOpOperands {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     operation.getNumRegions! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_initOpOperands {operation : OperationPtr} :
     operation.getRegion! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) idx =
     operation.getRegion! ctx idx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_initOpOperands {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     blockOperandPtr.get! ctx := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_initOpOperands {block : BlockPtr} :
     block.getNumArguments! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     block.getNumArguments! ctx := by
@@ -471,19 +472,19 @@ BlockArgumentPtr.get!_initOpOperands is too complex to be expressed, and should 
 in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_initOpOperands {region : RegionPtr} :
     (region.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).firstBlock =
     (region.get! ctx).firstBlock := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_initOpOperands {region : RegionPtr} :
     (region.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).lastBlock =
     (region.get! ctx).lastBlock := by
   fun_induction Rewriter.initOpOperands <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_initOpOperands {region : RegionPtr} :
     (region.get! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn)).parent =
     (region.get! ctx).parent := by
@@ -494,7 +495,7 @@ ValuePtr.getFirstUse!_initOpOperands is too complex to be expressed, and should 
 in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_initOpOperands {value : ValuePtr} :
     value.getType! (Rewriter.initOpOperands ctx op h₁ operands h₂ h₃ n hn) =
     value.getType! ctx := by
@@ -505,7 +506,7 @@ OpOperandPtrPtr.get!_initOpOperands is too complex to be expressed, and should n
 in practice, as we should reason at a higher-level abstraction at this point.
 -/
 
-@[grind =]
+@[grind =, simp_getset]
 theorem Rewriter.initOpOperands_inBounds (ptr : GenericPtr) :
     ptr.InBounds (initOpOperands ctx op h₁ operands h₂ h₃ n hn) ↔
     match ptr with

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.Rewriter.Basic
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 public section
 
@@ -58,49 +59,49 @@ variable {op : OperationPtr} {newAttrs : DictionaryAttr} {opIn : op.InBounds ctx
 
 attribute [local grind] Rewriter.setAttributes
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.get!_setAttributes {block : BlockPtr} :
     block.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     block.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_setAttributes {block : BlockPtr} :
     (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).firstUse =
     (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_setAttributes {block : BlockPtr} :
     (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).prev =
     (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_setAttributes {block : BlockPtr} :
     (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).next =
     (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_setAttributes {block : BlockPtr} :
     (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).parent =
     (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_setAttributes {block : BlockPtr} :
     (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_setAttributes {block : BlockPtr} :
     (block.get! (Rewriter.setAttributes ctx op newAttrs opIn)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.get!_setAttributes {op' : OperationPtr} :
     op'.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     if op' = op then
@@ -109,163 +110,163 @@ theorem OperationPtr.get!_setAttributes {op' : OperationPtr} :
       op'.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_setAttributes {op' : OperationPtr} :
     (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).prev =
     (op'.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_setAttributes {op' : OperationPtr} :
     (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).next =
     (op'.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_setAttributes {op' : OperationPtr} :
     (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).parent =
     (op'.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_setAttributes {op' : OperationPtr} :
     op'.getOpType! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getOpType! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.attrs!_setAttributes {op' : OperationPtr} :
     (op'.get! (Rewriter.setAttributes ctx op newAttrs opIn)).attrs =
     if op' = op then newAttrs else (op'.get! ctx).attrs  := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_setAttributes {op' : OperationPtr} :
     op'.getProperties! (Rewriter.setAttributes ctx op newAttrs opIn) opCode =
     op'.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_setAttributes {op' : OperationPtr} :
     op'.getNumResults! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_setAttributes {opResult : OpResultPtr} :
     opResult.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_setAttributes {op' : OperationPtr} :
     op'.getNumOperands! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_setAttributes {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_setAttributes {op' : OperationPtr} :
     op'.getOperands! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_setAttributes {op' : OperationPtr} :
     op'.getNumSuccessors! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_setAttributes {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_setAttributes {op' : OperationPtr} :
     op'.getSuccessor! (Rewriter.setAttributes ctx op newAttrs opIn) index =
     op'.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_setAttributes {op' : OperationPtr} :
     op'.getSuccessors! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_setAttributes {op' : OperationPtr} :
     op'.getNumRegions! (Rewriter.setAttributes ctx op newAttrs opIn) =
     op'.getNumRegions! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_setAttributes {op' : OperationPtr} :
     op'.getRegion! (Rewriter.setAttributes ctx op newAttrs opIn) index =
     op'.getRegion! ctx index := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_setAttributes {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get!  (Rewriter.setAttributes ctx op newAttrs opIn) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_setAttributes {block : BlockPtr} :
     block.getNumArguments! (Rewriter.setAttributes ctx op newAttrs opIn) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_setAttributes {blockArgument : BlockArgumentPtr} :
     blockArgument.get!  (Rewriter.setAttributes ctx op newAttrs opIn) =
     blockArgument.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_setAttributes {region : RegionPtr} :
     region.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_setAttributes {region : RegionPtr} :
     (region.get! (Rewriter.setAttributes ctx op newAttrs opIn)).firstBlock =
     (region.get! ctx).firstBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_setAttributes {region : RegionPtr} :
     (region.get! (Rewriter.setAttributes ctx op newAttrs opIn)).lastBlock =
     (region.get! ctx).lastBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_setAttributes {region : RegionPtr} :
     (region.get! (Rewriter.setAttributes ctx op newAttrs opIn)).parent =
     (region.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_setAttributes {value : ValuePtr} :
     value.getFirstUse! (Rewriter.setAttributes ctx op newAttrs opIn)  =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_setAttributes {value : ValuePtr} :
     value.getType! (Rewriter.setAttributes ctx op newAttrs opIn)  =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_setAttributes {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.setAttributes ctx op newAttrs opIn) =
     opOperandPtr.get! ctx := by
@@ -281,49 +282,49 @@ variable {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode}
 
 attribute [local grind] Rewriter.setProperties
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.get!_setProperties {block : BlockPtr} :
     block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop) =
     block.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_setProperties {block : BlockPtr} :
     (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).firstUse =
     (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_setProperties {block : BlockPtr} :
     (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).prev =
     (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_setProperties {block : BlockPtr} :
     (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).next =
     (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_setProperties {block : BlockPtr} :
     (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).parent =
     (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_setProperties {block : BlockPtr} :
     (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_setProperties {block : BlockPtr} :
     (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.get!_setProperties {operation : OperationPtr} :
     operation.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop) =
     if operation = op then
@@ -334,37 +335,37 @@ theorem OperationPtr.get!_setProperties {operation : OperationPtr} :
       operation.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_setProperties {op' : OperationPtr} :
     (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).prev =
     (op'.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_setProperties {op' : OperationPtr} :
     (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).next =
     (op'.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_setProperties {op' : OperationPtr} :
     (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).parent =
     (op'.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_setProperties {op' : OperationPtr} :
     op'.getOpType! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getOpType! ctx := by
   grind
 
-@[simp ,grind =]
+@[simp ,grind =, simp_getset]
 theorem OperationPtr.attrs!_setProperties {op' : OperationPtr} :
     (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).attrs =
     (op'.get! ctx).attrs := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getProperties!_setProperties
     {GetterDialect : Type} [HasOpInfo GetterDialect]
     [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect}
@@ -382,127 +383,127 @@ theorem OperationPtr.getProperties!_setProperties
       op'.getProperties! ctx getterOpCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_setProperties {op' : OperationPtr} :
     op'.getNumResults! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_setProperties {opResult : OpResultPtr} :
     opResult.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_setProperties {op' : OperationPtr} :
     op'.getNumOperands! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_setProperties {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_setProperties {op' : OperationPtr} :
     op'.getOperands! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_setProperties {op' : OperationPtr} :
     op'.getNumSuccessors! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_setProperties {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_setProperties {op' : OperationPtr} :
     op'.getSuccessor! (Rewriter.setProperties ctx op opCode newProps opIn) index =
     op'.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_setProperties {op' : OperationPtr} :
     op'.getSuccessors! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_setProperties {op' : OperationPtr} :
     op'.getNumRegions! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumRegions! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_setProperties {op' : OperationPtr} :
     op'.getRegion! (Rewriter.setProperties ctx op opCode newProps opIn) index =
     op'.getRegion! ctx index := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_setProperties {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get!  (Rewriter.setProperties ctx op opCode newProps opIn) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_setProperties {block : BlockPtr} :
     block.getNumArguments! (Rewriter.setProperties ctx op opCode newProps opIn) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_setProperties {blockArgument : BlockArgumentPtr} :
     blockArgument.get!  (Rewriter.setProperties ctx op opCode newProps opIn) =
     blockArgument.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_setProperties {region : RegionPtr} :
     region.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_setProperties {region : RegionPtr} :
     (region.get! (Rewriter.setProperties ctx op opCode newProps opIn)).firstBlock =
     (region.get! ctx).firstBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_setProperties {region : RegionPtr} :
     (region.get! (Rewriter.setProperties ctx op opCode newProps opIn)).lastBlock =
     (region.get! ctx).lastBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.parent!_setProperties {region : RegionPtr} :
     (region.get! (Rewriter.setProperties ctx op opCode newProps opIn)).parent =
     (region.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_setProperties {value : ValuePtr} :
     value.getFirstUse! (Rewriter.setProperties ctx op opCode newProps opIn)  =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_setProperties {value : ValuePtr} :
     value.getType! (Rewriter.setProperties ctx op opCode newProps opIn)  =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_setProperties {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     opOperandPtr.get! ctx := by

--- a/Veir/Rewriter/GetSet/Regions.lean
+++ b/Veir/Rewriter/GetSet/Regions.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -60,165 +61,165 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.pushRegion
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.get!_pushRegion {block : BlockPtr} :
     block.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     block.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_pushRegion {operation : OperationPtr} :
     (operation.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_pushRegion {operation : OperationPtr} :
     (operation.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_pushRegion {operation : OperationPtr} :
     (operation.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_pushRegion {operation : OperationPtr} :
     operation.getOpType! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_pushRegion {operation : OperationPtr} :
     (operation.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_pushRegion {operation : OperationPtr} :
     operation.getProperties! (Rewriter.pushRegion ctx op region hop hregion hregionParent) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_pushRegion {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     operation.getNumResults! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.get!_pushRegion {opResult : OpResultPtr} :
     opResult.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_pushRegion {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_pushRegion {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_pushRegion {operation : OperationPtr} :
     operation.getOperands! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_pushRegion {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_pushRegion {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_pushRegion {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.pushRegion ctx op region hop hregion hregionParent) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_pushRegion {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_pushRegion {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     if operation = op then operation.getNumRegions! ctx + 1
     else operation.getNumRegions! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getRegion!_pushRegion {operation : OperationPtr} :
     operation.getRegion! (Rewriter.pushRegion ctx op region hop hregion hregionParent) index =
     if operation = op ∧ index = operation.getNumRegions! ctx then region
     else operation.getRegion! ctx index := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_pushRegion {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_pushRegion {block : BlockPtr} :
     block.getNumArguments! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_pushRegion {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.firstBlock!_pushRegion {r : RegionPtr} :
     (r.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).firstBlock =
     (r.get! ctx).firstBlock := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.lastBlock!_pushRegion {r : RegionPtr} :
     (r.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).lastBlock =
     (r.get! ctx).lastBlock := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem RegionPtr.parent!_pushRegion {r : RegionPtr} :
     (r.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent)).parent =
     if r = region then some op else (r.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_pushRegion {value : ValuePtr} :
     value.getFirstUse! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     value.getFirstUse! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_pushRegion {value : ValuePtr} :
     value.getType! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     value.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_pushRegion {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.pushRegion ctx op region hop hregion hregionParent) =
     opOperandPtr.get! ctx := by
@@ -233,111 +234,111 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.initOpRegions
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.get!_initOpRegions {block : BlockPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     block.get! ctx' = block.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.prev!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (operation.get! ctx').prev = (operation.get! ctx).prev := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.next!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (operation.get! ctx').next = (operation.get! ctx).next := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.parent!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (operation.get! ctx').parent = (operation.get! ctx).parent := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getOpType!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getOpType! ctx' = operation.getOpType! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.attrs!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (operation.get! ctx').attrs = (operation.get! ctx).attrs := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getProperties!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getProperties! ctx' opCode = operation.getProperties! ctx opCode := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumResults!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getNumResults! ctx' = operation.getNumResults! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumOperands!_initOpRegions {operation : OperationPtr} {ctx' : IRContext OpInfo}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getNumOperands! ctx' = operation.getNumOperands! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpResultPtr.get!_initOpRegions {opResult : OpResultPtr}
     (h : Rewriter.initOpRegions ctx op regions idx h₁ h₂ h₃ h₄ = some ctx') :
     opResult.get! ctx' = opResult.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpOperandPtr.get!_initOpRegions {opOperand : OpOperandPtr}
     (h : Rewriter.initOpRegions ctx op regions idx h₁ h₂ h₃ h₄ = some ctx') :
     opOperand.get! ctx' = opOperand.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getOperands!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getOperands! ctx' = operation.getOperands! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumSuccessors!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getNumSuccessors! ctx' = operation.getNumSuccessors! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockOperandPtr.get!_initOpRegions {blockOperand : BlockOperandPtr}
     (h : Rewriter.initOpRegions ctx op regions idx h₁ h₂ h₃ h₄ = some ctx') :
     blockOperand.get! ctx' = blockOperand.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getSuccessor!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions idx h₁ h₂ h₃ h₄ = some ctx') :
     operation.getSuccessor! ctx' i = operation.getSuccessor! ctx i := by
   fun_induction Rewriter.initOpRegions <;> grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getSuccessors!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions idx h₁ h₂ h₃ h₄ = some ctx') :
     operation.getSuccessors! ctx' = operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_initOpRegions h,
     OperationPtr.getNumSuccessors!_initOpRegions h]
 
-@[grind =>]
+@[grind =>, simp_getset]
 theorem OperationPtr.getNumRegions!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getNumRegions! ctx' =
     if operation = op then op.getNumRegions! ctx + (regions.size - index) else operation.getNumRegions! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getRegion!_initOpRegions {operation : OperationPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     operation.getRegion! ctx' idx =
@@ -345,36 +346,37 @@ theorem OperationPtr.getRegion!_initOpRegions {operation : OperationPtr}
     else operation.getRegion! ctx idx := by
   fun_induction Rewriter.initOpRegions <;> grind (splits := 15)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockOperandPtrPtr.get!_initOpRegions {blockOperandPtr : BlockOperandPtrPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     blockOperandPtr.get! ctx' = blockOperandPtr.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.getNumArguments!_initOpRegions {block : BlockPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     block.getNumArguments! ctx' = block.getNumArguments! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockArgumentPtr.get!_initOpRegions {blockArg : BlockArgumentPtr}
     (h : Rewriter.initOpRegions ctx op regions idx h₁ h₂ h₃ h₄ = some ctx') :
     blockArg.get! ctx' = blockArg.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.firstBlock!_initOpRegions {region : RegionPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (region.get! ctx').firstBlock = (region.get! ctx).firstBlock := by
   fun_induction Rewriter.initOpRegions <;> grind (instances := 5000)
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.lastBlock!_initOpRegions {region : RegionPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (region.get! ctx').lastBlock = (region.get! ctx).lastBlock := by
   fun_induction Rewriter.initOpRegions <;> grind (instances := 5000)
 
+@[simp_getset]
 theorem RegionPtr.parent!_initOpRegions_gen {region : RegionPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     (region.get! ctx').parent =
@@ -394,24 +396,25 @@ theorem RegionPtr.parent!_initOpRegions {region : RegionPtr}
   congr
   grind [Array.mem_iff_getElem]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem ValuePtr.getFirstUse!_initOpRegions {value : ValuePtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     value.getFirstUse! ctx' = value.getFirstUse! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem ValuePtr.getType!_initOpRegions {value : ValuePtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     value.getType! ctx' = value.getType! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpOperandPtrPtr.get!_initOpRegions {opOperandPtr : OpOperandPtrPtr}
     (h : Rewriter.initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx') :
     opOperandPtr.get! ctx' = opOperandPtr.get! ctx := by
   fun_induction Rewriter.initOpRegions <;> grind
 
+@[simp_getset]
 theorem Rewriter.initOpRegions_inBounds {ptr : GenericPtr} {ctx' : IRContext OpInfo} :
     initOpRegions ctx op regions index h₁ h₂ h₃ h₄ = some ctx' →
     (ptr.InBounds ctx ↔ ptr.InBounds ctx') := by

--- a/Veir/Rewriter/GetSet/ReplaceUse.lean
+++ b/Veir/Rewriter/GetSet/ReplaceUse.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -54,104 +55,104 @@ variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 section Rewriter.replaceUse
 
-@[simp, grind .]
+@[simp, grind ., simp_getset]
 theorem BlockOperandPtr.get!_replaceUse {bop : BlockOperandPtr} :
     bop.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     bop.get! ctx := by
   unfold Rewriter.replaceUse
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_replaceUse {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def, Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_replaceUse {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def, Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_replaceUse {b : BlockPtr} :
     (b.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).firstOp =
     (b.get! ctx).firstOp := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_replaceUse {b : BlockPtr} :
     (b.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).lastOp =
     (b.get! ctx).lastOp := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_replaceUse {b : BlockPtr} :
     (b.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).next =
     (b.get! ctx).next := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_replaceUse {b : BlockPtr} :
     (b.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).prev =
     (b.get! ctx).prev := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_replaceUse {b : BlockPtr} :
     (b.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).parent =
     (b.get! ctx).parent := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_replaceUse {op : OperationPtr} :
     (op.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).parent =
     (op.get! ctx).parent := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_replaceUse {op : OperationPtr} :
     (op.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).next =
     (op.get! ctx).next := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_replaceUse {op : OperationPtr} :
     (op.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).prev =
     (op.get! ctx).prev := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_replaceUse {op : OperationPtr} :
     op.getOpType! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     op.getOpType! ctx := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_replaceUse {op : OperationPtr} :
     (op.get! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).attrs =
     (op.get! ctx).attrs := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_replaceUse {op : OperationPtr} :
     op.getProperties! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) opCode =
     op.getProperties! ctx opCode := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_replaceUse :
     OperationPtr.getNumOperands! op (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     OperationPtr.getNumOperands! op ctx := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.owner!_replaceUse :
     (OpOperandPtr.get! opr (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).owner =
     (OpOperandPtr.get! opr ctx).owner := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.value!_replaceUse :
     (OpOperandPtr.get! opr (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).value =
     if use = opr then
@@ -160,7 +161,7 @@ theorem OpOperandPtr.value!_replaceUse :
       (OpOperandPtr.get! opr ctx).value := by
   grind [Rewriter.replaceUse]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getOperands!_replaceUse :
     OperationPtr.getOperands! op (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     if use.op = op then
@@ -170,67 +171,67 @@ theorem OperationPtr.getOperands!_replaceUse :
   simp only [Rewriter.replaceUse]
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_replaceUse :
     OperationPtr.getNumSuccessors! op (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     OperationPtr.getNumSuccessors! op ctx := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_replaceUse :
     OperationPtr.getNumResults! op (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     OperationPtr.getNumResults! op ctx := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.owner!_replaceUse :
     (OpResultPtr.get! opr (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).owner =
     (OpResultPtr.get! opr ctx).owner := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpResultPtr.index!_replaceUse :
     (OpResultPtr.get! opr (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).index =
     (OpResultPtr.get! opr ctx).index := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_replaceUse :
     OperationPtr.getNumRegions! op (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     OperationPtr.getNumRegions! op ctx := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegions!_replaceUse :
     OperationPtr.getRegion! op (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     OperationPtr.getRegion! op ctx := by
   grind (instances := 2000) [Rewriter.replaceUse] -- TODO: instance threshold reached when adding lemmas for Region.allocEmpty
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_replaceUse :
     BlockPtr.getNumArguments! block (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     BlockPtr.getNumArguments! block ctx := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.owner!_replaceUse :
     (BlockArgumentPtr.get! arg (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).owner =
     (BlockArgumentPtr.get! arg ctx).owner := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.index!_replaceUse :
     (BlockArgumentPtr.get! arg (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn)).index =
     (BlockArgumentPtr.get! arg ctx).index := by
   grind [Rewriter.replaceUse]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_replaceUse :
     RegionPtr.get! reg (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     RegionPtr.get! reg ctx := by
   grind (instances := 2000) [Rewriter.replaceUse]  -- TODO: instance threshold reached when adding lemmas for Region.allocEmpty
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getType!_replaceUse {v : ValuePtr} :
     v.getType! (Rewriter.replaceUse ctx use value' useIn newValueInBounds ctxIn) =
     v.getType! ctx := by
@@ -243,79 +244,79 @@ section Rewriter.replaceValue?
 
 attribute [local grind] Rewriter.replaceValue?
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockOperandPtr.get!_replaceValue? {bop : BlockOperandPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     bop.get! newCtx = bop.get! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getSuccessor!_replaceValue? {operation : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     operation.getSuccessor! newCtx index = operation.getSuccessor! ctx index := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getSuccessors!_replaceValue? {operation : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     operation.getSuccessors! newCtx = operation.getSuccessors! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.firstOp!_replaceValue? {b : BlockPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (b.get! newCtx).firstOp = (b.get! ctx).firstOp := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.lastOp!_replaceValue? {b : BlockPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (b.get! newCtx).lastOp = (b.get! ctx).lastOp := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.next!_replaceValue? {b : BlockPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (b.get! newCtx).next = (b.get! ctx).next := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.prev!_replaceValue? {b : BlockPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (b.get! newCtx).prev = (b.get! ctx).prev := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.parent!_replaceValue? {b : BlockPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (b.get! newCtx).parent = (b.get! ctx).parent := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.parent!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (op.get! newCtx).parent = (op.get! ctx).parent := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.next!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (op.get! newCtx).next = (op.get! ctx).next := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.prev!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (op.get! newCtx).prev = (op.get! ctx).prev := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumOperands!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     op.getNumOperands! newCtx = op.getNumOperands! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpOperandPtr.owner!_replaceValue? {opr : OpOperandPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (opr.get! newCtx).owner = (opr.get! ctx).owner := by
@@ -327,61 +328,61 @@ theorem OpOperandPtr.owner!_replaceValue? {opr : OpOperandPtr} :
  preservation to be stated.
 -/
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumSuccessors!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     op.getNumSuccessors! newCtx = op.getNumSuccessors! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumResults!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     op.getNumResults! newCtx = op.getNumResults! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpResultPtr.owner!_replaceValue? {opr : OpResultPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (opr.get! newCtx).owner = (opr.get! ctx).owner := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OpResultPtr.index!_replaceValue? {opr : OpResultPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (opr.get! newCtx).index = (opr.get! ctx).index := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getNumRegions!_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     op.getNumRegions! newCtx = op.getNumRegions! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem OperationPtr.getRegions_replaceValue? {op : OperationPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     op.getRegion! newCtx index = op.getRegion! ctx index := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockPtr.getNumArguments!_replaceValue? {block : BlockPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     block.getNumArguments! newCtx = block.getNumArguments! ctx := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockArgumentPtr.owner!_replaceValue? {arg : BlockArgumentPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (arg.get! newCtx).owner = (arg.get! ctx).owner := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem BlockArgumentPtr.index!_replaceValue? {arg : BlockArgumentPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     (arg.get! newCtx).index = (arg.get! ctx).index := by
   induction depth generalizing ctx <;> simp only [Rewriter.replaceValue?] <;> grind
 
-@[simp, grind =>]
+@[simp, grind =>, simp_getset]
 theorem RegionPtr.get!_replaceValue? {reg : RegionPtr} :
     Rewriter.replaceValue? ctx oldValue newValue oldIn newIn ctxIn depth = some newCtx →
     reg.get! newCtx = reg.get! ctx := by

--- a/Veir/Rewriter/GetSet/Results.lean
+++ b/Veir/Rewriter/GetSet/Results.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 
 public section
@@ -60,56 +61,56 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.pushResult
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.get!_pushResult {block : BlockPtr} :
     block.get! (Rewriter.pushResult ctx op type hop) =
     block.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_pushResult {operation : OperationPtr} :
     (operation.get! (Rewriter.pushResult ctx op type hop)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_pushResult {operation : OperationPtr} :
     (operation.get! (Rewriter.pushResult ctx op type hop)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_pushResult {operation : OperationPtr} :
     (operation.get! (Rewriter.pushResult ctx op type hop)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_pushResult {operation : OperationPtr} :
     operation.getOpType! (Rewriter.pushResult ctx op type hop) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_pushResult {operation : OperationPtr} :
     (operation.get! (Rewriter.pushResult ctx op type hop)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_pushResult {operation : OperationPtr} :
     operation.getProperties! (Rewriter.pushResult ctx op type hop) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.getNumResults!_pushResult {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.pushResult ctx op type hop) =
     if operation = op then operation.getNumResults! ctx + 1
     else operation.getNumResults! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpResultPtr.get!_pushResult {opResult : OpResultPtr} :
     opResult.get! (Rewriter.pushResult ctx op type hop) =
     if opResult = op.nextResult ctx then
@@ -117,85 +118,85 @@ theorem OpResultPtr.get!_pushResult {opResult : OpResultPtr} :
     else opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_pushResult {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.pushResult ctx op type hop) =
     operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_pushResult {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.pushResult ctx op type hop) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_pushResult {operation : OperationPtr} :
     operation.getOperands! (Rewriter.pushResult ctx op type hop) =
     operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_pushResult {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.pushResult ctx op type hop) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_pushResult {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.pushResult ctx op type hop) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_pushResult {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.pushResult ctx op type hop) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_pushResult {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.pushResult ctx op type hop) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_pushResult {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.pushResult ctx op type hop) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_pushResult {operation : OperationPtr} :
     operation.getRegion! (Rewriter.pushResult ctx op type hop) idx =
     operation.getRegion! ctx idx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_pushResult {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.pushResult ctx op type hop) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_pushResult {block : BlockPtr} :
     block.getNumArguments! (Rewriter.pushResult ctx op type hop) =
     block.getNumArguments! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_pushResult {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.pushResult ctx op type hop) =
     blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_pushResult {region : RegionPtr} :
     region.get! (Rewriter.pushResult ctx op type hop) =
     region.get! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_pushResult {value : ValuePtr} :
     value.getFirstUse! (Rewriter.pushResult ctx op type hop) =
     if value = op.nextResult ctx then
@@ -204,7 +205,7 @@ theorem ValuePtr.getFirstUse!_pushResult {value : ValuePtr} :
       value.getFirstUse! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getType!_pushResult {value : ValuePtr} :
     value.getType! (Rewriter.pushResult ctx op type hop) =
     if value = op.nextResult ctx then
@@ -213,7 +214,7 @@ theorem ValuePtr.getType!_pushResult {value : ValuePtr} :
       value.getType! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_pushResult {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.pushResult ctx op type hop) =
     if opOperandPtr = OpOperandPtrPtr.valueFirstUse (op.nextResult ctx) then
@@ -231,49 +232,49 @@ variable {op : OperationPtr}
 
 attribute [local grind] Rewriter.initOpResults
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.get!_initOpResults {block : BlockPtr} :
     block.get! (Rewriter.initOpResults ctx op types index hop hidx) = block.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_initOpResults {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpResults ctx op types index hop hidx)).prev =
     (operation.get! ctx).prev := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_initOpResults {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpResults ctx op types index hop hidx)).next =
     (operation.get! ctx).next := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_initOpResults {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpResults ctx op types index hop hidx)).parent =
     (operation.get! ctx).parent := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_initOpResults {operation : OperationPtr} :
     operation.getOpType! (Rewriter.initOpResults ctx op types index hop hidx) =
     operation.getOpType! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_initOpResults {operation : OperationPtr} :
     (operation.get! (Rewriter.initOpResults ctx op types index hop hidx)).attrs =
     (operation.get! ctx).attrs := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_initOpResults {operation : OperationPtr} :
     operation.getProperties! (Rewriter.initOpResults ctx op types index hop hidx) opCode =
     operation.getProperties! ctx opCode := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_initOpResults {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.initOpResults ctx op types index hop hidx) =
     if operation = op then op.getNumResults! ctx + (types.size - index) else operation.getNumResults! ctx := by
@@ -287,7 +288,9 @@ theorem OpResultPtr.get!_initOpResults {opResult : OpResultPtr} {index : Nat} {h
     else opResult.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind [cases OpResultPtr]
 
-@[grind =]
+attribute [simp_getset] OpResultPtr.get!_initOpResults
+
+@[grind =, simp_getset]
 theorem OpResultPtr.type!_initOpResults {opResult : OpResultPtr} {index : Nat} {hidx} :
     (opResult.get! (Rewriter.initOpResults ctx op types index hop hidx)).type =
     if h : opResult.op = op ∧ opResult.index < types.size ∧ op.getNumResults! ctx ≤ opResult.index then
@@ -295,14 +298,14 @@ theorem OpResultPtr.type!_initOpResults {opResult : OpResultPtr} {index : Nat} {
     else (opResult.get! ctx).type := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpResultPtr.firstUse!_initOpResults {opResult : OpResultPtr} {index : Nat} {hidx} :
     (opResult.get! (Rewriter.initOpResults ctx op types index hop hidx)).firstUse =
     if opResult.op = op ∧ opResult.index < types.size ∧ op.getNumResults! ctx ≤ opResult.index then none
     else (opResult.get! ctx).firstUse := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpResultPtr.index!_initOpResults {opResult : OpResultPtr} {index : Nat} {hidx} :
     (opResult.get! (Rewriter.initOpResults ctx op types index hop hidx)).index =
     if opResult.op = op ∧ opResult.index < types.size ∧ op.getNumResults! ctx ≤ opResult.index then
@@ -310,90 +313,90 @@ theorem OpResultPtr.index!_initOpResults {opResult : OpResultPtr} {index : Nat} 
     else (opResult.get! ctx).index := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpResultPtr.owner!_initOpResults {opResult : OpResultPtr} {index : Nat} {hidx} :
     (opResult.get! (Rewriter.initOpResults ctx op types index hop hidx)).owner =
     if opResult.op = op ∧ opResult.index < types.size ∧ op.getNumResults! ctx ≤ opResult.index then op
     else (opResult.get! ctx).owner := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_initOpResults {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.initOpResults ctx op types index hop hidx) = operation.getNumOperands! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_initOpResults {opOperand : OpOperandPtr} {index} {hidx} :
     opOperand.get! (Rewriter.initOpResults ctx op types index hop hidx) = opOperand.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_initOpResults {operation : OperationPtr} {index} {hidx} :
     operation.getOperands! (Rewriter.initOpResults ctx op types index hop hidx) = operation.getOperands! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_initOpResults {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.initOpResults ctx op types index hop hidx) =
     operation.getNumSuccessors! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_initOpResults {blockOperand : BlockOperandPtr} {index} {hidx} :
     blockOperand.get! (Rewriter.initOpResults ctx op types index hop hidx) =
     blockOperand.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_initOpResults {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.initOpResults ctx op types index hop hidx) i =
     operation.getSuccessor! ctx i := by
   fun_induction Rewriter.initOpResults <;> grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_initOpResults {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.initOpResults ctx op types index hop hidx) =
     operation.getSuccessors! ctx := by
   simp only [OperationPtr.getSuccessors!_def, OperationPtr.getSuccessor!_initOpResults,
     OperationPtr.getNumSuccessors!_initOpResults]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_initOpResults {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.initOpResults ctx op types index hop hidx) =
     operation.getNumRegions! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_initOpResults {operation : OperationPtr} :
     operation.getRegion! (Rewriter.initOpResults ctx op types index hop hidx) idx =
     operation.getRegion! ctx idx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_initOpResults {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.initOpResults ctx op types index hop hidx) =
     blockOperandPtr.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_initOpResults {block : BlockPtr} :
     block.getNumArguments! (Rewriter.initOpResults ctx op types index hop hidx) =
     block.getNumArguments! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockArgumentPtr.get!_initOpResults {blockArg : BlockArgumentPtr} {index} {hidx} :
     blockArg.get! (Rewriter.initOpResults ctx op types index hop hidx) =
     blockArg.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_initOpResults {region : RegionPtr} :
     region.get! (Rewriter.initOpResults ctx op types index hop hidx) =
     region.get! ctx := by
   fun_induction Rewriter.initOpResults <;> grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_initOpResults {value : ValuePtr} :
     value.getFirstUse! (Rewriter.initOpResults ctx op types index hop hidx) =
     match value with
@@ -406,7 +409,7 @@ theorem ValuePtr.getFirstUse!_initOpResults {value : ValuePtr} :
   · grind
   · cases value <;> grind [cases OpResultPtr, cases ValuePtr]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getType!_initOpResults {value : ValuePtr} :
     value.getType! (Rewriter.initOpResults ctx op types index hop hidx) =
     match value with
@@ -419,7 +422,7 @@ theorem ValuePtr.getType!_initOpResults {value : ValuePtr} :
   · grind
   · cases value <;> grind [cases OpResultPtr, cases ValuePtr]
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_initOpResults {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.initOpResults ctx op types index hop hidx) =
     match opOperandPtr with
@@ -431,7 +434,7 @@ theorem OpOperandPtrPtr.get!_initOpResults {opOperandPtr : OpOperandPtrPtr} :
   · grind
   · simp only [get!_valueFirstUse_eq, ValuePtr.getFirstUse!_initOpResults, dite_eq_ite]; grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem Rewriter.initOpResults_inBounds (ptr : GenericPtr) :
     ptr.InBounds (initOpResults ctx op types index hop hidx) ↔
     match ptr with

--- a/Veir/Rewriter/GetSet/Value.lean
+++ b/Veir/Rewriter/GetSet/Value.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Rewriter.Basic
 
 import all Veir.Rewriter.Basic
+import Veir.Rewriter.WfRewriter.GetSetTactic
 
 public section
 
@@ -59,7 +60,7 @@ variable {value : ValuePtr}
 
 attribute [local grind] Rewriter.setType
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockPtr.get!_setType {block : BlockPtr} :
     block.get! (Rewriter.setType ctx value newType valueIn) =
     match value with
@@ -72,43 +73,43 @@ theorem BlockPtr.get!_setType {block : BlockPtr} :
         block.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstUse!_setType {block : BlockPtr} :
     (block.get! (Rewriter.setType ctx value newType valueIn)).firstUse =
     (block.get! ctx).firstUse := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.prev!_setType {block : BlockPtr} :
     (block.get! (Rewriter.setType ctx value newType valueIn)).prev =
     (block.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.next!_setType {block : BlockPtr} :
     (block.get! (Rewriter.setType ctx value newType valueIn)).next =
     (block.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.parent!_setType {block : BlockPtr} :
     (block.get! (Rewriter.setType ctx value newType valueIn)).parent =
     (block.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.firstOp!_setType {block : BlockPtr} :
     (block.get! (Rewriter.setType ctx value newType valueIn)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.lastOp!_setType {block : BlockPtr} :
     (block.get! (Rewriter.setType ctx value newType valueIn)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OperationPtr.get!_setType {operation : OperationPtr} :
     operation.get! (Rewriter.setType ctx value newType valueIn) =
     match value with
@@ -121,49 +122,49 @@ theorem OperationPtr.get!_setType {operation : OperationPtr} :
     | ValuePtr.blockArgument _ => operation.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.prev!_setType {operation : OperationPtr} :
     (operation.get! (Rewriter.setType ctx value newType valueIn)).prev =
     (operation.get! ctx).prev := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.next!_setType {operation : OperationPtr} :
     (operation.get! (Rewriter.setType ctx value newType valueIn)).next =
     (operation.get! ctx).next := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.parent!_setType {operation : OperationPtr} :
     (operation.get! (Rewriter.setType ctx value newType valueIn)).parent =
     (operation.get! ctx).parent := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOpType!_setType {operation : OperationPtr} :
     operation.getOpType! (Rewriter.setType ctx value newType valueIn) =
     operation.getOpType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.attrs!_setType {operation : OperationPtr} :
     (operation.get! (Rewriter.setType ctx value newType valueIn)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getProperties!_setType {operation : OperationPtr} :
     operation.getProperties! (Rewriter.setType ctx value newType valueIn) opCode =
     operation.getProperties! ctx opCode := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumResults!_setType {operation : OperationPtr} :
     operation.getNumResults! (Rewriter.setType ctx value newType valueIn) =
     operation.getNumResults! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem OpResultPtr.get!_setType {opResult : OpResultPtr} :
     opResult.get! (Rewriter.setType ctx value newType valueIn) =
     if value = ValuePtr.opResult opResult then
@@ -172,73 +173,73 @@ theorem OpResultPtr.get!_setType {opResult : OpResultPtr} :
       opResult.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumOperands!_setType {operation : OperationPtr} :
     operation.getNumOperands! (Rewriter.setType ctx value newType valueIn) =
     operation.getNumOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtr.get!_setType {opOperand : OpOperandPtr} :
     opOperand.get! (Rewriter.setType ctx value newType valueIn) =
     opOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getOperands!_setType {operation : OperationPtr} :
     operation.getOperands! (Rewriter.setType ctx value newType valueIn) =
     operation.getOperands! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumSuccessors!_setType {operation : OperationPtr} :
     operation.getNumSuccessors! (Rewriter.setType ctx value newType valueIn) =
     operation.getNumSuccessors! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtr.get!_setType {blockOperand : BlockOperandPtr} :
     blockOperand.get! (Rewriter.setType ctx value newType valueIn) =
     blockOperand.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessor!_setType {operation : OperationPtr} :
     operation.getSuccessor! (Rewriter.setType ctx value newType valueIn) index =
     operation.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getSuccessors!_setType {operation : OperationPtr} :
     operation.getSuccessors! (Rewriter.setType ctx value newType valueIn) =
     operation.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getNumRegions!_setType {operation : OperationPtr} :
     operation.getNumRegions! (Rewriter.setType ctx value newType valueIn) =
     operation.getNumRegions! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OperationPtr.getRegion!_setType {operation : OperationPtr} :
     operation.getRegion! (Rewriter.setType ctx value newType valueIn) idx =
     operation.getRegion! ctx idx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockOperandPtrPtr.get!_setType {blockOperandPtr : BlockOperandPtrPtr} :
     blockOperandPtr.get! (Rewriter.setType ctx value newType valueIn) =
     blockOperandPtr.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem BlockPtr.getNumArguments!_setType {block : BlockPtr} :
     block.getNumArguments! (Rewriter.setType ctx value newType valueIn) =
     block.getNumArguments! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem BlockArgumentPtr.get!_setType {blockArg : BlockArgumentPtr} :
     blockArg.get! (Rewriter.setType ctx value newType valueIn) =
     if value = ValuePtr.blockArgument blockArg then
@@ -247,25 +248,25 @@ theorem BlockArgumentPtr.get!_setType {blockArg : BlockArgumentPtr} :
       blockArg.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem RegionPtr.get!_setType {region : RegionPtr} :
     region.get! (Rewriter.setType ctx value newType valueIn) =
     region.get! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem ValuePtr.getFirstUse!_setType {value' : ValuePtr} :
     value'.getFirstUse! (Rewriter.setType ctx value newType valueIn) =
     value'.getFirstUse! ctx := by
   grind
 
-@[grind =]
+@[grind =, simp_getset]
 theorem ValuePtr.getType!_setType {value' : ValuePtr} :
     value'.getType! (Rewriter.setType ctx value newType valueIn) =
     if value = value' then newType else value'.getType! ctx := by
   grind
 
-@[simp, grind =]
+@[simp, grind =, simp_getset]
 theorem OpOperandPtrPtr.get!_setType {opOperandPtr : OpOperandPtrPtr} :
     opOperandPtr.get! (Rewriter.setType ctx value newType valueIn) =
     opOperandPtr.get! ctx := by

--- a/Veir/Rewriter/WfRewriter/GetSetTactic.lean
+++ b/Veir/Rewriter/WfRewriter/GetSetTactic.lean
@@ -7,10 +7,10 @@ public section
 /-!
 # `@[simp_getset]` attribute and `simp_getset` tactics
 
-This module defines the `simp_getset` and `simp_getset?` tactics, which tries to apply all
-`@[simp_getset]`-tagged theorems. These theorems are equalities with a single explicit argument
-of the form `f ... = ...`. The tactic then looks for hypotheses matching this shape, and
-applies the theorems with these hypothesese passed as arguments.
+This module defines the `simp_getset` and `simp_getset?` tactics, which try to apply all
+`@[simp_getset]`-tagged theorems. Unconditional theorems are used as ordinary simp rules. For
+theorems whose only explicit argument is an equality of the form `f ... = ...`, the tactic looks
+for hypotheses matching this shape and applies the theorems with these hypotheses as arguments.
 -/
 
 namespace Veir
@@ -21,53 +21,59 @@ open Lean Meta
 ## `@[simp_getset]` attribute
 -/
 
-/-- State of the `simp_getset` attribute: a map from a head constant
-    to the array of theorem names tagged with `@[simp_getset]`
-    that have that constant as the head of the LHS of their first explicit
-    hypothesis. -/
-abbrev SimpGetSetState := Std.HashMap Name (Array Name)
+/-- State of the `simp_getset` attribute: unconditional theorem names together with a map from
+    a head constant to the theorem names whose only explicit hypothesis is an equality with that
+    constant at the head of its LHS. -/
+meta structure SimpGetSetState where
+  unconditional : Array Name := #[]
+  conditional : Std.HashMap Name (Array Name) := {}
+  deriving Inhabited
 
-/-- Add a theorem to the `headFun` entry. -/
-private meta def SimpGetSetState.add (s : SimpGetSetState) (headFun th : Name) : SimpGetSetState :=
-  s.insert headFun ((s.get? headFun |>.getD #[]).push th)
+/-- Add an unconditional theorem or a theorem to the given `headFun` entry. -/
+private meta def SimpGetSetState.add
+    (s : SimpGetSetState) (headFun : Option Name) (th : Name) : SimpGetSetState :=
+  match headFun with
+  | none => { s with unconditional := s.unconditional.push th }
+  | some headFun =>
+      { s with conditional :=
+          s.conditional.insert headFun ((s.conditional.get? headFun |>.getD #[]).push th) }
 
 /-- A persistent environment variable that holds a `SimpGetSetState`. -/
 public meta initialize simpGetSetExt :
-    SimplePersistentEnvExtension (Name × Name) SimpGetSetState ←
+    SimplePersistentEnvExtension (Option Name × Name) SimpGetSetState ←
   registerSimplePersistentEnvExtension {
     name          := `simpGetSetExt
-    addImportedFn := fun ass => ass.foldl (init := {}) fun s as =>
+    addImportedFn := fun ass => ass.foldl (init := default) fun s as =>
       as.foldl (init := s) fun s (target, th) => s.add target th
     addEntryFn    := fun s (target, th) => s.add target th
   }
 
-/-- Infer the target head function of a `@[simp_getset]` theorem: take its first explicit
-    argument, require it to be an equality, and return the head constant of the LHS. -/
-private meta def inferWfGetSetTarget (declName : Name) : MetaM Name := do
+/-- Infer the target head function of a `@[simp_getset]` theorem. If its only explicit argument
+    is an equality, return the head constant of its LHS; otherwise returns `none`. -/
+private meta def inferGetSetTarget (declName : Name) : MetaM (Option Name) := do
   let info ← getConstInfo declName
   forallTelescopeReducing info.type fun xs _ => do
     for x in xs do
       let ldecl ← x.fvarId!.getDecl
       unless ldecl.binderInfo.isExplicit do continue
-      let some (_, lhs, _) := (← whnf ldecl.type).eq?
-        | throwError "@[simp_getset]: first explicit argument must be an equality"
+      let some (_, lhs, _) := (← whnf ldecl.type).eq? | return none
       let some head := lhs.getAppFn.constName?
         | throwError
-          "@[simp_getset]: LHS of the first explicit argument must be an constant application"
-      return head
-    throwError "@[simp_getset]: theorem has no explicit argument"
+          "@[simp_getset]: LHS of the only explicit argument must be an constant application"
+      return some head
+    return none
 
 /-- Register the `@[simp_getset]` attribute. -/
 meta initialize registerBuiltinAttribute {
   name  := `simp_getset
-  descr := "Get-set theorem; used by the `simp_getset` tactic. The theorem must take a \
-            `f ... = _` hypothesis as its first explicit argument, and the theorem \
-            conclusion must be an equality."
+  descr := "Get-set theorem; used by the `simp_getset` tactic. If its first explicit argument \
+            is a `f ... = _` hypothesis, the theorem \
+            is only applied when the local context contains a matching hypothesis."
   applicationTime := .afterCompilation
   add   := fun decl _stx kind => do
     unless kind == .global do
       throwError "@[simp_getset] only supports the global attribute kind"
-    let target ← MetaM.run' (inferWfGetSetTarget decl)
+    let target ← MetaM.run' (inferGetSetTarget decl)
     setEnv (simpGetSetExt.addEntry (← getEnv) (target, decl))
 }
 
@@ -75,18 +81,20 @@ meta initialize registerBuiltinAttribute {
 ## `simp_getset` tactics
 -/
 
-/-- Collect simp lemma arguments for the `simp_getset` family of tactics: for every
-    hypothesis `h : f ... = _` in the local context where `f` is the head constant
-    of some `@[simp_getset]`-tagged theorem, produce one `lem h` simp argument per
-    matching theorem `lem`. -/
+/-- Collect simp lemma arguments for the `simp_getset` family of tactics: add unconditional
+    theorems directly and, for every hypothesis `h : f ... = _` in the local context, add one
+    `lem h` argument per conditional theorem registered for `f`. -/
 private meta def collectSimpGetSetArgs :
     Elab.Tactic.TacticM (Array (TSyntax `Lean.Parser.Tactic.simpLemma)) := do
   let state := simpGetSetExt.getState (← getEnv)
   let mut simpArgs : Array (TSyntax `Lean.Parser.Tactic.simpLemma) := #[]
+  for n in state.unconditional do
+    let lem := mkIdent n
+    simpArgs := simpArgs.push (← `(Lean.Parser.Tactic.simpLemma| $lem:ident))
   for ldecl in ← getLCtx do
     let some (_, lhs, _) := ldecl.type.eq? | continue
     let some head := lhs.getAppFn.constName? | continue
-    let some lemmas := state.get? head | continue
+    let some lemmas := state.conditional.get? head | continue
     let h := mkIdent ldecl.userName
     for n in lemmas do
       let lem := mkIdent n


### PR DESCRIPTION
This will allow us to use the `simp_getset` tactic for proofs about `Rewriter` operations. It is a slightly better simp set as it allows to also `simp` things that require one hypothesis.

`simp_getset` is a tactic to automatically apply these lemmas using `simp`. It is much faster than `grind`, and can be use non-terminally.

This change also modifies the `simp_getset` (`SimpGetSet.lean`) tactic, so that we can annotate both unconditional and conditional rewrites.