### PR TITLE
chore: move isTerminator into HasOpInfo

### DIFF
--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -55,6 +55,10 @@ def Cf.isConstantLike (_op : Cf) : Bool :=
 def Cf.hasSSADominance (_op : Cf) (_index : Nat) : Bool :=
   true
 
+/-- Every `cf` operation is a branch, and so terminates its block. -/
+def Cf.isTerminator (_op : Cf) : Bool :=
+  true
+
 #generate_dialect Cf
 
 instance : HasOpInfo Cf where
@@ -68,6 +72,7 @@ instance : HasOpInfo Cf where
   writesMemory := Cf.writesMemory
   isConstantLike := Cf.isConstantLike
   hasSSADominance := Cf.hasSSADominance
+  isTerminator := Cf.isTerminator
 
 /--
 Verify the local invariants of a `cf` operation in any operation-info type

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -67,6 +67,11 @@ def Func.isConstantLike (_op : Func) : Bool :=
 def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
   true
 
+def Func.isTerminator (op : Func) : Bool :=
+  match op with
+  | .return => true
+  | .func | .call => false
+
 #generate_dialect Func
 
 instance : HasOpInfo Func where
@@ -80,6 +85,7 @@ instance : HasOpInfo Func where
   writesMemory := Func.writesMemory
   isConstantLike := Func.isConstantLike
   hasSSADominance := Func.hasSSADominance
+  isTerminator := Func.isTerminator
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -66,6 +66,11 @@ def HW.isConstantLike (op : HW) : Bool :=
 def HW.hasSSADominance (_op : HW) (_index : Nat) : Bool :=
   true
 
+def HW.isTerminator (op : HW) : Bool :=
+  match op with
+  | .output => true
+  | _ => false
+
 #generate_dialect HW
 
 instance : HasOpInfo HW where
@@ -79,6 +84,7 @@ instance : HasOpInfo HW where
   writesMemory := HW.writesMemory
   isConstantLike := HW.isConstantLike
   hasSSADominance := HW.hasSSADominance
+  isTerminator := HW.isTerminator
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -365,6 +365,11 @@ def Llvm.isConstantLike (op : Llvm) : Bool :=
 def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
   true
 
+def Llvm.isTerminator (op : Llvm) : Bool :=
+  match op with
+  | .br | .cond_br | .return | .unreachable => true
+  | _ => false
+
 #generate_dialect Llvm
 
 instance : HasOpInfo Llvm where
@@ -378,6 +383,7 @@ instance : HasOpInfo Llvm where
   writesMemory := Llvm.writesMemory
   isConstantLike := Llvm.isConstantLike
   hasSSADominance := Llvm.hasSSADominance
+  isTerminator := Llvm.isTerminator
 
 end
 

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -148,6 +148,13 @@ def PDL.hasNoTerminator (op : PDL) (_index : Nat) : Bool :=
   | .rewrite => true
   | _ => false
 
+/-- MLIR marks `pdl.rewrite` itself a `Terminator`: it is the last operation of
+    the `pdl.pattern` body it lives in. -/
+def PDL.isTerminator (op : PDL) : Bool :=
+  match op with
+  | .rewrite => true
+  | _ => false
+
 #generate_dialect PDL
 
 instance : HasOpInfo PDL where
@@ -162,6 +169,7 @@ instance : HasOpInfo PDL where
   isConstantLike := PDL.isConstantLike
   hasSSADominance := PDL.hasSSADominance
   hasNoTerminator := PDL.hasNoTerminator
+  isTerminator := PDL.isTerminator
 
 /--
   The element kind of a PDL handle type, treating a non-range handle as a range

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -71,6 +71,10 @@ def Riscv_Cf.isConstantLike (_op : Riscv_Cf) : Bool :=
 def Riscv_Cf.hasSSADominance (_op : Riscv_Cf) (_index : Nat) : Bool :=
   true
 
+/-- Every `riscv_cf` operation is a branch, and so terminates its block. -/
+def Riscv_Cf.isTerminator (_op : Riscv_Cf) : Bool :=
+  true
+
 #generate_dialect Riscv_Cf
 
 instance : HasOpInfo Riscv_Cf where
@@ -84,6 +88,7 @@ instance : HasOpInfo Riscv_Cf where
   writesMemory := Riscv_Cf.writesMemory
   isConstantLike := Riscv_Cf.isConstantLike
   hasSSADominance := Riscv_Cf.hasSSADominance
+  isTerminator := Riscv_Cf.isTerminator
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -33,21 +33,6 @@ match opCode with
 | .test op => Test.propertiesOf op
 
 /--
-  Does this OpCode count as an MLIR basic block terminator?
--/
-def OpCode.isTerminator (opCode : OpCode) : Bool :=
-  match opCode with
-  | .cf .br | .cf .cond_br
-  | .func .return
-  | .llvm .br | .llvm .cond_br | .llvm .return | .llvm .unreachable
-  | .riscv_cf .branch | .riscv_cf .beq | .riscv_cf .bne
-  | .riscv_cf .beqz | .riscv_cf .bnez
-  | .riscv_cf .blt | .riscv_cf .bge | .riscv_cf .bltu | .riscv_cf .bgeu
-  | .hw .output
-  | .pdl .rewrite => true
-  | _ => false
-
-/--
   Does an operation with this opcode and these properties read memory?
 -/
 def OpCode.readsMemory (opCode : OpCode) (props : _propertiesOf opCode) : Bool :=
@@ -182,6 +167,28 @@ def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
   | .test op => HasOpInfo.hasNoTerminator op index
 
 /--
+  Does this OpCode count as an MLIR basic block terminator? Dialects that do
+  not say otherwise inherit the `HasOpInfo` default of `false`.
+-/
+def OpCode.isTerminator (opCode : OpCode) : Bool :=
+  match opCode with
+  | .arith op => HasOpInfo.isTerminator op
+  | .llvm op => HasOpInfo.isTerminator op
+  | .riscv op => HasOpInfo.isTerminator op
+  | .riscv_cf op => HasOpInfo.isTerminator op
+  | .riscv_stack op => HasOpInfo.isTerminator op
+  | .rv64 op => HasOpInfo.isTerminator op
+  | .mod_arith op => HasOpInfo.isTerminator op
+  | .cf op => HasOpInfo.isTerminator op
+  | .comb op => HasOpInfo.isTerminator op
+  | .hw op => HasOpInfo.isTerminator op
+  | .builtin op => HasOpInfo.isTerminator op
+  | .func op => HasOpInfo.isTerminator op
+  | .datapath op => HasOpInfo.isTerminator op
+  | .pdl op => HasOpInfo.isTerminator op
+  | .test op => HasOpInfo.isTerminator op
+
+/--
   Does this `OpCode` materialize a literal constant value, i.e. an op
   whose single result is a compile-time constant taken from its
   properties, with no SSA operands and no side effects?
@@ -261,6 +268,7 @@ instance : HasOpInfo OpCode where
   isConstantLike := OpCode.isConstantLike
   hasSSADominance := OpCode.hasSSADominance
   hasNoTerminator := OpCode.hasNoTerminator
+  isTerminator := OpCode.isTerminator
 
 #generate_has_dialect_instances OpCode
 

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -96,6 +96,10 @@ class HasOpInfo (opCode: Type)
   terminator requirement.
   -/
   hasNoTerminator : opCode → Nat → Bool := fun _ _ => false
+  /--
+  Does this OpCode count as an MLIR basic block terminator?
+  -/
+  isTerminator : opCode → Bool := fun _ => false
 
 instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
   hash := HasOpInfo.propertiesHash.hash


### PR DESCRIPTION
isTerminator was lonely all by itself, and now joins the rest of the family