### PR TITLE
feat(IR): support dialect-local setProperties

### DIFF
--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -29,12 +29,6 @@ abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arit
 #guard Arith.from? (Arith.addi : OpCode) = some Arith.addi
 #guard Arith.from? (OpCode.builtin .module) = none
 
-def Veir.OperationPtr.setProperties!' {OpInfo Dialect : Type} [HasOpInfo OpInfo]
-    [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-    (op : OperationPtr) (ctx : WfIRContext OpInfo) (opCode : Dialect)
-    (props : HasDialectOpInfo.propertiesOf opCode) : WfIRContext OpInfo :=
-  WfRewriter.setProperties! ctx op (HasDialect.ofDialectProperties OpInfo opCode props)
-
 /--
 A minimal pass that can be instantiated for any ambient opcode type containing
 the Arith dialect. It exercises both opcode projection and property transport.
@@ -47,12 +41,10 @@ private def genericArithAwarePass {OpInfo : Type} [HasOpInfo OpInfo]
     /- Matching an `arith` operation, here an `addi`. -/
     let some .addi := Arith.from? (op.getOpType! ctx.raw) | return ctx
     /- Getting the property of an operation with a type based on the dialect. -/
-    let _a := op.getProperties! ctx.raw Arith.addi
-    /- Check that we automatically derive the correct properties type. -/
-    let _b : ArithIntegerOverflowFlagsProperties := _a
-    /- Create -/
-    let ctx := op.setProperties!' ctx Arith.addi
-      (ArithIntegerOverflowFlagsProperties.mk { nsw := true, nuw := false })
+    let _a : ArithIntegerOverflowFlagsProperties := op.getProperties! ctx.raw Arith.addi
+    /- Set dialect-local properties. -/
+    let props := ArithIntegerOverflowFlagsProperties.mk { nsw := true, nuw := false }
+    let ctx := WfRewriter.setProperties! (Dialect := Arith) ctx op Arith.addi props
     return ctx
 
 example : Pass OpCode := genericArithAwarePass

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -1103,27 +1103,43 @@ theorem getProperties!_eq_of_OperationPtr_get!_eq {op : OperationPtr} {opCode : 
     op.getProperties! ctx opCode = op.getProperties! ctx' opCode := by
   grind [OperationPtr.get!, getProperties!]
 
-def setProperties {opCode : OpInfo} (op : OperationPtr) (ctx : IRContext OpInfo)
-    (newProperties : HasOpInfo.propertiesOf opCode)
+/--
+Set the properties of an operation of type `opCode`.
+The passed `opCode` can either be of the global `OpInfo` type, or the dialect-specific
+`Dialect` type. The `OpInfo` version is often the one used when manipulating generic operations,
+while the `Dialect` version is often easier to use when manipulating dialect-specific operations.
+-/
+def setProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect)
+    (newProperties : HasDialectOpInfo.propertiesOf opCode)
     (inBounds : op.InBounds ctx := by grind)
     (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
   let oldOp := op.get ctx (by grind)
-  op.set ctx { oldOp with properties := h ▸ newProperties }
+  let newPropertiesGlobal := HasDialect.ofDialectProperties OpInfo opCode newProperties
+  op.set ctx { oldOp with properties := h ▸ newPropertiesGlobal }
 
-def setProperties! {opCode : OpInfo} (op : OperationPtr) (ctx : IRContext OpInfo)
-  (newProperties : HasOpInfo.propertiesOf opCode)
+/--
+Set the properties of an operation of type `opCode`.
+The implicitely passed `opCode` can either be of the global `OpInfo` type, or the dialect-specific
+`Dialect` type. The `OpInfo` version is often the one used when manipulating generic operations,
+while the `Dialect` version is often easier to use when manipulating dialect-specific operations.
+
+This function panics if the given operation is not in bounds.
+-/
+def setProperties! {opCode : Dialect} (op : OperationPtr) (ctx : IRContext OpInfo)
+  (newProperties : HasDialectOpInfo.propertiesOf opCode)
   (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   have h : (op.get! ctx).opType = opCode := by grind [getOpType!]
   let oldOp := op.get! ctx
-  op.set ctx { oldOp with properties := h ▸ newProperties }
+  let newPropertiesGlobal := HasDialect.ofDialectProperties OpInfo opCode newProperties
+  op.set ctx { oldOp with properties := h ▸ newPropertiesGlobal }
 
 @[grind =_, eq_bang ←]
-theorem setProperties!_eq_setProperties {op : OperationPtr}
-    (newProperties : HasOpInfo.propertiesOf opCode) (inBounds : op.InBounds ctx)
+theorem setProperties!_eq_setProperties {op : OperationPtr} {opCode : Dialect}
+    (newProperties : HasDialectOpInfo.propertiesOf opCode) (inBounds : op.InBounds ctx)
     (hprop : op.getOpType! ctx = opCode) :
     op.setProperties! ctx newProperties =
-    op.setProperties ctx newProperties inBounds := by
+    op.setProperties ctx opCode newProperties inBounds := by
   grind [setProperties, setProperties!]
 
 def nextOperand (op : OperationPtr) (ctx : IRContext OpInfo)

--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -696,8 +696,12 @@ theorem OperationPtr.pushResult_fieldsInBounds {newResult : OpResult} {op : Oper
   prove_fieldsInBounds
 
 @[grind .]
-theorem OperationPtr.setProperties_fieldsInBounds :
-    ctx.FieldsInBounds → (setProperties op ctx newProperties inBounds hprop).FieldsInBounds := by
+theorem OperationPtr.setProperties_fieldsInBounds
+    {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    {op : OperationPtr} {inBounds : op.InBounds ctx}
+    {opCode : Dialect} {newProperties : HasDialectOpInfo.propertiesOf opCode}
+    {hprop : op.getOpType! ctx = opCode} :
+    ctx.FieldsInBounds → (setProperties op ctx opCode newProperties inBounds hprop).FieldsInBounds := by
   prove_fieldsInBounds_operation ctx
 
 @[grind .]

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -1319,178 +1319,179 @@ theorem OpOperandPtrPtr.get!_OperationPtr_pushResult {opOperandPtr : OpOperandPt
 section OperationPtr.setProperties
 
 variable {operation' : OperationPtr}
-variable {setterOpCode' : OpInfo}
-variable {newProperties : HasOpInfo.propertiesOf setterOpCode'}
+variable {newProperties : HasDialectOpInfo.propertiesOf opCode}
 variable {inBounds : operation'.InBounds ctx}
-variable {hprop : operation'.getOpType! ctx = setterOpCode'}
+variable {hprop : operation'.getOpType! ctx = opCode}
 
 @[simp, grind =]
 theorem BlockPtr.get!_OperationPtr_setProperties {block : BlockPtr} :
-    block.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    block.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     block.get! ctx := by
   grind
 
 @[grind =]
 theorem OperationPtr.get!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     if operation = operation' then
       { operation.get! ctx with
         opType := operation'.getOpType! ctx
-        properties := hprop ▸ newProperties }
+        properties := hprop ▸ HasDialect.ofDialectProperties OpInfo opCode newProperties }
     else
       operation.get! ctx := by
   grind
 
 @[grind =]
-theorem OperationPtr.getProperties!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getProperties! (OperationPtr.setProperties (opCode := setterOpCode') operation' ctx newProperties inBounds hprop) opCode =
+theorem OperationPtr.getProperties!_OperationPtr_setProperties
+    {GetterDialect : Type} [HasDialectOpInfo GetterDialect]
+    [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect}
+    {operation : OperationPtr} :
+    operation.getProperties!
+      (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop)
+      getterOpCode =
     if operation = operation' then
-      if h : (opCode : OpInfo) = setterOpCode' then
-        HasDialect.toDialectProperties opCode (h ▸ newProperties)
+      if h : ofDialect OpInfo opCode = ofDialect OpInfo getterOpCode then
+        HasDialect.properties_eq_of_ofDialect_eq h ▸ newProperties
       else
         default
     else
-      operation.getProperties! ctx opCode := by
+      operation.getProperties! ctx getterOpCode := by
   grind
 
 /- We probably do not want both this lemma and the previous one to be grind.
   TODO: make a decision about this
 -/
 @[grind =]
-theorem OperationPtr.getProperties!_OperationPtr_setProperties_same_opCode
-    {operation : OperationPtr} (h : (opCode : OpInfo) = setterOpCode') :
-    operation.getProperties!
-      (OperationPtr.setProperties (opCode := setterOpCode') operation' ctx
-        newProperties inBounds hprop) opCode =
+theorem OperationPtr.getProperties!_OperationPtr_setProperties_same_opCode {operation : OperationPtr} :
+    operation.getProperties! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) opCode =
     if operation = operation' then
-      HasDialect.toDialectProperties opCode (h ▸ newProperties)
+      newProperties
     else
       operation.getProperties! ctx opCode := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.prev!_OperationPtr_setProperties {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop)).prev =
+    (operation.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop)).prev =
     (operation.get! ctx).prev := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.next!_OperationPtr_setProperties {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop)).next =
+    (operation.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop)).next =
     (operation.get! ctx).next := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.parent!_OperationPtr_setProperties {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop)).parent =
+    (operation.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop)).parent =
     (operation.get! ctx).parent := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOpType!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getOpType! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getOpType! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     operation.getOpType! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.attrs!_OperationPtr_setProperties {operation : OperationPtr} :
-    (operation.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop)).attrs =
+    (operation.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop)).attrs =
     (operation.get! ctx).attrs := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumResults!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getNumResults! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getNumResults! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     operation.getNumResults! ctx := by
   grind
 
 @[simp, grind =]
 theorem OpResultPtr.get!_OperationPtr_setProperties {opResult : OpResultPtr} :
-    opResult.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    opResult.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     opResult.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumOperands!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getNumOperands! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getNumOperands! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     operation.getNumOperands! ctx := by
   grind
 
 @[simp, grind =]
 theorem OpOperandPtr.get!_OperationPtr_setProperties {opOperand : OpOperandPtr} :
-    opOperand.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    opOperand.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     opOperand.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOperands!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getOperands! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getOperands! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     operation.getOperands! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumSuccessors!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getNumSuccessors! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getNumSuccessors! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     operation.getNumSuccessors! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockOperandPtr.get!_OperationPtr_setProperties {blockOperand : BlockOperandPtr} :
-    blockOperand.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    blockOperand.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     blockOperand.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumRegions!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getNumRegions! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    operation.getNumRegions! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     operation.getNumRegions! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getRegion!_OperationPtr_setProperties {operation : OperationPtr} :
-    operation.getRegion! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) i =
+    operation.getRegion! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) i =
     operation.getRegion! ctx i := by
   grind
 
 @[simp, grind =]
 theorem BlockOperandPtrPtr.get!_OperationPtr_setProperties {blockOperandPtr : BlockOperandPtrPtr} :
-    blockOperandPtr.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    blockOperandPtr.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     blockOperandPtr.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.getNumArguments!_OperationPtr_setProperties {block : BlockPtr} :
-    block.getNumArguments! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    block.getNumArguments! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     block.getNumArguments! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockArgumentPtr.get!_OperationPtr_setProperties {blockArg : BlockArgumentPtr} :
-    blockArg.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    blockArg.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     blockArg.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.get!_OperationPtr_setProperties {region : RegionPtr} :
-    region.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    region.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     region.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem ValuePtr.getFirstUse!_OperationPtr_setProperties {value : ValuePtr} :
-    value.getFirstUse! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    value.getFirstUse! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     value.getFirstUse! ctx := by
   grind
 
 @[simp, grind =]
 theorem ValuePtr.getType!_OperationPtr_setProperties {value : ValuePtr} :
-    value.getType! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    value.getType! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     value.getType! ctx := by
   grind
 
 @[simp, grind =]
 theorem OpOperandPtrPtr.get!_OperationPtr_setProperties {opOperandPtr : OpOperandPtrPtr} :
-    opOperandPtr.get! (OperationPtr.setProperties operation' ctx newProperties inBounds hprop) =
+    opOperandPtr.get! (OperationPtr.setProperties operation' ctx opCode newProperties inBounds hprop) =
     opOperandPtr.get! ctx := by
   grind
 

--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -178,8 +178,11 @@ theorem OperationPtr.setBlockOperands_OpOperandPtr_InBounds_mono_ne {opOperand :
   grind
 
 @[grind =]
-theorem OperationPtr.setProperties_genericPtr_mono (ptr : GenericPtr)  :
-    ptr.InBounds (setProperties op ctx newProperties h propEq) ↔ ptr.InBounds ctx := by
+theorem OperationPtr.setProperties_genericPtr_mono (ptr : GenericPtr)
+    {opCode : Dialect} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    {newProperties : HasDialectOpInfo.propertiesOf opCode}
+    {propEq : op.getOpType! ctx = opCode} :
+    ptr.InBounds (setProperties op ctx opCode newProperties h propEq) ↔ ptr.InBounds ctx := by
   grind
 
 @[grind =]

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -189,6 +189,18 @@ theorem ofDialect_injective {op₁ op₂ : Dialect} :
   intro h
   grind [congrArg (toDialect? Dialect) h]
 
+/-- Equal global opcodes have equal dialect-local property types. -/
+theorem properties_eq_of_ofDialect_eq
+    {Dialect₁ Dialect₂ : Type}
+    [HasDialectOpInfo Dialect₁] [HasDialectOpInfo Dialect₂]
+    [hasDialect₁ : HasDialect OpInfo Dialect₁]
+    [hasDialect₂ : HasDialect OpInfo Dialect₂]
+    {op₁ : Dialect₁} {op₂ : Dialect₂}
+    (h : ofDialect OpInfo op₁ = ofDialect OpInfo op₂) :
+    HasDialectOpInfo.propertiesOf op₁ = HasDialectOpInfo.propertiesOf op₂ := by
+  simp [← hasDialect₁.properties_eq op₁, ← hasDialect₂.properties_eq op₂]
+  grind [ofDialect]
+
 @[simp]
 theorem toDialect?_eq_some_iff (opInfo : OpInfo) (op : Dialect) :
     toDialect? Dialect opInfo = some op ↔ ofDialect OpInfo op = opInfo := by
@@ -208,6 +220,20 @@ def toDialectProperties (op : Dialect)
     (props : HasOpInfo.propertiesOf (opCode := OpInfo) op) :
     HasDialectOpInfo.propertiesOf op :=
   (dialectInj.properties_eq op).symm ▸ props
+
+@[simp, grind =]
+theorem toDialectProperties_cast_ofDialectProperties_eq
+    {Dialect₁ Dialect₂ : Type}
+    [HasDialectOpInfo Dialect₁] [HasDialectOpInfo Dialect₂]
+    [hasDialect₁ : HasDialect OpInfo Dialect₁]
+    [hasDialect₂ : HasDialect OpInfo Dialect₂]
+    {op₁ : Dialect₁} {op₂ : Dialect₂}
+    (h : ofDialect OpInfo op₁ = ofDialect OpInfo op₂)
+    (props : HasDialectOpInfo.propertiesOf op₁) :
+    toDialectProperties op₂ (h ▸ ofDialectProperties OpInfo op₁ props) =
+      properties_eq_of_ofDialect_eq h ▸ props := by
+  apply eq_of_heq
+  exact (cast_heq _ _).trans ((eqRec_heq h _).trans ((cast_heq _ _).trans (cast_heq _ _).symm))
 
 /-- Coercion from a dialect property to the global property type. -/
 instance {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -88,18 +88,19 @@ def getEntryBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Blo
 def setFunctionType (wfCtx : WfIRContext OpCode) (funcOp : OperationPtr)
     (inputs outputs : Array Attribute)
     (opInBounds : funcOp.InBounds wfCtx.raw := by grind) : WfIRContext OpCode :=
-  match h : funcOp.getOpType wfCtx.raw opInBounds with
-  | .func .func =>
+  let opType := funcOp.getOpType! wfCtx.raw
+  if h : opType = ofDialect OpCode Func.func then
     let ftType : TypeAttr := ⟨.functionType { inputs, outputs }, by simp⟩
     let props : FuncFuncProperties := funcOp.getProperties! wfCtx.raw Func.func
     let newProps : FuncFuncProperties := { props with function_type := some ftType }
-    WfRewriter.setProperties (opCode := .func .func) wfCtx funcOp newProps opInBounds
-  | .llvm .func =>
+    WfRewriter.setProperties wfCtx funcOp Func.func newProps opInBounds
+  else if h : opType = ofDialect OpCode Llvm.func then
     let ftType : TypeAttr := ⟨.llvmFunctionType { inputs, outputs }, by simp⟩
     let props : LLVMFuncProperties := funcOp.getProperties! wfCtx.raw Llvm.func
     let newProps : LLVMFuncProperties := { props with function_type := some ftType }
-    WfRewriter.setProperties (opCode := .llvm .func) wfCtx funcOp newProps opInBounds
-  | _ => wfCtx
+    WfRewriter.setProperties wfCtx funcOp Llvm.func newProps opInBounds
+  else
+    wfCtx
 
 /-- Sets the function type to the given input/output type lists, panicking if the op
     is out of bounds.

--- a/Veir/Passes/Canonicalize.lean
+++ b/Veir/Passes/Canonicalize.lean
@@ -25,7 +25,7 @@ def canonicalizeModArithConstant (rewriter : PatternRewriter OpCode) (op : Opera
   if canonicalValue = props.value.value then return rewriter
   let canonicalProps : ModArithConstantProperties :=
     { value := { props.value with value := canonicalValue } }
-  return rewriter.setProperties! op (.mod_arith .constant) canonicalProps
+  return rewriter.setProperties! op Mod_Arith.constant canonicalProps
 
 def commutativeConstantRHS (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -215,13 +215,14 @@ def insertOp! (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (ip : Insert
 /--
 Set the properties of an operation in place, and re-enqueue it.
 -/
-def setProperties (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : OpInfo)
-    (newProps : HasOpInfo.propertiesOf opCode)
+def setProperties {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : Dialect)
+    (newProps : HasDialectOpInfo.propertiesOf opCode)
     (opIn : op.InBounds rewriter.ctx.raw := by grind)
     (hprop : op.getOpType! rewriter.ctx.raw = opCode := by grind)
     : PatternRewriter OpInfo :=
   { rewriter with
-    ctx := WfRewriter.setProperties rewriter.ctx op newProps (by grind) (by grind),
+    ctx := WfRewriter.setProperties rewriter.ctx op opCode newProps opIn hprop,
     hasDoneAction := true,
     worklist := rewriter.worklist.push op,
   }
@@ -230,8 +231,9 @@ def setProperties (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode 
 Set the properties of an operation in place, panicking if the operation is out of bounds, or if
 the property types don't match.
 -/
-def setProperties! (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : OpInfo)
-    (newProps : HasOpInfo.propertiesOf opCode) : PatternRewriter OpInfo :=
+def setProperties! {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : Dialect)
+    (newProps : HasDialectOpInfo.propertiesOf opCode) : PatternRewriter OpInfo :=
   if opIn : op.InBounds rewriter.ctx.raw then
     if hprop : op.getOpType! rewriter.ctx.raw = opCode then
       rewriter.setProperties op opCode newProps opIn hprop

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -300,22 +300,38 @@ theorem Rewriter.setAttributes_fieldsInBounds :
     ctx.FieldsInBounds → (setAttributes ctx op newAttrs opIn).FieldsInBounds := by
   grind [setAttributes, OperationPtr.setAttributes_fieldsInBounds]
 
-/-- Set the properties of an operation. -/
-def Rewriter.setProperties {opCode : OpInfo} (ctx: IRContext OpInfo) (op: OperationPtr)
-    (newProps: HasOpInfo.propertiesOf opCode)
+section Rewriter.setProperties
+
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect}
+
+/--
+Set the properties of an operation of type `opCode`.
+The implicitely passed `opCode` can either be of the global `OpInfo` type, or the dialect-specific
+`Dialect` type. The `OpInfo` version is often the one used when manipulating generic operations,
+while the `Dialect` version is often easier to use when manipulating dialect-specific operations.
+-/
+def Rewriter.setProperties (ctx: IRContext OpInfo) (op: OperationPtr)
+    (opCode : Dialect := by grind)
+    (newProps: HasDialectOpInfo.propertiesOf opCode)
     (opIn : op.InBounds ctx := by grind)
     (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
-  op.setProperties ctx newProps opIn hprop
+  op.setProperties ctx opCode newProps opIn hprop
+
+variable {op : OperationPtr} {newProperties : HasDialectOpInfo.propertiesOf opCode}
+variable {opIn : op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
 
 @[grind =]
 theorem Rewriter.setProperties_inBounds (ptr : GenericPtr) :
-    ptr.InBounds (setProperties ctx op newProperties opIn hprop) ↔ ptr.InBounds ctx := by
+    ptr.InBounds (setProperties ctx op opCode newProperties opIn hprop) ↔ ptr.InBounds ctx := by
   grind [setProperties]
 
 @[grind .]
 theorem Rewriter.setProperties_fieldsInBounds :
-    ctx.FieldsInBounds → (setProperties ctx op newProperties opIn hprop).FieldsInBounds := by
+    ctx.FieldsInBounds → (setProperties ctx op opCode newProperties opIn hprop).FieldsInBounds := by
   grind [setProperties, OperationPtr.setProperties_fieldsInBounds]
+
+end Rewriter.setProperties
 
 /--
 Set the type of a value (an op result or a block argument).

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -276,227 +276,235 @@ end Rewriter.setAttributes
 
 section Rewriter.setProperties
 
-variable {opCode: OpInfo} {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode} {opIn : op.InBounds ctx}
-         {opIn: op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
+variable {op : OperationPtr} {newProps : HasDialectOpInfo.propertiesOf opCode}
+         {opIn : op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
 
 attribute [local grind] Rewriter.setProperties
 
 @[simp, grind =]
 theorem BlockPtr.get!_setProperties {block : BlockPtr} :
-    block.get! (Rewriter.setProperties ctx op newProps opIn hprop) =
+    block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop) =
     block.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.firstUse!_setProperties {block : BlockPtr} :
-    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).firstUse =
+    (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).firstUse =
     (block.get! ctx).firstUse := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.prev!_setProperties {block : BlockPtr} :
-    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).prev =
+    (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).prev =
     (block.get! ctx).prev := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.next!_setProperties {block : BlockPtr} :
-    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).next =
+    (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).next =
     (block.get! ctx).next := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.parent!_setProperties {block : BlockPtr} :
-    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).parent =
+    (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).parent =
     (block.get! ctx).parent := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.firstOp!_setProperties {block : BlockPtr} :
-    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).firstOp =
+    (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).firstOp =
     (block.get! ctx).firstOp := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.lastOp!_setProperties {block : BlockPtr} :
-    (block.get! (Rewriter.setProperties ctx op newProps opIn hprop)).lastOp =
+    (block.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop)).lastOp =
     (block.get! ctx).lastOp := by
   grind
 
 @[grind =]
 theorem OperationPtr.get!_setProperties {operation : OperationPtr} :
-    operation.get! (Rewriter.setProperties ctx op newProps opIn hprop) =
+    operation.get! (Rewriter.setProperties ctx op opCode newProps opIn hprop) =
     if operation = op then
-      { operation.get! ctx with opType := op.getOpType! ctx, properties := hprop ▸ newProps }
+      { operation.get! ctx with
+        opType := op.getOpType! ctx
+        properties := hprop ▸ HasDialect.ofDialectProperties OpInfo opCode newProps }
     else
       operation.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.prev!_setProperties {op' : OperationPtr} :
-    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).prev =
+    (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).prev =
     (op'.get! ctx).prev := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.next!_setProperties {op' : OperationPtr} :
-    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).next =
+    (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).next =
     (op'.get! ctx).next := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.parent!_setProperties {op' : OperationPtr} :
-    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).parent =
+    (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).parent =
     (op'.get! ctx).parent := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOpType!_setProperties {op' : OperationPtr} :
-    op'.getOpType! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getOpType! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getOpType! ctx := by
   grind
 
 @[simp ,grind =]
 theorem OperationPtr.attrs!_setProperties {op' : OperationPtr} :
-    (op'.get! (Rewriter.setProperties ctx op newProps opIn)).attrs =
+    (op'.get! (Rewriter.setProperties ctx op opCode newProps opIn)).attrs =
     (op'.get! ctx).attrs := by
   grind
 
 @[grind =]
 theorem OperationPtr.getProperties!_setProperties
-    {op' : OperationPtr} {getterOpCode : Dialect} :
-    op'.getProperties! (Rewriter.setProperties ctx op newProps opIn hprop) getterOpCode =
+    {GetterDialect : Type} [HasDialectOpInfo GetterDialect]
+    [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect}
+    {op' : OperationPtr} :
+    op'.getProperties!
+      (Rewriter.setProperties ctx op opCode newProps opIn hprop)
+      getterOpCode =
     if op' = op then
-      if h : (getterOpCode : OpInfo) = opCode then
-        HasDialect.toDialectProperties getterOpCode (h ▸ newProps)
-      else default
+      if h : ofDialect OpInfo opCode = ofDialect OpInfo getterOpCode then
+        HasDialect.toDialectProperties getterOpCode
+          (h ▸ HasDialect.ofDialectProperties OpInfo opCode newProps)
+      else
+        default
     else
       op'.getProperties! ctx getterOpCode := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumResults!_setProperties {op' : OperationPtr} :
-    op'.getNumResults! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumResults! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumResults! ctx := by
   grind
 
 @[simp, grind =]
 theorem OpResultPtr.get!_setProperties {opResult : OpResultPtr} :
-    opResult.get! (Rewriter.setProperties ctx op newProps opIn) =
+    opResult.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     opResult.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumOperands!_setProperties {op' : OperationPtr} :
-    op'.getNumOperands! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumOperands! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumOperands! ctx := by
   grind
 
 @[simp, grind =]
 theorem OpOperandPtr.get!_setProperties {opOperand : OpOperandPtr} :
-    opOperand.get! (Rewriter.setProperties ctx op newProps opIn) =
+    opOperand.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     opOperand.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOperands!_setProperties {op' : OperationPtr} :
-    op'.getOperands! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getOperands! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getOperands! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumSuccessors!_setProperties {op' : OperationPtr} :
-    op'.getNumSuccessors! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumSuccessors! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumSuccessors! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockOperandPtr.get!_setProperties {blockOperand : BlockOperandPtr} :
-    blockOperand.get! (Rewriter.setProperties ctx op newProps opIn) =
+    blockOperand.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     blockOperand.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getSuccessor!_setProperties {op' : OperationPtr} :
-    op'.getSuccessor! (Rewriter.setProperties ctx op newProps opIn) index =
+    op'.getSuccessor! (Rewriter.setProperties ctx op opCode newProps opIn) index =
     op'.getSuccessor! ctx index := by
   grind [OperationPtr.getSuccessor!_def]
 
 @[simp, grind =]
 theorem OperationPtr.getSuccessors!_setProperties {op' : OperationPtr} :
-    op'.getSuccessors! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getSuccessors! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getSuccessors! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
 @[simp, grind =]
 theorem OperationPtr.getNumRegions!_setProperties {op' : OperationPtr} :
-    op'.getNumRegions! (Rewriter.setProperties ctx op newProps opIn) =
+    op'.getNumRegions! (Rewriter.setProperties ctx op opCode newProps opIn) =
     op'.getNumRegions! ctx := by
   grind [OperationPtr.getSuccessors!_def]
 
 @[simp, grind =]
 theorem OperationPtr.getRegion!_setProperties {op' : OperationPtr} :
-    op'.getRegion! (Rewriter.setProperties ctx op newProps opIn) index =
+    op'.getRegion! (Rewriter.setProperties ctx op opCode newProps opIn) index =
     op'.getRegion! ctx index := by
   grind [OperationPtr.getSuccessors!_def]
 
 @[simp, grind =]
 theorem BlockOperandPtrPtr.get!_setProperties {blockOperandPtr : BlockOperandPtrPtr} :
-    blockOperandPtr.get!  (Rewriter.setProperties ctx op newProps opIn) =
+    blockOperandPtr.get!  (Rewriter.setProperties ctx op opCode newProps opIn) =
     blockOperandPtr.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.getNumArguments!_setProperties {block : BlockPtr} :
-    block.getNumArguments! (Rewriter.setProperties ctx op newProps opIn) =
+    block.getNumArguments! (Rewriter.setProperties ctx op opCode newProps opIn) =
     block.getNumArguments! ctx := by
   grind
 
 @[simp, grind =]
 theorem BlockArgumentPtr.get!_setProperties {blockArgument : BlockArgumentPtr} :
-    blockArgument.get!  (Rewriter.setProperties ctx op newProps opIn) =
+    blockArgument.get!  (Rewriter.setProperties ctx op opCode newProps opIn) =
     blockArgument.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.get!_setProperties {region : RegionPtr} :
-    region.get! (Rewriter.setProperties ctx op newProps opIn) =
+    region.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     region.get! ctx := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.firstBlock!_setProperties {region : RegionPtr} :
-    (region.get! (Rewriter.setProperties ctx op newProps opIn)).firstBlock =
+    (region.get! (Rewriter.setProperties ctx op opCode newProps opIn)).firstBlock =
     (region.get! ctx).firstBlock := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.lastBlock!_setProperties {region : RegionPtr} :
-    (region.get! (Rewriter.setProperties ctx op newProps opIn)).lastBlock =
+    (region.get! (Rewriter.setProperties ctx op opCode newProps opIn)).lastBlock =
     (region.get! ctx).lastBlock := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.parent!_setProperties {region : RegionPtr} :
-    (region.get! (Rewriter.setProperties ctx op newProps opIn)).parent =
+    (region.get! (Rewriter.setProperties ctx op opCode newProps opIn)).parent =
     (region.get! ctx).parent := by
   grind
 
 @[simp, grind =]
 theorem ValuePtr.getFirstUse!_setProperties {value : ValuePtr} :
-    value.getFirstUse! (Rewriter.setProperties ctx op newProps opIn)  =
+    value.getFirstUse! (Rewriter.setProperties ctx op opCode newProps opIn)  =
     value.getFirstUse! ctx := by
   grind
 
 @[simp, grind =]
 theorem ValuePtr.getType!_setProperties {value : ValuePtr} :
-    value.getType! (Rewriter.setProperties ctx op newProps opIn)  =
+    value.getType! (Rewriter.setProperties ctx op opCode newProps opIn)  =
     value.getType! ctx := by
   grind
 
 @[simp, grind =]
 theorem OpOperandPtrPtr.get!_setProperties {opOperandPtr : OpOperandPtrPtr} :
-    opOperandPtr.get! (Rewriter.setProperties ctx op newProps opIn) =
+    opOperandPtr.get! (Rewriter.setProperties ctx op opCode newProps opIn) =
     opOperandPtr.get! ctx := by
   grind
 

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -311,11 +311,14 @@ end setAttributes
 
 section setProperties
 
-theorem OperationPtr.setProperties_WellFormed {opCode : OpInfo} (ctx: IRContext OpInfo)
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect} {newProps : HasDialectOpInfo.propertiesOf opCode}
+
+theorem OperationPtr.setProperties_WellFormed (ctx: IRContext OpInfo)
   (op: OperationPtr) (hctx : ctx.WellFormed) (hop : op.InBounds ctx)
   (hprop : op.getOpType! ctx = opCode := by grind)
-  (newProperties: HasOpInfo.propertiesOf opCode) :
-  (op.setProperties ctx newProperties hop hprop).WellFormed := by
+  (newProperties: HasDialectOpInfo.propertiesOf opCode) :
+  (op.setProperties ctx opCode newProperties hop hprop).WellFormed := by
   have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := hctx
   constructor
   · grind
@@ -323,49 +326,51 @@ theorem OperationPtr.setProperties_WellFormed {opCode : OpInfo} (ctx: IRContext 
     have ⟨array, harray⟩ := h₂ val (by grind)
     exists array
     simp only [Std.ExtHashSet.filter_empty] at harray ⊢
-    apply ValuePtr.DefUse.unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply ValuePtr.DefUse.unchanged harray (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
   · intro blk hblk
     have ⟨array, harray⟩ := h₃ blk (by grind)
     exists array
     simp only [Std.ExtHashSet.filter_empty] at harray ⊢
-    apply BlockPtr.DefUse.unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply BlockPtr.DefUse.unchanged harray (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
   · intro blk hblk
     have ⟨array, harray⟩ := h₄ blk (by grind)
     exists array
-    apply BlockPtr.OpChain_unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply BlockPtr.OpChain_unchanged harray (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
   · intro reg hreg
     have ⟨array, harray⟩ := h₅ reg (by grind)
     exists array
-    apply RegionPtr.blockChain_unchanged harray (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply RegionPtr.blockChain_unchanged harray (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
   · intro op' hop'
     have h_wf := h₆ op' (by grind)
-    apply OperationPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply OperationPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
   · intro blk hblk
     have h_wf := h₇ blk (by grind)
-    apply BlockPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply BlockPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
   · intro reg hreg
     have h_wf := h₈ reg (by grind)
-    apply RegionPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx newProperties hop hprop) <;> grind
+    apply RegionPtr.WellFormed_unchanged h_wf (ctx' := op.setProperties ctx opCode newProperties hop hprop) <;> grind
 
 theorem BlockPtr.opChain_OperationPtr_setProperties
     (hWf : BlockPtr.OpChain block' ctx array)
     {op : OperationPtr} (hop : op.InBounds ctx)
-    {opCode : OpInfo} (newProps : HasOpInfo.propertiesOf opCode)
+    (newProps : HasDialectOpInfo.propertiesOf opCode)
     (hprop : op.getOpType! ctx = opCode := by grind) :
-    BlockPtr.OpChain block' (op.setProperties ctx newProps hop hprop) array := by
+    BlockPtr.OpChain block' (op.setProperties ctx opCode newProps hop hprop) array := by
   apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
 
 @[grind =]
 theorem BlockPtr.operationList_operationPtr_setProperties
     (hctx : ctx.WellFormed) :
-    BlockPtr.operationList block' (OperationPtr.setProperties op ctx newProps hop hprop) ctx' blockInBounds' =
+    BlockPtr.operationList block' (OperationPtr.setProperties op ctx opCode newProps hop hprop) ctx' blockInBounds' =
     BlockPtr.operationList block' ctx hctx (by grind) := by
   simp only [← BlockPtr.operationList_iff_BlockPtr_OpChain]
   grind [BlockPtr.opChain_OperationPtr_setProperties]
 
 theorem Rewriter.setProperties_WellFormed
+    {op : OperationPtr} {hop : op.InBounds ctx}
+    {hprop : op.getOpType! ctx = opCode}
     (hctx : ctx.WellFormed) :
-    (Rewriter.setProperties ctx op newProps hop hprop).WellFormed := by
+    (Rewriter.setProperties ctx op opCode newProps hop hprop).WellFormed := by
    grind [setProperties, OperationPtr.setProperties_WellFormed]
 
 end setProperties

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -166,23 +166,26 @@ def WfRewriter.setAttributes! (wfCtx : WfIRContext OpInfo) (op : OperationPtr) (
 
 /-- Set the properties of an operation. -/
 @[inline]
-def WfRewriter.setProperties {opCode : OpInfo} (wfCtx : WfIRContext OpInfo) (op : OperationPtr)
-    (newProps : HasOpInfo.propertiesOf opCode)
+def WfRewriter.setProperties {Dialect : Type} [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo)
+    (op : OperationPtr) (opCode : Dialect) (newProps : HasDialectOpInfo.propertiesOf opCode)
     (opIn : op.InBounds wfCtx.raw := by grind)
     (hprop : op.getOpType! wfCtx.raw = opCode := by grind) :
     WfIRContext OpInfo :=
-  ⟨Rewriter.setProperties wfCtx.raw op newProps opIn hprop,
+  ⟨Rewriter.setProperties wfCtx.raw op opCode newProps opIn hprop,
     by grind [Rewriter.setProperties_WellFormed]⟩
 
 /--
 Set the properties of an operation, panicking if the operation is out of bounds, or if the
 property types don't match.
 -/
-def WfRewriter.setProperties! {opCode : OpInfo} (wfCtx : WfIRContext OpInfo) (op : OperationPtr)
-    (newProperties : HasOpInfo.propertiesOf opCode) : WfIRContext OpInfo :=
+def WfRewriter.setProperties! {Dialect : Type} [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo)
+    (op : OperationPtr) (opCode : Dialect) (newProperties : HasDialectOpInfo.propertiesOf opCode) :
+    WfIRContext OpInfo :=
   if opIn : op.InBounds wfCtx.raw then
     if hprop : op.getOpType! wfCtx.raw = opCode then
-      WfRewriter.setProperties wfCtx op newProperties opIn hprop
+      WfRewriter.setProperties wfCtx op opCode newProperties opIn hprop
     else
       panic! "WfRewriter.setProperties! failed: property types don't match"
   else

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -1065,174 +1065,180 @@ section WfRewriter.setProperties
 
 attribute [local grind] WfRewriter.setProperties
 
-variable {opCode: OpInfo} {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode} {opIn : op.InBounds ctx.raw}
-         {opIn: op.InBounds ctx.raw} {hprop : op.getOpType! ctx.raw = opCode}
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect} {op : OperationPtr}
+         {newProps : HasDialectOpInfo.propertiesOf opCode}
+         {opIn : op.InBounds ctx.raw} {hprop : op.getOpType! ctx.raw = opCode}
 
 @[simp, grind =]
 theorem BlockPtr.prev!_wfRewriter_setProperties {block : BlockPtr} :
-    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).prev =
+    (block.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).prev =
     (block.get! ctx.raw).prev := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.next!_wfRewriter_setProperties {block : BlockPtr} :
-    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).next =
+    (block.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).next =
     (block.get! ctx.raw).next := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.parent!_wfRewriter_setProperties {block : BlockPtr} :
-    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop).raw)).parent =
+    (block.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw)).parent =
     (block.get! ctx.raw).parent := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.firstOp!_wfRewriter_setProperties {block : BlockPtr} :
-    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).firstOp =
+    (block.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).firstOp =
     (block.get! ctx.raw).firstOp := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.lastOp!_wfRewriter_setProperties {block : BlockPtr} :
-    (block.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).lastOp =
+    (block.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).lastOp =
     (block.get! ctx.raw).lastOp := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.prev!_wfRewriter_setProperties {op' : OperationPtr} :
-    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).prev =
+    (op'.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).prev =
     (op'.get! ctx.raw).prev := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.next!_wfRewriter_setProperties {op' : OperationPtr} :
-    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).next =
+    (op'.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).next =
     (op'.get! ctx.raw).next := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.parent!_wfRewriter_setProperties {op' : OperationPtr} :
-    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).parent =
+    (op'.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).parent =
     (op'.get! ctx.raw).parent := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOpType!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getOpType! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getOpType! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getOpType! ctx := by
   grind
 
 @[simp ,grind =]
 theorem OperationPtr.attrs!_wfRewriter_setProperties {op' : OperationPtr} :
-    (op'.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).attrs =
+    (op'.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).attrs =
     (op'.get! ctx.raw).attrs := by
   grind
 
 @[grind =]
 theorem OperationPtr.getProperties!_wfRewriter_setProperties
-    {op' : OperationPtr} {getterOpCode : Dialect} :
-    op'.getProperties! (WfRewriter.setProperties ctx op newProps opIn hprop).raw getterOpCode =
+    {GetterDialect : Type} [HasDialectOpInfo GetterDialect]
+    [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect} {op' : OperationPtr} :
+    op'.getProperties!
+      (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw getterOpCode =
     if op' = op then
-      if h : (getterOpCode : OpInfo) = opCode then
-        HasDialect.toDialectProperties getterOpCode (h ▸ newProps)
-      else default
+      if h : ofDialect OpInfo opCode = ofDialect OpInfo getterOpCode then
+        HasDialect.toDialectProperties getterOpCode
+          (h ▸ HasDialect.ofDialectProperties OpInfo opCode newProps)
+      else
+        default
     else
       op'.getProperties! ctx.raw getterOpCode := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumResults!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getNumResults! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumResults! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getNumResults! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumOperands!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getNumOperands! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumOperands! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getNumOperands! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOperand!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getOperand! (WfRewriter.setProperties ctx op newProps opIn hprop).raw index =
+    op'.getOperand! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw index =
     op'.getOperand! ctx.raw index := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getOperands!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getOperands! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getOperands! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getOperands! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumSuccessors!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getNumSuccessors! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumSuccessors! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getNumSuccessors! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getSuccessor!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getSuccessor! (WfRewriter.setProperties ctx op newProps opIn hprop).raw index =
+    op'.getSuccessor! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw index =
     op'.getSuccessor! ctx.raw index := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getSuccessors!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getSuccessors! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getSuccessors! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getSuccessors! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getNumRegions!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getNumRegions! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getNumRegions! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getNumRegions! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getRegions!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getRegions! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getRegions! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getRegions! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.firstBlock!_wfRewriter_setProperties {region : RegionPtr} :
-    (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).firstBlock =
+    (region.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).firstBlock =
     (region.get! ctx.raw).firstBlock := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getRegion!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getRegion! (WfRewriter.setProperties ctx op newProps opIn hprop).raw index =
+    op'.getRegion! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw index =
     op'.getRegion! ctx.raw index := by
   grind
 
 @[simp, grind =]
 theorem BlockPtr.getNumArguments!_wfRewriter_setProperties {block : BlockPtr} :
-    block.getNumArguments! (WfRewriter.setProperties ctx op newProps opIn).raw =
+    block.getNumArguments! (WfRewriter.setProperties ctx op opCode newProps opIn).raw =
     block.getNumArguments! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.lastBlock!_wfRewriter_setProperties {region : RegionPtr} :
-    (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).lastBlock =
+    (region.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).lastBlock =
     (region.get! ctx.raw).lastBlock := by
   grind
 
 @[simp, grind =]
 theorem RegionPtr.parent!_wfRewriter_setProperties {region : RegionPtr} :
-    (region.get! ((WfRewriter.setProperties ctx op newProps opIn hprop)).raw).parent =
+    (region.get! ((WfRewriter.setProperties ctx op opCode newProps opIn hprop)).raw).parent =
     (region.get! ctx.raw).parent := by
   grind
 
 @[simp, grind =]
 theorem ValuePtr.getType!_wfRewriter_setProperties {value : ValuePtr} :
-    value.getType! (WfRewriter.setProperties ctx op newProps opIn hprop).raw  =
+    value.getType! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw  =
     value.getType! ctx.raw := by
   grind
 
 @[simp, grind =]
 theorem OperationPtr.getResultTypes!_wfRewriter_setProperties {op' : OperationPtr} :
-    op'.getResultTypes! (WfRewriter.setProperties ctx op newProps opIn hprop).raw =
+    op'.getResultTypes! (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw =
     op'.getResultTypes! ctx.raw := by
   grind
 


### PR DESCRIPTION
With this change, `setProperties` can now allow opcodes that are dialect-local rather than global. This means that we can use `setProperties` with a generic `OpInfo` with an `HasDialect OpInfo Dialect`, and pass a property that is definitionaly equal to the opcode property.