### PR TITLE
feat: Introduce `LocalRewritePattern.Sound`

### DIFF
--- a/Veir/PatternRewriter/Semantics.lean
+++ b/Veir/PatternRewriter/Semantics.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.Interpreter
 public import Veir.Passes.Matching
+import Veir.Dominance.Basic
 
 import all Veir.Interpreter.Basic
 
@@ -77,6 +78,17 @@ def LocalRewritePattern.ReturnOps
   ∀ newOp, newOp ∈ newOps ↔ newOp.InBounds newCtx.raw ∧ ¬newOp.InBounds ctx.raw
 
 /--
+The operations returned by the pattern are pairwise distinct.
+
+Since we insert the returned operations one by one before the matched operation, the rewrite
+must not return the same operation twice.
+-/
+def LocalRewritePattern.ReturnOpsNodup (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ ctx op newCtx newOps newValues,
+  pattern ctx op = some (newCtx, some (newOps, newValues)) →
+  newOps.toList.Nodup
+
+/--
 The pattern returns the same number of values as the number of results of the matched operation.
 -/
 def LocalRewritePattern.ReturnValues (pattern : LocalRewritePattern OpCode) : Prop :=
@@ -90,6 +102,24 @@ All values returned by the pattern are in bounds of the new context.
 def LocalRewritePattern.ReturnValuesInBounds (pattern : LocalRewritePattern OpCode) : Prop :=
   ∀ ctx op newCtx newOps newValues, pattern ctx op = some (newCtx, some (newOps, newValues)) →
   ∀ v ∈ newValues, v.InBounds newCtx.raw
+
+/-- No value returned by the pattern is one of `op`'s own result pointers. -/
+def LocalRewritePattern.ReturnValuesNotOwnResults (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ ctx op newCtx newOps newValues, pattern ctx op = some (newCtx, some (newOps, newValues)) →
+  ∀ v ∈ newValues, v ∉ op.getResults! newCtx.raw
+
+/--
+Every new value that comes from the original context has to dominate the program point where the
+old operation is being replaced.
+-/
+def LocalRewritePattern.ReturnValuesDominate (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ ctx op newCtx newOps newValues, pattern ctx op = some (newCtx, some (newOps, newValues)) →
+  ∀ v ∈ newValues, v.InBounds ctx.raw → v.dominatesIp (InsertPoint.before op) ctx
+
+/-- The matched operation has no regions. -/
+def LocalRewritePattern.MatchedOpHasNoRegions (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ ctx op newCtx newOps newValues, pattern ctx op = some (newCtx, some (newOps, newValues)) →
+  op.getNumRegions! ctx.raw = 0
 
 /--
 Indexed access on the returned values is in bounds of the new context.
@@ -158,3 +188,66 @@ def LocalRewritePattern.PreservesSemantics
     ∃ targetValues,
       newValues.mapM (newState'.variables.getVar? ·) = some targetValues ∧
       sourceValues ⊒ targetValues
+
+/--
+Applying the pattern as a local rewrite preserves the dominance-wellformedness of the context.
+-/
+def LocalRewritePattern.RewritePreservesDom (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) (rewriter' : PatternRewriter OpCode),
+    RewritePattern.fromLocalRewrite pattern rewriter op opInBounds = some rewriter' →
+    rewriter.ctx.Dom → rewriter'.ctx.Dom
+
+/--
+Applying the pattern as a local rewrite preserves the verification-wellformedness of the context.
+-/
+def LocalRewritePattern.RewritePreservesVerified (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) (rewriter' : PatternRewriter OpCode),
+    RewritePattern.fromLocalRewrite pattern rewriter op opInBounds = some rewriter' →
+    rewriter.ctx.Verified → rewriter'.ctx.Verified
+
+/--
+Preserves block-level dominance.
+This is a strong property that will be simplified in the future in favor of a condition
+on the successors of the matched operation and the new operations.
+-/
+def LocalRewritePattern.RewritePreservesBlockDominance (pattern : LocalRewritePattern OpCode) : Prop :=
+  ∀ (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) (rewriter' : PatternRewriter OpCode),
+    RewritePattern.fromLocalRewrite pattern rewriter op opInBounds = some rewriter' →
+    ∀ (b₁ b₂ : BlockPtr), b₁.InBounds rewriter.ctx.raw → b₂.InBounds rewriter.ctx.raw →
+      (b₁.Dominates b₂ rewriter'.ctx ↔ b₁.Dominates b₂ rewriter.ctx)
+
+/--
+This proposition contains all the correctness obligations that a `LocalRewritePattern` must satisfy
+to derive a proof of global soundness of the transformation.
+-/
+structure LocalRewritePattern.Sound (pattern : LocalRewritePattern OpCode) : Prop where
+  /-- The pattern returns the input context whenever there are no errors and no match. -/
+  returnsCtxNoChanges : pattern.ReturnsCtxNoChanges
+  /-- On a match, the output context is only modified by creating new operations. -/
+  returnCtxChanges : pattern.ReturnCtxChanges
+  /-- On a match, the returned operations are exactly the newly created ones. -/
+  returnOps : pattern.ReturnOps
+  /-- The returned operations are pairwise distinct (required for the driver's insert loop). -/
+  returnOpsNodup : pattern.ReturnOpsNodup
+  /-- The pattern returns one value per result of the matched operation. -/
+  returnValues : pattern.ReturnValues
+  /-- All returned values are in bounds of the new context. -/
+  returnValuesInBounds : pattern.ReturnValuesInBounds
+  /-- No returned value is one of `op`'s own result pointers. -/
+  returnValuesNotOwnResults : pattern.ReturnValuesNotOwnResults
+  /-- Every forwarded pre-existing returned value dominates the point before `op`. -/
+  returnValuesDominate : pattern.ReturnValuesDominate
+  /-- The matched operation has no regions. -/
+  matchedOpHasNoRegions : pattern.MatchedOpHasNoRegions
+  /-- Interpreting the matched operation is refined by interpreting the new operations. -/
+  preservesSemantics :
+    pattern.PreservesSemantics returnOps returnCtxChanges returnValuesInBounds returnValues
+  /-- The driver-applied rewrite preserves dominance-wellformedness. -/
+  rewritePreservesDom : pattern.RewritePreservesDom
+  /-- The driver-applied rewrite preserves verification. -/
+  rewritePreservesVerified : pattern.RewritePreservesVerified
+  /-- The driver-applied rewrite preserves block-level dominance. -/
+  rewritePreservesBlockDominance : pattern.RewritePreservesBlockDominance


### PR DESCRIPTION
This proposition contains all the correctness obligations that a `LocalRewritePattern` must satisfy to derive a proof of global soundness of the transformation.

This proposition is enough to prove the global soundness of the transformation, however some of these conditions are still too hard to prove for each rewrite (such as `rewritePreservesDom`). Future commits will refine this to provide a better set of propositions.