### PR TITLE
feat(match): add the value-producing `match` operations

### DIFF
--- a/Test/Match/constant_types_element_invalid.mlir
+++ b/Test/Match/constant_types_element_invalid.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// Every element of `match.constant_types` is a type.
+"builtin.module"() ({
+  %a = "match.constant_types"() <{value = [i32, 4 : i32]}> : () -> !pdl.range<type>
+}) : () -> ()
+
+// CHECK: match.constant_types: expected 'value' to hold types, but got 4

--- a/Test/Match/extract_element_invalid.mlir
+++ b/Test/Match/extract_element_invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// `match.extract` yields one element of the range, so the result type is the
+// range's element type.
+"builtin.module"() ({
+  %r = "test.test"() : () -> !pdl.range<value>
+  %a = "match.extract"(%r) <{index = 0 : i32}> : (!pdl.range<value>) -> !pdl.type
+}) : () -> ()
+
+// CHECK: match.extract: Expected the result to have the element type of the range, '!pdl.value'

--- a/Test/Match/get_operand_index_invalid.mlir
+++ b/Test/Match/get_operand_index_invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// The index of `match.get_operand` is mandatory and non-negative.
+"builtin.module"() ({
+  %op = "test.test"() : () -> !pdl.operation
+  %a = "match.get_operand"(%op) <{index = -1 : i32}> : (!pdl.operation) -> !match.optional<!pdl.value>
+}) : () -> ()
+
+// CHECK: match.get_operand: expected 'index' to be non-negative, but got -1

--- a/Test/Match/get_operand_result_type_invalid.mlir
+++ b/Test/Match/get_operand_result_type_invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// Navigation that can fail returns `!match.optional<...>`, never a bare handle.
+"builtin.module"() ({
+  %op = "test.test"() : () -> !pdl.operation
+  %a = "match.get_operand"(%op) <{index = 0 : i32}> : (!pdl.operation) -> !pdl.value
+}) : () -> ()
+
+// CHECK: match.get_operand: Expected the result to be of type '!match.optional<!pdl.value>'

--- a/Test/Match/get_value_type_range_invalid.mlir
+++ b/Test/Match/get_value_type_range_invalid.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// A range of values gives a range of types, not a single type.
+"builtin.module"() ({
+  %r = "test.test"() : () -> !pdl.range<value>
+  %a = "match.get_value_type"(%r) : (!pdl.range<value>) -> !pdl.type
+}) : () -> ()
+
+// CHECK: match.get_value_type: Expected the result to be of type '!pdl.range<type>'

--- a/Test/Match/value_ops.mlir
+++ b/Test/Match/value_ops.mlir
@@ -1,0 +1,57 @@
+// RUN: VEIR_ROUNDTRIP
+
+// `MLIR_ROUNDTRIP` is deliberately absent: `match` is an unmerged upstream
+// proposal, so no released `mlir-opt` knows these operations. Add it once it
+// lands.
+//
+// The value-producing subset of the dialect: constants and navigation, all of
+// them `Pure`. Navigation that can fail returns `!match.optional<...>`; the
+// rest return bare handles.
+
+"builtin.module"() ({
+  %op = "test.test"() : () -> !pdl.operation
+  %val = "test.test"() : () -> !pdl.value
+  %vals = "test.test"() : () -> !pdl.range<value>
+  %attr = "test.test"() : () -> !pdl.attribute
+
+  %ca = "match.constant_attribute"() <{value = 42 : i32}> : () -> !pdl.attribute
+  %ct = "match.constant_type"() <{value = i32}> : () -> !pdl.type
+  %cts = "match.constant_types"() <{value = [i32, i64]}> : () -> !pdl.range<type>
+
+  // Nullable navigation. `get_operands` and `get_results` take an optional
+  // index; without one they stand for the whole list.
+  %o0 = "match.get_operand"(%op) <{index = 0 : i32}> : (!pdl.operation) -> !match.optional<!pdl.value>
+  %os = "match.get_operands"(%op) : (!pdl.operation) -> !match.optional<!pdl.range<value>>
+  %r0 = "match.get_result"(%op) <{index = 0 : i32}> : (!pdl.operation) -> !match.optional<!pdl.value>
+  %rs = "match.get_results"(%op) <{index = 1 : i32}> : (!pdl.operation) -> !match.optional<!pdl.range<value>>
+  %ga = "match.get_attribute"(%op) <{name = "value"}> : (!pdl.operation) -> !match.optional<!pdl.attribute>
+  %def = "match.get_defining_op"(%val) : (!pdl.value) -> !match.optional<!pdl.operation>
+
+  // Non-nullable navigation. A range in gives a range out.
+  %vt = "match.get_value_type"(%val) : (!pdl.value) -> !pdl.type
+  %vts = "match.get_value_type"(%vals) : (!pdl.range<value>) -> !pdl.range<type>
+  %at = "match.get_attribute_type"(%attr) : (!pdl.attribute) -> !pdl.type
+  %us = "match.get_users"(%val) : (!pdl.value) -> !pdl.range<operation>
+  %ex = "match.extract"(%vals) <{index = 0 : i32}> : (!pdl.range<value>) -> !pdl.value
+  %ea = "match.get_each"(%vals) : (!pdl.range<value>) -> !pdl.value
+}) : () -> ()
+
+// CHECK:      %[[op:.*]] = "test.test"() : () -> !pdl.operation
+// CHECK-NEXT: %[[val:.*]] = "test.test"() : () -> !pdl.value
+// CHECK-NEXT: %[[vals:.*]] = "test.test"() : () -> !pdl.range<value>
+// CHECK-NEXT: %[[attr:.*]] = "test.test"() : () -> !pdl.attribute
+// CHECK-NEXT: %{{.*}} = "match.constant_attribute"() <{"value" = 42 : i32}> : () -> !pdl.attribute
+// CHECK-NEXT: %{{.*}} = "match.constant_type"() <{"value" = i32}> : () -> !pdl.type
+// CHECK-NEXT: %{{.*}} = "match.constant_types"() <{"value" = [i32, i64]}> : () -> !pdl.range<type>
+// CHECK-NEXT: %{{.*}} = "match.get_operand"(%[[op]]) <{"index" = 0 : i32}> : (!pdl.operation) -> !match.optional<!pdl.value>
+// CHECK-NEXT: %{{.*}} = "match.get_operands"(%[[op]]) : (!pdl.operation) -> !match.optional<!pdl.range<value>>
+// CHECK-NEXT: %{{.*}} = "match.get_result"(%[[op]]) <{"index" = 0 : i32}> : (!pdl.operation) -> !match.optional<!pdl.value>
+// CHECK-NEXT: %{{.*}} = "match.get_results"(%[[op]]) <{"index" = 1 : i32}> : (!pdl.operation) -> !match.optional<!pdl.range<value>>
+// CHECK-NEXT: %{{.*}} = "match.get_attribute"(%[[op]]) <{"name" = "value"}> : (!pdl.operation) -> !match.optional<!pdl.attribute>
+// CHECK-NEXT: %{{.*}} = "match.get_defining_op"(%[[val]]) : (!pdl.value) -> !match.optional<!pdl.operation>
+// CHECK-NEXT: %{{.*}} = "match.get_value_type"(%[[val]]) : (!pdl.value) -> !pdl.type
+// CHECK-NEXT: %{{.*}} = "match.get_value_type"(%[[vals]]) : (!pdl.range<value>) -> !pdl.range<type>
+// CHECK-NEXT: %{{.*}} = "match.get_attribute_type"(%[[attr]]) : (!pdl.attribute) -> !pdl.type
+// CHECK-NEXT: %{{.*}} = "match.get_users"(%[[val]]) : (!pdl.value) -> !pdl.range<operation>
+// CHECK-NEXT: %{{.*}} = "match.extract"(%[[vals]]) <{"index" = 0 : i32}> : (!pdl.range<value>) -> !pdl.value
+// CHECK-NEXT: %{{.*}} = "match.get_each"(%[[vals]]) : (!pdl.range<value>) -> !pdl.value

--- a/Veir/Dialects/Match/OpInfo.lean
+++ b/Veir/Dialects/Match/OpInfo.lean
@@ -1,0 +1,260 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Verifier.Basic
+public import Veir.Dialects.Match.Properties
+meta import Veir.Meta.OpCode
+
+namespace Veir
+
+public section
+
+/--
+  The `match` dialect: an intermediate representation between `pdl` and
+  `pdl_interp` that makes pattern navigation and the matcher-tree structure
+  explicit in IR.
+
+  This is the value-producing subset: the constant and navigation operations,
+  all of which are `Pure`. The test operations (`match.has_name`,
+  `match.equal`, ...) carry an implicit control effect -- on failure control
+  transfers to the enclosing failure scope -- and the structural operations
+  (`match.matcher`, `match.try`, the switches, `match.success`) need region and
+  symbol-reference features VeIR does not have yet. Both groups follow.
+-/
+@[opcodes]
+inductive Match where
+| constant_attribute
+| constant_type
+| constant_types
+| extract
+| get_attribute
+| get_attribute_type
+| get_defining_op
+| get_each
+| get_operand
+| get_operands
+| get_result
+| get_results
+| get_users
+| get_value_type
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[expose, properties_of]
+def Match.propertiesOf (op : Match) : Type :=
+match op with
+| .constant_attribute => MatchConstantAttributeProperties
+| .constant_type => MatchConstantTypeProperties
+| .constant_types => MatchConstantTypesProperties
+| .extract => MatchIndexProperties
+| .get_attribute => MatchGetAttributeProperties
+| .get_attribute_type => Unit
+| .get_defining_op => Unit
+| .get_each => Unit
+| .get_operand => MatchIndexProperties
+| .get_operands => MatchOptionalIndexProperties
+| .get_result => MatchIndexProperties
+| .get_results => MatchOptionalIndexProperties
+| .get_users => Unit
+| .get_value_type => Unit
+
+/-- Reject any property on an operation that carries none. -/
+private def noProperties (opName : String) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String Unit :=
+  if attrDict.size > 0 then
+    let plural := if attrDict.size = 1 then "property" else "properties"
+    .error s!"{opName}: expected no properties, but got {attrDict.size} {plural}"
+  else
+    .ok ()
+
+def Match.fromAttrDict
+    (op : Match) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Match.propertiesOf op) :=
+  match op with
+  | .constant_attribute => MatchConstantAttributeProperties.fromAttrDict attrDict
+  | .constant_type => MatchConstantTypeProperties.fromAttrDict attrDict
+  | .constant_types => MatchConstantTypesProperties.fromAttrDict attrDict
+  | .extract => MatchIndexProperties.fromAttrDict "match.extract" attrDict
+  | .get_attribute => MatchGetAttributeProperties.fromAttrDict attrDict
+  | .get_attribute_type => noProperties "match.get_attribute_type" attrDict
+  | .get_defining_op => noProperties "match.get_defining_op" attrDict
+  | .get_each => noProperties "match.get_each" attrDict
+  | .get_operand => MatchIndexProperties.fromAttrDict "match.get_operand" attrDict
+  | .get_operands => MatchOptionalIndexProperties.fromAttrDict "match.get_operands" attrDict
+  | .get_result => MatchIndexProperties.fromAttrDict "match.get_result" attrDict
+  | .get_results => MatchOptionalIndexProperties.fromAttrDict "match.get_results" attrDict
+  | .get_users => noProperties "match.get_users" attrDict
+  | .get_value_type => noProperties "match.get_value_type" attrDict
+
+def Match.toAttrDict
+    (op : Match) (props : Match.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .constant_attribute =>
+    (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 props.value
+  | .constant_type =>
+    (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 props.value
+  | .constant_types =>
+    (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 (.arrayAttr props.value)
+  | .extract | .get_operand | .get_result =>
+    (Std.HashMap.emptyWithCapacity 1).insert "index".toUTF8 (.integerAttr props.index)
+  | .get_attribute =>
+    (Std.HashMap.emptyWithCapacity 1).insert "name".toUTF8 (.stringAttr props.name)
+  | .get_operands | .get_results =>
+    match props.index with
+    | some index => (Std.HashMap.emptyWithCapacity 1).insert "index".toUTF8 (.integerAttr index)
+    | none => Std.HashMap.emptyWithCapacity 0
+  | .get_attribute_type | .get_defining_op | .get_each | .get_users | .get_value_type =>
+    Std.HashMap.emptyWithCapacity 0
+
+/-- Every operation in this subset is `Pure`, exactly as MLIR marks them. -/
+def Match.hasSideEffects (_op : Match) (_props : Match.propertiesOf _op) : Bool :=
+  false
+
+def Match.readsMemory (_op : Match) (_props : Match.propertiesOf _op) : Bool :=
+  false
+
+def Match.writesMemory (_op : Match) (_props : Match.propertiesOf _op) : Bool :=
+  false
+
+def Match.isConstantLike (_op : Match) : Bool :=
+  false
+
+def Match.hasSSADominance (_op : Match) (_index : Nat) : Bool :=
+  true
+
+def Match.hasNoTerminator (_op : Match) (_index : Nat) : Bool :=
+  false
+
+#generate_dialect Match
+
+instance : HasDialectOpInfo Match where
+  fromName := Match.fromName
+  name := Match.name
+  propertiesOf := Match.propertiesOf
+  fromAttrDict := Match.fromAttrDict
+  toAttrDict := Match.toAttrDict
+  hasSideEffects := Match.hasSideEffects
+  readsMemory := Match.readsMemory
+  writesMemory := Match.writesMemory
+  isConstantLike := Match.isConstantLike
+  hasSSADominance := Match.hasSSADominance
+  hasNoTerminator := Match.hasNoTerminator
+
+/-- The element kind of a `!pdl.range<...>`, or `none` for any other type. -/
+private def rangeElement? (ty : Attribute) : Option PDL.RangeElement :=
+  match ty with
+  | .pdlRangeType rangeType => some rangeType.element
+  | _ => none
+
+/-- The type wrapped by a `!match.optional<...>`, or `none` for any other type. -/
+private def optionalInner? (ty : Attribute) : Option Attribute :=
+  match ty with
+  | .matchOptionalType optionalType => some optionalType.innerType
+  | _ => none
+
+/--
+Verify the local invariants of a `match` operation in any operation-info type
+containing the `match` dialect.
+
+Navigation that can fail returns `!match.optional<...>`; the wrapped type is
+checked here, which is the narrowing MLIR does in its type verifier and the
+type itself deliberately does not.
+-/
+def Match.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Match]
+    (opType : Match) (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let operandType (i : Nat) : Attribute := ((op.getOperand! ctx.raw i).getType! ctx.raw).val
+  let resultType : Attribute := ((op.getResult 0).get! ctx.raw).type.val
+  /- The wrapped type of a nullable navigation result. -/
+  let expectOptionalOf (expected : TypeAttr) (what : String) : Except String PUnit := do
+    let some inner := optionalInner? resultType
+      | throw s!"Expected the result to be of type '!match.optional<{what}>'"
+    if inner ≠ expected.val then
+      throw s!"Expected the result to be of type '!match.optional<{what}>'"
+  match opType with
+  | .constant_attribute =>
+    op.verifyPlainOpCounts ctx opIn 0 1
+    op.verifyResultTypeMatches ctx (PDL.AttributeType.mk : TypeAttr)
+      "Expected the result to be of type '!pdl.attribute'"
+  | .constant_type =>
+    op.verifyPlainOpCounts ctx opIn 0 1
+    op.verifyResultTypeMatches ctx (PDL.TypeType.mk : TypeAttr)
+      "Expected the result to be of type '!pdl.type'"
+  | .constant_types =>
+    op.verifyPlainOpCounts ctx opIn 0 1
+    op.verifyResultTypeMatches ctx (PDL.RangeType.mk .type : TypeAttr)
+      "Expected the result to be of type '!pdl.range<type>'"
+  | .get_operand | .get_result =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    if operandType 0 ≠ (PDL.OperationType.mk : TypeAttr).val then
+      throw "Expected the operand to be of type '!pdl.operation'"
+    expectOptionalOf (PDL.ValueType.mk : TypeAttr) "!pdl.value"
+  | .get_operands | .get_results =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    if operandType 0 ≠ (PDL.OperationType.mk : TypeAttr).val then
+      throw "Expected the operand to be of type '!pdl.operation'"
+    expectOptionalOf (PDL.RangeType.mk .value : TypeAttr) "!pdl.range<value>"
+  | .get_attribute =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    if operandType 0 ≠ (PDL.OperationType.mk : TypeAttr).val then
+      throw "Expected the operand to be of type '!pdl.operation'"
+    expectOptionalOf (PDL.AttributeType.mk : TypeAttr) "!pdl.attribute"
+  | .get_defining_op =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    /- A value or a range of values: the defining op of the first is used. -/
+    if operandType 0 ≠ (PDL.ValueType.mk : TypeAttr).val
+        && rangeElement? (operandType 0) ≠ some .value then
+      throw "Expected the operand to be of type '!pdl.value' or '!pdl.range<value>'"
+    expectOptionalOf (PDL.OperationType.mk : TypeAttr) "!pdl.operation"
+  | .get_value_type =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    /- Never fails, so the result is a bare handle; a range in gives a range
+       out. -/
+    if operandType 0 = (PDL.ValueType.mk : TypeAttr).val then
+      if resultType ≠ (PDL.TypeType.mk : TypeAttr).val then
+        throw "Expected the result to be of type '!pdl.type'"
+    else if rangeElement? (operandType 0) = some .value then
+      if rangeElement? resultType ≠ some .type then
+        throw "Expected the result to be of type '!pdl.range<type>'"
+    else
+      throw "Expected the operand to be of type '!pdl.value' or '!pdl.range<value>'"
+  | .get_attribute_type =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    if operandType 0 ≠ (PDL.AttributeType.mk : TypeAttr).val then
+      throw "Expected the operand to be of type '!pdl.attribute'"
+    op.verifyResultTypeMatches ctx (PDL.TypeType.mk : TypeAttr)
+      "Expected the result to be of type '!pdl.type'"
+  | .get_users =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    if operandType 0 ≠ (PDL.ValueType.mk : TypeAttr).val then
+      throw "Expected the operand to be of type '!pdl.value'"
+    op.verifyResultTypeMatches ctx (PDL.RangeType.mk .operation : TypeAttr)
+      "Expected the result to be of type '!pdl.range<operation>'"
+  | .extract =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    /- The result is one element of the range, so their element kinds agree. -/
+    let some element := rangeElement? (operandType 0)
+      | throw "Expected the operand to be of type '!pdl.range<...>'"
+    let expected : TypeAttr := match element with
+      | .attribute => PDL.AttributeType.mk
+      | .operation => PDL.OperationType.mk
+      | .type => PDL.TypeType.mk
+      | .value => PDL.ValueType.mk
+    if resultType ≠ expected.val then
+      throw s!"Expected the result to have the element type of the range, '!pdl.{element}'"
+  | .get_each =>
+    op.verifyPlainOpCounts ctx opIn 1 1
+    let some element := rangeElement? (operandType 0)
+      | throw "Expected the operand to be of type '!pdl.range<...>'"
+    let expected : TypeAttr := match element with
+      | .attribute => PDL.AttributeType.mk
+      | .operation => PDL.OperationType.mk
+      | .type => PDL.TypeType.mk
+      | .value => PDL.ValueType.mk
+    if resultType ≠ expected.val then
+      throw s!"Expected the result to have the element type of the range, '!pdl.{element}'"
+
+end
+
+end Veir

--- a/Veir/Dialects/Match/Properties.lean
+++ b/Veir/Dialects/Match/Properties.lean
@@ -1,0 +1,142 @@
+module
+
+public import Veir.IR.Attribute
+public import Std.Data.HashMap
+
+namespace Veir
+
+public section
+
+/--
+  Properties of the `match.constant_attribute` operation.
+
+  `value` is the constant attribute the handle stands for. Unlike
+  `pdl.attribute`, it is mandatory: the operation exists precisely to give a
+  literal a value of its own.
+-/
+structure MatchConstantAttributeProperties where
+  value : Attribute
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def MatchConstantAttributeProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String MatchConstantAttributeProperties := do
+  let some value := attrDict["value".toUTF8]?
+    | throw "match.constant_attribute: missing 'value' property"
+  if attrDict.size > 1 then
+    throw s!"match.constant_attribute: expected only the 'value' property, \
+             but got {attrDict.size} properties"
+  return { value }
+
+/--
+  Properties of the `match.constant_type` operation.
+-/
+structure MatchConstantTypeProperties where
+  value : TypeAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def MatchConstantTypeProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String MatchConstantTypeProperties := do
+  let some attr := attrDict["value".toUTF8]?
+    | throw "match.constant_type: missing 'value' property"
+  if _ : attr.isType = false then
+    throw s!"match.constant_type: expected 'value' to be a type attribute, but got {attr}"
+  else
+    if attrDict.size > 1 then
+      throw s!"match.constant_type: expected only the 'value' property, \
+               but got {attrDict.size} properties"
+    return { value := attr.asType }
+
+/--
+  Properties of the `match.constant_types` operation.
+
+  `value` is the array of constant types the range stands for.
+-/
+structure MatchConstantTypesProperties where
+  value : ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def MatchConstantTypesProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String MatchConstantTypesProperties := do
+  let some attr := attrDict["value".toUTF8]?
+    | throw "match.constant_types: missing 'value' property"
+  let .arrayAttr value := attr
+    | throw s!"match.constant_types: expected 'value' to be an array attribute, but got {attr}"
+  for element in value.value do
+    if element.isType = false then
+      throw s!"match.constant_types: expected 'value' to hold types, but got {element}"
+  if attrDict.size > 1 then
+    throw s!"match.constant_types: expected only the 'value' property, \
+             but got {attrDict.size} properties"
+  return { value }
+
+/--
+  Properties of the operations that index a single operand or result:
+  `match.get_operand` and `match.get_result`.
+
+  `index` is mandatory, which is what separates these from the `*s` forms below.
+-/
+structure MatchIndexProperties where
+  index : IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def MatchIndexProperties.fromAttrDict (opName : String)
+    (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String MatchIndexProperties := do
+  let some attr := attrDict["index".toUTF8]?
+    | throw s!"{opName}: missing 'index' property"
+  let .integerAttr index := attr
+    | throw s!"{opName}: expected 'index' to be an integer attribute, but got {attr}"
+  if index.value < 0 then
+    throw s!"{opName}: expected 'index' to be non-negative, but got {index.value}"
+  if attrDict.size > 1 then
+    throw s!"{opName}: expected only the 'index' property, but got {attrDict.size} properties"
+  return { index }
+
+/--
+  Properties of the operations that index a *group* of operands or results:
+  `match.get_operands` and `match.get_results`.
+
+  `index` is optional; when absent the operation stands for the whole list.
+-/
+structure MatchOptionalIndexProperties where
+  index : Option IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def MatchOptionalIndexProperties.fromAttrDict (opName : String)
+    (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String MatchOptionalIndexProperties := do
+  let index ← match attrDict["index".toUTF8]? with
+    | some (.integerAttr index) =>
+      if index.value < 0 then
+        throw s!"{opName}: expected 'index' to be non-negative, but got {index.value}"
+      pure (some index)
+    | some attr =>
+      throw s!"{opName}: expected 'index' to be an integer attribute, but got {attr}"
+    | none => pure none
+  if attrDict.size > (if index.isSome then 1 else 0) then
+    throw s!"{opName}: expected only the 'index' property, but got {attrDict.size} properties"
+  return { index }
+
+/--
+  Properties of the `match.get_attribute` operation.
+
+  `name` is the name of the attribute to look up on the operation.
+-/
+structure MatchGetAttributeProperties where
+  name : StringAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def MatchGetAttributeProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String MatchGetAttributeProperties := do
+  let some attr := attrDict["name".toUTF8]?
+    | throw "match.get_attribute: missing 'name' property"
+  let .stringAttr name := attr
+    | throw s!"match.get_attribute: expected 'name' to be a string attribute, but got {attr}"
+  if attrDict.size > 1 then
+    throw s!"match.get_attribute: expected only the 'name' property, \
+             but got {attrDict.size} properties"
+  return { name }
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -30,6 +30,7 @@ match opCode with
 | .func op => Func.propertiesOf op
 | .datapath op => Datapath.propertiesOf op
 | .pdl op => PDL.propertiesOf op
+| .«match» op => Match.propertiesOf op
 | .test op => Test.propertiesOf op
 
 /--
@@ -66,6 +67,7 @@ def OpCode.readsMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :
   | .func op, props => Func.readsMemory op props
   | .datapath op, props => Datapath.readsMemory op props
   | .pdl op, props => PDL.readsMemory op props
+  | .«match» op, props => Match.readsMemory op props
   | .test op, props => Test.readsMemory op props
 
 /--
@@ -87,6 +89,7 @@ def OpCode.writesMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool 
   | .func op, props => Func.writesMemory op props
   | .datapath op, props => Datapath.writesMemory op props
   | .pdl op, props => PDL.writesMemory op props
+  | .«match» op, props => Match.writesMemory op props
   | .test op, props => Test.writesMemory op props
 
 /--
@@ -117,6 +120,7 @@ def OpCode.hasSideEffects (opCode : OpCode) (props : _propertiesOf opCode) : Boo
   | .func op, props => Func.hasSideEffects op props
   | .datapath op, props => Datapath.hasSideEffects op props
   | .pdl op, props => PDL.hasSideEffects op props
+  | .«match» op, props => Match.hasSideEffects op props
   | .test op, props => Test.hasSideEffects op props
 
 inductive RegionKind where
@@ -156,6 +160,7 @@ def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
   | .func op => Func.hasSSADominance op index
   | .datapath op => Datapath.hasSSADominance op index
   | .pdl op => PDL.hasSSADominance op index
+  | .«match» op => Match.hasSSADominance op index
   | .test op => Test.hasSSADominance op index
 
 /--
@@ -179,6 +184,7 @@ def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
   | .func op => HasDialectOpInfo.hasNoTerminator op index
   | .datapath op => HasDialectOpInfo.hasNoTerminator op index
   | .pdl op => HasDialectOpInfo.hasNoTerminator op index
+  | .«match» op => HasDialectOpInfo.hasNoTerminator op index
   | .test op => HasDialectOpInfo.hasNoTerminator op index
 
 /--
@@ -205,6 +211,7 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | .func op => Func.isConstantLike op
   | .datapath op => Datapath.isConstantLike op
   | .pdl op => PDL.isConstantLike op
+  | .«match» op => Match.isConstantLike op
   | .test op => Test.isConstantLike op
 
 def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
@@ -224,6 +231,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   | .func op => Func.fromAttrDict op attrDict
   | .datapath op => Datapath.fromAttrDict op attrDict
   | .pdl op => PDL.fromAttrDict op attrDict
+  | .«match» op => Match.fromAttrDict op attrDict
   | .test op => Test.fromAttrDict op attrDict
 
 /--
@@ -247,6 +255,7 @@ def Properties.toAttrDict
   | .func op, props => Func.toAttrDict op props
   | .datapath op, props => Datapath.toAttrDict op props
   | .pdl op, props => PDL.toAttrDict op props
+  | .«match» op, props => Match.toAttrDict op props
   | .test op, props => Test.toAttrDict op props
 
 instance : HasDialectOpInfo OpCode where

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -23,6 +23,7 @@ public import Veir.Dialects.Datapath.OpInfo
 public import Veir.Dialects.Comb.OpInfo
 public import Veir.Dialects.HW.OpInfo
 public import Veir.Dialects.PDL.OpInfo
+public import Veir.Dialects.Match.OpInfo
 public import Veir.Dialects.Test.OpInfo
 
 open Std

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -352,6 +352,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .cf opType => Cf.verifyLocalInvariants opType op ctx opIn
   /- PDL -/
   | .pdl opType => PDL.verifyLocalInvariants opType op ctx opIn
+  /- MATCH -/
+  | .«match» opType => Match.verifyLocalInvariants opType op ctx opIn
   /- TEST -/
   | .test .test => do
     pure ()


### PR DESCRIPTION
Registers the `match` dialect with its constant and navigation operations — `constant_attribute`, `constant_type`, `constant_types`, the six nullable `get_*` navigations, `get_value_type`, `get_attribute_type`, `get_users`, `extract` and `get_each` — all `Pure`, as MLIR marks them. The two groups left out are left out for concrete reasons: the test operations (`has_name`, `equal`, `check_operand_count`, …) carry an implicit control effect that transfers to the enclosing failure scope on failure, which has no counterpart in VeIR's operation model, and the structural ones (`matcher`, `try`, the switches, `success`) need variadic regions, `NoTerminator` regions with block arguments, and nested symbol references that `FlatSymbolRefAttr` cannot hold. The verifier performs the narrowing MLIR puts in its type verifier and `!match.optional` deliberately does not — a nullable navigation must return `!match.optional<T>` for the right `T`, `extract` and `get_each` must yield the range's element type, and `get_value_type` maps a range to a range. Covered by a round-trip test over all fourteen operations plus five invalid tests; `MLIR_ROUNDTRIP` is skipped because no released `mlir-opt` knows these operations yet.