### PR TITLE
feat: add control flow branch interface

### DIFF
--- a/Veir.lean
+++ b/Veir.lean
@@ -11,6 +11,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.Printer
 import Veir.PatternRewriter.Basic
 import Veir.Interfaces.FoldInterfaces
+import Veir.Interfaces.ControlFlowInterfaces
 import Veir.Passes.ArithToLLVM.Proofs
 import Veir.Passes.Canonicalize.Proofs
 import Veir.Passes.RISCVCombines.Proofs

--- a/Veir/Interfaces.lean
+++ b/Veir/Interfaces.lean
@@ -7,3 +7,4 @@ import Veir.Interfaces.RegionKindInterfaces
 import Veir.Interfaces.SideEffectInterfaces
 import Veir.Interfaces.DeadCodeInterfaces
 import Veir.Interfaces.ConstantLikeInterfaces
+import Veir.Interfaces.ControlFlowInterfaces

--- a/Veir/Interfaces/ControlFlowInterfaces.lean
+++ b/Veir/Interfaces/ControlFlowInterfaces.lean
@@ -41,13 +41,9 @@ def getSuccessorOperands?
   let opType := branchOp.getOpType! raw
   match opType with
   | .cf .br | .llvm .br | .riscv_cf .branch =>
-    -- Unconditional branches have one successor and forward every operation operand.
-    if branchOp.getNumSuccessors! raw ≠ 1 || successorIndex ≠ 0 then
-      none
-    else
-      some {
-        forwardedOperands := branchOp.getOperands! raw
-      }
+    some {
+      forwardedOperands := branchOp.getOperands! raw
+    }
   | _ => do
     -- Determine whether this is a supported conditional branch and how many
     -- fixed operands appear before its successor operand segments.
@@ -66,26 +62,11 @@ def getSuccessorOperands?
     -- Read the operand segment metadata from the operation's typed properties.
     let attrs := Properties.toAttrDict opType (branchOp.getProperties! raw opType)
     let some (.denseArrayAttr sizes) := attrs["operandSegmentSizes".toUTF8]? | none
-    let successorCount := branchOp.getNumSuccessors! raw
     let segmentSizes := sizes.values
-    -- Validate the requested successor and the basic shape of the segment metadata.
-    if successorIndex ≥ successorCount then
-      none
-    if segmentSizes.size ≠ fixedOperandCount + successorCount then
-      none
-    if segmentSizes.extract 0 fixedOperandCount |>.any (· ≠ 1) then
-      none
-    if segmentSizes.any (· < 0) then
-      none
     -- Select the segment corresponding to the requested successor.
     let segmentIndex := fixedOperandCount + successorIndex
     let forwardedCountRaw ← segmentSizes[segmentIndex]?
     let forwardedCount := forwardedCountRaw.toNat
-    let operandCount := branchOp.getNumOperands! raw
-    -- Ensure the segment metadata accounts for every operation operand.
-    let segmentSum := segmentSizes.foldl (init := 0) fun acc value => acc + value.toNat
-    if segmentSum ≠ operandCount then
-      none
     -- Compute the operation operand index where this successor's forwarded values begin.
     let forwardedStart := fixedOperandCount +
       (segmentSizes.extract fixedOperandCount segmentIndex).foldl

--- a/Veir/Interfaces/ControlFlowInterfaces.lean
+++ b/Veir/Interfaces/ControlFlowInterfaces.lean
@@ -19,16 +19,9 @@ structure SuccessorOperands where
   forwardedOperands : Array ValuePtr
 deriving Inhabited, Repr, DecidableEq
 
-namespace SuccessorOperands
-
-/--
-  Return the SSA value forwarded to a successor block argument.
--/
-def getForwardedOperand?
-    (operands : SuccessorOperands) (blockArgumentIndex : Nat) : Option ValuePtr :=
-  operands.forwardedOperands[blockArgumentIndex]?
-
-end SuccessorOperands
+instance : GetElem SuccessorOperands Nat ValuePtr
+    (fun operands blockArgumentIndex => blockArgumentIndex < operands.forwardedOperands.size) where
+  getElem := fun operands blockArgumentIndex h => operands.forwardedOperands[blockArgumentIndex]'h
 
 namespace BranchOpInterface
 
@@ -83,7 +76,7 @@ def getSuccessorOperand?
     (branchOp : OperationPtr) (successorIndex blockArgumentIndex : Nat)
     (raw : IRContext OpCode) : Option ValuePtr :=
   getSuccessorOperands? branchOp successorIndex raw >>= fun operands =>
-    operands.getForwardedOperand? blockArgumentIndex
+    operands[blockArgumentIndex]?
 
 end BranchOpInterface
 

--- a/Veir/Interfaces/ControlFlowInterfaces.lean
+++ b/Veir/Interfaces/ControlFlowInterfaces.lean
@@ -59,6 +59,7 @@ def getSuccessorOperands?
       | .riscv_cf .bltu
       | .riscv_cf .bgeu => some 2
       | _ => none
+    -- TODO: Move the operandSegmentSizes logic to the respective dialects
     -- Read the operand segment metadata from the operation's typed properties.
     let attrs := Properties.toAttrDict opType (branchOp.getProperties! raw opType)
     let some (.denseArrayAttr sizes) := attrs["operandSegmentSizes".toUTF8]? | none

--- a/Veir/Interfaces/ControlFlowInterfaces.lean
+++ b/Veir/Interfaces/ControlFlowInterfaces.lean
@@ -23,6 +23,10 @@ instance : GetElem SuccessorOperands Nat ValuePtr
     (fun operands blockArgumentIndex => blockArgumentIndex < operands.forwardedOperands.size) where
   getElem := fun operands blockArgumentIndex h => operands.forwardedOperands[blockArgumentIndex]'h
 
+instance : GetElem? SuccessorOperands Nat ValuePtr
+    (fun operands blockArgumentIndex => blockArgumentIndex < operands.forwardedOperands.size) where
+  getElem? := fun operands blockArgumentIndex => operands.forwardedOperands[blockArgumentIndex]?
+
 namespace BranchOpInterface
 
 /--

--- a/Veir/Interfaces/ControlFlowInterfaces.lean
+++ b/Veir/Interfaces/ControlFlowInterfaces.lean
@@ -1,0 +1,110 @@
+module
+
+public import Veir.GlobalOpInfo
+
+/-!
+# ControlFlowInterfaces
+
+This file provides support for querying which operands are forwarded to a successor
+and mapping those operands to successor block arguments.
+-/
+
+namespace Veir
+
+public section
+
+/-- The SSA values forwarded from a branch operation to one of its successors. -/
+structure SuccessorOperands where
+  /-- The SSA values forwarded to the successor. -/
+  forwardedOperands : Array ValuePtr
+deriving Inhabited, Repr, DecidableEq
+
+namespace SuccessorOperands
+
+/--
+  Return the SSA value forwarded to a successor block argument.
+-/
+def getForwardedOperand?
+    (operands : SuccessorOperands) (blockArgumentIndex : Nat) : Option ValuePtr :=
+  operands.forwardedOperands[blockArgumentIndex]?
+
+end SuccessorOperands
+
+namespace BranchOpInterface
+
+/--
+  Return the operands passed to `successorIndex` of a branch operation.
+-/
+def getSuccessorOperands?
+    (branchOp : OperationPtr) (successorIndex : Nat) (raw : IRContext OpCode) :
+    Option SuccessorOperands :=
+  let opType := branchOp.getOpType! raw
+  match opType with
+  | .cf .br | .llvm .br | .riscv_cf .branch =>
+    -- Unconditional branches have one successor and forward every operation operand.
+    if branchOp.getNumSuccessors! raw ≠ 1 || successorIndex ≠ 0 then
+      none
+    else
+      some {
+        forwardedOperands := branchOp.getOperands! raw
+      }
+  | _ => do
+    -- Determine whether this is a supported conditional branch and how many
+    -- fixed operands appear before its successor operand segments.
+    let fixedOperandCount ← match opType with
+      | .cf .cond_br
+      | .llvm .cond_br
+      | .riscv_cf .beqz
+      | .riscv_cf .bnez => some 1
+      | .riscv_cf .beq
+      | .riscv_cf .bne
+      | .riscv_cf .blt
+      | .riscv_cf .bge
+      | .riscv_cf .bltu
+      | .riscv_cf .bgeu => some 2
+      | _ => none
+    -- Read the operand segment metadata from the operation's typed properties.
+    let attrs := Properties.toAttrDict opType (branchOp.getProperties! raw opType)
+    let some (.denseArrayAttr sizes) := attrs["operandSegmentSizes".toUTF8]? | none
+    let successorCount := branchOp.getNumSuccessors! raw
+    let segmentSizes := sizes.values
+    -- Validate the requested successor and the basic shape of the segment metadata.
+    if successorIndex ≥ successorCount then
+      none
+    if segmentSizes.size ≠ fixedOperandCount + successorCount then
+      none
+    if segmentSizes.extract 0 fixedOperandCount |>.any (· ≠ 1) then
+      none
+    if segmentSizes.any (· < 0) then
+      none
+    -- Select the segment corresponding to the requested successor.
+    let segmentIndex := fixedOperandCount + successorIndex
+    let forwardedCountRaw ← segmentSizes[segmentIndex]?
+    let forwardedCount := forwardedCountRaw.toNat
+    let operandCount := branchOp.getNumOperands! raw
+    -- Ensure the segment metadata accounts for every operation operand.
+    let segmentSum := segmentSizes.foldl (init := 0) fun acc value => acc + value.toNat
+    if segmentSum ≠ operandCount then
+      none
+    -- Compute the operation operand index where this successor's forwarded values begin.
+    let forwardedStart := fixedOperandCount +
+      (segmentSizes.extract fixedOperandCount segmentIndex).foldl
+        (init := 0) fun acc value => acc + value.toNat
+    -- Return only the operands forwarded to the requested successor.
+    some {
+      forwardedOperands := (branchOp.getOperands! raw).extract
+        forwardedStart (forwardedStart + forwardedCount)
+    }
+
+/-- Return the SSA value forwarded to a successor block argument. -/
+def getSuccessorOperand?
+    (branchOp : OperationPtr) (successorIndex blockArgumentIndex : Nat)
+    (raw : IRContext OpCode) : Option ValuePtr :=
+  getSuccessorOperands? branchOp successorIndex raw >>= fun operands =>
+    operands.getForwardedOperand? blockArgumentIndex
+
+end BranchOpInterface
+
+end
+
+end Veir


### PR DESCRIPTION
Implemented a very simple interface for branch operations. I skipped a lot of extra stuff (such as supporting branch ops that produce operands internally by the branch op - something VeIR has none of right now) that's in here: https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/ControlFlowInterfaces.h but it's a start. This will help https://github.com/opencompl/veir/pull/854 which would use this interface. The reason `SuccessorOperands` is a one field structure is to later have additional fields like the number of produced operands like I mentioned. Right now it'd be unused so I left it as is.