### PR TITLE
feat: constant materialization interface

### DIFF
--- a/UnitTest/FoldDecision.lean
+++ b/UnitTest/FoldDecision.lean
@@ -59,3 +59,183 @@ info: "ok"
 -/
 #guard_msgs in
 #eval! testFoldDecision
+
+private def testArithConstantMaterialization : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  match (.arith .addi : OpCode).materializeConstant (.int 32 (.val 15)) i32 with
+  | some ⟨.arith .constant, props⟩ =>
+    if props.value ≠ IntegerAttr.mk 15 (IntegerType.mk 32) then
+      return "arith materialized the wrong constant"
+    return "ok"
+  | _ => return "arith did not materialize arith.constant"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testArithConstantMaterialization
+
+private def testRiscvConstantMaterialization : String := Id.run do
+  let regType : TypeAttr := RegisterType.mk
+  let value : RuntimeValue := .reg ⟨BitVec.ofInt 64 (-77)⟩
+  match (.riscv .add : OpCode).materializeConstant value regType with
+  | some ⟨.riscv .li, props⟩ =>
+    if props.value ≠ IntegerAttr.mk (-77) (IntegerType.mk 64) then
+      return "RISC-V materialized the wrong immediate"
+    return "ok"
+  | _ => return "RISC-V did not materialize riscv.li"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testRiscvConstantMaterialization
+
+private def testModArithConstantMaterialization : String := Id.run do
+  let type : TypeAttr := ModArithType.mk (IntegerAttr.mk 251 (IntegerType.mk 8))
+  match (.mod_arith .add : OpCode).materializeConstant (.int 8 (.val 250)) type with
+  | some ⟨.mod_arith .constant, props⟩ =>
+    if props.value ≠ IntegerAttr.mk 250 (IntegerType.mk 8) then
+      return "mod_arith materialized the wrong constant"
+    return "ok"
+  | _ => return "mod_arith did not materialize mod_arith.constant"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testModArithConstantMaterialization
+
+/-- Comb has no constant of its own, so it materializes an HW operation. -/
+private def testCombConstantMaterialization : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  match (.comb .add : OpCode).materializeConstant (.int 32 (.val 7)) i32 with
+  | some ⟨.hw .constant, props⟩ =>
+    if props.value ≠ IntegerAttr.mk 7 (IntegerType.mk 32) then
+      return "comb materialized the wrong constant"
+    return "ok"
+  | _ => return "comb did not materialize hw.constant"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testCombConstantMaterialization
+
+private def testHWConstantMaterialization : String := Id.run do
+  let i16 : TypeAttr := IntegerType.mk 16
+  match (.hw .output : OpCode).materializeConstant (.int 16 (.val 9)) i16 with
+  | some ⟨.hw .constant, props⟩ =>
+    if props.value ≠ IntegerAttr.mk 9 (IntegerType.mk 16) then
+      return "hw materialized the wrong constant"
+    return "ok"
+  | _ => return "hw did not materialize hw.constant"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testHWConstantMaterialization
+
+private def testLlvmConstantMaterialization : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  match (.llvm .add : OpCode).materializeConstant (.int 32 (.val 21)) i32 with
+  | some ⟨.llvm .mlir__constant, props⟩ =>
+    if props.value ≠ .integer (IntegerAttr.mk 21 (IntegerType.mk 32)) then
+      return "LLVM materialized the wrong constant"
+    return "ok"
+  | _ => return "LLVM did not materialize llvm.mlir.constant"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testLlvmConstantMaterialization
+
+/-- LLVM can spell poison; the fold decision for `nsw` overflow reaches it. -/
+private def testLlvmPoisonMaterialization : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  match (.llvm .add : OpCode).materializeConstant (.int 32 .poison) i32 with
+  | some ⟨.llvm .mlir__poison, _⟩ => return "ok"
+  | _ => return "LLVM did not materialize llvm.mlir.poison"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testLlvmPoisonMaterialization
+
+/-- Arith has no poison operation of its own, so it reaches for LLVM's. -/
+private def testArithPoisonMaterialization : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  match (.arith .addi : OpCode).materializeConstant (.int 32 .poison) i32 with
+  | some ⟨.llvm .mlir__poison, _⟩ => return "ok"
+  | _ => return "arith did not materialize llvm.mlir.poison"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testArithPoisonMaterialization
+
+/--
+The whole way there: an `arith.addi` with `nsw` that overflows evaluates to
+poison, the fold decision carries it, and materialization spells it.
+-/
+private def testNswOverflowFoldsToPoison : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  let props : HasOpInfo.propertiesOf (.arith .addi : OpCode) :=
+    ArithIntegerOverflowFlagsProperties.mk { nsw := true, nuw := false }
+  let operands : Array (Option RuntimeValue) :=
+    #[some (.int 32 (.val (BitVec.ofInt 32 2147483647))), some (.int 32 (.val 1))]
+  match OpCode.foldsTo (.arith .addi) props #[i32] operands with
+  | some (.useConstant value) =>
+    match (.arith .addi : OpCode).materializeConstant value i32 with
+    | some ⟨.llvm .mlir__poison, _⟩ => return "ok"
+    | _ => return "nsw overflow did not materialize llvm.mlir.poison"
+  | _ => return "nsw overflow did not fold"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testNswOverflowFoldsToPoison
+
+/--
+The dialects with no materializer decline rather than materializing something
+from a neighbouring dialect. One representative per dialect; the dispatch in
+`OpCode.materializeConstant` lists them all explicitly, so a newly added
+dialect cannot silently join this set.
+-/
+private def testDialectsWithoutMaterializerDecline : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  let value : RuntimeValue := .int 32 (.val 3)
+  let cases : Array (String × OpCode) := #[
+    ("riscv_cf", .riscv_cf .branch), ("riscv_stack", .riscv_stack .alloca),
+    ("rv64", .rv64 .get_register), ("cf", .cf .br), ("builtin", .builtin .module),
+    ("func", .func .call), ("datapath", .datapath .compress),
+    ("pdl", .pdl .operation), ("test", .test .test)
+  ]
+  for (name, opCode) in cases do
+    if (opCode.materializeConstant value i32).isSome then
+      return s!"{name} materialized a constant but has no materializer"
+  return "ok"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDialectsWithoutMaterializerDecline
+
+/-- A value whose width disagrees with the result type is never materialized. -/
+private def testBitwidthMismatchIsRejected : String := Id.run do
+  let i32 : TypeAttr := IntegerType.mk 32
+  match (.arith .addi : OpCode).materializeConstant (.int 16 (.val 7)) i32 with
+  | none => return "ok"
+  | some _ => return "arith materialized a constant of the wrong width"
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testBitwidthMismatchIsRejected

--- a/Veir/ConstantMaterialization.lean
+++ b/Veir/ConstantMaterialization.lean
@@ -22,9 +22,9 @@ abbrev Materialized (OpInfo : Type) [HasOpInfo OpInfo] :=
   Inject a dialect-local opcode and its properties into `OpInfo`. This is how a
   dialect materializer names the operation it wants created.
 -/
-def Materialized.of {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+def Materialized.of {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (op : Dialect)
-    (properties : HasDialectOpInfo.propertiesOf op) : Materialized OpInfo :=
+    (properties : HasOpInfo.propertiesOf op) : Materialized OpInfo :=
   ⟨ofDialect OpInfo op, HasDialect.ofDialectProperties OpInfo op properties⟩
 
 end

--- a/Veir/ConstantMaterialization.lean
+++ b/Veir/ConstantMaterialization.lean
@@ -1,0 +1,32 @@
+module
+
+public import Veir.IR.OpInfo
+public import Veir.RuntimeValue
+
+/-!
+  # Constant materialization
+-/
+
+namespace Veir
+
+public section
+
+/--
+  A constant-like operation together with the properties that make it
+  materialize a particular value.
+-/
+abbrev Materialized (OpInfo : Type) [HasOpInfo OpInfo] :=
+  Σ op : OpInfo, HasOpInfo.propertiesOf op
+
+/--
+  Inject a dialect-local opcode and its properties into `OpInfo`. This is how a
+  dialect materializer names the operation it wants created.
+-/
+def Materialized.of {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasDialectOpInfo Dialect]
+    [HasDialect OpInfo Dialect] (op : Dialect)
+    (properties : HasDialectOpInfo.propertiesOf op) : Materialized OpInfo :=
+  ⟨ofDialect OpInfo op, HasDialect.ofDialectProperties OpInfo op properties⟩
+
+end
+
+end Veir

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -4,6 +4,8 @@ public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Arith.Properties
 public import Veir.Dialects.LLVM.Properties
+public import Veir.Dialects.LLVM.OpInfo
+public import Veir.ConstantMaterialization
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -141,6 +143,22 @@ instance : HasDialectOpInfo Arith where
   writesMemory := Arith.writesMemory
   isConstantLike := Arith.isConstantLike
   hasSSADominance := Arith.hasSSADominance
+
+/--
+Materialize integer results of folded arithmetic operations as `arith.constant`.
+Poison is materialized as `llvm.mlir.poison`.
+-/
+def Arith.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Arith]
+    [HasDialect OpInfo Llvm] (_op : Arith) (value : RuntimeValue) (type : TypeAttr) :
+    Option (Materialized OpInfo) :=
+  match value, type.val with
+  | .int bw (.val value), .integerType intType =>
+    if bw = intType.bitwidth then
+      some (.of Arith.constant (ArithConstantProperties.mk (IntegerAttr.mk value.toInt intType)))
+    else none
+  | .int bw .poison, .integerType intType =>
+    if bw = intType.bitwidth then some (.of Llvm.mlir__poison ()) else none
+  | _, _ => none
 
 end
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -3,6 +3,8 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Comb.Properties
+public import Veir.Dialects.HW.OpInfo
+public import Veir.ConstantMaterialization
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -88,6 +90,18 @@ instance : HasDialectOpInfo Comb where
   writesMemory := Comb.writesMemory
   isConstantLike := Comb.isConstantLike
   hasSSADominance := Comb.hasSSADominance
+
+/--
+CIRCT combinational folds use the HW dialect's integer constant.
+-/
+def Comb.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo HW]
+    (_op : Comb) (value : RuntimeValue) (type : TypeAttr) : Option (Materialized OpInfo) :=
+  match value, type.val with
+  | .int bw (.val value), .integerType intType =>
+    if bw = intType.bitwidth then
+      some (.of HW.constant (HWConstantProperties.mk (IntegerAttr.mk value.toInt intType)))
+    else none
+  | _, _ => none
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.HW.Properties
+public import Veir.ConstantMaterialization
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -79,6 +80,16 @@ instance : HasDialectOpInfo HW where
   writesMemory := HW.writesMemory
   isConstantLike := HW.isConstantLike
   hasSSADominance := HW.hasSSADominance
+
+/-- Materialize integer results as `hw.constant`. -/
+def HW.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo HW]
+    (_op : HW) (value : RuntimeValue) (type : TypeAttr) : Option (Materialized OpInfo) :=
+  match value, type.val with
+  | .int bw (.val value), .integerType intType =>
+    if bw = intType.bitwidth then
+      some (.of HW.constant (HWConstantProperties.mk (IntegerAttr.mk value.toInt intType)))
+    else none
+  | _, _ => none
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -4,6 +4,7 @@ public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.LLVM.Properties
 public import Veir.Dialects.Cf.Properties
+public import Veir.ConstantMaterialization
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -378,6 +379,26 @@ instance : HasDialectOpInfo Llvm where
   writesMemory := Llvm.writesMemory
   isConstantLike := Llvm.isConstantLike
   hasSSADominance := Llvm.hasSSADominance
+
+/-- Materialize constants produced by folding LLVM dialect operations. -/
+def Llvm.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Llvm]
+    (_op : Llvm) (value : RuntimeValue) (type : TypeAttr) : Option (Materialized OpInfo) :=
+  match value, type.val with
+  | .int bw (.val value), .integerType intType =>
+    if bw = intType.bitwidth then
+      some (.of Llvm.mlir__constant
+        (LLVMConstantProperties.mk (.integer (IntegerAttr.mk value.toInt intType))))
+    else none
+  | .int bw .poison, .integerType intType =>
+    if bw = intType.bitwidth then some (.of Llvm.mlir__poison ()) else none
+  | .float bw value, .floatType floatType =>
+    -- `llvm.mlir.constant` only interprets 64-bit floats, so anything narrower
+    -- would materialize a constant that cannot be read back.
+    if bw = floatType.bitwidth ∧ bw = 64 then
+      some (.of Llvm.mlir__constant
+        (LLVMConstantProperties.mk (.float (FloatAttr.mk value floatType))))
+    else none
+  | _, _ => none
 
 end
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.ModArith.Properties
+public import Veir.ConstantMaterialization
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -72,3 +73,17 @@ instance : HasDialectOpInfo Mod_Arith where
   writesMemory := Mod_Arith.writesMemory
   isConstantLike := Mod_Arith.isConstantLike
   hasSSADominance := Mod_Arith.hasSSADominance
+
+/--
+Materialize concrete modular-integer fold results.
+-/
+def Mod_Arith.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Mod_Arith]
+    (_op : Mod_Arith) (value : RuntimeValue) (type : TypeAttr) : Option (Materialized OpInfo) :=
+  match value, type.val with
+  | .int bw (.val value), .modArithType modType =>
+    if bw = modType.modulus.type.bitwidth then
+      some (.of Mod_Arith.constant
+        (ModArithConstantProperties.mk
+          (IntegerAttr.mk (Int.ofNat value.toNat) modType.modulus.type)))
+    else none
+  | _, _ => none

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.RISCV.Properties
+public import Veir.ConstantMaterialization
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -334,6 +335,18 @@ instance : HasDialectOpInfo Riscv where
   writesMemory := Riscv.writesMemory
   isConstantLike := Riscv.isConstantLike
   hasSSADominance := Riscv.hasSSADominance
+
+/--
+Materialize register-valued fold results as `riscv.li`. A register always holds
+64 bits, so the immediate is always an `i64`.
+-/
+def Riscv.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Riscv]
+    (_op : Riscv) (value : RuntimeValue) (type : TypeAttr) : Option (Materialized OpInfo) :=
+  match value, type.val with
+  | .reg value, .registerType _ =>
+    some (.of Riscv.li
+      (RISCVImmediateProperties.mk (IntegerAttr.mk value.val.toInt (IntegerType.mk 64))))
+  | _, _ => none
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -269,6 +269,28 @@ instance : HasOpInfo OpCode where
 abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
 
 /--
+Ask the dialect of `opCode` how to represent a folded
+constant. Dialects without a materializer, and values a dialect cannot
+represent, decline to fold.
+-/
+def OpCode.materializeConstant (opCode : OpCode) (value : RuntimeValue)
+    (type : TypeAttr) : Option (Materialized OpCode) := do
+  let materialized ←
+    match opCode with
+    | .arith op => Arith.materializeConstant op value type
+    | .comb op => Comb.materializeConstant op value type
+    | .hw op => HW.materializeConstant op value type
+    | .llvm op => Llvm.materializeConstant op value type
+    | .mod_arith op => Mod_Arith.materializeConstant op value type
+    | .riscv op => Riscv.materializeConstant op value type
+    -- Listed rather than folded into a catch-all so that adding a dialect
+    -- fails to compile until it decides how, or whether, to materialize.
+    | .riscv_cf _ | .riscv_stack _ | .rv64 _ | .cf _ | .builtin _
+    | .func _ | .datapath _ | .pdl _ | .test _ => none
+  guard materialized.fst.isConstantLike
+  return materialized
+
+/--
   Is this `OpCode` commutative in its operands, i.e. `op x y` always
   computes the same value as `op y x`?
 -/

--- a/Veir/Interfaces/FoldInterfaces.lean
+++ b/Veir/Interfaces/FoldInterfaces.lean
@@ -3,12 +3,13 @@ module
 public import Veir.Interfaces.ConstantLikeInterfaces
 public import Veir.Interpreter.Basic
 public import Veir.Interpreter.Evaluate
+public import Veir.PatternRewriter.Basic
 
 /-!
   # Constant folding decision interface
 
-  This file is the public entry point for deciding whether operations fold. It
-  does not provide IR mutation or constant materialization.
+  This file is the public entry point for deciding whether operations fold and
+  for materializing folded constants in the IR.
 -/
 
 public section
@@ -50,5 +51,16 @@ def OperationPtr.foldsTo (op : OperationPtr)
   OpCode.foldsTo opType
     (op.getProperties ctx.raw opType opInBounds (by grind))
     (op.getResultTypes ctx.raw opInBounds) constOperands
+
+/--
+Materialize `value` using the materialization hook of `foldingOpType`'s dialect.
+The hook may select a constant-like operation from another dialect.
+-/
+def PatternRewriter.materializeConstant! (rewriter : PatternRewriter OpCode)
+    (foldingOpType : OpCode) (value : RuntimeValue) (resultType : TypeAttr)
+    (insertionPoint : InsertPoint) : Option (PatternRewriter OpCode × OperationPtr) := do
+  let ⟨materializedOpType, properties⟩ ← foldingOpType.materializeConstant value resultType
+  rewriter.createOp! materializedOpType #[resultType] #[] #[] #[] properties
+    (some insertionPoint)
 
 end Veir

--- a/Veir/Interfaces/FoldInterfaces.lean
+++ b/Veir/Interfaces/FoldInterfaces.lean
@@ -55,12 +55,21 @@ def OperationPtr.foldsTo (op : OperationPtr)
 /--
 Materialize `value` using the materialization hook of `foldingOpType`'s dialect.
 The hook may select a constant-like operation from another dialect.
+
+The return values signal two different failure modes:
+* `some (rewriter, none)` - the constant cannot be materialized, this means the
+   rewrite doesn't happen but there's no cause for concern
+* `none` - the operation could not be created; in this case the entire pass
+   should generate a hard failure
 -/
 def PatternRewriter.materializeConstant! (rewriter : PatternRewriter OpCode)
     (foldingOpType : OpCode) (value : RuntimeValue) (resultType : TypeAttr)
-    (insertionPoint : InsertPoint) : Option (PatternRewriter OpCode × OperationPtr) := do
-  let ⟨materializedOpType, properties⟩ ← foldingOpType.materializeConstant value resultType
-  rewriter.createOp! materializedOpType #[resultType] #[] #[] #[] properties
+    (insertionPoint : InsertPoint) :
+    Option (PatternRewriter OpCode × Option OperationPtr) := do
+  let some ⟨opType, properties⟩ := foldingOpType.materializeConstant value resultType
+    | return (rewriter, none)
+  let (rewriter, op) ← rewriter.createOp! opType #[resultType] #[] #[] #[] properties
     (some insertionPoint)
+  return (rewriter, some op)
 
 end Veir

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1,7 +1,6 @@
 module
 
-public import Veir.Data.LLVM.Byte.Basic
-public import Veir.Data.RISCV.Reg.Basic
+public import Veir.RuntimeValue
 public import Veir.IR.WellFormed
 public import Veir.GlobalOpInfo
 
@@ -31,25 +30,6 @@ namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx : WfIRContext OpInfo}
-
-/--
-  The type-erased representation of a value in the interpreter.
--/
-inductive RuntimeValue where
-| int (bitwidth : Nat) (value : LLVM.Int bitwidth)
-| byte (bitwidth : Nat) (value : LLVM.Byte bitwidth)
-| float (bitwidth : Nat) (value : Float)
-| addr (value : UInt64)
-| reg (value : RISCV.Reg)
-deriving Inhabited
-
-instance : ToString (RuntimeValue) where
-  toString
-    | .int _ val => ToString.toString val
-    | .byte _ val => ToString.toString val
-    | .float _ val => ToString.toString val
-    | .addr val => ToString.toString val
-    | .reg val => ToString.toString val
 
 namespace RuntimeValue
 

--- a/Veir/RuntimeValue.lean
+++ b/Veir/RuntimeValue.lean
@@ -1,0 +1,33 @@
+module
+
+public import Veir.Data.LLVM.Byte.Basic
+public import Veir.Data.RISCV.Reg.Basic
+public import Veir.IR.Attribute
+
+namespace Veir
+
+public section
+
+/--
+  The type-erased representation of a value used by interpretation and
+  compile-time evaluation.
+-/
+inductive RuntimeValue where
+| int (bitwidth : Nat) (value : Data.LLVM.Int bitwidth)
+| byte (bitwidth : Nat) (value : Data.LLVM.Byte bitwidth)
+| float (bitwidth : Nat) (value : Float)
+| addr (value : UInt64)
+| reg (value : Data.RISCV.Reg)
+deriving Inhabited
+
+instance : ToString RuntimeValue where
+  toString
+    | .int _ val => ToString.toString val
+    | .byte _ val => ToString.toString val
+    | .float _ val => ToString.toString val
+    | .addr val => ToString.toString val
+    | .reg val => ToString.toString val
+
+end
+
+end Veir


### PR DESCRIPTION
ok this is nearly the last piece of constant folding.
what remains are:
- dialect-specific folding tables to capture things like `x * 0 -> 0`
- an actual pass that performs folding -- I'll put this in our canonicalizer if nobody objects
- (hopefully) using a folding interface as part of routine operation creation, like LLVM's `IRBuilder` does