### PR TITLE
ci: rename the Namespace job to `buildns`

### DIFF
--- a/.github/workflows/lean_action_ci_namespace.yml
+++ b/.github/workflows/lean_action_ci_namespace.yml
@@ -8,7 +8,7 @@ on:
   merge_group:
 
 jobs:
-  build:
+  buildns:
     # The runner profile pins the machine shape (32 vCPU, eight times what the
     # GitHub-hosted runner in the sibling `Lean Action CI` workflow gets, so
     # Lake builds with `-j32` instead of `-j4`), the cache volume and the git


### PR DESCRIPTION
Both CI workflows named their only job `build`, so runs appeared as `Lean Action CI / build` and `Lean Action CI (Namespace) / build`, distinct only by the workflow prefix. This renames the Namespace one to `buildns` so it is identifiable on its own.