### PR TITLE
chore: Move builtin verifier to `Builtin/` folder

### DIFF
--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
+public import Veir.Verifier.Basic
 public import Veir.Dialects.Builtin.Properties
 meta import Veir.Meta.OpCode
 
@@ -82,6 +83,30 @@ instance : HasOpInfo Builtin where
   isConstantLike := Builtin.isConstantLike
   hasSSADominance := Builtin.hasSSADominance
   hasNoTerminator := Builtin.hasNoTerminator
+
+/--
+Verify the local invariants of a `builtin` operation in any operation-info type
+containing the `builtin` dialect.
+-/
+@[expose]
+def Builtin.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Builtin] (opType : Builtin) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .unregistered => pure ()
+  | .unrealized_conversion_cast => do
+    op.verifyPlainOpCounts ctx opIn 1 1
+    pure ()
+  | .module => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "Expected 1 region"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
 
 end
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -213,22 +213,8 @@ def OperationPtr.verifyModArithConstantOp (op : OperationPtr) (ctx: WfIRContext 
 -/
 def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext OpCode) (opIn : op.InBounds ctx.raw) : Except String PUnit :=
   match op.getOpType ctx.raw opIn with
-  | .builtin .unregistered => pure ()
-  | .builtin .unrealized_conversion_cast => do
-    op.verifyPlainOpCounts ctx opIn 1 1
-    pure ()
-  /- ARITH -/
+  | .builtin opType => Builtin.verifyLocalInvariants opType op ctx opIn
   | .arith opType => Arith.verifyLocalInvariants opType op ctx opIn
-  | .builtin .module => do
-    if op.getNumOperands ctx.raw opIn ≠ 0 then
-      throw "Expected 0 operands"
-    if op.getNumResults ctx.raw opIn ≠ 0 then
-      throw "Expected 0 results"
-    if op.getNumRegions ctx.raw opIn ≠ 1 then
-      throw "Expected 1 region"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
   | .datapath .compress => do
     if op.getNumOperands ctx.raw opIn ≤ op.getNumResults ctx.raw opIn then
       throw "Number of inputs must be greater than the number of results"


### PR DESCRIPTION
This is part of the plan of making all verifiers depend on an arbitrary `OpInfo` instead of `OpCode`.