### PR TITLE
feat(verifier): Align llvm.ashr with the other llvm shift operations

### DIFF
--- a/Test/Interpreter/LLVM/byte.mlir
+++ b/Test/Interpreter/LLVM/byte.mlir
@@ -1,7 +1,7 @@
 // RUN: veir-interpret %s | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "main", function_type = () -> (!llvm.byte<64>, i32, i32, !llvm.byte<64>, !llvm.byte<64>)}> ({
+  "func.func"() <{sym_name = "main", function_type = () -> (!llvm.byte<64>, i32, i32, !llvm.byte<64>, !llvm.byte<64>, !llvm.byte<64>)}> ({
     %1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
     %2 = "llvm.mlir.constant"() <{ "value" = 17 : i64 }> : () -> i64
     %3 = "llvm.mlir.poison"() : () -> i8
@@ -19,9 +19,10 @@
     %13 = "llvm.bitcast"(%11) : (!llvm.byte<32>) -> i32
     %14 = "llvm.mlir.constant"() <{ "value" = 4 : i64 }> : () -> i64
     %15 = "llvm.shl"(%7, %14) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
-    %16 = "llvm.freeze"(%7) : (!llvm.byte<64>) -> !llvm.byte<64>
-    "func.return"(%7, %12, %13, %15, %16) : (!llvm.byte<64>, i32, i32, !llvm.byte<64>, !llvm.byte<64>) -> ()
+    %16 = "llvm.ashr"(%7, %14) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+    %17 = "llvm.freeze"(%7) : (!llvm.byte<64>) -> !llvm.byte<64>
+    "func.return"(%7, %12, %13, %15, %16, %17) : (!llvm.byte<64>, i32, i32, !llvm.byte<64>, !llvm.byte<64>, !llvm.byte<64>) -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: Program output: #[0b000000000000000000000000????????00000000000000000000000000010001#64, poison, 0x00000011#32, 0b00000000000000000000????????000000000000000000000000000100010000#64, 0b0000000000000000000000000000000000000000000000000000000000010001#64]
+// CHECK: Program output: #[0b000000000000000000000000????????00000000000000000000000000010001#64, poison, 0x00000011#32, 0b00000000000000000000????????000000000000000000000000000100010000#64, 0b0000000000000000000000000000????????0000000000000000000000000001#64, 0b0000000000000000000000000000000000000000000000000000000000010001#64]

--- a/Test/Verifier/llvm_shift_ok.mlir
+++ b/Test/Verifier/llvm_shift_ok.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-opt %s | filecheck %s
+
+// Check that the shift amount may either be of the same type as the result, or a llvm.byte of the
+// same width. (See OperationPtr.IsVerifiedLLVMShift)
+"builtin.module"() ({
+  "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i64 ()>}> ({
+    %0 = "llvm.mlir.poison"() : () -> !llvm.byte<64>
+    %1 = "llvm.mlir.constant"() <{ "value" = 1 : i64 }> : () -> i64
+    %2 = "llvm.mlir.constant"() <{ "value" = 42 : i64 }> : () -> i64
+    %3 = "llvm.shl"(%0, %1) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+    %4 = "llvm.lshr"(%0, %1) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+    %5 = "llvm.ashr"(%0, %1) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+    %6 = "llvm.shl"(%2, %1) : (i64, i64) -> i64
+    %7 = "llvm.lshr"(%2, %1) : (i64, i64) -> i64
+    %8 = "llvm.ashr"(%2, %1) : (i64, i64) -> i64
+    "llvm.return"(%6) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.shl"(%{{.*}}, %{{.*}}) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+// CHECK: "llvm.lshr"(%{{.*}}, %{{.*}}) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+// CHECK: "llvm.ashr"(%{{.*}}, %{{.*}}) : (!llvm.byte<64>, i64) -> !llvm.byte<64>
+// CHECK: "llvm.shl"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+// CHECK: "llvm.lshr"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64
+// CHECK: "llvm.ashr"(%{{.*}}, %{{.*}}) : (i64, i64) -> i64

--- a/Test/Verifier/llvm_shift_ok.mlir
+++ b/Test/Verifier/llvm_shift_ok.mlir
@@ -1,3 +1,4 @@
+// TODO: Use MLIR-ROUNDTRIP once upstream supports shift operations on llvm.byte.
 // RUN: veir-opt %s | filecheck %s
 
 // Check that the shift amount may either be of the same type as the result, or a llvm.byte of the

--- a/Veir/Data/LLVM/Byte/Basic.lean
+++ b/Veir/Data/LLVM/Byte/Basic.lean
@@ -86,6 +86,20 @@ def lshr (x : Byte w) (y : Int w) (exact := false) : Byte w :=
       simp [←BitVec.ushiftRight_and_distrib, x.h]
     )⟩
 
+@[veir_bv_normalize]
+def ashr (x : Byte w) (y : Int w) (exact := false) : Byte w :=
+  let y' := y.getValueD
+  if y.isPoison || y'.toNat ≥ w then
+    allPoison
+  else if exact ∧ (x.val.sshiftRight' y') <<< y' ≠ x.val then
+    allPoison
+  else if exact ∧ (x.poison.sshiftRight' y') <<< y' ≠ x.poison then
+    allPoison
+  else
+    ⟨x.val.sshiftRight' y', x.poison.sshiftRight' y', by (
+      simp [←BitVec.sshiftRight_and_distrib, x.h]
+    )⟩
+
 def freeze (x : Byte w) : Byte w :=
   ⟨x.val, 0#w, by grind⟩
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -523,13 +523,13 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
       | throw "Expected result to have !llvm.ptr type"
     pure ()
   | .and | .or | .xor | .intr__smax | .intr__smin
-  | .intr__umax | .intr__umin | .add | .sub | .ashr | .mul | .sdiv | .udiv
+  | .intr__umax | .intr__umin | .add | .sub | .mul | .sdiv | .udiv
   | .srem | .urem | .intr__sadd__sat | .intr__uadd__sat
   | .intr__ssub__sat | .intr__usub__sat | .intr__sshl__sat | .intr__ushl__sat => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyIntegerBinop ctx opIn
     pure ()
-  | .lshr | .shl => do
+  | .lshr | .shl | .ashr => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyLLVMShift ctx opIn
     pure ()

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -888,10 +888,17 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasOpInfo.propertiesOf 
       return (#[.byte bw (LLVM.Byte.lshr lhs rhs properties.exact)], mem, none)
     | _ => none
   | .ashr => do
-    let [.int bw lhs, .int bw' rhs] := operands.toList | none
-    if h: bw' ≠ bw then none else
-    let rhs := rhs.cast (by simp at h; exact h)
-    return (#[.int bw (LLVM.Int.ashr lhs rhs properties.exact)], mem, none)
+    let [lhs, .int bw' rhs] := operands.toList | none
+    match lhs with
+    | .int bw lhs =>
+      if h: bw' ≠ bw then none else
+      let rhs := rhs.cast (by simp at h; exact h)
+      return (#[.int bw (LLVM.Int.ashr lhs rhs properties.exact)], mem, none)
+    | .byte bw lhs =>
+      if h: bw' ≠ bw then none else
+      let rhs := rhs.cast (by simp at h; exact h)
+      return (#[.byte bw (LLVM.Byte.ashr lhs rhs properties.exact)], mem, none)
+    | _ => none
   | .intr__fshl => do
     let [.int bw a, .int bw' b, .int bw'' c] := operands.toList | none
     if h: bw' ≠ bw then none else

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -432,6 +432,11 @@ theorem OperationPtr.Verified.llvm_lshr {op : OperationPtr} {opInBounds}
     op.IsVerifiedLLVMShift ctx := OperationPtr.Verified.llvmShift opVerify <| by
     simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
 
+theorem OperationPtr.Verified.llvm_ashr {op : OperationPtr} {opInBounds}
+    (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .ashr) :
+    op.IsVerifiedLLVMShift ctx := OperationPtr.Verified.llvmShift opVerify <| by
+    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+
 theorem OperationPtr.Verified.arith_addi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .addi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
@@ -809,11 +814,6 @@ theorem OperationPtr.Verified.llvm_add {op : OperationPtr} {opInBounds}
 
 theorem OperationPtr.Verified.llvm_sub {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .sub) :
-    op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
-
-theorem OperationPtr.Verified.llvm_ashr {op : OperationPtr} {opInBounds}
-    (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .ashr) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
     simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
 


### PR DESCRIPTION
The verifier previously required the shift amount operand of `llvm.ashr` to have the same type as the result. 
This aligns `llvm.ashr` with the other shift operations in the LLVM dialect, allowing `ashr` to be used on a `llvm.byte` type.

This also aligns the `ashr` operation in the interpreter.