### PR TITLE
chore: Move datapath verifier to `Datapath/` folder

### DIFF
--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
+public import Veir.Verifier.Basic
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -55,6 +56,42 @@ instance : HasOpInfo Datapath where
   getEffects := Datapath.getEffects
   isConstantLike := Datapath.isConstantLike
   hasSSADominance := Datapath.hasSSADominance
+
+/--
+Verify the local invariants of a `datapath` operation in any operation-info
+type containing the `datapath` dialect.
+-/
+@[expose]
+def Datapath.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Datapath] (opType : Datapath) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .compress => do
+    if op.getNumOperands ctx.raw opIn ≤ op.getNumResults ctx.raw opIn then
+      throw "Number of inputs must be greater than the number of results"
+    if op.getNumResults ctx.raw opIn < 2 then
+      throw "Expected at least 2 results"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .partial_product => do
+    if op.getNumOperands ctx.raw opIn ≠ 2 then
+      throw "Expected 2 operands"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .pos_partial_product => do
+    if op.getNumOperands ctx.raw opIn ≠ 3 then
+      throw "Expected 3 operands"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
 
 end
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -215,32 +215,7 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   match op.getOpType ctx.raw opIn with
   | .builtin opType => Builtin.verifyLocalInvariants opType op ctx opIn
   | .arith opType => Arith.verifyLocalInvariants opType op ctx opIn
-  | .datapath .compress => do
-    if op.getNumOperands ctx.raw opIn ≤ op.getNumResults ctx.raw opIn then
-      throw "Number of inputs must be greater than the number of results"
-    if op.getNumResults ctx.raw opIn < 2 then
-      throw "Expected at least 2 results"
-    if op.getNumRegions ctx.raw opIn ≠ 0 then
-      throw "Expected 0 regions"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
-  | .datapath .partial_product => do
-    if op.getNumOperands ctx.raw opIn ≠ 2 then
-      throw "Expected 2 operands"
-    if op.getNumRegions ctx.raw opIn ≠ 0 then
-      throw "Expected 0 regions"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
-  | .datapath .pos_partial_product => do
-    if op.getNumOperands ctx.raw opIn ≠ 3 then
-      throw "Expected 3 operands"
-    if op.getNumRegions ctx.raw opIn ≠ 0 then
-      throw "Expected 0 regions"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
+  | .datapath opType => Datapath.verifyLocalInvariants opType op ctx opIn
   /- FUNC -/
   | .func .func => do
     if op.getNumRegions ctx.raw opIn ≠ 1 then


### PR DESCRIPTION
This is part of the plan of making all verifiers depend on an arbitrary `OpInfo` instead of `OpCode`.