### PR TITLE
chore: Move `hw` and `comb` dialects verifier to their respective folder

### DIFF
--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.Comb.Properties
+public import Veir.Verifier.Basic
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -85,6 +86,42 @@ instance : HasOpInfo Comb where
   getEffects := Comb.getEffects
   isConstantLike := Comb.isConstantLike
   hasSSADominance := Comb.hasSSADominance
+
+/--
+Verify the local invariants of a `comb` operation in any operation-info type
+containing the `comb` dialect.
+-/
+def Comb.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo Comb] (opType : Comb) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .add | .and | .mul | .or | .xor => do
+    if op.getNumOperands ctx.raw opIn < 1 then
+      throw "Expected 1 or more operands"
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .concat => do
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .divs | .divu | .icmp | .mods | .modu | .shl | .shrs | .shru | .sub => do
+    op.verifyPlainOpCounts ctx opIn 2 1
+    pure ()
+  | .extract | .parity | .replicate | .reverse => do
+    op.verifyPlainOpCounts ctx opIn 1 1
+    pure ()
+  | .mux => do
+    op.verifyPlainOpCounts ctx opIn 3 1
+    pure ()
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -3,6 +3,7 @@ module
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
 public import Veir.Dialects.HW.Properties
+public import Veir.Verifier.Basic
 meta import Veir.Meta.OpCode
 
 namespace Veir
@@ -82,6 +83,31 @@ instance : HasOpInfo HW where
   isConstantLike := HW.isConstantLike
   hasSSADominance := HW.hasSSADominance
   isTerminator := HW.isTerminator
+
+/--
+Verify the local invariants of an `hw` operation in any operation-info type
+containing the `hw` dialect.
+-/
+def HW.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    [HasDialect OpInfo HW] (opType : HW) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .constant => do
+    op.verifyPlainOpCounts ctx opIn 0 1
+    pure ()
+  | .module => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "Expected 1 region"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    pure ()
+  | .output => do
+    op.verifyTerminatorCounts ctx opIn 0
+    pure ()
 
 end
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -33,52 +33,8 @@ def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext Op
   | .riscv_cf opType => Riscv_Cf.verifyLocalInvariants opType op ctx opIn
   | .riscv_stack opType => Riscv_Stack.verifyLocalInvariants opType op ctx opIn
   | .rv64 opType => Rv64.verifyLocalInvariants opType op ctx opIn
-  /- Comb -/
-  | .comb .add | .comb .and | .comb .mul | .comb .or | .comb .xor => do
-    if op.getNumOperands ctx.raw opIn < 1 then
-      throw "Expected 1 or more operands"
-    if op.getNumResults ctx.raw opIn ≠ 1 then
-      throw "Expected 1 result"
-    if op.getNumRegions ctx.raw opIn ≠ 0 then
-      throw "Expected 0 regions"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
-  | .comb .concat => do
-    if op.getNumResults ctx.raw opIn ≠ 1 then
-      throw "Expected 1 result"
-    if op.getNumRegions ctx.raw opIn ≠ 0 then
-      throw "Expected 0 regions"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
-  | .comb .divs | .comb .divu | .comb .icmp | .comb .mods | .comb .modu | .comb .shl
-  | .comb .shrs | .comb .shru | .comb .sub => do
-    op.verifyPlainOpCounts ctx opIn 2 1
-    pure ()
-  | .comb .extract | .comb .parity | .comb .replicate | .comb .reverse => do
-    op.verifyPlainOpCounts ctx opIn 1 1
-    pure ()
-  | .comb .mux => do
-    op.verifyPlainOpCounts ctx opIn 3 1
-    pure ()
-  /- HW -/
-  | .hw .constant => do
-    op.verifyPlainOpCounts ctx opIn 0 1
-    pure ()
-  | .hw .module => do
-    if op.getNumOperands ctx.raw opIn ≠ 0 then
-      throw "Expected 0 operands"
-    if op.getNumResults ctx.raw opIn ≠ 0 then
-      throw "Expected 0 results"
-    if op.getNumRegions ctx.raw opIn ≠ 1 then
-      throw "Expected 1 region"
-    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
-      throw "Expected 0 successors"
-    pure ()
-  | .hw .output => do
-    op.verifyTerminatorCounts ctx opIn 0
-    pure ()
+  | .comb opType => Comb.verifyLocalInvariants opType op ctx opIn
+  | .hw opType => HW.verifyLocalInvariants opType op ctx opIn
 
 /--
   Return the kind of this region.


### PR DESCRIPTION
This is part of the plan of making all verifiers depend on an arbitrary `OpInfo` instead of `OpCode`.