### PR TITLE
chore: Move `matchCastOp` and its lemma to its own folder.

### DIFF
--- a/Veir/Passes/Matching.lean
+++ b/Veir/Passes/Matching.lean
@@ -1,6 +1,8 @@
 module
 
 public import Veir.Passes.Matching.Basic
+public import Veir.Passes.Matching.Builtin.Basic
+public import Veir.Passes.Matching.Builtin.Lemmas
 public import Veir.Passes.Matching.LLVM.Basic
 public import Veir.Passes.Matching.LLVM.Lemmas
 public import Veir.Passes.Matching.RISCV.Basic

--- a/Veir/Passes/Matching/Builtin/Basic.lean
+++ b/Veir/Passes/Matching/Builtin/Basic.lean
@@ -1,0 +1,13 @@
+module
+
+public import Veir.Passes.Matching.Basic
+
+public section
+
+/-! This file contains helper functions to match Builtin operations when defining a rewrite. -/
+
+namespace Veir
+
+def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option ValuePtr := do
+  let (op, _) ← matchOp op ctx (.builtin .unrealized_conversion_cast) 1
+  return op[0]!

--- a/Veir/Passes/Matching/Builtin/Lemmas.lean
+++ b/Veir/Passes/Matching/Builtin/Lemmas.lean
@@ -1,0 +1,21 @@
+module
+
+public import Veir.Passes.Matching.Builtin.Basic
+
+import all Veir.Passes.Matching.Builtin.Basic
+
+public section
+
+/-! This file contains lemmas that characterize the behavior of the Builtin matching functions. -/
+
+namespace Veir
+
+/-- What matching `builtin.unrealized_conversion_cast` (via `matchCastOp`) syntactically guarantees. -/
+theorem matchCastOp_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand} :
+    matchCastOp op ctx = some operand →
+    op.getOpType! ctx = .builtin .unrealized_conversion_cast ∧
+    op.getNumResults! ctx = 1 ∧
+    op.getOperands! ctx = #[operand] := by
+  intro hmatch
+  simp only [matchCastOp, bind, Option.bind, pure] at hmatch
+  grind

--- a/Veir/Passes/Matching/LLVM/Basic.lean
+++ b/Veir/Passes/Matching/LLVM/Basic.lean
@@ -66,10 +66,6 @@ def getDefiningOp (val : ValuePtr) (_ctx : IRContext OpCode) : Option OperationP
   let .opResult opResultPtr := val | none
   some opResultPtr.op
 
-def matchCastOp (op : OperationPtr) (ctx : IRContext OpCode) : Option ValuePtr := do
-  let (op, _) ← matchOp op ctx (.builtin .unrealized_conversion_cast) 1
-  return op[0]!
-
 def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) : Option (ValuePtr × ValuePtr × propertiesOf (OpCode.llvm .ashr)) := do
   let (op, properties) ← matchOp op ctx (.llvm .ashr) 2
   return (op[0]!, op[1]!, properties)

--- a/Veir/Passes/Matching/LLVM/Lemmas.lean
+++ b/Veir/Passes/Matching/LLVM/Lemmas.lean
@@ -131,16 +131,6 @@ theorem getDefiningOp_implies {val : ValuePtr} {ctx : IRContext OpCode} {op} :
   simp only [getDefiningOp] at hmatch
   grind
 
-/-- What matching `builtin.unrealized_conversion_cast` (via `matchCastOp`) syntactically guarantees. -/
-theorem matchCastOp_implies {op : OperationPtr} {ctx : IRContext OpCode} {operand} :
-    matchCastOp op ctx = some operand →
-    op.getOpType! ctx = .builtin .unrealized_conversion_cast ∧
-    op.getNumResults! ctx = 1 ∧
-    op.getOperands! ctx = #[operand] := by
-  intro hmatch
-  simp only [matchCastOp, bind, Option.bind, pure] at hmatch
-  grind
-
 /-- What matching `llvm.ashr` (via `matchAshr`) syntactically guarantees. -/
 theorem matchAshr_implies {op : OperationPtr} {ctx : IRContext OpCode} {lhs rhs props} :
     matchAshr op ctx = some (lhs, rhs, props) →


### PR DESCRIPTION
`matchCastOp` was placed in an LLVM folder, but is about a Builtin operation.