### PR TITLE
feat: allocate effect

### DIFF
--- a/UnitTest/SideEffectInterfaces.lean
+++ b/UnitTest/SideEffectInterfaces.lean
@@ -19,6 +19,8 @@ private def volatileMemProperties : RISCVMemProperties :=
 #guard OpCode.getEffects (.llvm .store) (default : StoreProperties) == .write
 #guard OpCode.getEffects (.llvm .store) volatileStoreProperties == .readWrite
 
+#guard OpCode.getEffects (.llvm .alloca) (default : AllocaProperties) == .allocate
+
 #guard OpCode.getEffects (.arith .addi) (default : ArithIntegerOverflowFlagsProperties) == .none
 
 /- RISC-V models volatility the same way, on its own load and store opcodes. -/
@@ -31,6 +33,9 @@ private def volatileMemProperties : RISCVMemProperties :=
 
 #guard OpCode.getEffects (.riscv .add) (default : Unit) == .none
 
+#guard OpCode.getEffects (.riscv_stack .alloca)
+  (default : RISCVStackAllocaProperties) == .allocate
+
 /-
   A call is conservative in both directions: we have no interprocedural effect
   analysis, so the callee may do anything. Upstream reaches the same answer by
@@ -38,13 +43,13 @@ private def volatileMemProperties : RISCVMemProperties :=
   all and so has unknown effects.
 -/
 
-#guard OpCode.getEffects (.func .call) (default : FuncCallProperties) == .readWrite
+#guard OpCode.getEffects (.func .call) (default : FuncCallProperties) == .unknown
 
-/- Operations carrying regions are conservatively treated as reading and writing. -/
+/- Operations carrying regions conservatively have every modeled memory effect. -/
 
 /-- A `builtin.module` op, which always carries a single region. -/
 private def moduleWithRegion : OperationPtr × IRContext OpCode :=
   let (ctx, moduleOp) := WfIRContext.create! OpCode
   (moduleOp, ctx.raw)
 
-#guard moduleWithRegion.1.getEffects moduleWithRegion.2 == .readWrite
+#guard moduleWithRegion.1.getEffects moduleWithRegion.2 == .unknown

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -46,7 +46,7 @@ def Builtin.getEffects
     (op : Builtin) (_props : Builtin.propertiesOf op) : MemoryEffects :=
   match op with
   | .unrealized_conversion_cast => .none
-  | _ => .readWrite
+  | _ => .unknown
 
 def Builtin.isConstantLike (_op : Builtin) : Bool :=
   false

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -55,7 +55,7 @@ def Func.hasSideEffects (_op : Func) (_props : Func.propertiesOf _op) : Bool :=
 def Func.getEffects
     (op : Func) (_props : Func.propertiesOf op) : MemoryEffects :=
   match op with
-  | .call => .readWrite
+  | .call => .unknown
   | .func | .return => .none
 
 def Func.isConstantLike (_op : Func) : Bool :=

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -312,6 +312,7 @@ def Llvm.hasSideEffects (op : Llvm) (props : Llvm.propertiesOf op) : Bool :=
 
 def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :=
   match op, props with
+  | .alloca, _ => .allocate
   | .load, props => if props.volatile_ then .readWrite else .read
   | .store, props => if props.volatile_ then .readWrite else .write
   | .mlir__constant, _ | .mlir__poison, _ | .mlir__addressof, _
@@ -334,7 +335,7 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
   | .intr__sshl__sat, _ | .intr__ushl__sat, _
   | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _ => .none
   -- For everything else: be conservative!
-  | _, _ => .readWrite
+  | _, _ => .unknown
 
 def Llvm.isConstantLike (op : Llvm) : Bool :=
   match op with

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -42,7 +42,7 @@ def Riscv_Stack.hasSideEffects
 
 def Riscv_Stack.getEffects
     (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : MemoryEffects :=
-  .none
+  .allocate
 
 def Riscv_Stack.isConstantLike (_op : Riscv_Stack) : Bool :=
   false

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -32,7 +32,7 @@ def Test.hasSideEffects (_op : Test) (_props : Test.propertiesOf _op) : Bool :=
 
 def Test.getEffects
     (_op : Test) (_props : Test.propertiesOf _op) : MemoryEffects :=
-  .readWrite
+  .unknown
 
 def Test.isConstantLike (_op : Test) : Bool :=
   false

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -13,17 +13,27 @@ structure MemoryEffects where
   reads : Bool
   /-- The operation may mutate memory, without necessarily dereferencing it. -/
   writes : Bool
+  /--
+  The operation may allocate memory, without necessarily reading or writing it.
+  -/
+  allocates : Bool
 deriving Inhabited, Repr, DecidableEq
 
 namespace MemoryEffects
 
-def none : MemoryEffects := { reads := false, writes := false }
+def none : MemoryEffects := { reads := false, writes := false, allocates := false }
 
-def read : MemoryEffects := { reads := true, writes := false }
+def read : MemoryEffects := { reads := true, writes := false, allocates := false }
 
-def write : MemoryEffects := { reads := false, writes := true }
+def write : MemoryEffects := { reads := false, writes := true, allocates := false }
 
-def readWrite : MemoryEffects := { reads := true, writes := true }
+def readWrite : MemoryEffects := { reads := true, writes := true, allocates := false }
+
+def allocate : MemoryEffects := { reads := false, writes := false, allocates := true }
+
+/-- A conservative summary for an operation whose memory effects are unknown. -/
+def unknown : MemoryEffects :=
+  { reads := true, writes := true, allocates := true }
 
 end MemoryEffects
 
@@ -75,11 +85,11 @@ class HasOpInfo (opCode: Type)
   the effects as well before running an operation against memory that is not
   the program's.
 
-  Defaults to `.readWrite` for every opcode, which conservatively assumes
-  memory is both read and written.
+  Defaults to `.unknown` for every opcode, which conservatively assumes every
+  modeled memory effect.
   -/
   getEffects : (op : opCode) → propertiesOf op → MemoryEffects :=
-    fun _ _ => .readWrite
+    fun _ _ => .unknown
   /--
   Whether an operation with this opcode materializes a literal constant
   value: no operands, one result, no side effects, and a result that is

--- a/Veir/Interfaces/SideEffectInterfaces.lean
+++ b/Veir/Interfaces/SideEffectInterfaces.lean
@@ -38,7 +38,7 @@ def OperationPtr.hasSideEffects {OpInfo : Type} [HasOpInfo OpInfo]
 -/
 def OperationPtr.getEffects {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : IRContext OpInfo) : MemoryEffects :=
-  if op.getNumRegions! ctx != 0 then .readWrite else
+  if op.getNumRegions! ctx != 0 then .unknown else
   let opType := op.getOpType! ctx
   HasOpInfo.getEffects opType (op.getProperties! ctx opType)
 

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -16,7 +16,8 @@ namespace Veir
 private def isFoldEvaluationCandidate
     (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode) : Bool :=
   !HasOpInfo.hasSideEffects opCode properties &&
-    !(HasOpInfo.getEffects opCode properties).reads
+    let effects := HasOpInfo.getEffects opCode properties
+    !effects.reads && !effects.allocates
 
 /--
   Evaluate an operation with the interpreter, given the runtime values of its


### PR DESCRIPTION
this adds an allocate effect to the values returned by `getEffect()`.
as far as I know, this will be sufficient for our current requirements in DCE, CSE, and related passes. as in, once this lands, we can remove our other side effect machinery and use this alone to reason about effects.