### PR TITLE
chore: Move `riscv` dialects verifier to their respective folder

### DIFF
--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.RISCV_Cf.Properties
+public import Veir.Verifier.Basic
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -84,6 +85,57 @@ instance : HasOpInfo Riscv_Cf where
   isConstantLike := Riscv_Cf.isConstantLike
   hasSSADominance := Riscv_Cf.hasSSADominance
   isTerminator := Riscv_Cf.isTerminator
+
+/--
+Verify the local invariants of a `riscv_cf` operation in any operation-info
+type containing the `riscv_cf` dialect.
+-/
+def Riscv_Cf.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Riscv_Cf] (opType : Riscv_Cf) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .branch =>
+    op.verifyUnconditionalBranch ctx opIn
+  | .beq => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.beq).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
+    pure ()
+  | .bne => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.bne).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
+    pure ()
+  | .blt => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.blt).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
+    pure ()
+  | .bge => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.bge).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
+    pure ()
+  | .bltu => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.bltu).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
+    pure ()
+  | .bgeu => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.bgeu).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
+    pure ()
+  | .beqz => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.beqz).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 1
+    pure ()
+  | .bnez => do
+    op.verifyTerminatorCounts ctx opIn 2
+    let sizes := (op.getProperties! ctx.raw Riscv_Cf.bnez).operandSegmentSizes
+    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 1
+    pure ()
 
 end
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -2,7 +2,9 @@ module
 
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
+public import Veir.Verifier.Basic
 public import Veir.Dialects.RISCV_Stack.Properties
+public import Veir.Dialects.RISCV.OpInfo
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -60,6 +62,31 @@ instance : HasOpInfo Riscv_Stack where
   getEffects := Riscv_Stack.getEffects
   isConstantLike := Riscv_Stack.isConstantLike
   hasSSADominance := Riscv_Stack.hasSSADominance
+
+/--
+Verify the local invariants of a `riscv_stack` operation in any operation-info
+type containing the `riscv_stack` dialect.
+-/
+def Riscv_Stack.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Riscv_Stack] (opType : Riscv_Stack) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .alloca => do
+    op.verifyPlainOpCounts ctx opIn 0 1
+    op.verifyRISCVRegisterTypes ctx opIn
+    let properties := op.getProperties! ctx.raw Riscv_Stack.alloca
+    if properties.size.type.bitwidth ≠ 64 then
+      throw "attribute 'size' must be a 64-bit signless integer attribute"
+    if properties.size.value < 0 then
+      throw "size must be nonnegative"
+    if properties.alignment.type.bitwidth ≠ 64 then
+      throw "attribute 'alignment' must be a 64-bit signless integer attribute"
+    if properties.alignment.value ≤ 0 then
+      throw "alignment must be a positive power of two"
+    let alignment := properties.alignment.value.toNat
+    if alignment &&& (alignment - 1) ≠ 0 then
+      throw "alignment must be a positive power of two"
+    pure ()
 
 end
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.IR.OpInfo
 public import Veir.IR.Simp
+public import Veir.Verifier.Basic
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -54,6 +55,18 @@ instance : HasOpInfo Rv64 where
   getEffects := Rv64.getEffects
   isConstantLike := Rv64.isConstantLike
   hasSSADominance := Rv64.hasSSADominance
+
+/--
+Verify the local invariants of an `rv64` operation in any operation-info type
+containing the `rv64` dialect.
+-/
+def Rv64.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Rv64] (opType : Rv64) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .get_register => do
+    op.verifyPlainOpCounts ctx opIn 0 1
+    pure ()
 
 end
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -30,70 +30,9 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .llvm opType => Llvm.verifyLocalInvariants opType op ctx opIn
   | .mod_arith opType => Mod_Arith.verifyLocalInvariants opType op ctx opIn
   | .riscv opType => Riscv.verifyLocalInvariants opType op ctx opIn
-  /- RISCV CF -/
-  | .riscv_cf .branch => do
-    op.verifyUnconditionalBranch ctx opIn
-  | .riscv_cf .beq => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .beq)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
-    pure ()
-  | .riscv_cf .bne => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bne)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
-    pure ()
-  | .riscv_cf .blt => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .blt)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
-    pure ()
-  | .riscv_cf .bge => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bge)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
-    pure ()
-  | .riscv_cf .bltu => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bltu)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
-    pure ()
-  | .riscv_cf .bgeu => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bgeu)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 2
-    pure ()
-  | .riscv_cf .beqz => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .beqz)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 1
-    pure ()
-  | .riscv_cf .bnez => do
-    op.verifyTerminatorCounts ctx opIn 2
-    let sizes := (op.getProperties! ctx.raw (OpCode.riscv_cf .bnez)).operandSegmentSizes
-    op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 1
-    pure ()
-  /- RISCV Stack -/
-  | .riscv_stack .alloca => do
-    op.verifyPlainOpCounts ctx opIn 0 1
-    op.verifyRISCVRegisterTypes ctx opIn
-    let properties := op.getProperties! ctx.raw Riscv_Stack.alloca
-    if properties.size.type.bitwidth ≠ 64 then
-      throw "attribute 'size' must be a 64-bit signless integer attribute"
-    if properties.size.value < 0 then
-      throw "size must be nonnegative"
-    if properties.alignment.type.bitwidth ≠ 64 then
-      throw "attribute 'alignment' must be a 64-bit signless integer attribute"
-    if properties.alignment.value ≤ 0 then
-      throw "alignment must be a positive power of two"
-    let alignment := properties.alignment.value.toNat
-    if alignment &&& (alignment - 1) ≠ 0 then
-      throw "alignment must be a positive power of two"
-    pure ()
-  /- RISCV 64-bit -/
-  | .rv64 .get_register => do
-    op.verifyPlainOpCounts ctx opIn 0 1
-    pure ()
+  | .riscv_cf opType => Riscv_Cf.verifyLocalInvariants opType op ctx opIn
+  | .riscv_stack opType => Riscv_Stack.verifyLocalInvariants opType op ctx opIn
+  | .rv64 opType => Rv64.verifyLocalInvariants opType op ctx opIn
   /- Comb -/
   | .comb .add | .comb .and | .comb .mul | .comb .or | .comb .xor => do
     if op.getNumOperands ctx.raw opIn < 1 then


### PR DESCRIPTION
This is part of the plan of making all verifiers depend on an arbitrary `OpInfo` instead of `OpCode`.