### PR TITLE
chore: Move `propertiesOf` abbrev to `OpInfo`

### DIFF
--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -251,8 +251,6 @@ instance : HasOpInfo OpCode where
 
 #generate_has_dialect_instances OpCode
 
-abbrev propertiesOf := HasOpInfo.propertiesOf (self := instHasOpInfoOpCode)
-
 /--
   Is this `OpCode` commutative in its operands, i.e. `op x y` always
   computes the same value as `op y x`?

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -112,6 +112,9 @@ class HasOpInfo (opCode: Type)
   -/
   isTerminator : opCode → Bool := fun _ => false
 
+abbrev propertiesOf {OpCode : Type} [HasOpInfo OpCode] (opCode : OpCode) :=
+  HasOpInfo.propertiesOf opCode
+
 instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
   hash := HasOpInfo.propertiesHash.hash
 

--- a/Veir/Passes/ArithToLLVM.lean
+++ b/Veir/Passes/ArithToLLVM.lean
@@ -33,14 +33,14 @@ def emitLLVMIntConst (rewriter : PatternRewriter OpCode) (value : Int) (width : 
 
 /-- Emit a binary `llvm` op `lOp` with result type `resTy` on `a` and `b`. -/
 def emitLLVMBin (rewriter : PatternRewriter OpCode) (lOp : Llvm)
-    (props : propertiesOf (.llvm lOp)) (resTy : TypeAttr) (a b : ValuePtr)
+    (props : propertiesOf (OpCode.llvm lOp)) (resTy : TypeAttr) (a b : ValuePtr)
     (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
   let (rewriter, op) ← rewriter.createOp! (.llvm lOp) #[resTy] #[a, b] #[] #[] props (some ip)
   return (rewriter, op.getResult 0)
 
 /-- Emit a unary `llvm` op `lOp` (e.g. `sext`/`zext`/`trunc`) with result type `resTy`. -/
 def emitLLVMUnary (rewriter : PatternRewriter OpCode) (lOp : Llvm)
-    (props : propertiesOf (.llvm lOp)) (resTy : TypeAttr) (a : ValuePtr)
+    (props : propertiesOf (OpCode.llvm lOp)) (resTy : TypeAttr) (a : ValuePtr)
     (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
   let (rewriter, op) ← rewriter.createOp! (.llvm lOp) #[resTy] #[a] #[] #[] props (some ip)
   return (rewriter, op.getResult 0)
@@ -66,7 +66,7 @@ def intBitwidth (rewriter : PatternRewriter OpCode) (v : ValuePtr) : Option Nat 
   the properties with `convert`.
 -/
 def lower1to1 (aOp : Arith) (lOp : Llvm)
-    (convert : propertiesOf (.arith aOp) → propertiesOf (.llvm lOp)) (numOperands : Nat)
+    (convert : propertiesOf (OpCode.arith aOp) → propertiesOf (OpCode.llvm lOp)) (numOperands : Nat)
     (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (operands, props) := matchOp op rewriter.ctx (.arith aOp) numOperands

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -38,7 +38,7 @@ def getIntByteTypeBitwidth (t : TypeAttr) : Option Nat :=
 def lowerUnaryWLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × P))
     (op64 op32 : Riscv)
-    (props64 : propertiesOf (.riscv op64)) (props32 : propertiesOf (.riscv op32))
+    (props64 : propertiesOf (OpCode.riscv op64)) (props32 : propertiesOf (OpCode.riscv op32))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (operand, _) := match? op ctx | return (ctx, none)
@@ -66,8 +66,8 @@ def lowerUnaryWLocal {P : Type}
 def lowerExtLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × P))
     (op8 op16 op32 : Riscv)
-    (props8 : propertiesOf (.riscv op8)) (props16 : propertiesOf (.riscv op16))
-    (props32 : propertiesOf (.riscv op32))
+    (props8 : propertiesOf (OpCode.riscv op8)) (props16 : propertiesOf (OpCode.riscv op16))
+    (props32 : propertiesOf (OpCode.riscv op32))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (operand, _) := match? op ctx | return (ctx, none)
@@ -98,7 +98,7 @@ def lowerExtLocal {P : Type}
 def lowerBinaryWLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))
     (op64 op32 : Riscv)
-    (props64 : propertiesOf (.riscv op64)) (props32 : propertiesOf (.riscv op32))
+    (props64 : propertiesOf (OpCode.riscv op64)) (props32 : propertiesOf (OpCode.riscv op32))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _) := match? op ctx | return (ctx, none)
@@ -124,7 +124,7 @@ def lowerBinaryWLocal {P : Type}
 def lowerByteBinaryWLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))
     (op64 op32 : Riscv)
-    (props64 : propertiesOf (.riscv op64)) (props32 : propertiesOf (.riscv op32))
+    (props64 : propertiesOf (OpCode.riscv op64)) (props32 : propertiesOf (OpCode.riscv op32))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _) := match? op ctx | return (ctx, none)
@@ -153,7 +153,7 @@ def lowerByteBinaryWLocal {P : Type}
 -/
 def lowerBinaryRegLocal
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr))
-    (rop : Riscv) (props : propertiesOf (.riscv rop))
+    (rop : Riscv) (props : propertiesOf (OpCode.riscv rop))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs) := match? op ctx | return (ctx, none)
@@ -174,7 +174,7 @@ def lowerBinaryRegLocal
 -/
 def lowerBitwiseRegLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))
-    (rop : Riscv) (props : propertiesOf (.riscv rop))
+    (rop : Riscv) (props : propertiesOf (OpCode.riscv rop))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _) := match? op ctx | return (ctx, none)
@@ -194,7 +194,7 @@ def lowerBitwiseRegLocal {P : Type}
 -/
 def lowerSignedMinMaxLocal
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr))
-    (rop : Riscv) (props : propertiesOf (.riscv rop))
+    (rop : Riscv) (props : propertiesOf (OpCode.riscv rop))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs) := match? op ctx | return (ctx, none)
@@ -228,7 +228,7 @@ def lowerSignedMinMaxLocal
 def lowerRotateLocal
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × ValuePtr))
     (op64 op32 : Riscv)
-    (props64 : propertiesOf (.riscv op64)) (props32 : propertiesOf (.riscv op32))
+    (props64 : propertiesOf (OpCode.riscv op64)) (props32 : propertiesOf (OpCode.riscv op32))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (a, b, amt) := match? op ctx | return (ctx, none)

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -28,7 +28,7 @@ def singleSetBit (x : BitVec 64) : Option Int :=
 -/
 def lowerBinopNotLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × ValuePtr × P))
-    (dst : Riscv) (props : propertiesOf (.riscv dst))
+    (dst : Riscv) (props : propertiesOf (OpCode.riscv dst))
     (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _) := match? op ctx | return (ctx, none)
@@ -94,7 +94,7 @@ def xnor (rewriter : PatternRewriter OpCode) (op : OperationPtr)
 def orcbMaskBV (y : Nat) : BitVec 64 := BitVec.ofNat 64 0x0101010101010101 <<< y
 
 def matchOrcbRight (b m : ValuePtr) (y : Nat) (ctx : IRContext OpCode) :
-    Option (propertiesOf (.llvm .lshr)) := do
+    Option (propertiesOf (OpCode.llvm .lshr)) := do
   if y = 0 then
     if b = m then return { exact := false } else none
   let some bOp := getDefiningOp b ctx | none

--- a/Veir/Passes/Matching/Arith/Basic.lean
+++ b/Veir/Passes/Matching/Arith/Basic.lean
@@ -14,7 +14,6 @@ def matchArithConstantIntVal (val : ValuePtr) (ctx : IRContext OpCode) : Option 
   let properties := result.op.getProperties! ctx Arith.constant
   return properties.value
 
-def matchArithRemui (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.arith .remui)) := do
+def matchArithRemui (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.arith .remui)) := do
   let (op, properties) ← matchOp op ctx (.arith .remui) 2
   return (op[0]!, op[1]!, properties)
-  

--- a/Veir/Passes/Matching/LLVM/Basic.lean
+++ b/Veir/Passes/Matching/LLVM/Basic.lean
@@ -9,19 +9,19 @@ public section
 namespace Veir
 
 
-def matchAddi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .add)) := do
+def matchAddi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .add)) := do
   let (op, properties) ← matchOp op ctx (.llvm .add) 2
   return (op[0]!, op[1]!, properties)
 
-def matchAdd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .add)) := do
+def matchAdd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .add)) := do
   let (op, properties) ← matchOp op ctx (.llvm .add) 2
   return (op[0]!, op[1]!, properties)
 
-def matchSubi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .sub)) := do
+def matchSubi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .sub)) := do
   let (op, properties) ← matchOp op ctx (.llvm .sub) 2
   return (op[0]!, op[1]!, properties)
 
-def matchMuli (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .mul)) := do
+def matchMuli (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .mul)) := do
   let (op, properties) ← matchOp op ctx (.llvm .mul) 2
   return (op[0]!, op[1]!, properties)
 
@@ -29,11 +29,11 @@ def matchAndi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr ×
   let (op, _) ← matchOp op ctx (.llvm .and) 2
   return (op[0]!, op[1]!)
 
-def matchAnd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .and)) := do
+def matchAnd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .and)) := do
   let (op, properties) ← matchOp op ctx (.llvm .and) 2
   return (op[0]!, op[1]!, properties)
 
-def matchOri (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .or)) := do
+def matchOri (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .or)) := do
   let (op, properties) ← matchOp op ctx (.llvm .or) 2
   return (op[0]!, op[1]!, properties)
 
@@ -70,15 +70,15 @@ def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option ValuePtr :
   let (op, _) ← matchOp op ctx (.builtin .unrealized_conversion_cast) 1
   return op[0]!
 
-def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .ashr)) := do
+def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .ashr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .ashr) 2
   return (op[0]!, op[1]!, properties)
 
-def matchIcmp (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .icmp)) := do
+def matchIcmp (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .icmp)) := do
   let (op, properties) ← matchOp op ctx (.llvm .icmp) 2
   return (op[0]!, op[1]!, properties)
 
-def matchOr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .or)) := do
+def matchOr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .or)) := do
   let (op, properties) ← matchOp op ctx (.llvm .or) 2
   return (op[0]!, op[1]!, properties)
 
@@ -88,7 +88,7 @@ def matchSelect (op : OperationPtr) (ctx : IRContext OpCode) :
   let (op, _) ← matchOp op ctx (.llvm .select) 3
   return (op[0]!, op[1]!, op[2]!)
 
-def matchXor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .xor)) := do
+def matchXor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .xor)) := do
   let (op, properties) ← matchOp op ctx (.llvm .xor) 2
   return (op[0]!, op[1]!, properties)
 
@@ -160,70 +160,70 @@ def matchNot (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
   guard (cst.value = -1)
   return lhs
 
-def matchMul (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .mul)) := do
+def matchMul (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .mul)) := do
   let (op, properties) ← matchOp op ctx (.llvm .mul) 2
   return (op[0]!, op[1]!, properties)
 
-def matchSdiv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .sdiv)) := do
+def matchSdiv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .sdiv)) := do
   let (op, properties) ← matchOp op ctx (.llvm .sdiv) 2
   return (op[0]!, op[1]!, properties)
 
-def matchUdiv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .udiv)) := do
+def matchUdiv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .udiv)) := do
   let (op, properties) ← matchOp op ctx (.llvm .udiv) 2
   return (op[0]!, op[1]!, properties)
 
-def matchSrem (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .srem)) := do
+def matchSrem (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .srem)) := do
   let (op, properties) ← matchOp op ctx (.llvm .srem) 2
   return (op[0]!, op[1]!, properties)
 
-def matchUrem (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .urem)) := do
+def matchUrem (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .urem)) := do
   let (op, properties) ← matchOp op ctx (.llvm .urem) 2
   return (op[0]!, op[1]!, properties)
 
-def matchSext (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .sext)) := do
+def matchSext (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.llvm .sext)) := do
   let (op, properties) ← matchOp op ctx (.llvm .sext) 1
   return (op[0]!, properties)
 
-def matchTrunc (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .trunc)) := do
+def matchTrunc (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.llvm .trunc)) := do
   let (op, properties) ← matchOp op ctx (.llvm .trunc) 1
   return (op[0]!, properties)
 
-def matchZext (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .zext)) := do
+def matchZext (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.llvm .zext)) := do
   let (op, properties) ← matchOp op ctx (.llvm .zext) 1
   return (op[0]!, properties)
 
-def matchShl (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .shl)) := do
+def matchShl (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .shl)) := do
   let (op, properties) ← matchOp op ctx (.llvm .shl) 2
   return (op[0]!, op[1]!, properties)
 
-def matchLshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .lshr)) := do
+def matchLshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .lshr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .lshr) 2
   return (op[0]!, op[1]!, properties)
 
-def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.llvm .sub)) := do
+def matchSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .sub)) := do
   let (op, properties) ← matchOp op ctx (.llvm .sub) 2
   return (op[0]!, op[1]!, properties)
 
-def matchBitcast (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .bitcast)) := do
+def matchBitcast (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.llvm .bitcast)) := do
   let (op, properties) ← matchOp op ctx (.llvm .bitcast) 1
   return (op[0]!, properties)
 
-def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.llvm .load)) := do
+def matchLoad (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.llvm .load)) := do
   let (op, properties) ← matchOp op ctx (.llvm .load) 1
   return (op[0]!, properties)
 
 def matchCtlz (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × propertiesOf (.llvm .intr__ctlz)) := do
+    Option (ValuePtr × propertiesOf (OpCode.llvm .intr__ctlz)) := do
   let (op, properties) ← matchOp op ctx (.llvm .intr__ctlz) 1
   return (op[0]!, properties)
 
 def matchCttz (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × propertiesOf (.llvm .intr__cttz)) := do
+    Option (ValuePtr × propertiesOf (OpCode.llvm .intr__cttz)) := do
   let (op, properties) ← matchOp op ctx (.llvm .intr__cttz) 1
   return (op[0]!, properties)
 
 def matchCtpop (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × propertiesOf (.llvm .intr__ctpop)) := do
+    Option (ValuePtr × propertiesOf (OpCode.llvm .intr__ctpop)) := do
   let (op, properties) ← matchOp op ctx (.llvm .intr__ctpop) 1
   return (op[0]!, properties)
 
@@ -239,7 +239,7 @@ def matchBitreverse (op : OperationPtr) (ctx : IRContext OpCode) : Option ValueP
   Match a `llvm.getelementptr` with a single dynamic index.
 -/
 def matchGetelementptr (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × ValuePtr × propertiesOf (.llvm .getelementptr)) := do
+    Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .getelementptr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .getelementptr) 2
   return (op[0]!, op[1]!, properties)
 
@@ -248,7 +248,7 @@ def matchPoison (op : OperationPtr) (ctx : IRContext OpCode) : Option Unit := do
   return ()
 
 def matchStore (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × ValuePtr × propertiesOf (.llvm .store)) := do
+    Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .store)) := do
   guard (op.getOpType! ctx = .llvm .store)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx

--- a/Veir/Passes/Matching/RISCV/Basic.lean
+++ b/Veir/Passes/Matching/RISCV/Basic.lean
@@ -8,458 +8,458 @@ public section
 
 namespace Veir
 
-def matchRVLi (op : OperationPtr) (ctx : IRContext OpCode) : Option (propertiesOf (.riscv .li)) := do
+def matchRVLi (op : OperationPtr) (ctx : IRContext OpCode) : Option (propertiesOf (OpCode.riscv .li)) := do
   let (_, cst) ← matchOp op ctx (.riscv .li) 0
   return cst
 
-def matchRVLui (op : OperationPtr) (ctx : IRContext OpCode) : Option (propertiesOf (.riscv .lui)) := do
+def matchRVLui (op : OperationPtr) (ctx : IRContext OpCode) : Option (propertiesOf (OpCode.riscv .lui)) := do
   let (_, cst) ← matchOp op ctx (.riscv .lui) 0
   return cst
 
-def matchRVAuipc (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .auipc)) := do
+def matchRVAuipc (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .auipc)) := do
   let (op, properties) ← matchOp op ctx (.riscv .auipc) 1
   return (op[0]!,  properties)
 
-def matchRVAddi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .addi)) := do
+def matchRVAddi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .addi)) := do
   let (op, properties) ← matchOp op ctx (.riscv .addi) 1
   return (op[0]!,  properties)
 
-def matchRVSlti (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .slti)) := do
+def matchRVSlti (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .slti)) := do
   let (op, properties) ← matchOp op ctx (.riscv .slti) 1
   return (op[0]!,  properties)
 
-def matchRVSltiu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sltiu)) := do
+def matchRVSltiu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sltiu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sltiu) 1
   return (op[0]!,  properties)
 
-def matchRVAndi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .andi)) := do
+def matchRVAndi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .andi)) := do
   let (op, properties) ← matchOp op ctx (.riscv .andi) 1
   return (op[0]!,  properties)
 
-def matchRVOri (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .ori)) := do
+def matchRVOri (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .ori)) := do
   let (op, properties) ← matchOp op ctx (.riscv .ori) 1
   return (op[0]!,  properties)
 
-def matchRVXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .xori)) := do
+def matchRVXori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .xori)) := do
   let (op, properties) ← matchOp op ctx (.riscv .xori) 1
   return (op[0]!,  properties)
 
-def matchRVAddiw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .addiw)) := do
+def matchRVAddiw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .addiw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .addiw) 1
   return (op[0]!,  properties)
 
-def matchRVSlli (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .slli)) := do
+def matchRVSlli (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .slli)) := do
   let (op, properties) ← matchOp op ctx (.riscv .slli) 1
   return (op[0]!,  properties)
 
-def matchRVSrli (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .srli)) := do
+def matchRVSrli (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .srli)) := do
   let (op, properties) ← matchOp op ctx (.riscv .srli) 1
   return (op[0]!,  properties)
 
-def matchRVSrai (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .srai)) := do
+def matchRVSrai (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .srai)) := do
   let (op, properties) ← matchOp op ctx (.riscv .srai) 1
   return (op[0]!,  properties)
 
-def matchRVAdd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .add)) := do
+def matchRVAdd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .add)) := do
   let (op, properties) ← matchOp op ctx (.riscv .add) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sub)) := do
+def matchRVSub (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sub)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sub) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSll (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sll)) := do
+def matchRVSll (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sll)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sll) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSlt (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .slt)) := do
+def matchRVSlt (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .slt)) := do
   let (op, properties) ← matchOp op ctx (.riscv .slt) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSltu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sltu)) := do
+def matchRVSltu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sltu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sltu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVXor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .xor)) := do
+def matchRVXor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .xor)) := do
   let (op, properties) ← matchOp op ctx (.riscv .xor) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSrl (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .srl)) := do
+def matchRVSrl (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .srl)) := do
   let (op, properties) ← matchOp op ctx (.riscv .srl) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSra (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sra)) := do
+def matchRVSra (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sra)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sra) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVOr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .or)) := do
+def matchRVOr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .or)) := do
   let (op, properties) ← matchOp op ctx (.riscv .or) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVAnd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .and)) := do
+def matchRVAnd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .and)) := do
   let (op, properties) ← matchOp op ctx (.riscv .and) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSlliw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .slliw)) := do
+def matchRVSlliw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .slliw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .slliw) 1
   return (op[0]!,  properties)
 
-def matchRVSrliw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .srliw)) := do
+def matchRVSrliw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .srliw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .srliw) 1
   return (op[0]!,  properties)
 
-def matchRVSraiw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sraiw)) := do
+def matchRVSraiw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sraiw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sraiw) 1
   return (op[0]!,  properties)
 
-def matchRVAddw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .addw)) := do
+def matchRVAddw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .addw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .addw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSubw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .subw)) := do
+def matchRVSubw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .subw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .subw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSllw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sllw)) := do
+def matchRVSllw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sllw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sllw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSrlw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .srlw)) := do
+def matchRVSrlw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .srlw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .srlw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSraw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sraw)) := do
+def matchRVSraw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sraw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sraw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRem (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .rem)) := do
+def matchRVRem (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .rem)) := do
   let (op, properties) ← matchOp op ctx (.riscv .rem) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRemu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .remu)) := do
+def matchRVRemu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .remu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .remu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRemw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .remw)) := do
+def matchRVRemw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .remw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .remw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRemuw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .remuw)) := do
+def matchRVRemuw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .remuw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .remuw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMul (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .mul)) := do
+def matchRVMul (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .mul)) := do
   let (op, properties) ← matchOp op ctx (.riscv .mul) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMulh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .mulh)) := do
+def matchRVMulh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .mulh)) := do
   let (op, properties) ← matchOp op ctx (.riscv .mulh) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMulhu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .mulhu)) := do
+def matchRVMulhu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .mulhu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .mulhu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMulhsu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .mulhsu)) := do
+def matchRVMulhsu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .mulhsu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .mulhsu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMulw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .mulw)) := do
+def matchRVMulw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .mulw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .mulw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVDiv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .div)) := do
+def matchRVDiv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .div)) := do
   let (op, properties) ← matchOp op ctx (.riscv .div) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVDivw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .divw)) := do
+def matchRVDivw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .divw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .divw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVDivu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .divu)) := do
+def matchRVDivu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .divu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .divu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVDivuw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .divuw)) := do
+def matchRVDivuw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .divuw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .divuw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVAdduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .adduw)) := do
+def matchRVAdduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .adduw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .adduw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSh1adduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh1adduw)) := do
+def matchRVSh1adduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh1adduw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sh1adduw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSh2adduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh2adduw)) := do
+def matchRVSh2adduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh2adduw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sh2adduw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSh3adduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh3adduw)) := do
+def matchRVSh3adduw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh3adduw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sh3adduw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSh1add (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh1add)) := do
+def matchRVSh1add (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh1add)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sh1add) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSh2add (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh2add)) := do
+def matchRVSh2add (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh2add)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sh2add) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSh3add (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh3add)) := do
+def matchRVSh3add (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh3add)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sh3add) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSlliuw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .slliuw)) := do
+def matchRVSlliuw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .slliuw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .slliuw) 1
   return (op[0]!,  properties)
 
-def matchRVAndn (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .andn)) := do
+def matchRVAndn (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .andn)) := do
   let (op, properties) ← matchOp op ctx (.riscv .andn) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVOrn (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .orn)) := do
+def matchRVOrn (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .orn)) := do
   let (op, properties) ← matchOp op ctx (.riscv .orn) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVXnor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .xnor)) := do
+def matchRVXnor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .xnor)) := do
   let (op, properties) ← matchOp op ctx (.riscv .xnor) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMax (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .max)) := do
+def matchRVMax (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .max)) := do
   let (op, properties) ← matchOp op ctx (.riscv .max) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMaxu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .maxu)) := do
+def matchRVMaxu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .maxu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .maxu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMin (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .min)) := do
+def matchRVMin (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .min)) := do
   let (op, properties) ← matchOp op ctx (.riscv .min) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVMinu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .minu)) := do
+def matchRVMinu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .minu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .minu) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRol (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .rol)) := do
+def matchRVRol (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .rol)) := do
   let (op, properties) ← matchOp op ctx (.riscv .rol) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .ror)) := do
+def matchRVRor (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .ror)) := do
   let (op, properties) ← matchOp op ctx (.riscv .ror) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRolw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .rolw)) := do
+def matchRVRolw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .rolw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .rolw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVRorw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .rorw)) := do
+def matchRVRorw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .rorw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .rorw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVSextb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sextb)) := do
+def matchRVSextb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sextb)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sextb) 1
   return (op[0]!,  properties)
 
-def matchRVSexth (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sexth)) := do
+def matchRVSexth (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sexth)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sexth) 1
   return (op[0]!,  properties)
 
-def matchRVZexth (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .zexth)) := do
+def matchRVZexth (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .zexth)) := do
   let (op, properties) ← matchOp op ctx (.riscv .zexth) 1
   return (op[0]!,  properties)
 
-def matchRVClz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .clz)) := do
+def matchRVClz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .clz)) := do
   let (op, properties) ← matchOp op ctx (.riscv .clz) 1
   return (op[0]!,  properties)
 
-def matchRVClzw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .clzw)) := do
+def matchRVClzw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .clzw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .clzw) 1
   return (op[0]!,  properties)
 
-def matchRVCtz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .ctz)) := do
+def matchRVCtz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .ctz)) := do
   let (op, properties) ← matchOp op ctx (.riscv .ctz) 1
   return (op[0]!,  properties)
 
-def matchRVCtzw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .ctzw)) := do
+def matchRVCtzw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .ctzw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .ctzw) 1
   return (op[0]!,  properties)
 
-def matchRVCpop (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .cpop)) := do
+def matchRVCpop (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .cpop)) := do
   let (op, properties) ← matchOp op ctx (.riscv .cpop) 1
   return (op[0]!,  properties)
 
-def matchRVCpopw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .cpopw)) := do
+def matchRVCpopw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .cpopw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .cpopw) 1
   return (op[0]!,  properties)
 
-def matchRVOrcb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .orcb)) := do
+def matchRVOrcb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .orcb)) := do
   let (op, properties) ← matchOp op ctx (.riscv .orcb) 1
   return (op[0]!,  properties)
 
-def matchRVRev8 (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .rev8)) := do
+def matchRVRev8 (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .rev8)) := do
   let (op, properties) ← matchOp op ctx (.riscv .rev8) 1
   return (op[0]!,  properties)
 
-def matchRVRoriw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .roriw)) := do
+def matchRVRoriw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .roriw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .roriw) 1
   return (op[0]!,  properties)
 
-def matchRVRori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .rori)) := do
+def matchRVRori (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .rori)) := do
   let (op, properties) ← matchOp op ctx (.riscv .rori) 1
   return (op[0]!,  properties)
 
-def matchRVBclr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .bclr)) := do
+def matchRVBclr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .bclr)) := do
   let (op, properties) ← matchOp op ctx (.riscv .bclr) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVBext (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .bext)) := do
+def matchRVBext (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .bext)) := do
   let (op, properties) ← matchOp op ctx (.riscv .bext) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVBinv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .binv)) := do
+def matchRVBinv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .binv)) := do
   let (op, properties) ← matchOp op ctx (.riscv .binv) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVBset (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .bset)) := do
+def matchRVBset (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .bset)) := do
   let (op, properties) ← matchOp op ctx (.riscv .bset) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVBclri (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .bclri)) := do
+def matchRVBclri (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .bclri)) := do
   let (op, properties) ← matchOp op ctx (.riscv .bclri) 1
   return (op[0]!,  properties)
 
-def matchRVBexti (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .bexti)) := do
+def matchRVBexti (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .bexti)) := do
   let (op, properties) ← matchOp op ctx (.riscv .bexti) 1
   return (op[0]!,  properties)
 
-def matchRVBinvi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .binvi)) := do
+def matchRVBinvi (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .binvi)) := do
   let (op, properties) ← matchOp op ctx (.riscv .binvi) 1
   return (op[0]!,  properties)
 
-def matchRVBseti (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .bseti)) := do
+def matchRVBseti (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .bseti)) := do
   let (op, properties) ← matchOp op ctx (.riscv .bseti) 1
   return (op[0]!,  properties)
 
-def matchRVPack (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .pack)) := do
+def matchRVPack (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .pack)) := do
   let (op, properties) ← matchOp op ctx (.riscv .pack) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVPackh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .packh)) := do
+def matchRVPackh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .packh)) := do
   let (op, properties) ← matchOp op ctx (.riscv .packh) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVPackw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .packw)) := do
+def matchRVPackw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .packw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .packw) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVCzeroeqz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .czeroeqz)) := do
+def matchRVCzeroeqz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .czeroeqz)) := do
   let (op, properties) ← matchOp op ctx (.riscv .czeroeqz) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVCzeronez (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .czeronez)) := do
+def matchRVCzeronez (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .czeronez)) := do
   let (op, properties) ← matchOp op ctx (.riscv .czeronez) 2
   return (op[0]!, op[1]!, properties)
 
-def matchRVLd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .ld)) := do
+def matchRVLd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .ld)) := do
   let (op, properties) ← matchOp op ctx (.riscv .ld) 1
   return (op[0]!,  properties)
 
-def matchRVLw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .lw)) := do
+def matchRVLw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .lw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .lw) 1
   return (op[0]!,  properties)
 
-def matchRVLwu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .lwu)) := do
+def matchRVLwu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .lwu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .lwu) 1
   return (op[0]!,  properties)
 
-def matchRVLh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .lh)) := do
+def matchRVLh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .lh)) := do
   let (op, properties) ← matchOp op ctx (.riscv .lh) 1
   return (op[0]!,  properties)
 
-def matchRVLhu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .lhu)) := do
+def matchRVLhu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .lhu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .lhu) 1
   return (op[0]!,  properties)
 
-def matchRVLb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .lb)) := do
+def matchRVLb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .lb)) := do
   let (op, properties) ← matchOp op ctx (.riscv .lb) 1
   return (op[0]!,  properties)
 
-def matchRVLbu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .lbu)) := do
+def matchRVLbu (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .lbu)) := do
   let (op, properties) ← matchOp op ctx (.riscv .lbu) 1
   return (op[0]!,  properties)
 
-def matchRVSd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sd)) := do
+def matchRVSd (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sd)) := do
   guard (op.getOpType! ctx = .riscv .sd)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
   let properties := op.getProperties! ctx Riscv.sd
   return (operands[0]!, operands[1]!, properties)
 
-def matchRVSw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sw)) := do
+def matchRVSw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sw)) := do
   guard (op.getOpType! ctx = .riscv .sw)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
   let properties := op.getProperties! ctx Riscv.sw
   return (operands[0]!, operands[1]!, properties)
 
-def matchRVSh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sh)) := do
+def matchRVSh (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sh)) := do
   guard (op.getOpType! ctx = .riscv .sh)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
   let properties := op.getProperties! ctx Riscv.sh
   return (operands[0]!, operands[1]!, properties)
 
-def matchRVSb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (.riscv .sb)) := do
+def matchRVSb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv .sb)) := do
   guard (op.getOpType! ctx = .riscv .sb)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx
   let properties := op.getProperties! ctx Riscv.sb
   return (operands[0]!, operands[1]!, properties)
 
-def matchRVMv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .mv)) := do
+def matchRVMv (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .mv)) := do
   let (op, properties) ← matchOp op ctx (.riscv .mv) 1
   return (op[0]!,  properties)
 
-def matchRVNot (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .not)) := do
+def matchRVNot (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .not)) := do
   let (op, properties) ← matchOp op ctx (.riscv .not) 1
   return (op[0]!,  properties)
 
-def matchRVNeg (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .neg)) := do
+def matchRVNeg (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .neg)) := do
   let (op, properties) ← matchOp op ctx (.riscv .neg) 1
   return (op[0]!,  properties)
 
-def matchRVNegw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .negw)) := do
+def matchRVNegw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .negw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .negw) 1
   return (op[0]!,  properties)
 
-def matchRVSextw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sextw)) := do
+def matchRVSextw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sextw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sextw) 1
   return (op[0]!,  properties)
 
-def matchRVZextb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .zextb)) := do
+def matchRVZextb (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .zextb)) := do
   let (op, properties) ← matchOp op ctx (.riscv .zextb) 1
   return (op[0]!,  properties)
 
-def matchRVZextw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .zextw)) := do
+def matchRVZextw (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .zextw)) := do
   let (op, properties) ← matchOp op ctx (.riscv .zextw) 1
   return (op[0]!,  properties)
 
-def matchRVSeqz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .seqz)) := do
+def matchRVSeqz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .seqz)) := do
   let (op, properties) ← matchOp op ctx (.riscv .seqz) 1
   return (op[0]!,  properties)
 
-def matchRVSnez (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .snez)) := do
+def matchRVSnez (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .snez)) := do
   let (op, properties) ← matchOp op ctx (.riscv .snez) 1
   return (op[0]!,  properties)
 
-def matchRVSltz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sltz)) := do
+def matchRVSltz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sltz)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sltz) 1
   return (op[0]!,  properties)
 
-def matchRVSgtz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (.riscv .sgtz)) := do
+def matchRVSgtz (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × propertiesOf (OpCode.riscv .sgtz)) := do
   let (op, properties) ← matchOp op ctx (.riscv .sgtz) 1
   return (op[0]!,  properties)

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -88,7 +88,7 @@ def emitArithConstant (rewriter : PatternRewriter OpCode) (c : Int) (width : Nat
 
 /-- Emit a binary Arith op `arithOp` on `a` and `b` -/
 def emitArithBinOp (rewriter : PatternRewriter OpCode) (arithOp : Arith)
-    (props : propertiesOf (.arith arithOp)) (a b : ValuePtr) (ip : InsertPoint) :
+    (props : propertiesOf (OpCode.arith arithOp)) (a b : ValuePtr) (ip : InsertPoint) :
     Option (PatternRewriter OpCode × ValuePtr) := do
   let ty := a.getType! rewriter.ctx.raw
   let (rewriter, r) ← rewriter.createOp! (.arith arithOp)

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -1757,7 +1757,7 @@ def sexth_xor := drop_ext_of_bitwise .sexth .xor false
     These stores have no results, so they can't go through `matchOp` (which
     requires exactly one). -/
 private def matchRiscvStore (store : Riscv) (op : OperationPtr) (ctx : IRContext OpCode) :
-    Option (ValuePtr × ValuePtr × propertiesOf (.riscv store)) := do
+    Option (ValuePtr × ValuePtr × propertiesOf (OpCode.riscv store)) := do
   guard (op.getOpType! ctx = .riscv store)
   guard (op.getNumOperands! ctx = 2)
   let operands := op.getOperands! ctx


### PR DESCRIPTION
This change is part of the plan of removing the use of `OpCode` in the codebase in favor of `HasOpInfo` and `HasDialect`.