### PR TITLE
feat(test): support MLIR_VALID lit predicate

### DIFF
--- a/Test/Verifier/arith_select_float_ok.mlir
+++ b/Test/Verifier/arith_select_float_ok.mlir
@@ -1,4 +1,5 @@
 // RUN: veir-opt %s | filecheck %s
+// RUN: MLIR_VALID
 
 // arith.select accepts values of any type, including floats.
 

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -62,12 +62,19 @@ if mlir_opt:
 	#    messages. We'd rather test the error message of `veir-opt`.
     config.substitutions.append(("MLIR_INVALID",
      "not mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s"))
+    # Assert that `mlir-opt` accepts the input. Pass
+    # `--allow-unregistered-dialect` so this can also be used by tests containing
+    # operations that VeIR recognizes but the local MLIR installation does not.
+    config.substitutions.append(("MLIR_VALID",
+     "mlir-opt --allow-unregistered-dialect --mlir-print-op-generic --mlir-print-local-scope %s"))
   else:
     print(f"'mlir-opt' version {version_short} ({version}) detected, but only {mlir_versions_supported} supported. Skipping MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP", "true"))
     config.substitutions.append(("MLIR_UNREGISTERED_ROUNDTRIP", "true"))
     config.substitutions.append(("MLIR_INVALID", "true"))
+    config.substitutions.append(("MLIR_VALID", "true"))
 else:
   config.substitutions.append(("MLIR_ROUNDTRIP", "true"))
   config.substitutions.append(("MLIR_UNREGISTERED_ROUNDTRIP", "true"))
   config.substitutions.append(("MLIR_INVALID", "true"))
+  config.substitutions.append(("MLIR_VALID", "true"))

--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -62,11 +62,9 @@ if mlir_opt:
 	#    messages. We'd rather test the error message of `veir-opt`.
     config.substitutions.append(("MLIR_INVALID",
      "not mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s"))
-    # Assert that `mlir-opt` accepts the input. Pass
-    # `--allow-unregistered-dialect` so this can also be used by tests containing
-    # operations that VeIR recognizes but the local MLIR installation does not.
+    # Assert that `mlir-opt` accepts the input.
     config.substitutions.append(("MLIR_VALID",
-     "mlir-opt --allow-unregistered-dialect --mlir-print-op-generic --mlir-print-local-scope %s"))
+     "mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s"))
   else:
     print(f"'mlir-opt' version {version_short} ({version}) detected, but only {mlir_versions_supported} supported. Skipping MLIR compatibility tests")
     config.substitutions.append(("MLIR_ROUNDTRIP", "true"))


### PR DESCRIPTION
we already have lit support for `MLIR_INVALID` to assert that upstream MLIR does not accept a particular piece of code. this PR adds its friend, asserting that upstream MLIR does accept it. I plan to use this in upcoming PRs.

this PR also uses `MLIR_VALID` once, to ensure that it works