### PR TITLE
feat(IR): support dialect-local operation creation (#1214)

### DIFF
--- a/UnitTest/Verifier.lean
+++ b/UnitTest/Verifier.lean
@@ -36,14 +36,14 @@ private def contextWithCrossRegionSuccessor : Except String (WfIRContext OpCode)
     WfRewriter.createBlock! ctx #[] (some (.atEnd targetRegion))
 
   let (ctx, _) :=
-      (WfRewriter.createOp! ctx (.test .test) #[] #[] #[] #[sourceRegion] ()
+      (WfRewriter.createOp! ctx Test.test #[] #[] #[] #[sourceRegion] ()
         (some (.atEnd moduleBlock))).get!
   let (ctx, _) :=
-      (WfRewriter.createOp! ctx (.test .test) #[] #[] #[] #[targetRegion] ()
+      (WfRewriter.createOp! ctx Test.test #[] #[] #[] #[targetRegion] ()
         (some (.atEnd moduleBlock))).get!
 
   let (ctx, _) :=
-      (WfRewriter.createOp! ctx (.cf .br) #[] #[] #[targetBlock] #[] ()
+      (WfRewriter.createOp! ctx Cf.br #[] #[] #[targetBlock] #[] ()
         (some (.atEnd sourceBlock))).get!
   return ctx
 

--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -151,7 +151,7 @@ def addIConstantFoldingLocal (ctx: WfIRContext OpCode) (op: OperationPtr) :
   let lhsVal := (lhsOp.getProperties! ctx.raw Arith.constant).value.value
   let rhsVal := (rhsOp.getProperties! ctx.raw Arith.constant).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
-  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] newVal none sorry sorry sorry sorry
   return (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 def addIZeroFolding (rewriter: PatternRewriter OpCode) (op: OperationPtr) (_ : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
@@ -240,7 +240,7 @@ def addIConstantFolding (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (W
   let lhsVal := (lhsOp.getProperties! ctx.raw Arith.constant).value.value
   let rhsVal := (rhsOp.getProperties! ctx.raw Arith.constant).value.value
   let newVal := ArithConstantProperties.mk (IntegerAttr.mk (lhsVal + rhsVal) (IntegerType.mk 32))
-  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] newVal (some $ .before op) sorry sorry sorry sorry
   let mut ctx ← WfRewriter.replaceOp? ctx op newOp sorry sorry sorry sorry sorry
 
   if (lhsValuePtr.getFirstUse ctx.raw (by sorry)).isNone then
@@ -293,7 +293,7 @@ def mulITwoReduce (ctx: WfIRContext OpCode) (op: OperationPtr) : Option (WfIRCon
   -- Get the lhs value
   let lhsValuePtr := op.getOperand ctx.raw 0 (by sorry) (by sorry)
 
-  let (ctx, newOp) ← WfRewriter.createOp ctx (.arith .addi) #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) (some $ .before op) sorry sorry sorry sorry
+  let (ctx, newOp) ← WfRewriter.createOp ctx Arith.addi #[IntegerType.mk 32] #[lhsValuePtr, lhsValuePtr] #[] #[] (ArithIntegerOverflowFlagsProperties.mk { nsw := false, nuw := false }) (some $ .before op) sorry sorry sorry sorry
   let mut ctx ← WfRewriter.replaceOp? ctx op newOp sorry sorry sorry sorry sorry
 
   if (rhsValuePtr.getFirstUse ctx.raw (by sorry)).isNone then
@@ -356,18 +356,18 @@ def constFoldTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) (
   let root := ArithConstantProperties.mk (IntegerAttr.mk root (IntegerType.mk 32))
   let inc := ArithConstantProperties.mk (IntegerAttr.mk inc (IntegerType.mk 32))
   let (gctx, topOp, insertPoint) ← empty
-  let mut (gctx, gacc) ← WfRewriter.createOp gctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry
+  let mut (gctx, gacc) ← WfRewriter.createOp gctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry
   for i in [0:size] do
     let ⟨thisOp, prop⟩ : (op : OpCode) × propertiesOf op := if (i % 100 < pc) then ⟨opcode, prop⟩ else ⟨.arith .andi, ()⟩
     let (ctx, acc) := (gctx, gacc)
-    let (ctx, rhsOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry
+    let (ctx, rhsOp) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry
     let lhsVal := acc.getResult 0
     let rhsVal := rhsOp.getResult 0
     let (ctx, acc) ← WfRewriter.createOp ctx thisOp #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry
     (gctx, gacc) := (ctx, acc)
 
   let accRes := gacc.getResult 0
-  let (ctx, op) ← WfRewriter.createOp gctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
+  let (ctx, op) ← WfRewriter.createOp gctx Test.test #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
   (ctx, topOp)
 
 def addZeroTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
@@ -387,7 +387,7 @@ def constFoldTreeSparse (opcode : OpCode) (prop : propertiesOf opcode) (size pc 
     let incAttr := ArithConstantProperties.mk (IntegerAttr.mk inc (IntegerType.mk 32))
     let (gctx, topOp, insertPoint) ← empty
 
-    let mut (gctx, root) ← WfRewriter.createOp gctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] rootAttr insertPoint sorry sorry sorry sorry
+    let mut (gctx, root) ← WfRewriter.createOp gctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] rootAttr insertPoint sorry sorry sorry sorry
     let mut runningTotals := #[root.getResult 0]
     let mut constants := #[]
 
@@ -397,7 +397,7 @@ def constFoldTreeSparse (opcode : OpCode) (prop : propertiesOf opcode) (size pc 
       let const ← randBool 20
 
       if const then
-        let (ctx, op) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] incAttr insertPoint sorry sorry sorry sorry
+        let (ctx, op) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] incAttr insertPoint sorry sorry sorry sorry
         constants := constants.push (op.getResult 0)
         gctx := ctx
 
@@ -409,7 +409,7 @@ def constFoldTreeSparse (opcode : OpCode) (prop : propertiesOf opcode) (size pc 
             runningTotals := runningTotals.push (op.getResult 0)
             gctx := ctx
 
-    let (ctx, op) ← WfRewriter.createOp gctx (.test .test) #[] #[runningTotals.back!] #[] #[] () insertPoint sorry sorry sorry sorry
+    let (ctx, op) ← WfRewriter.createOp gctx Test.test #[] #[runningTotals.back!] #[] #[] () insertPoint sorry sorry sorry sorry
     return (ctx, topOp)
 
 def addZeroTreeSparse (size pc : Nat) : Option (WfIRContext OpCode × OperationPtr) :=
@@ -432,8 +432,8 @@ def constReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) 
   let root := ArithConstantProperties.mk (IntegerAttr.mk root (IntegerType.mk 32))
   let inc := ArithConstantProperties.mk (IntegerAttr.mk inc (IntegerType.mk 32))
   let (ctx, topOp, insertPoint) ← empty
-  let (ctx, acc) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry
-  let (ctx, reuse) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry
+  let (ctx, acc) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] root insertPoint sorry sorry sorry sorry
+  let (ctx, reuse) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] inc insertPoint sorry sorry sorry sorry
 
   let mut (gctx, gacc) := (ctx, acc)
   for i in [0:size] do
@@ -447,7 +447,7 @@ def constReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc: Nat) 
   let (ctx, acc) := (gctx, gacc)
 
   let accRes := acc.getResult 0
-  let (ctx, op) ← WfRewriter.createOp ctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
+  let (ctx, op) ← WfRewriter.createOp ctx Test.test #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
   (ctx, topOp)
 
 def addZeroReuseTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=
@@ -466,8 +466,8 @@ def constLotsOfReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc:
   let lhs := ArithConstantProperties.mk (IntegerAttr.mk lhs (IntegerType.mk 32))
   let rhs := ArithConstantProperties.mk (IntegerAttr.mk rhs (IntegerType.mk 32))
   let (ctx, topOp, insertPoint) ← empty
-  let (ctx, lhsOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] lhs insertPoint sorry sorry sorry sorry
-  let (ctx, rhsOp) ← WfRewriter.createOp ctx (.arith .constant) #[IntegerType.mk 32] #[] #[] #[] rhs insertPoint sorry sorry sorry sorry
+  let (ctx, lhsOp) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] lhs insertPoint sorry sorry sorry sorry
+  let (ctx, rhsOp) ← WfRewriter.createOp ctx Arith.constant #[IntegerType.mk 32] #[] #[] #[] rhs insertPoint sorry sorry sorry sorry
   let lhsVal := lhsOp.getResult 0
   let rhsVal := rhsOp.getResult 0
   let (ctx, reuse) ← WfRewriter.createOp ctx opcode #[IntegerType.mk 32] #[lhsVal, rhsVal] #[] #[] prop insertPoint sorry sorry sorry sorry
@@ -484,7 +484,7 @@ def constLotsOfReuseTree (opcode: OpCode) (prop : propertiesOf opcode) (size pc:
   let (ctx, acc) := (gctx, gacc)
 
   let accRes := acc.getResult 0
-  let (ctx, op) ← WfRewriter.createOp ctx (.test .test) #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
+  let (ctx, op) ← WfRewriter.createOp ctx Test.test #[] #[accRes] #[] #[] () insertPoint sorry sorry sorry sorry
   (ctx, topOp)
 
 def addZeroLotsOfReuseTree (size pc: Nat) : Option (WfIRContext OpCode × OperationPtr) :=

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -1193,10 +1193,13 @@ theorem nextResult!_eq_getResult {op : OperationPtr} :
     op.nextResult! ctx = op.getResult (op.getNumResults! ctx) := by
   rfl
 
-def allocEmpty (ctx : IRContext OpInfo) (opType : OpInfo) (properties : HasOpInfo.propertiesOf opType) :
+def allocEmpty {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    (ctx : IRContext OpInfo) (opType : Dialect)
+    (properties : HasDialectOpInfo.propertiesOf opType) :
     Option (IRContext OpInfo × OperationPtr) :=
   let newOpPtr : OperationPtr := ⟨ctx.nextID⟩
-  let operation := Operation.empty opType properties
+  let globalProperties := HasDialect.ofDialectProperties OpInfo opType properties
+  let operation := Operation.empty (opType : OpInfo) globalProperties
   if _ : ctx.operations.contains newOpPtr then none else
   let ctx := { ctx with nextID := ctx.nextID + 1 }
   let ctx := newOpPtr.set ctx operation

--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -723,6 +723,8 @@ theorem OperationPtr.pushBlockOperand_push_fieldsInBounds
 attribute [local grind] Operation.empty in
 @[grind .]
 theorem OperationPtr.allocEmpty_fieldsInBounds
+    {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    {type : Dialect} {prop : HasDialectOpInfo.propertiesOf type}
     (heq : allocEmpty ctx type prop = some (ctx', ptr')) :
     ctx.FieldsInBounds → ctx'.FieldsInBounds := by
   prove_fieldsInBounds

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -53,6 +53,10 @@ setup_grind_with_get_set_definitions
 
 /- OperationPtr.allocEmpty -/
 
+variable {CreateDialect : Type} [HasDialectOpInfo CreateDialect]
+  [HasDialect OpInfo CreateDialect]
+variable {ty : CreateDialect} {properties : HasDialectOpInfo.propertiesOf ty}
+
 @[simp, grind =>]
 theorem BlockPtr.get!_OperationPtr_allocEmpty {block : BlockPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
@@ -63,14 +67,16 @@ theorem BlockPtr.get!_OperationPtr_allocEmpty {block : BlockPtr}
 theorem OperationPtr.get!_OperationPtr_allocEmpty {operation : OperationPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
     operation.get! ctx' =
-    if operation = op' then Operation.empty ty properties else operation.get! ctx := by
+    if operation = op' then
+      Operation.empty (ty : OpInfo) (HasDialect.ofDialectProperties OpInfo ty properties)
+    else operation.get! ctx := by
   grind
 
 @[grind =>]
 theorem OperationPtr.getOpType!_OperationPtr_allocEmpty {operation : OperationPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
     operation.getOpType! ctx' =
-    if operation = op' then ty else operation.getOpType! ctx := by
+    if operation = op' then (ty : OpInfo) else operation.getOpType! ctx := by
   grind
 
 @[grind =>]
@@ -104,8 +110,8 @@ theorem OperationPtr.getProperties!_OperationPtr_allocEmpty {operation : Operati
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
     operation.getProperties! ctx' opCode =
     if operation = op' then
-      if h : (opCode : OpInfo) = ty then
-        HasDialect.toDialectProperties opCode (h ▸ properties)
+      if h : ofDialect OpInfo ty = ofDialect OpInfo opCode then
+        HasDialect.properties_eq_of_ofDialect_eq h ▸ properties
       else default
     else
       operation.getProperties! ctx opCode := by

--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -190,6 +190,10 @@ theorem OperationPtr.setAttributes_genericPtr_mono (ptr : GenericPtr) :
     ptr.InBounds (op.setAttributes ctx newAttrs h) ↔ ptr.InBounds ctx := by
   grind
 
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {ty : Dialect}
+variable {properties : HasDialectOpInfo.propertiesOf ty}
+
 @[grind .]
 theorem OpResultPtr.allocEmpty_no_results {opResult : OpResultPtr}
     (heq : OperationPtr.allocEmpty ctx ty properties = some (ctx', op')) :
@@ -210,30 +214,30 @@ theorem BlockOperandPtr.allocEmpty_no_operands {blockOperand : BlockOperandPtr}
 
 @[grind =>]
 theorem OperationPtr.allocEmpty_genericPtr_iff (ptr : GenericPtr)
-    (heq : allocEmpty ctx type properties = some (ctx', ptr')) :
+    (heq : allocEmpty ctx ty properties = some (ctx', ptr')) :
     ptr.InBounds ctx' ↔ (ptr.InBounds ctx ∨ ptr = .operation ptr') := by
   grind
 
 theorem OperationPtr.allocEmpty_operationPtr_iff (ptr : OperationPtr)
-    (heq : allocEmpty ctx type properties = some (ctx', ptr')) :
+    (heq : allocEmpty ctx ty properties = some (ctx', ptr')) :
     ptr.InBounds ctx' ↔ (ptr.InBounds ctx ∨ ptr =  ptr') := by
   grind
 
 @[grind . ]
 theorem OperationPtr.allocEmpty_genericPtr_mono (ptr : GenericPtr)
-    (heq : allocEmpty ctx type properties = some (ctx', ptr')) :
+    (heq : allocEmpty ctx ty properties = some (ctx', ptr')) :
     ptr.InBounds ctx → ptr.InBounds ctx' := by
   grind
 
 @[grind .]
 theorem OperationPtr.allocEmpty_not_inBounds
-    (heq : allocEmpty ctx type properties = some (ctx', ptr')) :
+    (heq : allocEmpty ctx ty properties = some (ctx', ptr')) :
     ¬ ptr'.InBounds ctx := by
   grind
 
 @[grind .]
 theorem OperationPtr.allocEmpty_newBlock_inBounds
-    (heq : allocEmpty ctx type properties = some (ctx', ptr)) :
+    (heq : allocEmpty ctx ty properties = some (ctx', ptr)) :
     ptr.InBounds ctx' := by
   grind
 

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -197,14 +197,6 @@ def modifyContextM (f : WfIRContext OpInfo → MlirParserM OpInfo (WfIRContext O
   modifyContextM' (fun ctx => do pure ((), ← f ctx))
 
 /--
-  The operation code used for forward-reference placeholders.
-  We use a throwaway operation result (specifically a `builtin.unrealized_conversion_cast`)
-  to stand in for a value that is referenced before it is defined.
--/
-def placeholderOpCode : OpInfo :=
-  ofDialect OpInfo Builtin.unrealized_conversion_cast
-
-/--
   Create a detached, single-result placeholder operation of the given type.
   Its result is used to stand in for a value that has been referenced but not yet
   defined. The operation is not inserted into any block; once the real definition is
@@ -214,8 +206,8 @@ def placeholderOpCode : OpInfo :=
 def createForwardRefPlaceholder (ty : TypeAttr) (loc : Location) :
     MlirParserM OpInfo OperationPtr :=
   modifyContextM' fun ctx => do
-    match WfRewriter.createOp ctx placeholderOpCode #[ty] #[] #[] #[]
-        (default : HasOpInfo.propertiesOf placeholderOpCode) none with
+    match WfRewriter.createOp ctx Builtin.unrealized_conversion_cast #[ty] #[] #[] #[]
+      default none with
     | none => throwAt loc "internal error: failed to create forward-reference placeholder"
     | some (ctx', op) => pure (op, ctx')
 

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -79,15 +79,15 @@ def reconcileRegIntCastLocal (ctx : WfIRContext OpCode) (op : OperationPtr) :
   /- Replace the initial operation's output with a zero-extension of the parent's input -/
   match interBw with
   | 8 =>
-      let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .zextb) #[RegisterType.mk] #[parentInput]
+      let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.zextb #[RegisterType.mk] #[parentInput]
         #[] #[] () none
       return (ctx, some (#[newOp], #[newOp.getResult 0]))
   | 16 =>
-      let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .zexth) #[RegisterType.mk] #[parentInput]
+      let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.zexth #[RegisterType.mk] #[parentInput]
         #[] #[] () none
       return (ctx, some (#[newOp], #[newOp.getResult 0]))
   | 32 =>
-      let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .zextw) #[RegisterType.mk] #[parentInput]
+      let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.zextw #[RegisterType.mk] #[parentInput]
         #[] #[] () none
       return (ctx, some (#[newOp], #[newOp.getResult 0]))
   | bw =>
@@ -98,10 +98,10 @@ def reconcileRegIntCastLocal (ctx : WfIRContext OpCode) (op : OperationPtr) :
       /- for bitwidths with no dedicated instruction, shift left then right -/
       if bw >= 64 then none else
       let imm := IntegerAttr.mk (64-bw) (.mk 64)
-      let (ctx, shlOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[parentInput]
-        #[] #[] ⟨imm⟩ none
-      let (ctx, srlOp) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk]
-        #[shlOp.getResult 0] #[] #[] ⟨imm⟩ none
+      let (ctx, shlOp) ← WfRewriter.createOp! ctx Riscv.slli #[RegisterType.mk] #[parentInput]
+        #[] #[] (⟨imm⟩ : RISCVImmediateProperties) none
+      let (ctx, srlOp) ← WfRewriter.createOp! ctx Riscv.srli #[RegisterType.mk]
+        #[shlOp.getResult 0] #[] #[] (⟨imm⟩ : RISCVImmediateProperties) none
       return (ctx, some (#[shlOp, srlOp], #[srlOp.getResult 0]))
 
 

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -65,7 +65,7 @@ def coerceFunction (coercion : BoundaryCoercion) (ctx : WfIRContext OpCode)
       ctx := WfRewriter.setType ctx bap newType sorry
       let ip := InsertPoint.atStart entry ctx.raw sorry
       let some (ctx', cast) := WfRewriter.createOp ctx
-        (.builtin .unrealized_conversion_cast) #[origType] #[] #[] #[] default (some ip)
+        Builtin.unrealized_conversion_cast #[origType] #[] #[] #[] default (some ip)
         sorry sorry sorry sorry | return ctx
       let ctx' := WfRewriter.replaceValue ctx' bap (cast.getResult 0) sorry sorry sorry
       ctx := WfRewriter.pushOperand ctx' cast bap sorry sorry
@@ -83,7 +83,7 @@ def coerceFunction (coercion : BoundaryCoercion) (ctx : WfIRContext OpCode)
       match coercion.target opType with
       | some newType =>
         let some (ctx', cast) := WfRewriter.createOp ctx
-          (.builtin .unrealized_conversion_cast) #[newType] #[opVal] #[] #[] default
+          Builtin.unrealized_conversion_cast #[newType] #[opVal] #[] #[] default
           (some (InsertPoint.before retOp)) sorry sorry sorry sorry | return ctx
         ctx := WfRewriter.replaceOperand ctx' ⟨retOp, j⟩ (cast.getResult 0) sorry sorry
         -- The `j`-th operand maps to the `j`-th declared result: the verifier guarantees

--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -23,7 +23,7 @@ def mulITwoToAddi_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   if cst.value ≠ 2 then
     return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[lhs.getType! ctx.raw] #[lhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[lhs.getType! ctx.raw] #[lhs, lhs]
     #[] #[] properties none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -43,7 +43,7 @@ def mulIZeroToCst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType type := (lhs.getType! ctx.raw).val
     | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[lhs.getType! ctx.raw] #[]
     #[] #[] cstProp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -106,7 +106,7 @@ def subiSelfToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType type := (lhs.getType! ctx.raw).val
     | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[lhs.getType! ctx.raw] #[]
     #[] #[] cstProp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -139,7 +139,7 @@ def andiZeroToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType type := (lhs.getType! ctx.raw).val
     | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[lhs.getType! ctx.raw] #[]
     #[] #[] cstProp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -200,7 +200,7 @@ def xoriSelfToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType type := (lhs.getType! ctx.raw).val
     | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[lhs.getType! ctx.raw] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[lhs.getType! ctx.raw] #[]
     #[] #[] cstProp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -237,7 +237,7 @@ def deMorganAndToOr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let resultType := a.getType! ctx.raw
   let orProps : DisjointProperties := { disjoint := false }
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .or) #[resultType] #[a, b]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[resultType] #[a, b]
     #[] #[] orProps none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -260,7 +260,7 @@ def deMorganOrToAnd_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some b := matchNot orR ctx
     | return (ctx, none)
   let resultType := a.getType! ctx.raw
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[resultType] #[a, b]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[resultType] #[a, b]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 

--- a/Veir/Passes/InstructionSelection/Common.lean
+++ b/Veir/Passes/InstructionSelection/Common.lean
@@ -17,7 +17,7 @@ namespace Veir
 -/
 def castToRegLocal (ctx : WfIRContext OpCode) (v : ValuePtr) :
     Option (WfIRContext OpCode × OperationPtr) :=
-  WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast)
+  WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast
       #[RegisterType.mk] #[v] #[] #[] () none
 
 /--
@@ -31,7 +31,7 @@ def castToRegLocal (ctx : WfIRContext OpCode) (v : ValuePtr) :
 def replaceWithRegLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (reg : ValuePtr) :
     Option (WfIRContext OpCode × OperationPtr) :=
   let type := ((op.getResult 0).get! ctx.raw).type
-  WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast)
+  WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast
       #[type] #[reg] #[] #[] () none
 
 end Veir

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -46,10 +46,10 @@ def lowerUnaryWLocal {P : Type}
   let (ctx, castOp) ← castToRegLocal ctx operand
   let (ctx, retOp) ←
     if opType.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv op32) #[RegisterType.mk] #[castOp.getResult 0]
+      WfRewriter.createOp! ctx op32 #[RegisterType.mk] #[castOp.getResult 0]
           #[] #[] props32 none
     else
-      WfRewriter.createOp! ctx (.riscv op64) #[RegisterType.mk] #[castOp.getResult 0]
+      WfRewriter.createOp! ctx op64 #[RegisterType.mk] #[castOp.getResult 0]
           #[] #[] props64 none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
   some (ctx, some (#[castOp, retOp, castBackOp], #[castBackOp.getResult 0]))
@@ -77,13 +77,13 @@ def lowerExtLocal {P : Type}
   let (ctx, castOp) ← castToRegLocal ctx operand
   let (ctx, retOp) ←
     if opType.bitwidth = 8 then
-      WfRewriter.createOp! ctx (.riscv op8) #[RegisterType.mk] #[castOp.getResult 0]
+      WfRewriter.createOp! ctx op8 #[RegisterType.mk] #[castOp.getResult 0]
           #[] #[] props8 none
     else if opType.bitwidth = 16 then
-      WfRewriter.createOp! ctx (.riscv op16) #[RegisterType.mk] #[castOp.getResult 0]
+      WfRewriter.createOp! ctx op16 #[RegisterType.mk] #[castOp.getResult 0]
           #[] #[] props16 none
     else
-      WfRewriter.createOp! ctx (.riscv op32) #[RegisterType.mk] #[castOp.getResult 0]
+      WfRewriter.createOp! ctx op32 #[RegisterType.mk] #[castOp.getResult 0]
           #[] #[] props32 none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
   some (ctx, some (#[castOp, retOp, castBackOp], #[castBackOp.getResult 0]))
@@ -109,10 +109,10 @@ def lowerBinaryWLocal {P : Type}
   let (ctx, rcastOp) ← castToRegLocal ctx rhs
   let (ctx, retOp) ←
     if ltype.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv op32) #[RegisterType.mk]
+      WfRewriter.createOp! ctx op32 #[RegisterType.mk]
           #[lcastOp.getResult 0, rcastOp.getResult 0] #[] #[] props32 none
     else
-      WfRewriter.createOp! ctx (.riscv op64) #[RegisterType.mk]
+      WfRewriter.createOp! ctx op64 #[RegisterType.mk]
           #[lcastOp.getResult 0, rcastOp.getResult 0] #[] #[] props64 none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
   some (ctx, some (#[lcastOp, rcastOp, retOp, castBackOp], #[castBackOp.getResult 0]))
@@ -134,10 +134,10 @@ def lowerByteBinaryWLocal {P : Type}
   let (ctx, rcastOp) ← castToRegLocal ctx rhs
   let (ctx, retOp) ←
     if bw = 32 then
-      WfRewriter.createOp! ctx (.riscv op32) #[RegisterType.mk]
+      WfRewriter.createOp! ctx op32 #[RegisterType.mk]
           #[lcastOp.getResult 0, rcastOp.getResult 0] #[] #[] props32 none
     else
-      WfRewriter.createOp! ctx (.riscv op64) #[RegisterType.mk]
+      WfRewriter.createOp! ctx op64 #[RegisterType.mk]
           #[lcastOp.getResult 0, rcastOp.getResult 0] #[] #[] props64 none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
   some (ctx, some (#[lcastOp, rcastOp, retOp, castBackOp], #[castBackOp.getResult 0]))
@@ -160,7 +160,7 @@ def lowerBinaryRegLocal
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
   let (ctx, lCastOp) ← castToRegLocal ctx lhs
   let (ctx, rCastOp) ← castToRegLocal ctx rhs
-  let (ctx, mOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk]
+  let (ctx, mOp) ← WfRewriter.createOp! ctx rop #[RegisterType.mk]
       #[lCastOp.getResult 0, rCastOp.getResult 0] #[] #[] props none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (mOp.getResult 0)
   some (ctx, some (#[lCastOp, rCastOp, mOp, castBackOp], #[castBackOp.getResult 0]))
@@ -181,7 +181,7 @@ def lowerBitwiseRegLocal {P : Type}
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 ∧ t.bitwidth ≠ 8 ∧ t.bitwidth ≠ 1 then return (ctx, none)
   let (ctx, lCastOp) ← castToRegLocal ctx lhs
   let (ctx, rCastOp) ← castToRegLocal ctx rhs
-  let (ctx, mOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk]
+  let (ctx, mOp) ← WfRewriter.createOp! ctx rop #[RegisterType.mk]
       #[lCastOp.getResult 0, rCastOp.getResult 0] #[] #[] props none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (mOp.getResult 0)
   some (ctx, some (#[lCastOp, rCastOp, mOp, castBackOp], #[castBackOp.getResult 0]))
@@ -203,16 +203,16 @@ def lowerSignedMinMaxLocal
   let (ctx, rCastOp) ← castToRegLocal ctx rhs
   /- For i32, sign-extend before the compare so negative values order correctly. -/
   if t.bitwidth = 32 then
-    let (ctx, ls) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[lCastOp.getResult 0]
+    let (ctx, ls) ← WfRewriter.createOp! ctx Riscv.sextw #[RegisterType.mk] #[lCastOp.getResult 0]
         #[] #[] () none
-    let (ctx, rs) ← WfRewriter.createOp! ctx (.riscv .sextw) #[RegisterType.mk] #[rCastOp.getResult 0]
+    let (ctx, rs) ← WfRewriter.createOp! ctx Riscv.sextw #[RegisterType.mk] #[rCastOp.getResult 0]
         #[] #[] () none
-    let (ctx, mOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk]
+    let (ctx, mOp) ← WfRewriter.createOp! ctx rop #[RegisterType.mk]
         #[ls.getResult 0, rs.getResult 0] #[] #[] props none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (mOp.getResult 0)
     some (ctx, some (#[lCastOp, rCastOp, ls, rs, mOp, castBackOp], #[castBackOp.getResult 0]))
   else
-    let (ctx, mOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk]
+    let (ctx, mOp) ← WfRewriter.createOp! ctx rop #[RegisterType.mk]
         #[lCastOp.getResult 0, rCastOp.getResult 0] #[] #[] props none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (mOp.getResult 0)
     some (ctx, some (#[lCastOp, rCastOp, mOp, castBackOp], #[castBackOp.getResult 0]))
@@ -238,10 +238,10 @@ def lowerRotateLocal
   let (ctx, amtCastOp) ← castToRegLocal ctx amt
   let (ctx, rotOp) ←
     if t.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv op32) #[RegisterType.mk]
+      WfRewriter.createOp! ctx op32 #[RegisterType.mk]
           #[valCastOp.getResult 0, amtCastOp.getResult 0] #[] #[] props32 none
     else
-      WfRewriter.createOp! ctx (.riscv op64) #[RegisterType.mk]
+      WfRewriter.createOp! ctx op64 #[RegisterType.mk]
           #[valCastOp.getResult 0, amtCastOp.getResult 0] #[] #[] props64 none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (rotOp.getResult 0)
   some (ctx, some (#[valCastOp, amtCastOp, rotOp, castBackOp], #[castBackOp.getResult 0]))
@@ -299,11 +299,11 @@ def bswap_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let (ctx, castOp) ← castToRegLocal ctx operand
   /- rev8 reverses all 8 bytes; for i32 the wanted bytes end up in the high 32 bits,
      so shift them down with srli 32. -/
-  let (ctx, rev8Op) ← WfRewriter.createOp! ctx (.riscv .rev8) #[RegisterType.mk] #[castOp.getResult 0]
+  let (ctx, rev8Op) ← WfRewriter.createOp! ctx Riscv.rev8 #[RegisterType.mk] #[castOp.getResult 0]
       #[] #[] () none
   if opType.bitwidth = 32 then
     let sh32 := RISCVImmediateProperties.mk (IntegerAttr.mk 32 (IntegerType.mk 64))
-    let (ctx, srliOp) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk] #[rev8Op.getResult 0]
+    let (ctx, srliOp) ← WfRewriter.createOp! ctx Riscv.srli #[RegisterType.mk] #[rev8Op.getResult 0]
         #[] #[] sh32 none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (srliOp.getResult 0)
     some (ctx, some (#[castOp, rev8Op, srliOp, castBackOp], #[castBackOp.getResult 0]))
@@ -325,18 +325,18 @@ def bswap (rewriter : PatternRewriter OpCode) (op : OperationPtr)
 def bitreverseStageLocal (mask shamt : Int) (ctx : WfIRContext OpCode) (input : ValuePtr) :
     Option (WfIRContext OpCode × Array OperationPtr × ValuePtr) := do
   let maskAttr := RISCVImmediateProperties.mk (IntegerAttr.mk mask (IntegerType.mk 64))
-  let (ctx, maskOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+  let (ctx, maskOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
       #[] #[] maskAttr none
-  let (ctx, lowOp) ← WfRewriter.createOp! ctx (.riscv .and) #[RegisterType.mk]
+  let (ctx, lowOp) ← WfRewriter.createOp! ctx Riscv.and #[RegisterType.mk]
       #[maskOp.getResult 0, input] #[] #[] () none
   let shamtAttr := RISCVImmediateProperties.mk (IntegerAttr.mk shamt (IntegerType.mk 64))
-  let (ctx, lowShiftOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk]
+  let (ctx, lowShiftOp) ← WfRewriter.createOp! ctx Riscv.slli #[RegisterType.mk]
       #[lowOp.getResult 0] #[] #[] shamtAttr none
-  let (ctx, highShiftOp) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk]
+  let (ctx, highShiftOp) ← WfRewriter.createOp! ctx Riscv.srli #[RegisterType.mk]
       #[input] #[] #[] shamtAttr none
-  let (ctx, highOp) ← WfRewriter.createOp! ctx (.riscv .and) #[RegisterType.mk]
+  let (ctx, highOp) ← WfRewriter.createOp! ctx Riscv.and #[RegisterType.mk]
       #[maskOp.getResult 0, highShiftOp.getResult 0] #[] #[] () none
-  let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk]
+  let (ctx, orOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk]
       #[lowShiftOp.getResult 0, highOp.getResult 0] #[] #[] () none
   return (ctx, #[maskOp, lowOp, lowShiftOp, highShiftOp, highOp, orOp], orOp.getResult 0)
 
@@ -355,10 +355,10 @@ def bitreverse_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     let (ctx, ops1, x1) ← bitreverseStageLocal 0x55555555 1 ctx (castOp.getResult 0)
     let (ctx, ops2, x2) ← bitreverseStageLocal 0x33333333 2 ctx x1
     let (ctx, ops3, x3) ← bitreverseStageLocal 0x0f0f0f0f 4 ctx x2
-    let (ctx, rev8Op) ← WfRewriter.createOp! ctx (.riscv .rev8) #[RegisterType.mk] #[x3]
+    let (ctx, rev8Op) ← WfRewriter.createOp! ctx Riscv.rev8 #[RegisterType.mk] #[x3]
         #[] #[] () none
     let sh32 := RISCVImmediateProperties.mk (IntegerAttr.mk 32 (IntegerType.mk 64))
-    let (ctx, srliOp) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk] #[rev8Op.getResult 0]
+    let (ctx, srliOp) ← WfRewriter.createOp! ctx Riscv.srli #[RegisterType.mk] #[rev8Op.getResult 0]
         #[] #[] sh32 none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (srliOp.getResult 0)
     some (ctx, some (#[castOp] ++ ops1 ++ ops2 ++ ops3 ++ #[rev8Op, srliOp, castBackOp], #[castBackOp.getResult 0]))
@@ -366,7 +366,7 @@ def bitreverse_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     let (ctx, ops1, x1) ← bitreverseStageLocal 0x5555555555555555 1 ctx (castOp.getResult 0)
     let (ctx, ops2, x2) ← bitreverseStageLocal 0x3333333333333333 2 ctx x1
     let (ctx, ops3, x3) ← bitreverseStageLocal 0x0f0f0f0f0f0f0f0f 4 ctx x2
-    let (ctx, retOp) ← WfRewriter.createOp! ctx (.riscv .rev8) #[RegisterType.mk] #[x3]
+    let (ctx, retOp) ← WfRewriter.createOp! ctx Riscv.rev8 #[RegisterType.mk] #[x3]
         #[] #[] () none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (retOp.getResult 0)
     some (ctx, some (#[castOp] ++ ops1 ++ ops2 ++ ops3 ++ #[retOp, castBackOp], #[castBackOp.getResult 0]))
@@ -387,9 +387,9 @@ def constant_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let type := ((op.getResult 0).get! ctx.raw).type
   let .integerType type' := type.val | return (ctx, none)
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 ∧ type'.bitwidth ≠ 1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
-      #[] #[] {value := const} none
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
+      #[] #[] ({value := const} : RISCVImmediateProperties) none
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[type]
       #[newOp.getResult 0] #[] #[] () none
   some (ctx, some (#[newOp, castOp], #[castOp.getResult 0]))
 
@@ -431,28 +431,28 @@ def ashr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType type' := type.val | return (ctx, none)
   if type'.bitwidth ≠ 64 ∧ type'.bitwidth ≠ 32 ∧ type'.bitwidth ≠ 8 then return (ctx, none)
   /- First, cast the operands to registers -/
-  let (ctx, lcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[lhs]
+  let (ctx, lcastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[lhs]
       #[] #[] () none
-  let (ctx, rcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[rhs]
+  let (ctx, rcastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[rhs]
       #[] #[] () none
   if type'.bitwidth = 8 then
-    let (ctx, lsOp) ← WfRewriter.createOp! ctx (.riscv .sextb) #[RegisterType.mk] #[lcastOp.getResult 0]
+    let (ctx, lsOp) ← WfRewriter.createOp! ctx Riscv.sextb #[RegisterType.mk] #[lcastOp.getResult 0]
           #[] #[] () none
-    let (ctx, sraOp) ← WfRewriter.createOp! ctx (.riscv .sra) #[RegisterType.mk] #[lsOp.getResult 0, rcastOp.getResult 0]
+    let (ctx, sraOp) ← WfRewriter.createOp! ctx Riscv.sra #[RegisterType.mk] #[lsOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () none
-    let (ctx, castSraOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
+    let (ctx, castSraOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[type] #[sraOp.getResult 0]
       #[] #[] () none
     return (ctx, some (#[lcastOp, rcastOp, lsOp, sraOp, castSraOp], #[castSraOp.getResult 0]))
   /- sraw for i32 (sign-extends result), sra for i64 -/
   let (ctx, sraOp) ←
     if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .sraw) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.sraw #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () none
     else
-      WfRewriter.createOp! ctx (.riscv .sra) #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.sra #[RegisterType.mk] #[lcastOp.getResult 0, rcastOp.getResult 0]
           #[] #[] () none
   /- Cast back result for type consistency -/
-  let (ctx, castSraOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[sraOp.getResult 0]
+  let (ctx, castSraOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[type] #[sraOp.getResult 0]
       #[] #[] () none
   return (ctx, some (#[lcastOp, rcastOp, sraOp, castSraOp], #[castSraOp.getResult 0]))
 
@@ -514,9 +514,9 @@ def icmpCastExtLocal (ctx : WfIRContext OpCode) (lhs rhs : ValuePtr) (ext : Opti
   | none => some (ctx, #[lcastOp, rcastOp], lcastOp.getResult 0, rcastOp.getResult 0)
   | some e =>
     let props : Riscv.propertiesOf e.op := cast e.hprops.symm ()
-    let (ctx, lsOp) ← WfRewriter.createOp! ctx (.riscv e.op) #[RegisterType.mk]
+    let (ctx, lsOp) ← WfRewriter.createOp! ctx e.op #[RegisterType.mk]
       #[lcastOp.getResult 0] #[] #[] props none
-    let (ctx, rsOp) ← WfRewriter.createOp! ctx (.riscv e.op) #[RegisterType.mk]
+    let (ctx, rsOp) ← WfRewriter.createOp! ctx e.op #[RegisterType.mk]
       #[rcastOp.getResult 0] #[] #[] props none
     some (ctx, #[lcastOp, rcastOp, lsOp, rsOp], lsOp.getResult 0, rsOp.getResult 0)
 
@@ -528,7 +528,7 @@ def icmpEmitCmpLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : V
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let (ctx, pre, a, b) ← icmpCastExtLocal ctx lhs rhs ext
   let (u, v) := if swap then (b, a) else (a, b)
-  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk] #[u, v]
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx rop #[RegisterType.mk] #[u, v]
     #[] #[] (cast hrop.symm ()) none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
   some (ctx, some (pre ++ #[cmpOp, castBackOp], #[castBackOp.getResult 0]))
@@ -543,9 +543,9 @@ def icmpEmitCmpImmLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs 
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let (ctx, pre, a, b) ← icmpCastExtLocal ctx lhs rhs ext
   let (u, v) := if swap then (b, a) else (a, b)
-  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv rop) #[RegisterType.mk] #[u, v]
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx rop #[RegisterType.mk] #[u, v]
     #[] #[] (cast hrop.symm ()) none
-  let (ctx, immOp) ← WfRewriter.createOp! ctx (.riscv ropImm) #[RegisterType.mk]
+  let (ctx, immOp) ← WfRewriter.createOp! ctx ropImm #[RegisterType.mk]
     #[cmpOp.getResult 0] #[] #[] (cast hropImm.symm icmpOneImm) none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (immOp.getResult 0)
   some (ctx, some (pre ++ #[cmpOp, immOp, castBackOp], #[castBackOp.getResult 0]))
@@ -556,7 +556,7 @@ def icmpEmitSeqzLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : 
     (ext : Option IcmpExtOp) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let (ctx, pre, a, _) ← icmpCastExtLocal ctx lhs rhs ext
-  let (ctx, immOp) ← WfRewriter.createOp! ctx (.riscv .sltiu) #[RegisterType.mk] #[a]
+  let (ctx, immOp) ← WfRewriter.createOp! ctx Riscv.sltiu #[RegisterType.mk] #[a]
     #[] #[] icmpOneImm none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (immOp.getResult 0)
   some (ctx, some (pre ++ #[immOp, castBackOp], #[castBackOp.getResult 0]))
@@ -567,9 +567,9 @@ def icmpEmitSnezLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs : 
     (ext : Option IcmpExtOp) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let (ctx, pre, a, _) ← icmpCastExtLocal ctx lhs rhs ext
-  let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+  let (ctx, liOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
     #[] #[] icmpZeroImm none
-  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk]
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx Riscv.sltu #[RegisterType.mk]
     #[liOp.getResult 0, a] #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
   some (ctx, some (pre ++ #[liOp, cmpOp, castBackOp], #[castBackOp.getResult 0]))
@@ -579,11 +579,11 @@ def icmpEmitXorSnezLocal (ctx : WfIRContext OpCode) (op : OperationPtr) (lhs rhs
     (ext : Option IcmpExtOp) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let (ctx, pre, a, b) ← icmpCastExtLocal ctx lhs rhs ext
-  let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xor) #[RegisterType.mk] #[b, a]
+  let (ctx, xorOp) ← WfRewriter.createOp! ctx Riscv.xor #[RegisterType.mk] #[b, a]
     #[] #[] () none
-  let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+  let (ctx, liOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
     #[] #[] icmpZeroImm none
-  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv .sltu) #[RegisterType.mk]
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx Riscv.sltu #[RegisterType.mk]
     #[liOp.getResult 0, xorOp.getResult 0] #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (cmpOp.getResult 0)
   some (ctx, some (pre ++ #[xorOp, liOp, cmpOp, castBackOp], #[castBackOp.getResult 0]))
@@ -772,10 +772,10 @@ def trunc_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
      Limiting to `{8, 16, 32, 64}` keeps the lowering sound and makes the widths concrete. -/
   if opBw ∉ [8, 16, 32, 64] ∨ resBw ∉ [8, 16, 32, 64] then return (ctx, none)
   /- First, cast the operand to registers -/
-  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[operand]
       #[] #[] () none
   /- Then, cast register to expected output width. -/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[resType] #[opCastOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[resType] #[opCastOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[opCastOp, castOp], #[castOp.getResult 0]))
 
@@ -835,10 +835,10 @@ def bitcast_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some resBw := Attribute.bitwidthOfType resType | return (ctx, none)
   if opBw ∉ [8, 16, 32, 64] ∨ resBw ∉ [8, 16, 32, 64] then return (ctx, none)
   /- First, cast the operand to registers -/
-  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[operand]
       #[] #[] () none
   /- Then, cast register to expected output type. -/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[resType] #[opCastOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[resType] #[opCastOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[opCastOp, castOp], #[castOp.getResult 0]))
 
@@ -877,7 +877,7 @@ def load_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   /- Split the address into a base register and a signed 12-bit offset. -/
   let (base, offset) := selectAddrRegImm ptr ctx.raw
   /- cast base (!llvm.ptr) -> register -/
-  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
+  let (ctx, pcastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[base]
       #[] #[] () none
   /- 64-bit `riscv.ld`, or its `lw` (i32) / `lb` (i8) variants. Volatility carries
      over from the `llvm.load`: the riscv op encodes the same, but the flag keeps
@@ -885,15 +885,15 @@ def load_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let immProps := RISCVMemProperties.mk (IntegerAttr.mk offset (IntegerType.mk 64)) llvmProps.volatile_
   let (ctx, ldOp) ←
     if type'.bitwidth = 8 then
-      WfRewriter.createOp! ctx (.riscv .lb) #[RegisterType.mk] #[pcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.lb #[RegisterType.mk] #[pcastOp.getResult 0]
         #[] #[] immProps none
     else if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .lw) #[RegisterType.mk] #[pcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.lw #[RegisterType.mk] #[pcastOp.getResult 0]
         #[] #[] immProps none
     else
-      WfRewriter.createOp! ctx (.riscv .ld) #[RegisterType.mk] #[pcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.ld #[RegisterType.mk] #[pcastOp.getResult 0]
         #[] #[] immProps none
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[ldOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[type] #[ldOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[pcastOp, ldOp, castOp], #[castOp.getResult 0]))
 
@@ -913,23 +913,23 @@ def store_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   /- Split the address into a base register and a signed 12-bit offset. -/
   let (base, offset) := selectAddrRegImm ptr ctx.raw
   /- cast base (!llvm.ptr) -> register -/
-  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[base]
+  let (ctx, pcastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[base]
       #[] #[] () none
   /- cast value (i64/i32/i8) -> register -/
-  let (ctx, valcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[arg]
+  let (ctx, valcastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[arg]
       #[] #[] () none
   /- 64-bit `riscv.sd`, or its `sw` (i32, low 4 bytes) / `sb` (i8, low byte): operands are (val, addr), no results.
      Volatility carries over from the `llvm.store`, as in `load_local`. -/
   let immProps := RISCVMemProperties.mk (IntegerAttr.mk offset (IntegerType.mk 64)) llvmProps.volatile_
   let (ctx, sdOp) ←
     if type'.bitwidth = 8 then
-      WfRewriter.createOp! ctx (.riscv .sb) #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.sb #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
         #[] #[] immProps none
     else if type'.bitwidth = 32 then
-      WfRewriter.createOp! ctx (.riscv .sw) #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.sw #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
         #[] #[] immProps none
     else
-      WfRewriter.createOp! ctx (.riscv .sd) #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
+      WfRewriter.createOp! ctx Riscv.sd #[] #[valcastOp.getResult 0, pcastOp.getResult 0]
         #[] #[] immProps none
   some (ctx, some (#[pcastOp, valcastOp, sdOp], #[]))
 
@@ -952,31 +952,31 @@ def getelementptr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if itype.bitwidth ≠ 64 then return (ctx, none)
   let some scale := Attribute.sizeOfType properties.elem_type.val | return (ctx, none)
   let type := ((op.getResult 0).get! ctx.raw).type
-  let (ctx, pcastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[ptr]
+  let (ctx, pcastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[ptr]
       #[] #[] () none
-  let (ctx, icastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[idx]
+  let (ctx, icastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[idx]
       #[] #[] () none
   let pReg := pcastOp.getResult 0
   let iReg := icastOp.getResult 0
   let (ctx, gepOps, retOp) ← match scale with
     | 1 =>
       /- ptr + idx -/
-      let (ctx, addOp) ← WfRewriter.createOp! ctx (.riscv .add) #[RegisterType.mk] #[pReg, iReg]
+      let (ctx, addOp) ← WfRewriter.createOp! ctx Riscv.add #[RegisterType.mk] #[pReg, iReg]
         #[] #[] () none
       pure (ctx, #[addOp], addOp)
     | 2 =>
       /- (idx << 1) + ptr -/
-      let (ctx, addOp) ← WfRewriter.createOp! ctx (.riscv .sh1add) #[RegisterType.mk] #[iReg, pReg]
+      let (ctx, addOp) ← WfRewriter.createOp! ctx Riscv.sh1add #[RegisterType.mk] #[iReg, pReg]
         #[] #[] () none
       pure (ctx, #[addOp], addOp)
     | 4 =>
       /- (idx << 2) + ptr -/
-      let (ctx, addOp) ← WfRewriter.createOp! ctx (.riscv .sh2add) #[RegisterType.mk] #[iReg, pReg]
+      let (ctx, addOp) ← WfRewriter.createOp! ctx Riscv.sh2add #[RegisterType.mk] #[iReg, pReg]
         #[] #[] () none
       pure (ctx, #[addOp], addOp)
     | 8 =>
       /- (idx << 3) + ptr -/
-      let (ctx, addOp) ← WfRewriter.createOp! ctx (.riscv .sh3add) #[RegisterType.mk] #[iReg, pReg]
+      let (ctx, addOp) ← WfRewriter.createOp! ctx Riscv.sh3add #[RegisterType.mk] #[iReg, pReg]
         #[] #[] () none
       pure (ctx, #[addOp], addOp)
     | _ =>
@@ -988,23 +988,23 @@ def getelementptr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
       if 0 < scale ∧ scale &&& (scale - 1) = 0 ∧ Nat.log2 scale < 64 then
         /- scale is a power of two: ptr + (idx << log2 scale) -/
         let k := RISCVImmediateProperties.mk (IntegerAttr.mk (Nat.log2 scale) (IntegerType.mk 64))
-        let (ctx, slliOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[iReg]
+        let (ctx, slliOp) ← WfRewriter.createOp! ctx Riscv.slli #[RegisterType.mk] #[iReg]
           #[] #[] k none
-        let (ctx, addOp) ← WfRewriter.createOp! ctx (.riscv .add) #[RegisterType.mk] #[pReg, slliOp.getResult 0]
+        let (ctx, addOp) ← WfRewriter.createOp! ctx Riscv.add #[RegisterType.mk] #[pReg, slliOp.getResult 0]
           #[] #[] () none
         pure (ctx, #[slliOp, addOp], addOp)
       else
         /- arbitrary scale: ptr + idx * scale -/
         let s := RISCVImmediateProperties.mk (IntegerAttr.mk scale (IntegerType.mk 64))
-        let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+        let (ctx, liOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
           #[] #[] s none
-        let (ctx, mulOp) ← WfRewriter.createOp! ctx (.riscv .mul) #[RegisterType.mk] #[iReg, liOp.getResult 0]
+        let (ctx, mulOp) ← WfRewriter.createOp! ctx Riscv.mul #[RegisterType.mk] #[iReg, liOp.getResult 0]
           #[] #[] () none
-        let (ctx, addOp) ← WfRewriter.createOp! ctx (.riscv .add) #[RegisterType.mk] #[pReg, mulOp.getResult 0]
+        let (ctx, addOp) ← WfRewriter.createOp! ctx Riscv.add #[RegisterType.mk] #[pReg, mulOp.getResult 0]
           #[] #[] () none
         pure (ctx, #[liOp, mulOp, addOp], addOp)
   /- Cast the resulting register back to `!llvm.ptr`. -/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[retOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[type] #[retOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[pcastOp, icastOp] ++ gepOps ++ #[castOp], #[castOp.getResult 0]))
 
@@ -1041,7 +1041,7 @@ def selectCzeroeqz_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some _ := matchConstantZero fval ctx | return (ctx, none)
   let (ctx, tCastOp) ← castToRegLocal ctx tval
   let (ctx, condCastOp) ← castToRegLocal ctx cond
-  let (ctx, czOp) ← WfRewriter.createOp! ctx (.riscv .czeroeqz) #[RegisterType.mk] #[tCastOp.getResult 0, condCastOp.getResult 0]
+  let (ctx, czOp) ← WfRewriter.createOp! ctx Riscv.czeroeqz #[RegisterType.mk] #[tCastOp.getResult 0, condCastOp.getResult 0]
       #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (czOp.getResult 0)
   some (ctx, some (#[tCastOp, condCastOp, czOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1064,7 +1064,7 @@ def selectCzeronez_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some _ := matchConstantZero tval ctx | return (ctx, none)
   let (ctx, fCastOp) ← castToRegLocal ctx fval
   let (ctx, condCastOp) ← castToRegLocal ctx cond
-  let (ctx, czOp) ← WfRewriter.createOp! ctx (.riscv .czeronez) #[RegisterType.mk] #[fCastOp.getResult 0, condCastOp.getResult 0]
+  let (ctx, czOp) ← WfRewriter.createOp! ctx Riscv.czeronez #[RegisterType.mk] #[fCastOp.getResult 0, condCastOp.getResult 0]
       #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (czOp.getResult 0)
   some (ctx, some (#[fCastOp, condCastOp, czOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1088,11 +1088,11 @@ def selectGeneral_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let (ctx, tCastOp) ← castToRegLocal ctx tval
   let (ctx, fCastOp) ← castToRegLocal ctx fval
   let (ctx, condCastOp) ← castToRegLocal ctx cond
-  let (ctx, eqzOp) ← WfRewriter.createOp! ctx (.riscv .czeroeqz) #[RegisterType.mk] #[tCastOp.getResult 0, condCastOp.getResult 0]
+  let (ctx, eqzOp) ← WfRewriter.createOp! ctx Riscv.czeroeqz #[RegisterType.mk] #[tCastOp.getResult 0, condCastOp.getResult 0]
       #[] #[] () none
-  let (ctx, nezOp) ← WfRewriter.createOp! ctx (.riscv .czeronez) #[RegisterType.mk] #[fCastOp.getResult 0, condCastOp.getResult 0]
+  let (ctx, nezOp) ← WfRewriter.createOp! ctx Riscv.czeronez #[RegisterType.mk] #[fCastOp.getResult 0, condCastOp.getResult 0]
       #[] #[] () none
-  let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk]
+  let (ctx, orOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk]
       #[eqzOp.getResult 0, nezOp.getResult 0]
       #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
@@ -1190,23 +1190,23 @@ def createRISCVImmLocal (ctx : WfIRContext OpCode)
     (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateProperties)
     (operands : Array ValuePtr) (value : Int) :
     Option (WfIRContext OpCode × OperationPtr) :=
-  WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] operands #[] #[]
+  WfRewriter.createOp! ctx dst #[RegisterType.mk] operands #[] #[]
       (cast h.symm (mkRISCVImm value)) none
 
 def createRISCVUnitLocal (ctx : WfIRContext OpCode)
     (dst : Riscv) (h : Riscv.propertiesOf dst = Unit) (operands : Array ValuePtr) :
     Option (WfIRContext OpCode × OperationPtr) :=
-  WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] operands #[] #[]
+  WfRewriter.createOp! ctx dst #[RegisterType.mk] operands #[] #[]
       (cast h.symm ()) none
 
 def signedSatSelectLocal (ctx : WfIRContext OpCode) (op : OperationPtr)
     (wrapped overflow sat : ValuePtr) :
     Option (WfIRContext OpCode × Array OperationPtr × Array ValuePtr) := do
-  let (ctx, wrappedOrZero) ← WfRewriter.createOp! ctx (.riscv .czeronez) #[RegisterType.mk]
+  let (ctx, wrappedOrZero) ← WfRewriter.createOp! ctx Riscv.czeronez #[RegisterType.mk]
       #[wrapped, overflow] #[] #[] () none
-  let (ctx, satOrZero) ← WfRewriter.createOp! ctx (.riscv .czeroeqz) #[RegisterType.mk]
+  let (ctx, satOrZero) ← WfRewriter.createOp! ctx Riscv.czeroeqz #[RegisterType.mk]
       #[sat, overflow] #[] #[] () none
-  let (ctx, selectOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk]
+  let (ctx, selectOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk]
       #[satOrZero.getResult 0, wrappedOrZero.getResult 0] #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (selectOp.getResult 0)
   return (ctx, #[wrappedOrZero, satOrZero, selectOp, castBackOp], #[castBackOp.getResult 0])
@@ -1450,7 +1450,7 @@ def fshrConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if t.bitwidth = 32 then
     let sh : Int := ((amtAttr.value % 32) + 32) % 32
     let imm := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-    let (ctx, roriOp) ← WfRewriter.createOp! ctx (.riscv .roriw) #[RegisterType.mk] #[valCastOp.getResult 0]
+    let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
         #[] #[] imm none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (roriOp.getResult 0)
     some (ctx, some (#[valCastOp, roriOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1458,7 +1458,7 @@ def fshrConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     /- The funnel-shift amount is taken modulo the bit width. -/
     let sh : Int := ((amtAttr.value % 64) + 64) % 64
     let imm := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-    let (ctx, roriOp) ← WfRewriter.createOp! ctx (.riscv .rori) #[RegisterType.mk] #[valCastOp.getResult 0]
+    let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.rori #[RegisterType.mk] #[valCastOp.getResult 0]
         #[] #[] imm none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (roriOp.getResult 0)
     some (ctx, some (#[valCastOp, roriOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1485,7 +1485,7 @@ def fshlConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     let sh : Int := ((amtAttr.value % 32) + 32) % 32
     let imm : Int := (32 - sh) % 32
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-    let (ctx, roriOp) ← WfRewriter.createOp! ctx (.riscv .roriw) #[RegisterType.mk] #[valCastOp.getResult 0]
+    let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
         #[] #[] immProps none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (roriOp.getResult 0)
     some (ctx, some (#[valCastOp, roriOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1494,7 +1494,7 @@ def fshlConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     let sh : Int := ((amtAttr.value % 64) + 64) % 64
     let imm : Int := (64 - sh) % 64
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-    let (ctx, roriOp) ← WfRewriter.createOp! ctx (.riscv .rori) #[RegisterType.mk] #[valCastOp.getResult 0]
+    let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.rori #[RegisterType.mk] #[valCastOp.getResult 0]
         #[] #[] immProps none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (roriOp.getResult 0)
     some (ctx, some (#[valCastOp, roriOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1540,31 +1540,31 @@ def fshlGeneral_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let (ctx, zCastOp) ← castToRegLocal ctx amt
   /- ~z, the inverse shift amount; the shift instruction masks it modulo `w`. -/
   let notImm := RISCVImmediateProperties.mk (IntegerAttr.mk (-1) (IntegerType.mk 64))
-  let (ctx, notzOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[zCastOp.getResult 0]
+  let (ctx, notzOp) ← WfRewriter.createOp! ctx Riscv.xori #[RegisterType.mk] #[zCastOp.getResult 0]
       #[] #[] notImm none
   let oneImm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
   /- shx = x << z ; shy = (y >> 1) >> ~z ; result = shx | shy. The i32 form uses
      the `w` shifts (only the low 32 bits of the `or` are observed). -/
   if t.bitwidth = 32 then
-    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sllw) #[RegisterType.mk] #[xCastOp.getResult 0, zCastOp.getResult 0]
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx Riscv.sllw #[RegisterType.mk] #[xCastOp.getResult 0, zCastOp.getResult 0]
         #[] #[] () none
-    let (ctx, y1Op) ← WfRewriter.createOp! ctx (.riscv .srliw) #[RegisterType.mk] #[yCastOp.getResult 0]
+    let (ctx, y1Op) ← WfRewriter.createOp! ctx Riscv.srliw #[RegisterType.mk] #[yCastOp.getResult 0]
         #[] #[] oneImm none
-    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srlw) #[RegisterType.mk] #[y1Op.getResult 0, notzOp.getResult 0]
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx Riscv.srlw #[RegisterType.mk] #[y1Op.getResult 0, notzOp.getResult 0]
         #[] #[] () none
-    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+    let (ctx, orOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
         #[] #[] () none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
     some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, shxOp, y1Op, shyOp, orOp, castBackOp],
       #[castBackOp.getResult 0]))
   else
-    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sll) #[RegisterType.mk] #[xCastOp.getResult 0, zCastOp.getResult 0]
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx Riscv.sll #[RegisterType.mk] #[xCastOp.getResult 0, zCastOp.getResult 0]
         #[] #[] () none
-    let (ctx, y1Op) ← WfRewriter.createOp! ctx (.riscv .srli) #[RegisterType.mk] #[yCastOp.getResult 0]
+    let (ctx, y1Op) ← WfRewriter.createOp! ctx Riscv.srli #[RegisterType.mk] #[yCastOp.getResult 0]
         #[] #[] oneImm none
-    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srl) #[RegisterType.mk] #[y1Op.getResult 0, notzOp.getResult 0]
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx Riscv.srl #[RegisterType.mk] #[y1Op.getResult 0, notzOp.getResult 0]
         #[] #[] () none
-    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+    let (ctx, orOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
         #[] #[] () none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
     some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, shxOp, y1Op, shyOp, orOp, castBackOp],
@@ -1587,31 +1587,31 @@ def fshrGeneral_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let (ctx, zCastOp) ← castToRegLocal ctx amt
   /- ~z, the inverse shift amount; the shift instruction masks it modulo `w`. -/
   let notImm := RISCVImmediateProperties.mk (IntegerAttr.mk (-1) (IntegerType.mk 64))
-  let (ctx, notzOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[zCastOp.getResult 0]
+  let (ctx, notzOp) ← WfRewriter.createOp! ctx Riscv.xori #[RegisterType.mk] #[zCastOp.getResult 0]
       #[] #[] notImm none
   let oneImm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
   /- shx = (x << 1) << ~z ; shy = y >> z ; result = shx | shy. The i32 form uses
      the `w` shifts (only the low 32 bits of the `or` are observed). -/
   if t.bitwidth = 32 then
-    let (ctx, x1Op) ← WfRewriter.createOp! ctx (.riscv .slliw) #[RegisterType.mk] #[xCastOp.getResult 0]
+    let (ctx, x1Op) ← WfRewriter.createOp! ctx Riscv.slliw #[RegisterType.mk] #[xCastOp.getResult 0]
         #[] #[] oneImm none
-    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sllw) #[RegisterType.mk] #[x1Op.getResult 0, notzOp.getResult 0]
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx Riscv.sllw #[RegisterType.mk] #[x1Op.getResult 0, notzOp.getResult 0]
         #[] #[] () none
-    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srlw) #[RegisterType.mk] #[yCastOp.getResult 0, zCastOp.getResult 0]
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx Riscv.srlw #[RegisterType.mk] #[yCastOp.getResult 0, zCastOp.getResult 0]
         #[] #[] () none
-    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+    let (ctx, orOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
         #[] #[] () none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
     some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, x1Op, shxOp, shyOp, orOp, castBackOp],
       #[castBackOp.getResult 0]))
   else
-    let (ctx, x1Op) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[xCastOp.getResult 0]
+    let (ctx, x1Op) ← WfRewriter.createOp! ctx Riscv.slli #[RegisterType.mk] #[xCastOp.getResult 0]
         #[] #[] oneImm none
-    let (ctx, shxOp) ← WfRewriter.createOp! ctx (.riscv .sll) #[RegisterType.mk] #[x1Op.getResult 0, notzOp.getResult 0]
+    let (ctx, shxOp) ← WfRewriter.createOp! ctx Riscv.sll #[RegisterType.mk] #[x1Op.getResult 0, notzOp.getResult 0]
         #[] #[] () none
-    let (ctx, shyOp) ← WfRewriter.createOp! ctx (.riscv .srl) #[RegisterType.mk] #[yCastOp.getResult 0, zCastOp.getResult 0]
+    let (ctx, shyOp) ← WfRewriter.createOp! ctx Riscv.srl #[RegisterType.mk] #[yCastOp.getResult 0, zCastOp.getResult 0]
         #[] #[] () none
-    let (ctx, orOp) ← WfRewriter.createOp! ctx (.riscv .or) #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
+    let (ctx, orOp) ← WfRewriter.createOp! ctx Riscv.or #[RegisterType.mk] #[shxOp.getResult 0, shyOp.getResult 0]
         #[] #[] () none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orOp.getResult 0)
     some (ctx, some (#[xCastOp, yCastOp, zCastOp, notzOp, x1Op, shxOp, shyOp, orOp, castBackOp],
@@ -1628,7 +1628,7 @@ def poisonConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some _ := matchPoison op ctx | return (ctx, none)
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (ctx, liOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+  let (ctx, liOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
       #[] #[] imm none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (liOp.getResult 0)
   some (ctx, some (#[liOp, castBackOp], #[castBackOp.getResult 0]))
@@ -1648,10 +1648,10 @@ def freeze_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType retType := type.val | return (ctx, none)
   if (opType.bitwidth ≠ 64 ∧ opType.bitwidth ≠ 32) ∨ (retType.bitwidth ≠ 64 ∧ retType.bitwidth ≠ 32) then return (ctx, none)
   /- First, cast the operand to registers -/
-  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[operand]
       #[] #[] () none
   /- Then, cast register to expected output width. -/
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[type] #[opCastOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[type] #[opCastOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[opCastOp, castOp], #[castOp.getResult 0]))
 

--- a/Veir/Passes/InstructionSelection/RISCV64Branches.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Branches.lean
@@ -21,13 +21,13 @@ def convertBranch (ctx : WfIRContext OpCode) (op : OperationPtr)
   for i in List.range (op.getNumOperands! c.raw) do
     let operand := op.getOperand! c.raw i
     let some (c', cast) := WfRewriter.createOp! c
-      (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand] #[]
+      Builtin.unrealized_conversion_cast #[RegisterType.mk] #[operand] #[]
       #[] default ip | return c
     c := c'
     casts := casts.push cast
 
   if op.getOpType! c = OpCode.llvm .br then do
-    let some (c', _) := WfRewriter.createOp! c (.riscv_cf .branch) #[]
+    let some (c', _) := WfRewriter.createOp! c Riscv_Cf.branch #[]
       (casts.map (fun cast => cast.getResult 0))
       #[op.getSuccessor! c.raw 0] #[] default ip | return c
     c := c'
@@ -37,7 +37,7 @@ def convertBranch (ctx : WfIRContext OpCode) (op : OperationPtr)
       (OpCode.llvm .cond_br)
     let props : RISCVBrProperties := ⟨condProps.operandSegmentSizes⟩
 
-    let some (c', _) := WfRewriter.createOp! c (.riscv_cf .bnez) #[]
+    let some (c', _) := WfRewriter.createOp! c Riscv_Cf.bnez #[]
       (casts.map (fun cast => cast.getResult 0))
       (op.getSuccessors! c.raw) #[] props ip | return c
     c := c'

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -42,7 +42,7 @@ def lowerBinopNotLocal {P : Type}
                | none => none) | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx x
   let (ctx, yCastOp) ← castToRegLocal ctx y
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk]
       #[xCastOp.getResult 0, yCastOp.getResult 0] #[] #[] props none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[xCastOp, yCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -133,7 +133,7 @@ def orcb_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some _zAttr := matchOrcbMask mo0 mo1 y ctx | return (ctx, none)
   let (ctx, mCastOp) ← castToRegLocal ctx m
   /- actual `riscv.orcb` -/
-  let (ctx, orcbOp) ← WfRewriter.createOp! ctx (.riscv .orcb) #[RegisterType.mk] #[mCastOp.getResult 0]
+  let (ctx, orcbOp) ← WfRewriter.createOp! ctx Riscv.orcb #[RegisterType.mk] #[mCastOp.getResult 0]
       #[] #[] () none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (orcbOp.getResult 0)
   some (ctx, some (#[mCastOp, orcbOp, castBackOp], #[castBackOp.getResult 0]))
@@ -180,7 +180,7 @@ def selectBinopImmLocal {α} (matchPair : OperationPtr → IRContext OpCode → 
   if imm.value < lo || imm.value > hi then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm.value (IntegerType.mk 64))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast h.symm immProps) none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -217,11 +217,11 @@ def sltiEmitLocal (op : OperationPtr) (lhs : ValuePtr) (dst : Riscv)
   if immVal < -2048 || immVal > 2047 then return (ctx, none)
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk immVal (IntegerType.mk 64))
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
-  let (ctx, cmpOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, cmpOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast h.symm immProps) none
   if wrap then
     let one := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-    let (ctx, xorOp) ← WfRewriter.createOp! ctx (.riscv .xori) #[RegisterType.mk] #[cmpOp.getResult 0]
+    let (ctx, xorOp) ← WfRewriter.createOp! ctx Riscv.xori #[RegisterType.mk] #[cmpOp.getResult 0]
         #[] #[] one none
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (xorOp.getResult 0)
     some (ctx, some (#[xCastOp, cmpOp, xorOp, castBackOp], #[castBackOp.getResult 0]))
@@ -319,7 +319,7 @@ def selectSingleBitLocal {α} (matchPair : OperationPtr → IRContext OpCode →
   let some n := singleSetBit (if complement then ~~~ bv else bv) | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk n (IntegerType.mk 64))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast h.symm immProps) none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -343,7 +343,7 @@ def bexti_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if sh.value < 0 || sh.value > 63 then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx x
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .bexti) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.bexti #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] immProps none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -366,7 +366,7 @@ def roriw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let sh : Int := ((amtAttr.value % 32) + 32) % 32
   let (ctx, valCastOp) ← castToRegLocal ctx a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .roriw) #[RegisterType.mk] #[valCastOp.getResult 0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
       #[] #[] immProps none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[valCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -391,7 +391,7 @@ def roliw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let imm : Int := (32 - sh) % 32
   let (ctx, valCastOp) ← castToRegLocal ctx a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .roriw) #[RegisterType.mk] #[valCastOp.getResult 0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
       #[] #[] immProps none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[valCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -417,7 +417,7 @@ def slliuw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if srcT.bitwidth ≠ 32 then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx x
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv .slliuw) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.slliuw #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] immProps none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
   some (ctx, some (#[xCastOp, newOp, castBackOp], #[castBackOp.getResult 0]))
@@ -436,12 +436,12 @@ def zext_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType opType := (operand.getType! ctx.raw).val | return (ctx, none)
   if opType.bitwidth ≠ 1 then return (ctx, none)
   /- First, cast the operand to registers -/
-  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[operand]
       #[] #[] () none
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 1 (IntegerType.mk 64))
-  let (ctx, andiOp) ← WfRewriter.createOp! ctx (.riscv .andi) #[RegisterType.mk] #[opCastOp.getResult 0]
+  let (ctx, andiOp) ← WfRewriter.createOp! ctx Riscv.andi #[RegisterType.mk] #[opCastOp.getResult 0]
       #[] #[] imm none
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[t] #[andiOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[t] #[andiOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[opCastOp, andiOp, castOp], #[castOp.getResult 0]))
 
@@ -459,14 +459,14 @@ def sext_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType opType := (operand.getType! ctx.raw).val | return (ctx, none)
   if opType.bitwidth ≠ 1 then return (ctx, none)
   /- First, cast the operand to registers -/
-  let (ctx, opCastOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[RegisterType.mk] #[operand]
+  let (ctx, opCastOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[RegisterType.mk] #[operand]
       #[] #[] () none
   let imm := RISCVImmediateProperties.mk (IntegerAttr.mk 63 (IntegerType.mk 6))
-  let (ctx, slliOp) ← WfRewriter.createOp! ctx (.riscv .slli) #[RegisterType.mk] #[opCastOp.getResult 0]
+  let (ctx, slliOp) ← WfRewriter.createOp! ctx Riscv.slli #[RegisterType.mk] #[opCastOp.getResult 0]
       #[] #[] imm none
-  let (ctx, sraiOp) ← WfRewriter.createOp! ctx (.riscv .srai) #[RegisterType.mk] #[slliOp.getResult 0]
+  let (ctx, sraiOp) ← WfRewriter.createOp! ctx Riscv.srai #[RegisterType.mk] #[slliOp.getResult 0]
       #[] #[] imm none
-  let (ctx, castOp) ← WfRewriter.createOp! ctx (.builtin .unrealized_conversion_cast) #[t] #[sraiOp.getResult 0]
+  let (ctx, castOp) ← WfRewriter.createOp! ctx Builtin.unrealized_conversion_cast #[t] #[sraiOp.getResult 0]
       #[] #[] () none
   some (ctx, some (#[opCastOp, slliOp, sraiOp, castOp], #[castOp.getResult 0]))
 
@@ -526,7 +526,7 @@ def udivPow2GenLocal (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateP
   let some k := matchUnsignedPow2Divisor width imm.value | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (ctx, shiftOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, shiftOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast h.symm shamt) none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (shiftOp.getResult 0)
   some (ctx, some (#[xCastOp, shiftOp, castBackOp], #[castBackOp.getResult 0]))
@@ -542,9 +542,9 @@ def negateRegLocal (negDst : Riscv) (h : Riscv.propertiesOf negDst = Unit)
     (ctx : WfIRContext OpCode) (x : ValuePtr) :
     Option (WfIRContext OpCode × Array OperationPtr × OperationPtr) := do
   let zero := RISCVImmediateProperties.mk (IntegerAttr.mk 0 (IntegerType.mk 64))
-  let (ctx, zeroOp) ← WfRewriter.createOp! ctx (.riscv .li) #[RegisterType.mk] #[]
+  let (ctx, zeroOp) ← WfRewriter.createOp! ctx Riscv.li #[RegisterType.mk] #[]
       #[] #[] zero none
-  let (ctx, negOp) ← WfRewriter.createOp! ctx (.riscv negDst) #[RegisterType.mk] #[zeroOp.getResult 0, x]
+  let (ctx, negOp) ← WfRewriter.createOp! ctx negDst #[RegisterType.mk] #[zeroOp.getResult 0, x]
       #[] #[] (cast h.symm ()) none
   some (ctx, #[zeroOp, negOp], negOp)
 
@@ -570,7 +570,7 @@ def sdivPow2ExactGenLocal (dst : Riscv) (hDst : Riscv.propertiesOf dst = RISCVIm
   let some (k, isNeg) := matchSignedPow2Divisor width imm.value | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (ctx, sraOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, sraOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast hDst.symm shamt) none
   if ¬ isNeg then
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (sraOp.getResult 0)
@@ -619,15 +619,15 @@ def sdivPow2GenLocal (shiftDst : Riscv) (hShift : Riscv.propertiesOf shiftDst = 
   if k = 0 then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shSign := RISCVImmediateProperties.mk (IntegerAttr.mk (width - 1) (IntegerType.mk 64))
-  let (ctx, signOp) ← WfRewriter.createOp! ctx (.riscv shiftDst) #[RegisterType.mk] #[xCastOp.getResult 0]
+  let (ctx, signOp) ← WfRewriter.createOp! ctx shiftDst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast hShift.symm shSign) none
   let shCorr := RISCVImmediateProperties.mk (IntegerAttr.mk (width - k) (IntegerType.mk 64))
-  let (ctx, corrOp) ← WfRewriter.createOp! ctx (.riscv corrDst) #[RegisterType.mk] #[signOp.getResult 0]
+  let (ctx, corrOp) ← WfRewriter.createOp! ctx corrDst #[RegisterType.mk] #[signOp.getResult 0]
       #[] #[] (cast hCorr.symm shCorr) none
-  let (ctx, biasedOp) ← WfRewriter.createOp! ctx (.riscv addDst) #[RegisterType.mk]
+  let (ctx, biasedOp) ← WfRewriter.createOp! ctx addDst #[RegisterType.mk]
       #[xCastOp.getResult 0, corrOp.getResult 0] #[] #[] (cast hAdd.symm ()) none
   let shQ := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
-  let (ctx, qOp) ← WfRewriter.createOp! ctx (.riscv shiftDst) #[RegisterType.mk] #[biasedOp.getResult 0]
+  let (ctx, qOp) ← WfRewriter.createOp! ctx shiftDst #[RegisterType.mk] #[biasedOp.getResult 0]
       #[] #[] (cast hShift.symm shQ) none
   if ¬ isNeg then
     let (ctx, castBackOp) ← replaceWithRegLocal ctx op (qOp.getResult 0)

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -91,9 +91,9 @@ def AndSextSext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchSext dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchSext dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -109,9 +109,9 @@ def OrSextSext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchSext dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchSext dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -127,9 +127,9 @@ def XorSextSext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchSext dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchSext dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -145,9 +145,9 @@ def AndZextZext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchZext dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchZext dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .zext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -163,9 +163,9 @@ def OrZextZext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchZext dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchZext dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .zext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -181,9 +181,9 @@ def XorZextZext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchZext dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchZext dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .zext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -199,9 +199,9 @@ def AndTruncTrunc_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchTrunc dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchTrunc dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .trunc) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.trunc #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -217,9 +217,9 @@ def OrTruncTrunc_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchTrunc dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchTrunc dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .trunc) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.trunc #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -235,9 +235,9 @@ def XorTruncTrunc_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, _xp) := matchTrunc dX ctx | return (ctx, none)
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, yp) := matchTrunc dY ctx | return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .trunc) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.trunc #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(inner.getResult 0)]
     #[] #[] yp none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -254,9 +254,9 @@ def AndShlShl_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchShl dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .shl) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.shl #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -273,9 +273,9 @@ def OrShlShl_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchShl dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .shl) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.shl #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -292,9 +292,9 @@ def XorShlShl_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchShl dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .shl) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.shl #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -311,9 +311,9 @@ def AndLshrLshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchLshr dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .lshr) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.lshr #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -330,9 +330,9 @@ def OrLshrLshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchLshr dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .lshr) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.lshr #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -349,9 +349,9 @@ def XorLshrLshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchLshr dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .lshr) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.lshr #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -368,9 +368,9 @@ def AndAshrAshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchAshr dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .ashr) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.ashr #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -387,9 +387,9 @@ def OrAshrAshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchAshr dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .ashr) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.ashr #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -406,9 +406,9 @@ def XorAshrAshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, p1) := matchAshr dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .ashr) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.ashr #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] p1 none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -425,9 +425,9 @@ def AndAndAnd_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, _) := matchAnd dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[x, y]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] () none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -444,9 +444,9 @@ def OrAndAnd_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, _) := matchAnd dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] () none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -463,9 +463,9 @@ def XorAndAnd_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dY := getDefiningOp v1 ctx | return (ctx, none)
   let some (y, z1, _) := matchAnd dY ctx | return (ctx, none)
   if z0 != z1 then return (ctx, none)
-  let (ctx, inner) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, inner) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, y]
     #[] #[] xprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[(inner.getResult 0), z0]
     #[] #[] () none
   some (ctx, some (#[inner, newOp], #[newOp.getResult 0]))
 
@@ -510,9 +510,9 @@ def sub_add_reg_x_sub_y_add_x_local (ctx : WfIRContext OpCode) (op : OperationPt
   if x != s0 then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[s0.getType! ctx.raw] #[(c0.getResult 0), y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[s0.getType! ctx.raw] #[(c0.getResult 0), y]
     #[] #[] sp none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -529,9 +529,9 @@ def sub_add_reg_x_sub_x_add_y_local (ctx : WfIRContext OpCode) (op : OperationPt
   if x != s0 then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[s0.getType! ctx.raw] #[(c0.getResult 0), y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[s0.getType! ctx.raw] #[(c0.getResult 0), y]
     #[] #[] sp none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -549,11 +549,11 @@ def xor_of_and_with_same_reg_local (ctx : WfIRContext OpCode) (op : OperationPtr
   if y2 != yval then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let m1 := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) xty))
-  let (ctx, c1) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, c1) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] m1 none
-  let (ctx, notx) ← WfRewriter.createOp! ctx (.llvm .xor) #[x.getType! ctx.raw] #[x, (c1.getResult 0)]
+  let (ctx, notx) ← WfRewriter.createOp! ctx Llvm.xor #[x.getType! ctx.raw] #[x, (c1.getResult 0)]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[x.getType! ctx.raw] #[(notx.getResult 0), yval]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[x.getType! ctx.raw] #[(notx.getResult 0), yval]
     #[] #[] () none
   some (ctx, some (#[c1, notx, newOp], #[newOp.getResult 0]))
 
@@ -575,7 +575,7 @@ def select_to_iminmax_ugt_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .ugt := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__umax) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__umax #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -592,7 +592,7 @@ def select_to_iminmax_uge_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .uge := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__umax) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__umax #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -609,7 +609,7 @@ def select_to_iminmax_sgt_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .sgt := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__smax) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__smax #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -626,7 +626,7 @@ def select_to_iminmax_sge_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .sge := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__smax) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__smax #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -643,7 +643,7 @@ def select_to_iminmax_ult_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .ult := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__umin) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__umin #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -660,7 +660,7 @@ def select_to_iminmax_ule_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .ule := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__umin) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__umin #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -677,7 +677,7 @@ def select_to_iminmax_slt_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .slt := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__smin) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__smin #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -694,7 +694,7 @@ def select_to_iminmax_sle_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .sle := ip.predicate | return (ctx, none)
   if il != tv then return (ctx, none)
   if ir != fv then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__smin) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__smin #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[tv, fv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -725,11 +725,11 @@ def select_of_zext_rw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dS := getDefiningOp v0 ctx | return (ctx, none)
   let some (cond, tv, fv) := matchSelect dS ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, zt) ← WfRewriter.createOp! ctx (.llvm .zext) #[outTy] #[tv]
+  let (ctx, zt) ← WfRewriter.createOp! ctx Llvm.zext #[outTy] #[tv]
     #[] #[] zp none
-  let (ctx, zf) ← WfRewriter.createOp! ctx (.llvm .zext) #[outTy] #[fv]
+  let (ctx, zf) ← WfRewriter.createOp! ctx Llvm.zext #[outTy] #[fv]
     #[] #[] zp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .select) #[outTy] #[cond, (zt.getResult 0), (zf.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.select #[outTy] #[cond, (zt.getResult 0), (zf.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[zt, zf, newOp], #[newOp.getResult 0]))
 
@@ -743,11 +743,11 @@ def select_of_truncate_rw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dS := getDefiningOp v0 ctx | return (ctx, none)
   let some (cond, tv, fv) := matchSelect dS ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, tt) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[tv]
+  let (ctx, tt) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[tv]
     #[] #[] tp none
-  let (ctx, tf) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[fv]
+  let (ctx, tf) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[fv]
     #[] #[] tp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .select) #[outTy] #[cond, (tt.getResult 0), (tf.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.select #[outTy] #[cond, (tt.getResult 0), (tf.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[tt, tf, newOp], #[newOp.getResult 0]))
 
@@ -763,7 +763,7 @@ def mulo_by_2_unsigned_signed_local (ctx : WfIRContext OpCode) (op : OperationPt
   let some (x, cval, mp) := matchMul op ctx | return (ctx, none)
   let some cst := matchConstantIntVal cval ctx | return (ctx, none)
   if cst.value ≠ 2 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[x.getType! ctx.raw] #[x, x]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[x.getType! ctx.raw] #[x, x]
     #[] #[] mp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -782,9 +782,9 @@ def add_shift_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (zeroV, b, subp) := matchSub dSub ctx | return (ctx, none)
   let some zc := matchConstantIntVal zeroV ctx | return (ctx, none)
   if zc.value ≠ 0 then return (ctx, none)
-  let (ctx, newShl) ← WfRewriter.createOp! ctx (.llvm .shl) #[b.getType! ctx.raw] #[b, c]
+  let (ctx, newShl) ← WfRewriter.createOp! ctx Llvm.shl #[b.getType! ctx.raw] #[b, c]
     #[] #[] shp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newShl.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newShl.getResult 0)]
     #[] #[] subp none
   some (ctx, some (#[newShl, newOp], #[newOp.getResult 0]))
 
@@ -802,9 +802,9 @@ def add_shift_commute_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (zeroV, b, subp) := matchSub dSub ctx | return (ctx, none)
   let some zc := matchConstantIntVal zeroV ctx | return (ctx, none)
   if zc.value ≠ 0 then return (ctx, none)
-  let (ctx, newShl) ← WfRewriter.createOp! ctx (.llvm .shl) #[b.getType! ctx.raw] #[b, c]
+  let (ctx, newShl) ← WfRewriter.createOp! ctx Llvm.shl #[b.getType! ctx.raw] #[b, c]
     #[] #[] shp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newShl.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newShl.getResult 0)]
     #[] #[] subp none
   some (ctx, some (#[newShl, newOp], #[newOp.getResult 0]))
 
@@ -826,9 +826,9 @@ def redundant_binop_in_equality_XPlusYEqX_local (ctx : WfIRContext OpCode) (op :
   if x != xval then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
     #[] #[] ip none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -845,9 +845,9 @@ def redundant_binop_in_equality_XPlusYNeX_local (ctx : WfIRContext OpCode) (op :
   if x != xval then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
     #[] #[] ip none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -864,9 +864,9 @@ def redundant_binop_in_equality_XMinusYEqX_local (ctx : WfIRContext OpCode) (op 
   if x != xval then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
     #[] #[] ip none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -883,9 +883,9 @@ def redundant_binop_in_equality_XMinusYNeX_local (ctx : WfIRContext OpCode) (op 
   if x != xval then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
     #[] #[] ip none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -902,9 +902,9 @@ def redundant_binop_in_equality_XXorYEqX_local (ctx : WfIRContext OpCode) (op : 
   if x != xval then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
     #[] #[] ip none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -921,9 +921,9 @@ def redundant_binop_in_equality_XXorYNeX_local (ctx : WfIRContext OpCode) (op : 
   if x != xval then return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) yty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[y, (c0.getResult 0)]
     #[] #[] ip none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -941,8 +941,8 @@ def select_1_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if ct.value ≠ 1 then return (ctx, none)
   let some cf := matchConstantIntVal fv ctx | return (ctx, none)
   if cf.value ≠ 0 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .zext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[cond]
-    #[] #[] { nneg := false } none
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[cond]
+    #[] #[] ({ nneg := false } : NnegProperties) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 def select_1_0 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -957,7 +957,7 @@ def select_neg1_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if ct.value ≠ -1 then return (ctx, none)
   let some cf := matchConstantIntVal fv ctx | return (ctx, none)
   if cf.value ≠ 0 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[cond]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[cond]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -975,12 +975,12 @@ def select_0_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if cf.value ≠ 1 then return (ctx, none)
   let .integerType cty := (cond.getType! ctx.raw).val | return (ctx, none)
   let m1 := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) cty))
-  let (ctx, c1) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[cond.getType! ctx.raw] #[]
+  let (ctx, c1) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[cond.getType! ctx.raw] #[]
     #[] #[] m1 none
-  let (ctx, ncond) ← WfRewriter.createOp! ctx (.llvm .xor) #[cond.getType! ctx.raw] #[cond, (c1.getResult 0)]
+  let (ctx, ncond) ← WfRewriter.createOp! ctx Llvm.xor #[cond.getType! ctx.raw] #[cond, (c1.getResult 0)]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .zext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(ncond.getResult 0)]
-    #[] #[] { nneg := false } none
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(ncond.getResult 0)]
+    #[] #[] ({ nneg := false } : NnegProperties) none
   some (ctx, some (#[c1, ncond, newOp], #[newOp.getResult 0]))
 
 def select_0_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -997,11 +997,11 @@ def select_0_neg1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if cf.value ≠ -1 then return (ctx, none)
   let .integerType cty := (cond.getType! ctx.raw).val | return (ctx, none)
   let m1 := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) cty))
-  let (ctx, c1) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[cond.getType! ctx.raw] #[]
+  let (ctx, c1) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[cond.getType! ctx.raw] #[]
     #[] #[] m1 none
-  let (ctx, ncond) ← WfRewriter.createOp! ctx (.llvm .xor) #[cond.getType! ctx.raw] #[cond, (c1.getResult 0)]
+  let (ctx, ncond) ← WfRewriter.createOp! ctx Llvm.xor #[cond.getType! ctx.raw] #[cond, (c1.getResult 0)]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sext) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(ncond.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(ncond.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[c1, ncond, newOp], #[newOp.getResult 0]))
 
@@ -1017,7 +1017,7 @@ def not_cmp_fold_eq_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dI := getDefiningOp icmpV ctx | return (ctx, none)
   let some (x, y, ip) := matchIcmp dI ctx | return (ctx, none)
   let .eq := ip.predicate | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (IcmpProperties.mk .ne) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1031,7 +1031,7 @@ def not_cmp_fold_ne_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dI := getDefiningOp icmpV ctx | return (ctx, none)
   let some (x, y, ip) := matchIcmp dI ctx | return (ctx, none)
   let .ne := ip.predicate | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (IcmpProperties.mk .eq) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1045,7 +1045,7 @@ def not_cmp_fold_ugt_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dI := getDefiningOp icmpV ctx | return (ctx, none)
   let some (x, y, ip) := matchIcmp dI ctx | return (ctx, none)
   let .ugt := ip.predicate | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (IcmpProperties.mk .ule) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1059,7 +1059,7 @@ def not_cmp_fold_uge_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dI := getDefiningOp icmpV ctx | return (ctx, none)
   let some (x, y, ip) := matchIcmp dI ctx | return (ctx, none)
   let .uge := ip.predicate | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (IcmpProperties.mk .ult) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1073,7 +1073,7 @@ def not_cmp_fold_sgt_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dI := getDefiningOp icmpV ctx | return (ctx, none)
   let some (x, y, ip) := matchIcmp dI ctx | return (ctx, none)
   let .sgt := ip.predicate | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (IcmpProperties.mk .sle) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1087,7 +1087,7 @@ def not_cmp_fold_sge_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dI := getDefiningOp icmpV ctx | return (ctx, none)
   let some (x, y, ip) := matchIcmp dI ctx | return (ctx, none)
   let .sge := ip.predicate | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (IcmpProperties.mk .slt) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1113,11 +1113,11 @@ def double_icmp_zero_and_combine_local (ctx : WfIRContext OpCode) (op : Operatio
   if cyv.value ≠ 0 then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) xty))
-  let (ctx, orOp) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
-    #[] #[] { disjoint := false } none
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, orOp) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
+    #[] #[] ({ disjoint := false } : DisjointProperties) none
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(orOp.getResult 0), (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(orOp.getResult 0), (c0.getResult 0)]
     #[] #[] ip0 none
   some (ctx, some (#[orOp, c0, newOp], #[newOp.getResult 0]))
 
@@ -1141,11 +1141,11 @@ def double_icmp_zero_or_combine_local (ctx : WfIRContext OpCode) (op : Operation
   if cyv.value ≠ 0 then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) xty))
-  let (ctx, orOp) ← WfRewriter.createOp! ctx (.llvm .or) #[x.getType! ctx.raw] #[x, y]
+  let (ctx, orOp) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
     #[] #[] oprops none
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(orOp.getResult 0), (c0.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(orOp.getResult 0), (c0.getResult 0)]
     #[] #[] ip0 none
   some (ctx, some (#[orOp, c0, newOp], #[newOp.getResult 0]))
 
@@ -1164,9 +1164,9 @@ def NotAPlusNegOne_rw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if cst.value ≠ -1 then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) xty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[x.getType! ctx.raw] #[(c0.getResult 0), x]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[x.getType! ctx.raw] #[(c0.getResult 0), x]
     #[] #[] ap none
   some (ctx, some (#[c0, newOp], #[newOp.getResult 0]))
 
@@ -1185,11 +1185,11 @@ def sub_one_from_sub_rw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, y, _sp2) := matchSub dSub ctx | return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
   let m1 := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) yty))
-  let (ctx, cm1) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[y.getType! ctx.raw] #[]
+  let (ctx, cm1) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[y.getType! ctx.raw] #[]
     #[] #[] m1 none
-  let (ctx, xorOp) ← WfRewriter.createOp! ctx (.llvm .xor) #[y.getType! ctx.raw] #[y, (cm1.getResult 0)]
+  let (ctx, xorOp) ← WfRewriter.createOp! ctx Llvm.xor #[y.getType! ctx.raw] #[y, (cm1.getResult 0)]
     #[] #[] () none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(xorOp.getResult 0), x]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(xorOp.getResult 0), x]
     #[] #[] sp none
   some (ctx, some (#[cm1, xorOp, newOp], #[newOp.getResult 0]))
 
@@ -1208,9 +1208,9 @@ def APlusC1MinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c1 := matchConstantIntVal c1v ctx | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value - c2.value) aty))
-  let (ctx, cf) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
     #[] #[] ap none
   some (ctx, some (#[cf, newOp], #[newOp.getResult 0]))
 
@@ -1229,9 +1229,9 @@ def C2MinusAPlusC1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c1 := matchConstantIntVal c1v ctx | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2.value - c1.value) aty))
-  let (ctx, cf) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
     #[] #[] sp none
   some (ctx, some (#[cf, newOp], #[newOp.getResult 0]))
 
@@ -1250,9 +1250,9 @@ def AMinusC1MinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c1 := matchConstantIntVal c1v ctx | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value + c2.value) aty))
-  let (ctx, cf) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
     #[] #[] sp none
   some (ctx, some (#[cf, newOp], #[newOp.getResult 0]))
 
@@ -1271,9 +1271,9 @@ def C1MinusAMinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c1 := matchConstantIntVal c1v ctx | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value - c2.value) aty))
-  let (ctx, cf) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
     #[] #[] sp none
   some (ctx, some (#[cf, newOp], #[newOp.getResult 0]))
 
@@ -1292,9 +1292,9 @@ def AMinusC1PlusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c1 := matchConstantIntVal c1v ctx | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2.value - c1.value) aty))
-  let (ctx, cf) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
     #[] #[] ap none
   some (ctx, some (#[cf, newOp], #[newOp.getResult 0]))
 
@@ -1313,7 +1313,7 @@ def or_and_xor_to_xor_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if y1 != y then return (ctx, none)
   let some cst := matchConstantIntVal m1v ctx | return (ctx, none)
   if cst.value ≠ -1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .or) #[andV.getType! ctx.raw] #[x, notV]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[andV.getType! ctx.raw] #[x, notV]
     #[] #[] oprops none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1332,7 +1332,7 @@ def and_xor_or_to_xor_and_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if y1 != y then return (ctx, none)
   let some cst := matchConstantIntVal m1v ctx | return (ctx, none)
   if cst.value ≠ -1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[orV.getType! ctx.raw] #[x, notV]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[orV.getType! ctx.raw] #[x, notV]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1374,9 +1374,9 @@ def AMinusBMinusC_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (A, sub1, sprops) := matchSub op ctx | return (ctx, none)
   let some dSub := getDefiningOp sub1 ctx | return (ctx, none)
   let some (B, C, _sprops1) := matchSub dSub ctx | return (ctx, none)
-  let (ctx, cMinusB) ← WfRewriter.createOp! ctx (.llvm .sub) #[sub1.getType! ctx.raw] #[C, B]
+  let (ctx, cMinusB) ← WfRewriter.createOp! ctx Llvm.sub #[sub1.getType! ctx.raw] #[C, B]
     #[] #[] sprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[A.getType! ctx.raw] #[A, (cMinusB.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[A.getType! ctx.raw] #[A, (cMinusB.getResult 0)]
     #[] #[] sprops none
   some (ctx, some (#[cMinusB, newOp], #[newOp.getResult 0]))
 
@@ -1451,7 +1451,7 @@ def srl_sra_signbitGen_local (srlDst : Riscv)
     return (ctx, none)
   let some sraOp := getDefiningOp operands[0]! ctx | return (ctx, none)
   let some (sraOperands, _) := matchOp sraOp ctx (.riscv sraDst) 1 | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv srlDst) #[RegisterType.mk] #[sraOperands[0]!]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx srlDst #[RegisterType.mk] #[sraOperands[0]!]
       #[] #[] outerImm none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1584,7 +1584,7 @@ private def drop_ext_binary_low_word_local (ext dst : Riscv) (ctx : WfIRContext 
   let (lhs, lhsChanged) := stripDefiningExt ext operands[0]! ctx
   let (rhs, rhsChanged) := stripDefiningExt ext operands[1]! ctx
   if !lhsChanged && !rhsChanged then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[lhs, rhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[lhs, rhs]
       #[] #[] props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1600,7 +1600,7 @@ private def drop_ext_unary_imm_low_word_local (ext dst : Riscv) (ctx : WfIRConte
   let some (operands, props) := matchOp op ctx (.riscv dst) 1 | return (ctx, none)
   let (src, changed) := stripDefiningExt ext operands[0]! ctx
   if !changed then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv dst) #[RegisterType.mk] #[src]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[src]
       #[] #[] props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -1780,7 +1780,7 @@ private def drop_ext_store_local (ext store : Riscv) (ctx : WfIRContext OpCode) 
   let some (val, addr, props) := matchRiscvStore store op ctx | return (ctx, none)
   let (val, changed) := stripDefiningExt ext val ctx
   if !changed then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.riscv store) #[] #[val, addr]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx store #[] #[val, addr]
       #[] #[] props none
   some (ctx, some (#[newOp], #[]))
 
@@ -1819,7 +1819,7 @@ def li_zero_to_x0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if cst.value.value ≠ 0 then return (ctx, none)
   /- Nothing to do for a dead `li 0`; leave it for DCE and avoid creating a dead x0. -/
   if !op.hasUses! ctx.raw then return (ctx, none)
-  let (ctx, x0Op) ← WfRewriter.createOp! ctx (.rv64 .get_register)
+  let (ctx, x0Op) ← WfRewriter.createOp! ctx Rv64.get_register
     #[(RegisterType.mk (some 0) : TypeAttr)] #[] #[] #[] () none
   some (ctx, some (#[x0Op], #[x0Op.getResult 0]))
 
@@ -1952,11 +1952,11 @@ def SubSmaxSub_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if a2 != a then return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 aty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, sub1) ← WfRewriter.createOp! ctx (.llvm .sub) #[a.getType! ctx.raw] #[(c0.getResult 0), a]
+  let (ctx, sub1) ← WfRewriter.createOp! ctx Llvm.sub #[a.getType! ctx.raw] #[(c0.getResult 0), a]
     #[] #[] sprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__smin) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__smin #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[c0, sub1, newOp], #[newOp.getResult 0]))
 
@@ -1976,11 +1976,11 @@ def SubUmaxSub_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if a2 != a then return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 aty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, sub1) ← WfRewriter.createOp! ctx (.llvm .sub) #[a.getType! ctx.raw] #[(c0.getResult 0), a]
+  let (ctx, sub1) ← WfRewriter.createOp! ctx Llvm.sub #[a.getType! ctx.raw] #[(c0.getResult 0), a]
     #[] #[] sprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__umin) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__umin #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[c0, sub1, newOp], #[newOp.getResult 0]))
 
@@ -2002,11 +2002,11 @@ def narrow_binop_add_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cst, _ap) := matchAdd dAdd ctx | return (ctx, none)
   let some _ := matchConstantIntVal cst ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, tx) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[x]
+  let (ctx, tx) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[x]
     #[] #[] tp none
-  let (ctx, tc) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[cst]
+  let (ctx, tc) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[cst]
     #[] #[] tp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[outTy] #[(tx.getResult 0), (tc.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[outTy] #[(tx.getResult 0), (tc.getResult 0)]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[tx, tc, newOp], #[newOp.getResult 0]))
 
@@ -2022,11 +2022,11 @@ def narrow_binop_sub_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cst, _sp) := matchSub dSub ctx | return (ctx, none)
   let some _ := matchConstantIntVal cst ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, tx) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[x]
+  let (ctx, tx) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[x]
     #[] #[] tp none
-  let (ctx, tc) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[cst]
+  let (ctx, tc) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[cst]
     #[] #[] tp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[outTy] #[(tx.getResult 0), (tc.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[outTy] #[(tx.getResult 0), (tc.getResult 0)]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[tx, tc, newOp], #[newOp.getResult 0]))
 
@@ -2042,11 +2042,11 @@ def narrow_binop_mul_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cst, _mp) := matchMul dMul ctx | return (ctx, none)
   let some _ := matchConstantIntVal cst ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, tx) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[x]
+  let (ctx, tx) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[x]
     #[] #[] tp none
-  let (ctx, tc) ← WfRewriter.createOp! ctx (.llvm .trunc) #[outTy] #[cst]
+  let (ctx, tc) ← WfRewriter.createOp! ctx Llvm.trunc #[outTy] #[cst]
     #[] #[] tp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mul) #[outTy] #[(tx.getResult 0), (tc.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mul #[outTy] #[(tx.getResult 0), (tc.getResult 0)]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[tx, tc, newOp], #[newOp.getResult 0]))
 
@@ -2076,7 +2076,7 @@ def zext_of_zext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dZ := getDefiningOp v0 ctx | return (ctx, none)
   let some (x, _) := matchZext dZ ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .zext) #[outTy] #[x]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[outTy] #[x]
     #[] #[] zp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2092,7 +2092,7 @@ def sext_of_sext_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dS := getDefiningOp v0 ctx | return (ctx, none)
   let some (x, _) := matchSext dS ctx | return (ctx, none)
   let outTy := (op.getResult 0 : ValuePtr).getType! ctx.raw
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sext) #[outTy] #[x]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[outTy] #[x]
     #[] #[] sp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2108,9 +2108,9 @@ def sub_to_add_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c := matchConstantIntVal cval ctx | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c.value) xty))
-  let (ctx, cn) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] negC none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (cn.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (cn.getResult 0)]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[cn, newOp], #[newOp.getResult 0]))
 
@@ -2128,11 +2128,11 @@ def sub_of_mul_const_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c := matchConstantIntVal cval ctx | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c.value) xty))
-  let (ctx, cn) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] negC none
-  let (ctx, newMul) ← WfRewriter.createOp! ctx (.llvm .mul) #[x.getType! ctx.raw] #[x, (cn.getResult 0)]
+  let (ctx, newMul) ← WfRewriter.createOp! ctx Llvm.mul #[x.getType! ctx.raw] #[x, (cn.getResult 0)]
     #[] #[] mp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newMul.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newMul.getResult 0)]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[cn, newMul, newOp], #[newOp.getResult 0]))
 
@@ -2149,7 +2149,7 @@ def select_not_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (c, m1v, _) := matchXor dC ctx | return (ctx, none)
   let some m1 := matchConstantIntVal m1v ctx | return (ctx, none)
   if m1.value ≠ -1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .select) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[c, fv, tv]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.select #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[c, fv, tv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2164,7 +2164,7 @@ def commute_const_add_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, props) := matchAdd op ctx | return (ctx, none)
   let some _ := matchConstantIntVal lhs ctx | return (ctx, none)
   if (matchConstantIntVal rhs ctx).isSome then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
     #[] #[] props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2177,7 +2177,7 @@ def commute_const_mul_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, props) := matchMul op ctx | return (ctx, none)
   let some _ := matchConstantIntVal lhs ctx | return (ctx, none)
   if (matchConstantIntVal rhs ctx).isSome then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mul) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mul #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
     #[] #[] props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2190,7 +2190,7 @@ def commute_const_and_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, _) := matchAnd op ctx | return (ctx, none)
   let some _ := matchConstantIntVal lhs ctx | return (ctx, none)
   if (matchConstantIntVal rhs ctx).isSome then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2203,7 +2203,7 @@ def commute_const_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, props) := matchOr op ctx | return (ctx, none)
   let some _ := matchConstantIntVal lhs ctx | return (ctx, none)
   if (matchConstantIntVal rhs ctx).isSome then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .or) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
     #[] #[] props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2216,7 +2216,7 @@ def commute_const_xor_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, rhs, _) := matchXor op ctx | return (ctx, none)
   let some _ := matchConstantIntVal lhs ctx | return (ctx, none)
   if (matchConstantIntVal rhs ctx).isSome then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .xor) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.xor #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2242,11 +2242,11 @@ def SubSminSub_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if a2 != a then return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 aty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, sub1) ← WfRewriter.createOp! ctx (.llvm .sub) #[a.getType! ctx.raw] #[(c0.getResult 0), a]
+  let (ctx, sub1) ← WfRewriter.createOp! ctx Llvm.sub #[a.getType! ctx.raw] #[(c0.getResult 0), a]
     #[] #[] sprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__smax) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__smax #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[c0, sub1, newOp], #[newOp.getResult 0]))
 
@@ -2266,11 +2266,11 @@ def SubUminSub_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if a2 != a then return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 aty))
-  let (ctx, c0) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[a.getType! ctx.raw] #[]
+  let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] z none
-  let (ctx, sub1) ← WfRewriter.createOp! ctx (.llvm .sub) #[a.getType! ctx.raw] #[(c0.getResult 0), a]
+  let (ctx, sub1) ← WfRewriter.createOp! ctx Llvm.sub #[a.getType! ctx.raw] #[(c0.getResult 0), a]
     #[] #[] sprops none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__umax) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__umax #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (sub1.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[c0, sub1, newOp], #[newOp.getResult 0]))
 
@@ -2294,11 +2294,11 @@ def lshr_of_trunc_of_lshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some c1 := matchConstantIntVal c1v ctx | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value + c2.value) xty))
-  let (ctx, cf) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] folded none
-  let (ctx, newLshr) ← WfRewriter.createOp! ctx (.llvm .lshr) #[x.getType! ctx.raw] #[x, (cf.getResult 0)]
+  let (ctx, newLshr) ← WfRewriter.createOp! ctx Llvm.lshr #[x.getType! ctx.raw] #[x, (cf.getResult 0)]
     #[] #[] ip none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .trunc) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(newLshr.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.trunc #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(newLshr.getResult 0)]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[cf, newLshr, newOp], #[newOp.getResult 0]))
 
@@ -2345,7 +2345,7 @@ def canonicalize_icmp_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | .slt => .sgt | .sgt => .slt | .sle => .sge | .sge => .sle
     | .ult => .ugt | .ugt => .ult | .ule => .uge | .uge => .ule
     | p => p
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .icmp) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.icmp #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[rhs, lhs]
     #[] #[] (IcmpProperties.mk swapped) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2366,7 +2366,7 @@ def bitreverse_shl_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (inner, y, _) := matchShl dShl ctx | return (ctx, none)
   let some dInner := getDefiningOp inner ctx | return (ctx, none)
   let some x := matchBitreverse dInner ctx | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .lshr) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.lshr #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (ExactProperties.mk false) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2381,7 +2381,7 @@ def bitreverse_lshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (inner, y, _) := matchLshr dLshr ctx | return (ctx, none)
   let some dInner := getDefiningOp inner ctx | return (ctx, none)
   let some x := matchBitreverse dInner ctx | return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .shl) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.shl #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y]
     #[] #[] (NswNuwProperties.mk false false) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -2401,9 +2401,9 @@ def udiv_by_pow2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some k := isConstantPowerOfTwo yv ctx | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let kConst := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (k : Int) xty))
-  let (ctx, ck) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, ck) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] kConst none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .lshr) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (ck.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.lshr #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (ck.getResult 0)]
     #[] #[] (ExactProperties.mk false) none
   some (ctx, some (#[ck, newOp], #[newOp.getResult 0]))
 
@@ -2417,9 +2417,9 @@ def mul_to_shl_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some k := isConstantPowerOfTwo yv ctx | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let kConst := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (k : Int) xty))
-  let (ctx, ck) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, ck) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] kConst none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .shl) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (ck.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.shl #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (ck.getResult 0)]
     #[] #[] mp none
   some (ctx, some (#[ck, newOp], #[newOp.getResult 0]))
 
@@ -2434,9 +2434,9 @@ def urem_pow2_to_mask_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let mask : Int := (2 ^ k : Int) - 1
   let maskConst := LLVMConstantProperties.mk (.integer (IntegerAttr.mk mask xty))
-  let (ctx, cm) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, cm) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] maskConst none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (cm.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (cm.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[cm, newOp], #[newOp.getResult 0]))
 
@@ -2457,9 +2457,9 @@ def funnel_shift_overshift_l_local (ctx : WfIRContext OpCode) (op : OperationPtr
   let bw : Int := (aty.bitwidth : Int)
   if c.value < bw then return (ctx, none)
   let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c.value % bw) aty))
-  let (ctx, cn) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[amt.getType! ctx.raw] #[]
+  let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[amt.getType! ctx.raw] #[]
     #[] #[] newAmt none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__fshl) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__fshl #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[cn, newOp], #[newOp.getResult 0]))
 
@@ -2475,9 +2475,9 @@ def funnel_shift_overshift_r_local (ctx : WfIRContext OpCode) (op : OperationPtr
   let bw : Int := (aty.bitwidth : Int)
   if c.value < bw then return (ctx, none)
   let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c.value % bw) aty))
-  let (ctx, cn) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[amt.getType! ctx.raw] #[]
+  let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[amt.getType! ctx.raw] #[]
     #[] #[] newAmt none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .intr__fshr) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__fshr #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[cn, newOp], #[newOp.getResult 0]))
 
@@ -2557,7 +2557,7 @@ def constant_fold_binop_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some result := folded | return (ctx, none)
   let .integerType rty := ((op.getResult 0 : ValuePtr).getType! ctx.raw).val | return (ctx, none)
   let foldedProps := LLVMConstantProperties.mk (.integer (IntegerAttr.mk result rty))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[]
     #[] #[] foldedProps none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 

--- a/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
+++ b/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
@@ -15,9 +15,9 @@ def sub_minus_one_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if cst.value ≠ -1 then return (ctx, none)
   let .integerType ctype := (op1.getType! ctx.raw).val | return (ctx, none)
   let cstOpProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) ctype))
-  let (ctx, cstOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[op1.getType! ctx.raw] #[]
+  let (ctx, cstOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[op1.getType! ctx.raw] #[]
     #[] #[] cstOpProp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .xor) #[op1.getType! ctx.raw] #[op1, (cstOp.getResult 0)]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.xor #[op1.getType! ctx.raw] #[op1, (cstOp.getResult 0)]
     #[] #[] () none
   some (ctx, some (#[cstOp, newOp], #[newOp.getResult 0]))
 
@@ -139,7 +139,7 @@ def same_val_zero_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if x != x1 then return (ctx, none)
   let .integerType type := (x.getType! ctx.raw).val | return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) type))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] cstProp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -159,7 +159,7 @@ def same_val_zero_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType type' := type.val | return (ctx, none)
   if type'.bitwidth ≠ 64 then return (ctx, none)
   let cstProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk 0 type'))
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[type] #[]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[type] #[]
       #[] #[] cstProp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -185,9 +185,9 @@ def mul_by_neg_one_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if cst.value ≠ -1 then return (ctx, none)
   let .integerType ctype := (x.getType! ctx.raw).val | return (ctx, none)
   let cstOpProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) ctype))
-  let (ctx, cstOp) ← WfRewriter.createOp! ctx (.llvm .mlir__constant) #[x.getType! ctx.raw] #[]
+  let (ctx, cstOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] cstOpProp none
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[x.getType! ctx.raw] #[(cstOp.getResult 0), x]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[x.getType! ctx.raw] #[(cstOp.getResult 0), x]
     #[] #[] _props none
   some (ctx, some (#[cstOp, newOp], #[newOp.getResult 0]))
 
@@ -205,7 +205,7 @@ def or_and_xor_to_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if y != y1 then return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx | return (ctx, none)
   if cst.value ≠ -1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .or) #[and.getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[and.getType! ctx.raw] #[x, y]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -223,7 +223,7 @@ def and_xor_or_to_and_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if y != y1 then return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx | return (ctx, none)
   if cst.value ≠ -1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .and) #[or.getType! ctx.raw] #[x, y]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[or.getType! ctx.raw] #[x, y]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -263,7 +263,7 @@ def APlusBMinusCMinusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp1 := getDefiningOp sub1 ctx | return (ctx, none)
   let some (B1, C, _props2) := matchSub defOp1 ctx | return (ctx, none)
   if B != B1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[add1.getType! ctx.raw] #[A, C]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[add1.getType! ctx.raw] #[A, C]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -279,7 +279,7 @@ def AMinusBMinusCMinusC_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp1 := getDefiningOp sub1 ctx | return (ctx, none)
   let some (B, C1, _props2) := matchSub defOp1 ctx | return (ctx, none)
   if C != C1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[sub2.getType! ctx.raw] #[A, B]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[sub2.getType! ctx.raw] #[A, B]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -294,7 +294,7 @@ def ZeroMinusAPlusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, A, _props1) := matchSub defOp ctx | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx | return (ctx, none)
   if cst.value ≠ 0 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[sub.getType! ctx.raw] #[B, A]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[sub.getType! ctx.raw] #[B, A]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -309,7 +309,7 @@ def APlusZeroMinusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, B, _props1) := matchSub defOp ctx | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx | return (ctx, none)
   if cst.value ≠ 0 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[A.getType! ctx.raw] #[A, B]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[A.getType! ctx.raw] #[A, B]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -349,7 +349,7 @@ def AMinusBPlusCMinusA_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp1 := getDefiningOp sub2 ctx | return (ctx, none)
   let some (C, A1, _props2) := matchSub defOp1 ctx | return (ctx, none)
   if A != A1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[sub1.getType! ctx.raw] #[C, B]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[sub1.getType! ctx.raw] #[C, B]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -365,7 +365,7 @@ def AMinusBPlusBMinusC_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp1 := getDefiningOp sub2 ctx | return (ctx, none)
   let some (B1, C, _props2) := matchSub defOp1 ctx | return (ctx, none)
   if B != B1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[sub1.getType! ctx.raw] #[A, C]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[sub1.getType! ctx.raw] #[A, C]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -381,7 +381,7 @@ def APlusBMinusAplusC_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp1 := getDefiningOp add1 ctx | return (ctx, none)
   let some (A1, C, _props2) := matchAdd defOp1 ctx | return (ctx, none)
   if A != A1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[A.getType! ctx.raw] #[B, C]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[A.getType! ctx.raw] #[B, C]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -397,7 +397,7 @@ def APlusBMinusCPlusA_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp1 := getDefiningOp add1 ctx | return (ctx, none)
   let some (C, A1, _props2) := matchAdd defOp1 ctx | return (ctx, none)
   if A != A1 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .sub) #[A.getType! ctx.raw] #[B, C]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[A.getType! ctx.raw] #[B, C]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
@@ -412,7 +412,7 @@ def AMinusZeroMinusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (lhs, B, _props1) := matchSub defOp ctx | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx | return (ctx, none)
   if cst.value ≠ 0 then return (ctx, none)
-  let (ctx, newOp) ← WfRewriter.createOp! ctx (.llvm .add) #[A.getType! ctx.raw] #[A, B]
+  let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[A.getType! ctx.raw] #[A, B]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -925,9 +925,16 @@ theorem Rewriter.initBlockOperands_inBounds_mono (ptr : GenericPtr) :
     grind
 
 @[irreducible]
-def Rewriter.createEmptyOp (ctx : IRContext OpInfo) (opType : OpInfo) (properties : HasOpInfo.propertiesOf opType) :
+def Rewriter.createEmptyOp {Dialect : Type} [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (ctx : IRContext OpInfo) (opType : Dialect)
+    (properties : HasDialectOpInfo.propertiesOf opType) :
     Option (IRContext OpInfo × OperationPtr) :=
   OperationPtr.allocEmpty ctx opType properties
+
+section Rewriter.createEmptyOp
+
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {properties : HasDialectOpInfo.propertiesOf opType}
 
 @[grind .]
 theorem Rewriter.createEmptyOp_new_inBounds
@@ -943,7 +950,7 @@ theorem Rewriter.createEmptyOp_new_not_inBounds
 
 @[grind =>]
 theorem Rewriter.createEmptyOp_genericPtr_mono (ptr : GenericPtr)
-    (heq : createEmptyOp ctx type properties = some (ctx', ptr')) :
+    (heq : createEmptyOp ctx opType properties = some (ctx', ptr')) :
     ptr.InBounds ctx' ↔ (ptr.InBounds ctx ∨ ptr = .operation ptr') := by
   grind [createEmptyOp]
 
@@ -953,10 +960,13 @@ theorem Rewriter.createEmptyOp_fieldsInBounds
     ctx.FieldsInBounds → ctx'.FieldsInBounds := by
   grind [createEmptyOp]
 
+end Rewriter.createEmptyOp
+
 @[irreducible]
-def Rewriter.createOp (ctx: IRContext OpInfo) (opType: OpInfo)
+def Rewriter.createOp {Dialect : Type} [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (ctx: IRContext OpInfo) (opType: Dialect)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
+    (regions: Array RegionPtr) (properties: HasDialectOpInfo.propertiesOf opType)
     (insertionPoint: Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds ctx := by grind)
     (hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds ctx := by grind)
@@ -979,6 +989,11 @@ def Rewriter.createOp (ctx: IRContext OpInfo) (opType: OpInfo)
     some (ctx, newOpPtr)
   | none =>
     (ctx, newOpPtr)
+
+section Rewriter.createOp
+
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {props : HasDialectOpInfo.propertiesOf opType}
 
 @[grind .]
 theorem Rewriter.createOp_inBounds_mono (ptr : GenericPtr)
@@ -1007,6 +1022,8 @@ theorem Rewriter.createOp_fieldsInBounds
     ctx.FieldsInBounds → newCtx.FieldsInBounds := by
   simp only [createOp] at heq
   grind
+
+end Rewriter.createOp
 
 @[irreducible]
 def IRContext.create OpInfo [HasOpInfo OpInfo] [HasDialect OpInfo Builtin]

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -57,6 +57,10 @@ variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
 variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {dialectOpType : Dialect}
+variable {CreateDialect : Type} [HasDialectOpInfo CreateDialect]
+  [HasDialect OpInfo CreateDialect]
+variable {opType : CreateDialect}
+variable {properties : HasDialectOpInfo.propertiesOf opType}
 section Rewriter.createEmptyOp
 
 variable {op : OperationPtr}
@@ -147,7 +151,7 @@ grind_pattern OperationPtr.parent!_createEmptyOp =>
 theorem OperationPtr.getOpType!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getOpType! ctx' =
-    if operation = op then opType else operation.getOpType! ctx := by
+    if operation = op then ofDialect OpInfo opType else operation.getOpType! ctx := by
   grind [Operation.empty]
 
 grind_pattern OperationPtr.getOpType!_createEmptyOp =>
@@ -166,8 +170,8 @@ theorem OperationPtr.getProperties!_createEmptyOp {operation : OperationPtr} :
     Rewriter.createEmptyOp ctx opType properties = some (ctx', op) →
     operation.getProperties! ctx' dialectOpType =
     if operation = op then
-      if h : (dialectOpType : OpInfo) = opType then
-        HasDialect.toDialectProperties dialectOpType (h ▸ properties)
+      if h : ofDialect OpInfo opType = ofDialect OpInfo dialectOpType then
+        HasDialect.properties_eq_of_ofDialect_eq h ▸ properties
       else default
     else
       operation.getProperties! ctx dialectOpType := by
@@ -470,7 +474,7 @@ theorem OperationPtr.getOpType!_createOp {operation : OperationPtr} :
     Rewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     operation.getOpType! ctx' =
-    if operation = newOp then opType else operation.getOpType! ctx := by
+    if operation = newOp then ofDialect OpInfo opType else operation.getOpType! ctx := by
   simp only [Rewriter.createOp]
   grind (gen := 20)
 
@@ -489,8 +493,8 @@ theorem OperationPtr.getProperties!_createOp {operation : OperationPtr} :
       insertionPoint h₁ h₂ h₃ h₄ h₅ = some (ctx', newOp) →
     operation.getProperties! ctx' dialectOpType =
     if operation = newOp then
-      if h : (dialectOpType : OpInfo) = opType then
-        HasDialect.toDialectProperties dialectOpType (h ▸ properties)
+      if h : ofDialect OpInfo opType = ofDialect OpInfo dialectOpType then
+        HasDialect.properties_eq_of_ofDialect_eq h ▸ properties
       else default
     else
       operation.getProperties! ctx dialectOpType := by

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -650,6 +650,11 @@ theorem OperationPtr.getOperand_Rewriter_eraseOp
     OperationPtr.getOperand op' ctx idx (by sorry) (by sorry) := by
   sorry
 
+section createOp
+
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {properties : HasDialectOpInfo.propertiesOf opType}
+
 theorem Rewriter.createEmptyOp_wellFormed  (hctx : IRContext.WellFormed ctx) :
     Rewriter.createEmptyOp ctx opType properties = some (newCtx, newOp) →
     newCtx.WellFormed := by
@@ -775,5 +780,7 @@ theorem BlockPtr.operationList_rewriter_createOp
       split <;>
         grind [Rewriter.initOpOperands_WellFormed, Rewriter.initBlockOperands_WellFormed,
           Rewriter.insertOp_WellFormed, IRContext.wellFormed_rewriter_initOpResults]
+
+end createOp
 
 end Veir

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -440,9 +440,10 @@ def WfRewriter.pushBlockOperand! (wfCtx : WfIRContext OpInfo) (opPtr : Operation
 
 /-- Create an operation and insert it at a given location. -/
 @[inline]
-def WfRewriter.createOp (wfCtx : WfIRContext OpInfo) (opType : OpInfo)
+def WfRewriter.createOp {Dialect : Type} [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo) (opType : Dialect)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
+    (regions : Array RegionPtr) (properties : HasDialectOpInfo.propertiesOf opType)
     (insertionPoint : Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw := by grind)
     (hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds wfCtx.raw := by grind)
@@ -458,9 +459,10 @@ Create an operation and insert it at a given location, panicking if any operand,
 or region is out of bounds, if the insertion point is out of bounds, or if the operation could
 not be created.
 -/
-def WfRewriter.createOp! (wfCtx : WfIRContext OpInfo) (opType : OpInfo)
+def WfRewriter.createOp! {Dialect : Type} [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo) (opType : Dialect)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
+    (regions : Array RegionPtr) (properties : HasDialectOpInfo.propertiesOf opType)
     (insertionPoint : Option InsertPoint)
     : Option (WfIRContext OpInfo × OperationPtr) :=
   if hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw then

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -45,9 +45,12 @@ namespace Veir
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx ctx' : WfIRContext OpInfo}
 variable {operation : OperationPtr} {region : RegionPtr} {block : BlockPtr} {value : ValuePtr}
-variable {opType : OpInfo}
 variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {dialectOpType : Dialect}
+variable {CreateDialect : Type} [HasDialectOpInfo CreateDialect]
+  [HasDialect OpInfo CreateDialect]
+variable {opType : CreateDialect}
+variable {properties : HasDialectOpInfo.propertiesOf opType}
 
 /-! ## `WfRewriter.createOp` -/
 
@@ -155,7 +158,7 @@ theorem OperationPtr.getOpType!_WfRewriter_createOp :
     WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     operation.getOpType! ctx'.raw =
-    if operation = newOp then opType else operation.getOpType! ctx.raw := by
+    if operation = newOp then ofDialect OpInfo opType else operation.getOpType! ctx.raw := by
   simp only [WfRewriter.createOp]
   grind (gen := 20)
 
@@ -174,12 +177,12 @@ theorem OperationPtr.getProperties!_WfRewriter_createOp :
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp) →
     operation.getProperties! ctx'.raw dialectOpType =
     if operation = newOp then
-      if h : (dialectOpType : OpInfo) = opType then
-        HasDialect.toDialectProperties dialectOpType (h ▸ properties)
+      if h : ofDialect OpInfo opType = ofDialect OpInfo dialectOpType then
+        HasDialect.properties_eq_of_ofDialect_eq h ▸ properties
       else default
     else operation.getProperties! ctx.raw dialectOpType := by
   simp only [WfRewriter.createOp]
-  grind (gen := 20)
+  grind (gen := 20) [HasDialect.toDialectProperties_cast_ofDialectProperties_eq]
 
 @[grind =>, simp_getset]
 theorem OperationPtr.getNumResults!_WfRewriter_createOp :
@@ -1065,7 +1068,6 @@ section WfRewriter.setProperties
 
 attribute [local grind] WfRewriter.setProperties
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect} {op : OperationPtr}
          {newProps : HasDialectOpInfo.propertiesOf opCode}
          {opIn : op.InBounds ctx.raw} {hprop : op.getOpType! ctx.raw = opCode}

--- a/Veir/Rewriter/WfRewriter/InBounds.lean
+++ b/Veir/Rewriter/WfRewriter/InBounds.lean
@@ -166,6 +166,11 @@ theorem WfRewriter.pushBlockOperand_inBounds_mono :
 
 /-! ## `WfRewriter.createOp` -/
 
+section WfRewriter.createOp
+
+variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {properties : HasDialectOpInfo.propertiesOf opType}
+
 @[grind →]
 theorem WfRewriter.createOp_new_inBounds (ptr : OperationPtr)
     (heq : WfRewriter.createOp ctx opType resultTypes operands blockOperands regions properties
@@ -186,6 +191,8 @@ theorem WfRewriter.createOp_inBounds_mono
       insertionPoint hoper hblockOperands hregions hins = some (ctx', newOp)) :
     ptr.InBounds ctx.raw → ptr.InBounds ctx'.raw := by
   grind [WfRewriter.createOp]
+
+end WfRewriter.createOp
 
 /-! ## `WfIRContext.create` -/
 


### PR DESCRIPTION
This allows to pass any `Dialect` opcode to `createOp`. This follows changes we have made to `getProperties` and `setProperties`.