### PR TITLE
feat(interpreter): allow global variables at the top level of a module

### DIFF
--- a/Test/Interpreter/global_at_top_level.mlir
+++ b/Test/Interpreter/global_at_top_level.mlir
@@ -1,0 +1,15 @@
+// RUN: veir-interpret %s | filecheck %s
+
+// An `llvm.mlir.global` alongside `@main` is a legal top-level op; the
+// interpreter must skip past it when looking for the entry point.
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, alignment = 4 : i64, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", unnamed_addr = 0 : i64, value = 41 : i32, visibility_ = 0 : i64}> ({
+  }) : () -> ()
+  "llvm.func"() <{CConv = #llvm.cconv<ccc>, function_type = !llvm.func<i32 ()>, linkage = #llvm.linkage<external>, sym_name = "main", visibility_ = 0 : i64}> ({
+    %x = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
+    "llvm.return"(%x) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000005#32]

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -50,7 +50,7 @@ partial def scanEntryPoints (ctx : IRContext OpCode) (op : Option OperationPtr)
     | .llvm .func | .func .func =>
       let entryPoints := if isZeroArgMainFunc ctx op then op :: entryPoints else entryPoints
       scanEntryPoints ctx (op.get! ctx).next entryPoints
-    | .llvm .module_flags =>
+    | .llvm .module_flags | .llvm .mlir__global =>
       scanEntryPoints ctx (op.get! ctx).next entryPoints
     | _ =>
       IO.eprintln "Error: Top-level operations are disallowed; define a zero-argument function named 'main'"


### PR DESCRIPTION
previously we insisted that main is the only entity at module top level, but we also want to permit globals there