### PR TITLE
feat: Merge `HasDialectOpInfo` and `HasOpInfo`

### DIFF
--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -17,8 +17,8 @@ example : HasDialect OpCode Builtin := inferInstance
 #guard OpCode.fromName "arith.addi".toUTF8 = some (.arith .addi)
 #guard OpCode.fromName "unknown.op".toUTF8 = none
 #guard OpCode.name (.arith .addi) = "arith.addi".toUTF8
-#guard HasDialectOpInfo.fromName (opCode := Arith) "arith.addi".toUTF8 = some .addi
-#guard HasDialectOpInfo.name (opCode := Arith) .addi = "arith.addi".toUTF8
+#guard HasOpInfo.fromName (opCode := Arith) "arith.addi".toUTF8 = some .addi
+#guard HasOpInfo.name (opCode := Arith) .addi = "arith.addi".toUTF8
 
 /-! Dialects can define conversion functions to and from the global opcode type. -/
 abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arith]

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -130,7 +130,7 @@ def Arith.hasSSADominance (_op : Arith) (_index : Nat) : Bool :=
 
 #generate_dialect Arith
 
-instance : HasDialectOpInfo Arith where
+instance : HasOpInfo Arith where
   fromName := Arith.fromName
   name := Arith.name
   propertiesOf := Arith.propertiesOf

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -70,7 +70,7 @@ def Builtin.hasNoTerminator (op : Builtin) (_index : Nat) : Bool :=
 
 #generate_dialect Builtin
 
-instance : HasDialectOpInfo Builtin where
+instance : HasOpInfo Builtin where
   fromName := Builtin.fromName
   name := Builtin.name
   propertiesOf := Builtin.propertiesOf

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -57,7 +57,7 @@ def Cf.hasSSADominance (_op : Cf) (_index : Nat) : Bool :=
 
 #generate_dialect Cf
 
-instance : HasDialectOpInfo Cf where
+instance : HasOpInfo Cf where
   fromName := Cf.fromName
   name := Cf.name
   propertiesOf := Cf.propertiesOf

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -77,7 +77,7 @@ def Comb.hasSSADominance (_op : Comb) (_index : Nat) : Bool :=
 
 #generate_dialect Comb
 
-instance : HasDialectOpInfo Comb where
+instance : HasOpInfo Comb where
   fromName := Comb.fromName
   name := Comb.name
   propertiesOf := Comb.propertiesOf

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -49,7 +49,7 @@ def Datapath.hasSSADominance (_op : Datapath) (_index : Nat) : Bool :=
 
 #generate_dialect Datapath
 
-instance : HasDialectOpInfo Datapath where
+instance : HasOpInfo Datapath where
   fromName := Datapath.fromName
   name := Datapath.name
   propertiesOf := Datapath.propertiesOf

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -69,7 +69,7 @@ def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
 
 #generate_dialect Func
 
-instance : HasDialectOpInfo Func where
+instance : HasOpInfo Func where
   fromName := Func.fromName
   name := Func.name
   propertiesOf := Func.propertiesOf

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -68,7 +68,7 @@ def HW.hasSSADominance (_op : HW) (_index : Nat) : Bool :=
 
 #generate_dialect HW
 
-instance : HasDialectOpInfo HW where
+instance : HasOpInfo HW where
   fromName := HW.fromName
   name := HW.name
   propertiesOf := HW.propertiesOf

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -367,7 +367,7 @@ def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
 
 #generate_dialect Llvm
 
-instance : HasDialectOpInfo Llvm where
+instance : HasOpInfo Llvm where
   fromName := Llvm.fromName
   name := Llvm.name
   propertiesOf := Llvm.propertiesOf

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -61,7 +61,7 @@ def Mod_Arith.hasSSADominance (_op : Mod_Arith) (_index : Nat) : Bool :=
 
 #generate_dialect Mod_Arith
 
-instance : HasDialectOpInfo Mod_Arith where
+instance : HasOpInfo Mod_Arith where
   fromName := Mod_Arith.fromName
   name := Mod_Arith.name
   propertiesOf := Mod_Arith.propertiesOf

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -150,7 +150,7 @@ def PDL.hasNoTerminator (op : PDL) (_index : Nat) : Bool :=
 
 #generate_dialect PDL
 
-instance : HasDialectOpInfo PDL where
+instance : HasOpInfo PDL where
   fromName := PDL.fromName
   name := PDL.name
   propertiesOf := PDL.propertiesOf

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -323,7 +323,7 @@ def Riscv.hasSSADominance (_op : Riscv) (_index : Nat) : Bool :=
 
 #generate_dialect Riscv
 
-instance : HasDialectOpInfo Riscv where
+instance : HasOpInfo Riscv where
   fromName := Riscv.fromName
   name := Riscv.name
   propertiesOf := Riscv.propertiesOf

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -73,7 +73,7 @@ def Riscv_Cf.hasSSADominance (_op : Riscv_Cf) (_index : Nat) : Bool :=
 
 #generate_dialect Riscv_Cf
 
-instance : HasDialectOpInfo Riscv_Cf where
+instance : HasOpInfo Riscv_Cf where
   fromName := Riscv_Cf.fromName
   name := Riscv_Cf.name
   propertiesOf := Riscv_Cf.propertiesOf

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -54,7 +54,7 @@ def Riscv_Stack.hasSSADominance (_op : Riscv_Stack) (_index : Nat) : Bool :=
 
 #generate_dialect Riscv_Stack
 
-instance : HasDialectOpInfo Riscv_Stack where
+instance : HasOpInfo Riscv_Stack where
   fromName := Riscv_Stack.fromName
   name := Riscv_Stack.name
   propertiesOf := Riscv_Stack.propertiesOf

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -46,7 +46,7 @@ def Rv64.hasSSADominance (_op : Rv64) (_index : Nat) : Bool :=
 
 #generate_dialect Rv64
 
-instance : HasDialectOpInfo Rv64 where
+instance : HasOpInfo Rv64 where
   fromName := Rv64.fromName
   name := Rv64.name
   propertiesOf := Rv64.propertiesOf

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -47,7 +47,7 @@ def Test.hasNoTerminator (_op : Test) (_index : Nat) : Bool :=
 
 #generate_dialect Test
 
-instance : HasDialectOpInfo Test where
+instance : HasOpInfo Test where
   fromName := Test.fromName
   name := Test.name
   propertiesOf := Test.propertiesOf

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -161,25 +161,25 @@ def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
 /--
   Whether the indexed region of this opcode is exempt from the requirement
   that each of its blocks ends in a terminator. Dialects that do not say
-  otherwise inherit the `HasDialectOpInfo` default of `false`.
+  otherwise inherit the `HasOpInfo` default of `false`.
 -/
 def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
   match opCode with
-  | .arith op => HasDialectOpInfo.hasNoTerminator op index
-  | .llvm op => HasDialectOpInfo.hasNoTerminator op index
-  | .riscv op => HasDialectOpInfo.hasNoTerminator op index
-  | .riscv_cf op => HasDialectOpInfo.hasNoTerminator op index
-  | .riscv_stack op => HasDialectOpInfo.hasNoTerminator op index
-  | .rv64 op => HasDialectOpInfo.hasNoTerminator op index
-  | .mod_arith op => HasDialectOpInfo.hasNoTerminator op index
-  | .cf op => HasDialectOpInfo.hasNoTerminator op index
-  | .comb op => HasDialectOpInfo.hasNoTerminator op index
-  | .hw op => HasDialectOpInfo.hasNoTerminator op index
-  | .builtin op => HasDialectOpInfo.hasNoTerminator op index
-  | .func op => HasDialectOpInfo.hasNoTerminator op index
-  | .datapath op => HasDialectOpInfo.hasNoTerminator op index
-  | .pdl op => HasDialectOpInfo.hasNoTerminator op index
-  | .test op => HasDialectOpInfo.hasNoTerminator op index
+  | .arith op => HasOpInfo.hasNoTerminator op index
+  | .llvm op => HasOpInfo.hasNoTerminator op index
+  | .riscv op => HasOpInfo.hasNoTerminator op index
+  | .riscv_cf op => HasOpInfo.hasNoTerminator op index
+  | .riscv_stack op => HasOpInfo.hasNoTerminator op index
+  | .rv64 op => HasOpInfo.hasNoTerminator op index
+  | .mod_arith op => HasOpInfo.hasNoTerminator op index
+  | .cf op => HasOpInfo.hasNoTerminator op index
+  | .comb op => HasOpInfo.hasNoTerminator op index
+  | .hw op => HasOpInfo.hasNoTerminator op index
+  | .builtin op => HasOpInfo.hasNoTerminator op index
+  | .func op => HasOpInfo.hasNoTerminator op index
+  | .datapath op => HasOpInfo.hasNoTerminator op index
+  | .pdl op => HasOpInfo.hasNoTerminator op index
+  | .test op => HasOpInfo.hasNoTerminator op index
 
 /--
   Does this `OpCode` materialize a literal constant value, i.e. an op
@@ -249,7 +249,7 @@ def Properties.toAttrDict
   | .pdl op, props => PDL.toAttrDict op props
   | .test op, props => Test.toAttrDict op props
 
-instance : HasDialectOpInfo OpCode where
+instance : HasOpInfo OpCode where
   fromName := OpCode.fromName
   name := OpCode.name
   propertiesOf := _propertiesOf
@@ -261,8 +261,6 @@ instance : HasDialectOpInfo OpCode where
   isConstantLike := OpCode.isConstantLike
   hasSSADominance := OpCode.hasSSADominance
   hasNoTerminator := OpCode.hasNoTerminator
-
-instance : HasOpInfo OpCode where
 
 #generate_has_dialect_instances OpCode
 

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -180,7 +180,7 @@ structure Operation (OpInfo : Type) [HasOpInfo OpInfo] where
 deriving Inhabited, Repr, Hashable
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 
 namespace Operation
 
@@ -1070,7 +1070,7 @@ type, in order to get the dialect-specific properties which is often easier to u
 @[inline]
 def getProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect)
     (inBounds : op.InBounds ctx := by grind)
-    (hprop : op.getOpType! ctx = opCode := by grind) : HasDialectOpInfo.propertiesOf opCode :=
+    (hprop : op.getOpType! ctx = opCode := by grind) : HasOpInfo.propertiesOf opCode :=
   have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
   let globalProperties := h ▸ (op.get ctx (by grind)).properties
   HasDialect.toDialectProperties opCode globalProperties
@@ -1085,7 +1085,7 @@ operation's type does not match the passed `opCode`.
 -/
 @[inline]
 def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo)
-    (opCode : Dialect) : HasDialectOpInfo.propertiesOf opCode :=
+    (opCode : Dialect) : HasOpInfo.propertiesOf opCode :=
   if h : (op.get! ctx).opType = opCode then
     let globalProperties := h ▸ (op.get! ctx).properties
     HasDialect.toDialectProperties opCode globalProperties
@@ -1110,7 +1110,7 @@ The passed `opCode` can either be of the global `OpInfo` type, or the dialect-sp
 while the `Dialect` version is often easier to use when manipulating dialect-specific operations.
 -/
 def setProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect)
-    (newProperties : HasDialectOpInfo.propertiesOf opCode)
+    (newProperties : HasOpInfo.propertiesOf opCode)
     (inBounds : op.InBounds ctx := by grind)
     (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
@@ -1127,7 +1127,7 @@ while the `Dialect` version is often easier to use when manipulating dialect-spe
 This function panics if the given operation is not in bounds.
 -/
 def setProperties! {opCode : Dialect} (op : OperationPtr) (ctx : IRContext OpInfo)
-  (newProperties : HasDialectOpInfo.propertiesOf opCode)
+  (newProperties : HasOpInfo.propertiesOf opCode)
   (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   have h : (op.get! ctx).opType = opCode := by grind [getOpType!]
   let oldOp := op.get! ctx
@@ -1136,7 +1136,7 @@ def setProperties! {opCode : Dialect} (op : OperationPtr) (ctx : IRContext OpInf
 
 @[grind =_, eq_bang ←]
 theorem setProperties!_eq_setProperties {op : OperationPtr} {opCode : Dialect}
-    (newProperties : HasDialectOpInfo.propertiesOf opCode) (inBounds : op.InBounds ctx)
+    (newProperties : HasOpInfo.propertiesOf opCode) (inBounds : op.InBounds ctx)
     (hprop : op.getOpType! ctx = opCode) :
     op.setProperties! ctx newProperties =
     op.setProperties ctx opCode newProperties inBounds := by
@@ -1193,9 +1193,9 @@ theorem nextResult!_eq_getResult {op : OperationPtr} :
     op.nextResult! ctx = op.getResult (op.getNumResults! ctx) := by
   rfl
 
-def allocEmpty {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+def allocEmpty {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     (ctx : IRContext OpInfo) (opType : Dialect)
-    (properties : HasDialectOpInfo.propertiesOf opType) :
+    (properties : HasOpInfo.propertiesOf opType) :
     Option (IRContext OpInfo × OperationPtr) :=
   let newOpPtr : OperationPtr := ⟨ctx.nextID⟩
   let globalProperties := HasDialect.ofDialectProperties OpInfo opType properties

--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -697,9 +697,9 @@ theorem OperationPtr.pushResult_fieldsInBounds {newResult : OpResult} {op : Oper
 
 @[grind .]
 theorem OperationPtr.setProperties_fieldsInBounds
-    {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+    {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     {op : OperationPtr} {inBounds : op.InBounds ctx}
-    {opCode : Dialect} {newProperties : HasDialectOpInfo.propertiesOf opCode}
+    {opCode : Dialect} {newProperties : HasOpInfo.propertiesOf opCode}
     {hprop : op.getOpType! ctx = opCode} :
     ctx.FieldsInBounds → (setProperties op ctx opCode newProperties inBounds hprop).FieldsInBounds := by
   prove_fieldsInBounds_operation ctx
@@ -723,8 +723,8 @@ theorem OperationPtr.pushBlockOperand_push_fieldsInBounds
 attribute [local grind] Operation.empty in
 @[grind .]
 theorem OperationPtr.allocEmpty_fieldsInBounds
-    {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-    {type : Dialect} {prop : HasDialectOpInfo.propertiesOf type}
+    {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+    {type : Dialect} {prop : HasOpInfo.propertiesOf type}
     (heq : allocEmpty ctx type prop = some (ctx', ptr')) :
     ctx.FieldsInBounds → ctx'.FieldsInBounds := by
   prove_fieldsInBounds

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -7,7 +7,7 @@ namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx ctx': IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode opCode' : Dialect}
 
 public section
@@ -53,9 +53,9 @@ setup_grind_with_get_set_definitions
 
 /- OperationPtr.allocEmpty -/
 
-variable {CreateDialect : Type} [HasDialectOpInfo CreateDialect]
+variable {CreateDialect : Type} [HasOpInfo CreateDialect]
   [HasDialect OpInfo CreateDialect]
-variable {ty : CreateDialect} {properties : HasDialectOpInfo.propertiesOf ty}
+variable {ty : CreateDialect} {properties : HasOpInfo.propertiesOf ty}
 
 @[simp, grind =>]
 theorem BlockPtr.get!_OperationPtr_allocEmpty {block : BlockPtr}
@@ -1325,7 +1325,7 @@ theorem OpOperandPtrPtr.get!_OperationPtr_pushResult {opOperandPtr : OpOperandPt
 section OperationPtr.setProperties
 
 variable {operation' : OperationPtr}
-variable {newProperties : HasDialectOpInfo.propertiesOf opCode}
+variable {newProperties : HasOpInfo.propertiesOf opCode}
 variable {inBounds : operation'.InBounds ctx}
 variable {hprop : operation'.getOpType! ctx = opCode}
 
@@ -1348,7 +1348,7 @@ theorem OperationPtr.get!_OperationPtr_setProperties {operation : OperationPtr} 
 
 @[grind =]
 theorem OperationPtr.getProperties!_OperationPtr_setProperties
-    {GetterDialect : Type} [HasDialectOpInfo GetterDialect]
+    {GetterDialect : Type} [HasOpInfo GetterDialect]
     [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect}
     {operation : OperationPtr} :
     operation.getProperties!

--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -179,8 +179,8 @@ theorem OperationPtr.setBlockOperands_OpOperandPtr_InBounds_mono_ne {opOperand :
 
 @[grind =]
 theorem OperationPtr.setProperties_genericPtr_mono (ptr : GenericPtr)
-    {opCode : Dialect} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-    {newProperties : HasDialectOpInfo.propertiesOf opCode}
+    {opCode : Dialect} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+    {newProperties : HasOpInfo.propertiesOf opCode}
     {propEq : op.getOpType! ctx = opCode} :
     ptr.InBounds (setProperties op ctx opCode newProperties h propEq) ↔ ptr.InBounds ctx := by
   grind
@@ -190,9 +190,9 @@ theorem OperationPtr.setAttributes_genericPtr_mono (ptr : GenericPtr) :
     ptr.InBounds (op.setAttributes ctx newAttrs h) ↔ ptr.InBounds ctx := by
   grind
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {ty : Dialect}
-variable {properties : HasDialectOpInfo.propertiesOf ty}
+variable {properties : HasOpInfo.propertiesOf ty}
 
 @[grind .]
 theorem OpResultPtr.allocEmpty_no_results {opResult : OpResultPtr}

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -7,7 +7,7 @@ namespace Veir
 
 public section
 
-class HasDialectOpInfo (opCode: Type)
+class HasOpInfo (opCode: Type)
     extends Hashable opCode, Repr opCode, Inhabited opCode where
   /-- Look up an operation by its fully qualified MLIR name. -/
   fromName : ByteArray → Option opCode
@@ -97,27 +97,20 @@ class HasDialectOpInfo (opCode: Type)
   -/
   hasNoTerminator : opCode → Nat → Bool := fun _ _ => false
 
-instance [HasDialectOpInfo opCode] {op : opCode} : Hashable (HasDialectOpInfo.propertiesOf op) where
-  hash := HasDialectOpInfo.propertiesHash.hash
+instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
+  hash := HasOpInfo.propertiesHash.hash
 
-instance [HasDialectOpInfo opCode] {op : opCode} : Inhabited (HasDialectOpInfo.propertiesOf op) where
-  default := HasDialectOpInfo.propertiesDefault.default
+instance [HasOpInfo opCode] {op : opCode} : Inhabited (HasOpInfo.propertiesOf op) where
+  default := HasOpInfo.propertiesDefault.default
 
-instance [HasDialectOpInfo opCode] {op : opCode} : Repr (HasDialectOpInfo.propertiesOf op) where
-  reprPrec := HasDialectOpInfo.propertiesRepr.reprPrec
+instance [HasOpInfo opCode] {op : opCode} : Repr (HasOpInfo.propertiesOf op) where
+  reprPrec := HasOpInfo.propertiesRepr.reprPrec
 
-instance [HasDialectOpInfo opCode] {op : opCode} : DecidableEq (HasDialectOpInfo.propertiesOf op) :=
-  HasDialectOpInfo.propertiesDecideEq
+instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) :=
+  HasOpInfo.propertiesDecideEq
 
-instance [HasDialectOpInfo opCode] : DecidableEq opCode :=
-  HasDialectOpInfo.decideEq
-
-/--
-The `HasOpInfo` type class provides the combined operation information for a
-global opcode type.
--/
-class HasOpInfo (opCode: Type)
-    extends Hashable opCode, Repr opCode, Inhabited opCode, HasDialectOpInfo opCode
+instance [HasOpInfo opCode] : DecidableEq opCode :=
+  HasOpInfo.decideEq
 
 /--
 `HasDialect OpInfo Dialect` states that `OpInfo` contains the operations from
@@ -128,7 +121,7 @@ a projection from the combined opcode type to dialect-local opcodes.
 The class also records that the dialect-local property family agree with the combined
 property family on the injected opcodes.
 -/
-class HasDialect (OpInfo Dialect : Type) [HasOpInfo OpInfo] [HasDialectOpInfo Dialect] where
+class HasDialect (OpInfo Dialect : Type) [HasOpInfo OpInfo] [HasOpInfo Dialect] where
   /--
   Given a dialect opcode, get the equivalent opcode.
   `Veir.ofDialect` or a coercion should be used instead of calling this function.
@@ -144,18 +137,18 @@ class HasDialect (OpInfo Dialect : Type) [HasOpInfo OpInfo] [HasDialectOpInfo Di
     project opInfo = some op ↔ inject op = opInfo
   /-- The equivalence between the properties of the injected opcode and the dialect opcode. -/
   properties_eq (op : Dialect) :
-    HasOpInfo.propertiesOf (inject op) = HasDialectOpInfo.propertiesOf op
+    HasOpInfo.propertiesOf (inject op) = HasOpInfo.propertiesOf op
 
 /--
 Project a global opcode to a dialect. Returns `none` when the opcode belongs
 to another dialect.
 -/
 def toDialect? (Dialect : Type) {OpInfo : Type} [HasOpInfo OpInfo]
-    [HasDialectOpInfo Dialect] [dialectInj : HasDialect OpInfo Dialect] (opInfo : OpInfo) :
+    [HasOpInfo Dialect] [dialectInj : HasDialect OpInfo Dialect] (opInfo : OpInfo) :
     Option Dialect :=
   HasDialect.project opInfo
 
-def ofDialect {Dialect : Type} (OpInfo : Type) [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+def ofDialect {Dialect : Type} (OpInfo : Type) [HasOpInfo OpInfo] [HasOpInfo Dialect]
     [dialectInj : HasDialect OpInfo Dialect] (op : Dialect) :
     OpInfo :=
   HasDialect.inject op
@@ -177,14 +170,14 @@ theorem ofDialect_hasDialectRefl (OpInfo : Type) [HasOpInfo OpInfo] (op : OpInfo
     ofDialect OpInfo op = op := by rfl
 
 /-- Coercion from a dialect opcode to the global opcode type. -/
-instance {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+instance {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (op : Dialect) :
     CoeDep Dialect op OpInfo where
   coe := ofDialect OpInfo op
 
 namespace HasDialect
 
-variable {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+variable {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
   [dialectInj : HasDialect OpInfo Dialect]
 
 /-- Projecting an injected dialect opcode recovers that opcode. -/
@@ -203,12 +196,12 @@ theorem ofDialect_injective {op₁ op₂ : Dialect} :
 /-- Equal global opcodes have equal dialect-local property types. -/
 theorem properties_eq_of_ofDialect_eq
     {Dialect₁ Dialect₂ : Type}
-    [HasDialectOpInfo Dialect₁] [HasDialectOpInfo Dialect₂]
+    [HasOpInfo Dialect₁] [HasOpInfo Dialect₂]
     [hasDialect₁ : HasDialect OpInfo Dialect₁]
     [hasDialect₂ : HasDialect OpInfo Dialect₂]
     {op₁ : Dialect₁} {op₂ : Dialect₂}
     (h : ofDialect OpInfo op₁ = ofDialect OpInfo op₂) :
-    HasDialectOpInfo.propertiesOf op₁ = HasDialectOpInfo.propertiesOf op₂ := by
+    HasOpInfo.propertiesOf op₁ = HasOpInfo.propertiesOf op₂ := by
   simp [← hasDialect₁.properties_eq op₁, ← hasDialect₂.properties_eq op₂]
   grind [ofDialect]
 
@@ -222,41 +215,41 @@ grind_pattern toDialect?_eq_some_iff =>
 
 /-- Convert dialect-local properties to the global property family. -/
 def ofDialectProperties (OpInfo : Type) [HasOpInfo OpInfo] [dialectInj : HasDialect OpInfo Dialect]
-    (op : Dialect) (props : HasDialectOpInfo.propertiesOf op) :
+    (op : Dialect) (props : HasOpInfo.propertiesOf op) :
     HasOpInfo.propertiesOf (opCode := OpInfo) op :=
   dialectInj.properties_eq op ▸ props
 
 /-- Convert global properties of an injected opcode back to dialect-local properties. -/
 def toDialectProperties (op : Dialect)
     (props : HasOpInfo.propertiesOf (opCode := OpInfo) op) :
-    HasDialectOpInfo.propertiesOf op :=
+    HasOpInfo.propertiesOf op :=
   (dialectInj.properties_eq op).symm ▸ props
 
 @[simp, grind =]
 theorem toDialectProperties_cast_ofDialectProperties_eq
     {Dialect₁ Dialect₂ : Type}
-    [HasDialectOpInfo Dialect₁] [HasDialectOpInfo Dialect₂]
+    [HasOpInfo Dialect₁] [HasOpInfo Dialect₂]
     [hasDialect₁ : HasDialect OpInfo Dialect₁]
     [hasDialect₂ : HasDialect OpInfo Dialect₂]
     {op₁ : Dialect₁} {op₂ : Dialect₂}
     (h : ofDialect OpInfo op₁ = ofDialect OpInfo op₂)
-    (props : HasDialectOpInfo.propertiesOf op₁) :
+    (props : HasOpInfo.propertiesOf op₁) :
     toDialectProperties op₂ (h ▸ ofDialectProperties OpInfo op₁ props) =
       properties_eq_of_ofDialect_eq h ▸ props := by
   apply eq_of_heq
   exact (cast_heq _ _).trans ((eqRec_heq h _).trans ((cast_heq _ _).trans (cast_heq _ _).symm))
 
 /-- Coercion from a dialect property to the global property type. -/
-instance {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+instance {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (x : Dialect) :
     CoeHead (HasOpInfo.propertiesOf (opCode := OpInfo) x)
-      (HasDialectOpInfo.propertiesOf x) where
+      (HasOpInfo.propertiesOf x) where
   coe := HasDialect.toDialectProperties x
 
 /- Projecting an injected properties recover the original properties. -/
 @[simp, grind =]
 theorem toDialectProperties_ofDialectProperties (op : Dialect)
-    (props : HasDialectOpInfo.propertiesOf op) :
+    (props : HasOpInfo.propertiesOf op) :
     toDialectProperties op (ofDialectProperties OpInfo op props) =
       props := by
   grind [toDialectProperties, ofDialectProperties]

--- a/Veir/Interfaces/ConstantLikeInterfaces.lean
+++ b/Veir/Interfaces/ConstantLikeInterfaces.lean
@@ -15,7 +15,7 @@ public section
 
 def OperationPtr.isConstantLike {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
-  HasDialectOpInfo.isConstantLike (op.getOpType! ctx)
+  HasOpInfo.isConstantLike (op.getOpType! ctx)
 
 def ValuePtr.isConstantLike {OpInfo : Type} [HasOpInfo OpInfo]
     (val : ValuePtr) (ctx : IRContext OpInfo) : Bool :=

--- a/Veir/Interfaces/RegionKindInterfaces.lean
+++ b/Veir/Interfaces/RegionKindInterfaces.lean
@@ -26,7 +26,7 @@ def RegionPtr.hasSSADominance (region : RegionPtr)
   match (region.get! ctx.raw).parent with
   | none => true
   | some parent =>
-      HasDialectOpInfo.hasSSADominance (parent.getOpType! ctx.raw)
+      HasOpInfo.hasSSADominance (parent.getOpType! ctx.raw)
         ((parent.get! ctx.raw).regions.idxOf region)
 
 end Veir

--- a/Veir/Interfaces/SideEffectInterfaces.lean
+++ b/Veir/Interfaces/SideEffectInterfaces.lean
@@ -29,7 +29,7 @@ public section
 def OperationPtr.hasSideEffects {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
   let opType := op.getOpType! ctx
-  HasDialectOpInfo.hasSideEffects opType (op.getProperties! ctx opType)
+  HasOpInfo.hasSideEffects opType (op.getProperties! ctx opType)
 
 /--
   May this operation read memory?
@@ -40,7 +40,7 @@ def OperationPtr.readsMemory {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
   if op.getNumRegions! ctx != 0 then true else
   let opType := op.getOpType! ctx
-  HasDialectOpInfo.readsMemory opType (op.getProperties! ctx opType)
+  HasOpInfo.readsMemory opType (op.getProperties! ctx opType)
 
 /--
   May this operation write memory?
@@ -51,7 +51,7 @@ def OperationPtr.writesMemory {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
   if op.getNumRegions! ctx != 0 then true else
   let opType := op.getOpType! ctx
-  HasDialectOpInfo.writesMemory opType (op.getProperties! ctx opType)
+  HasOpInfo.writesMemory opType (op.getProperties! ctx opType)
 
 end
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -544,7 +544,7 @@ def MemoryState.llvmLoad (state : MemoryState) (addr : UInt64) (type : TypeAttr)
 
 
 
-def Arith.interpretOp' (opType : Veir.Arith) (properties : HasDialectOpInfo.propertiesOf opType)
+def Arith.interpretOp' (opType : Veir.Arith) (properties : HasOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -759,7 +759,7 @@ private def ModArith.binaryOperands (bw : Nat) (operands : Array RuntimeValue) :
   else
     none
 
-def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasDialectOpInfo.propertiesOf opType)
+def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -797,7 +797,7 @@ def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasDialectOpIn
     return (#[RuntimeValue.int bw res], none)
 
 
-def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasDialectOpInfo.propertiesOf opType)
+def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
@@ -1121,7 +1121,7 @@ def riscvLoad (mem : MemoryState) (eaddr : BitVec 64) (bytes : Nat) (ext : LoadE
     | .zeroExt => val.setWidth 64
   return (extended, mem)
 
-def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasDialectOpInfo.propertiesOf opType)
+def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
@@ -1510,7 +1510,7 @@ def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasDialectOpInfo.prop
     let mem ← mem.store eaddr.toNat.toUInt64 ((UInt64.ofBitVec val).toByteArrayLE.extract 0 1)
     return (#[], mem, none)
 
-def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : HasDialectOpInfo.propertiesOf opType)
+def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : HasOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (_operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
@@ -1519,7 +1519,7 @@ def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : HasDialec
     let (mem, addr) := mem.alloc properties.size.value.toNat.toUInt64
     return (#[.reg ⟨.ofNat 64 addr.toNat⟩], mem, none)
 
-def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInfo.propertiesOf opType)
+def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     : Interp (Array RuntimeValue × Option ControlFlowAction) :=
   match opType with
@@ -1605,7 +1605,7 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasDialectOpInf
     else
       return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
 
-def Rv64.interpretOp' (opType : Veir.Rv64) (properties : HasDialectOpInfo.propertiesOf opType)
+def Rv64.interpretOp' (opType : Veir.Rv64) (properties : HasOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (_operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1616,7 +1616,7 @@ def Rv64.interpretOp' (opType : Veir.Rv64) (properties : HasDialectOpInfo.proper
     else
       none
 
-def Cf.interpretOp' (opType : Veir.Cf) (properties : HasDialectOpInfo.propertiesOf opType)
+def Cf.interpretOp' (opType : Veir.Cf) (properties : HasOpInfo.propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1637,7 +1637,7 @@ def Cf.interpretOp' (opType : Veir.Cf) (properties : HasDialectOpInfo.properties
     | .int 1 .poison => Interp.ub
     | _ => none
 
-def Comb.interpretOp' (opType : Veir.Comb) (properties : HasDialectOpInfo.propertiesOf opType)
+def Comb.interpretOp' (opType : Veir.Comb) (properties : HasOpInfo.propertiesOf opType)
     (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1652,7 +1652,7 @@ def Comb.interpretOp' (opType : Veir.Comb) (properties : HasDialectOpInfo.proper
     return (#[.int w (Veir.Data.Comb.add nl)], none)
   | _ => none
 
-def HW.interpretOp' (opType : Veir.HW) (properties : HasDialectOpInfo.propertiesOf opType)
+def HW.interpretOp' (opType : Veir.HW) (properties : HasOpInfo.propertiesOf opType)
     (resultTypes : Array TypeAttr) (_blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -15,8 +15,8 @@ namespace Veir
 -/
 private def isFoldEvaluationCandidate
     (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode) : Bool :=
-  !HasDialectOpInfo.hasSideEffects opCode properties &&
-    !HasDialectOpInfo.readsMemory opCode properties
+  !HasOpInfo.hasSideEffects opCode properties &&
+    !HasOpInfo.readsMemory opCode properties
 
 /--
   Evaluate an operation with the interpreter, given the runtime values of its

--- a/Veir/Meta/OpCode.lean
+++ b/Veir/Meta/OpCode.lean
@@ -199,7 +199,7 @@ elab "#generate_op_codes" : command => do
 /--
 Generate a `HasDialect OpInfo Dialect` instance for every dialect constructor
 of the merged `OpInfo` inductive. This command must be invoked after
-`HasOpInfo OpInfo` and all dialect-local `HasDialectOpInfo` instances have been
+`HasOpInfo OpInfo` and all dialect-local `HasOpInfo` instances have been
 defined.
 -/
 elab "#generate_has_dialect_instances" opInfo:ident : command => do

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -215,9 +215,9 @@ def insertOp! (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (ip : Insert
 /--
 Set the properties of an operation in place, and re-enqueue it.
 -/
-def setProperties {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+def setProperties {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : Dialect)
-    (newProps : HasDialectOpInfo.propertiesOf opCode)
+    (newProps : HasOpInfo.propertiesOf opCode)
     (opIn : op.InBounds rewriter.ctx.raw := by grind)
     (hprop : op.getOpType! rewriter.ctx.raw = opCode := by grind)
     : PatternRewriter OpInfo :=
@@ -231,9 +231,9 @@ def setProperties {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo
 Set the properties of an operation in place, panicking if the operation is out of bounds, or if
 the property types don't match.
 -/
-def setProperties! {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+def setProperties! {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : Dialect)
-    (newProps : HasDialectOpInfo.propertiesOf opCode) : PatternRewriter OpInfo :=
+    (newProps : HasOpInfo.propertiesOf opCode) : PatternRewriter OpInfo :=
   if opIn : op.InBounds rewriter.ctx.raw then
     if hprop : op.getOpType! rewriter.ctx.raw = opCode then
       rewriter.setProperties op opCode newProps opIn hprop

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -302,7 +302,7 @@ theorem Rewriter.setAttributes_fieldsInBounds :
 
 section Rewriter.setProperties
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 
 /--
@@ -313,12 +313,12 @@ while the `Dialect` version is often easier to use when manipulating dialect-spe
 -/
 def Rewriter.setProperties (ctx: IRContext OpInfo) (op: OperationPtr)
     (opCode : Dialect := by grind)
-    (newProps: HasDialectOpInfo.propertiesOf opCode)
+    (newProps: HasOpInfo.propertiesOf opCode)
     (opIn : op.InBounds ctx := by grind)
     (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   op.setProperties ctx opCode newProps opIn hprop
 
-variable {op : OperationPtr} {newProperties : HasDialectOpInfo.propertiesOf opCode}
+variable {op : OperationPtr} {newProperties : HasOpInfo.propertiesOf opCode}
 variable {opIn : op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
 
 @[grind =]
@@ -925,16 +925,16 @@ theorem Rewriter.initBlockOperands_inBounds_mono (ptr : GenericPtr) :
     grind
 
 @[irreducible]
-def Rewriter.createEmptyOp {Dialect : Type} [HasDialectOpInfo Dialect]
+def Rewriter.createEmptyOp {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (ctx : IRContext OpInfo) (opType : Dialect)
-    (properties : HasDialectOpInfo.propertiesOf opType) :
+    (properties : HasOpInfo.propertiesOf opType) :
     Option (IRContext OpInfo × OperationPtr) :=
   OperationPtr.allocEmpty ctx opType properties
 
 section Rewriter.createEmptyOp
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {properties : HasDialectOpInfo.propertiesOf opType}
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {properties : HasOpInfo.propertiesOf opType}
 
 @[grind .]
 theorem Rewriter.createEmptyOp_new_inBounds
@@ -963,10 +963,10 @@ theorem Rewriter.createEmptyOp_fieldsInBounds
 end Rewriter.createEmptyOp
 
 @[irreducible]
-def Rewriter.createOp {Dialect : Type} [HasDialectOpInfo Dialect]
+def Rewriter.createOp {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (ctx: IRContext OpInfo) (opType: Dialect)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions: Array RegionPtr) (properties: HasDialectOpInfo.propertiesOf opType)
+    (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
     (insertionPoint: Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds ctx := by grind)
     (hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds ctx := by grind)
@@ -992,8 +992,8 @@ def Rewriter.createOp {Dialect : Type} [HasDialectOpInfo Dialect]
 
 section Rewriter.createOp
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {props : HasDialectOpInfo.propertiesOf opType}
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {props : HasOpInfo.propertiesOf opType}
 
 @[grind .]
 theorem Rewriter.createOp_inBounds_mono (ptr : GenericPtr)

--- a/Veir/Rewriter/GetSet/BlockArguments.lean
+++ b/Veir/Rewriter/GetSet/BlockArguments.lean
@@ -49,7 +49,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 
 /-! ## `Rewriter.pushBlockArgument` -/

--- a/Veir/Rewriter/GetSet/BlockOperands.lean
+++ b/Veir/Rewriter/GetSet/BlockOperands.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 
 /-! ## `Rewriter.pushBlockOperand` -/

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -55,12 +55,12 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {dialectOpType : Dialect}
-variable {CreateDialect : Type} [HasDialectOpInfo CreateDialect]
+variable {CreateDialect : Type} [HasOpInfo CreateDialect]
   [HasDialect OpInfo CreateDialect]
 variable {opType : CreateDialect}
-variable {properties : HasDialectOpInfo.propertiesOf opType}
+variable {properties : HasOpInfo.propertiesOf opType}
 section Rewriter.createEmptyOp
 
 variable {op : OperationPtr}

--- a/Veir/Rewriter/GetSet/CreateRegion.lean
+++ b/Veir/Rewriter/GetSet/CreateRegion.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 
 section Rewriter.createRegion

--- a/Veir/Rewriter/GetSet/DetachBlockOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachBlockOperands.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 section Rewriter.detachBlockOperands.loop
 

--- a/Veir/Rewriter/GetSet/DetachOp.lean
+++ b/Veir/Rewriter/GetSet/DetachOp.lean
@@ -52,7 +52,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 section Rewriter.unsetParentAndNeighbors
 

--- a/Veir/Rewriter/GetSet/DetachOperands.lean
+++ b/Veir/Rewriter/GetSet/DetachOperands.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 section Rewriter.detachOperands.loop
 

--- a/Veir/Rewriter/GetSet/InsertOp.lean
+++ b/Veir/Rewriter/GetSet/InsertOp.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 section Rewriter.insertOp
 

--- a/Veir/Rewriter/GetSet/Operands.lean
+++ b/Veir/Rewriter/GetSet/Operands.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 /-! ## `Rewriter.pushOperand` -/
 

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -48,7 +48,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 /-! ## `Rewriter.setAttributes` -/
 
@@ -276,7 +276,7 @@ end Rewriter.setAttributes
 
 section Rewriter.setProperties
 
-variable {op : OperationPtr} {newProps : HasDialectOpInfo.propertiesOf opCode}
+variable {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode}
          {opIn : op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
 
 attribute [local grind] Rewriter.setProperties
@@ -366,7 +366,7 @@ theorem OperationPtr.attrs!_setProperties {op' : OperationPtr} :
 
 @[grind =]
 theorem OperationPtr.getProperties!_setProperties
-    {GetterDialect : Type} [HasDialectOpInfo GetterDialect]
+    {GetterDialect : Type} [HasOpInfo GetterDialect]
     [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect}
     {op' : OperationPtr} :
     op'.getProperties!

--- a/Veir/Rewriter/GetSet/Regions.lean
+++ b/Veir/Rewriter/GetSet/Regions.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 /-! ## `Rewriter.pushRegion` -/
 

--- a/Veir/Rewriter/GetSet/ReplaceUse.lean
+++ b/Veir/Rewriter/GetSet/ReplaceUse.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 section Rewriter.replaceUse
 

--- a/Veir/Rewriter/GetSet/Results.lean
+++ b/Veir/Rewriter/GetSet/Results.lean
@@ -50,7 +50,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 /-! ## `Rewriter.pushResult` -/
 

--- a/Veir/Rewriter/GetSet/Value.lean
+++ b/Veir/Rewriter/GetSet/Value.lean
@@ -49,7 +49,7 @@ namespace Veir
 
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode : Dialect}
 /-! ## `Rewriter.setType` -/
 

--- a/Veir/Rewriter/LinkedList/GetSet.lean
+++ b/Veir/Rewriter/LinkedList/GetSet.lean
@@ -53,7 +53,7 @@ variable {blockOperand blockOperand' : BlockOperandPtr}
 variable {value value' : ValuePtr}
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx ctx' : IRContext OpInfo}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {opCode propT : Dialect}
 
 /- OpOperandPtr.removeFromCurrent -/

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -311,13 +311,13 @@ end setAttributes
 
 section setProperties
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opCode : Dialect} {newProps : HasDialectOpInfo.propertiesOf opCode}
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opCode : Dialect} {newProps : HasOpInfo.propertiesOf opCode}
 
 theorem OperationPtr.setProperties_WellFormed (ctx: IRContext OpInfo)
   (op: OperationPtr) (hctx : ctx.WellFormed) (hop : op.InBounds ctx)
   (hprop : op.getOpType! ctx = opCode := by grind)
-  (newProperties: HasDialectOpInfo.propertiesOf opCode) :
+  (newProperties: HasOpInfo.propertiesOf opCode) :
   (op.setProperties ctx opCode newProperties hop hprop).WellFormed := by
   have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := hctx
   constructor
@@ -353,7 +353,7 @@ theorem OperationPtr.setProperties_WellFormed (ctx: IRContext OpInfo)
 theorem BlockPtr.opChain_OperationPtr_setProperties
     (hWf : BlockPtr.OpChain block' ctx array)
     {op : OperationPtr} (hop : op.InBounds ctx)
-    (newProps : HasDialectOpInfo.propertiesOf opCode)
+    (newProps : HasOpInfo.propertiesOf opCode)
     (hprop : op.getOpType! ctx = opCode := by grind) :
     BlockPtr.OpChain block' (op.setProperties ctx opCode newProps hop hprop) array := by
   apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
@@ -652,8 +652,8 @@ theorem OperationPtr.getOperand_Rewriter_eraseOp
 
 section createOp
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {properties : HasDialectOpInfo.propertiesOf opType}
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {properties : HasOpInfo.propertiesOf opType}
 
 theorem Rewriter.createEmptyOp_wellFormed  (hctx : IRContext.WellFormed ctx) :
     Rewriter.createEmptyOp ctx opType properties = some (newCtx, newOp) →

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -166,9 +166,9 @@ def WfRewriter.setAttributes! (wfCtx : WfIRContext OpInfo) (op : OperationPtr) (
 
 /-- Set the properties of an operation. -/
 @[inline]
-def WfRewriter.setProperties {Dialect : Type} [HasDialectOpInfo Dialect]
+def WfRewriter.setProperties {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo)
-    (op : OperationPtr) (opCode : Dialect) (newProps : HasDialectOpInfo.propertiesOf opCode)
+    (op : OperationPtr) (opCode : Dialect) (newProps : HasOpInfo.propertiesOf opCode)
     (opIn : op.InBounds wfCtx.raw := by grind)
     (hprop : op.getOpType! wfCtx.raw = opCode := by grind) :
     WfIRContext OpInfo :=
@@ -179,9 +179,9 @@ def WfRewriter.setProperties {Dialect : Type} [HasDialectOpInfo Dialect]
 Set the properties of an operation, panicking if the operation is out of bounds, or if the
 property types don't match.
 -/
-def WfRewriter.setProperties! {Dialect : Type} [HasDialectOpInfo Dialect]
+def WfRewriter.setProperties! {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo)
-    (op : OperationPtr) (opCode : Dialect) (newProperties : HasDialectOpInfo.propertiesOf opCode) :
+    (op : OperationPtr) (opCode : Dialect) (newProperties : HasOpInfo.propertiesOf opCode) :
     WfIRContext OpInfo :=
   if opIn : op.InBounds wfCtx.raw then
     if hprop : op.getOpType! wfCtx.raw = opCode then
@@ -440,10 +440,10 @@ def WfRewriter.pushBlockOperand! (wfCtx : WfIRContext OpInfo) (opPtr : Operation
 
 /-- Create an operation and insert it at a given location. -/
 @[inline]
-def WfRewriter.createOp {Dialect : Type} [HasDialectOpInfo Dialect]
+def WfRewriter.createOp {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo) (opType : Dialect)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions : Array RegionPtr) (properties : HasDialectOpInfo.propertiesOf opType)
+    (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
     (insertionPoint : Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw := by grind)
     (hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds wfCtx.raw := by grind)
@@ -459,10 +459,10 @@ Create an operation and insert it at a given location, panicking if any operand,
 or region is out of bounds, if the insertion point is out of bounds, or if the operation could
 not be created.
 -/
-def WfRewriter.createOp! {Dialect : Type} [HasDialectOpInfo Dialect]
+def WfRewriter.createOp! {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo) (opType : Dialect)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions : Array RegionPtr) (properties : HasDialectOpInfo.propertiesOf opType)
+    (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
     (insertionPoint : Option InsertPoint)
     : Option (WfIRContext OpInfo × OperationPtr) :=
   if hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw then

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -45,12 +45,12 @@ namespace Veir
 variable {OpInfo} [HasOpInfo OpInfo]
 variable {ctx ctx' : WfIRContext OpInfo}
 variable {operation : OperationPtr} {region : RegionPtr} {block : BlockPtr} {value : ValuePtr}
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {dialectOpType : Dialect}
-variable {CreateDialect : Type} [HasDialectOpInfo CreateDialect]
+variable {CreateDialect : Type} [HasOpInfo CreateDialect]
   [HasDialect OpInfo CreateDialect]
 variable {opType : CreateDialect}
-variable {properties : HasDialectOpInfo.propertiesOf opType}
+variable {properties : HasOpInfo.propertiesOf opType}
 
 /-! ## `WfRewriter.createOp` -/
 
@@ -1069,7 +1069,7 @@ section WfRewriter.setProperties
 attribute [local grind] WfRewriter.setProperties
 
 variable {opCode : Dialect} {op : OperationPtr}
-         {newProps : HasDialectOpInfo.propertiesOf opCode}
+         {newProps : HasOpInfo.propertiesOf opCode}
          {opIn : op.InBounds ctx.raw} {hprop : op.getOpType! ctx.raw = opCode}
 
 @[simp, grind =]
@@ -1134,7 +1134,7 @@ theorem OperationPtr.attrs!_wfRewriter_setProperties {op' : OperationPtr} :
 
 @[grind =]
 theorem OperationPtr.getProperties!_wfRewriter_setProperties
-    {GetterDialect : Type} [HasDialectOpInfo GetterDialect]
+    {GetterDialect : Type} [HasOpInfo GetterDialect]
     [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect} {op' : OperationPtr} :
     op'.getProperties!
       (WfRewriter.setProperties ctx op opCode newProps opIn hprop).raw getterOpCode =

--- a/Veir/Rewriter/WfRewriter/InBounds.lean
+++ b/Veir/Rewriter/WfRewriter/InBounds.lean
@@ -168,8 +168,8 @@ theorem WfRewriter.pushBlockOperand_inBounds_mono :
 
 section WfRewriter.createOp
 
-variable {Dialect : Type} [HasDialectOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {properties : HasDialectOpInfo.propertiesOf opType}
+variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {opType : Dialect} {properties : HasOpInfo.propertiesOf opType}
 
 @[grind →]
 theorem WfRewriter.createOp_new_inBounds (ptr : OperationPtr)


### PR DESCRIPTION
These two classes had no reason anymore to be split anymore, as they are isomorphic. With this, dialect opcodes and the global opcode both define `HasOpInfo`.