### PR TITLE
feat: Split some of the `HasOpInfo` fields into `IsOpCode`

### DIFF
--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -17,8 +17,8 @@ example : HasDialect OpCode Builtin := inferInstance
 #guard OpCode.fromName "arith.addi".toUTF8 = some (.arith .addi)
 #guard OpCode.fromName "unknown.op".toUTF8 = none
 #guard OpCode.name (.arith .addi) = "arith.addi".toUTF8
-#guard HasOpInfo.fromName (opCode := Arith) "arith.addi".toUTF8 = some .addi
-#guard HasOpInfo.name (opCode := Arith) .addi = "arith.addi".toUTF8
+#guard IsOpCode.fromName (opCode := Arith) "arith.addi".toUTF8 = some .addi
+#guard IsOpCode.name (opCode := Arith) .addi = "arith.addi".toUTF8
 
 /-! Dialects can define conversion functions to and from the global opcode type. -/
 abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arith]

--- a/UnitTest/FoldDecision.lean
+++ b/UnitTest/FoldDecision.lean
@@ -184,7 +184,7 @@ poison, the fold decision carries it, and materialization spells it.
 -/
 private def testNswOverflowFoldsToPoison : String := Id.run do
   let i32 : TypeAttr := IntegerType.mk 32
-  let props : HasOpInfo.propertiesOf (.arith .addi : OpCode) :=
+  let props : propertiesOf (.arith .addi : OpCode) :=
     ArithIntegerOverflowFlagsProperties.mk { nsw := true, nuw := false }
   let operands : Array (Option RuntimeValue) :=
     #[some (.int 32 (.val (BitVec.ofInt 32 2147483647))), some (.int 32 (.val 1))]

--- a/UnitTest/SideEffectInterfaces.lean
+++ b/UnitTest/SideEffectInterfaces.lean
@@ -58,7 +58,7 @@ private def moduleWithRegion : OperationPtr × IRContext OpCode :=
 /- Executable memory independence is derived from the complete memory-effect summary. -/
 
 private def opWithType {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpCode Dialect]
-    (opType : Dialect) (properties : HasOpInfo.propertiesOf opType) :
+    (opType : Dialect) (properties : propertiesOf opType) :
     OperationPtr × IRContext OpCode :=
   let (ctx, moduleOp) := WfIRContext.create! OpCode
   let moduleRegion := moduleOp.getRegion! ctx.raw 0

--- a/Veir/ConstantMaterialization.lean
+++ b/Veir/ConstantMaterialization.lean
@@ -15,16 +15,16 @@ public section
   A constant-like operation together with the properties that make it
   materialize a particular value.
 -/
-abbrev Materialized (OpInfo : Type) [HasOpInfo OpInfo] :=
-  Σ op : OpInfo, HasOpInfo.propertiesOf op
+abbrev Materialized (OpInfo : Type) [IsOpCode OpInfo] :=
+  Σ op : OpInfo, propertiesOf op
 
 /--
   Inject a dialect-local opcode and its properties into `OpInfo`. This is how a
   dialect materializer names the operation it wants created.
 -/
-def Materialized.of {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
+def Materialized.of {OpInfo Dialect : Type} [IsOpCode OpInfo] [IsOpCode Dialect]
     [HasDialect OpInfo Dialect] (op : Dialect)
-    (properties : HasOpInfo.propertiesOf op) : Materialized OpInfo :=
+    (properties : propertiesOf op) : Materialized OpInfo :=
   ⟨ofDialect OpInfo op, HasDialect.ofDialectProperties OpInfo op properties⟩
 
 end

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -164,7 +164,7 @@ def OperationPtr.verifyArithExtendedOp {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (secondResultIsI1 : Bool) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 2
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerType
     s!"{instrName}: Expected operand 0 to have integer type"
   ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyIntegerType

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -399,7 +399,7 @@ def OperationPtr.verifyLLVMShift {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerOrByteType
     s!"{instrName}: Expected operand 0 to have integer or byte type"
   ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyIntegerType
@@ -411,7 +411,7 @@ def OperationPtr.verifyLLVMICmp {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   -- `llvm.icmp` also compares pointers.
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerOrPointerType
     s!"{instrName}: Expected operand 0 to have integer or pointer type"

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -95,7 +95,7 @@ def OperationPtr.verifyModArithBinOp {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let operandType ← op.verifyOperandTypesMatch ctx 0 1
     s!"{instrName}: Expected operands to have the same type"
   op.verifyResultTypeMatches ctx operandType
@@ -106,7 +106,7 @@ def OperationPtr.verifyModArithConstantOp {OpInfo : Type} [HasOpInfo OpInfo]
     [HasDialect OpInfo Mod_Arith] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 0 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let mat ← ((op.getResult 0).get! ctx.raw).type.verifyModArithType
     s!"{instrName}: Expected result to have ModArithType"
   let value := (op.getProperties! ctx.raw Mod_Arith.constant).value.value

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -275,7 +275,7 @@ def OperationPtr.verifyRISCVimm12 {OpInfo : Type} [HasOpInfo OpInfo]
     (operands results : Nat) (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn operands results
   if imm < -2048 ∨ imm > 2047 then
-    let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+    let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
     throw s!"{instrName} immediate out of bounds: must fit in a signed 12-bit field [-2048, 2047]"
   else
     pure ()
@@ -289,7 +289,7 @@ def OperationPtr.verifyRISCVuimm5 {OpInfo : Type} [HasOpInfo OpInfo]
     (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 1 1
   if imm < 0 ∨ imm > 31 then
-    let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+    let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
     throw s!"{instrName} immediate out of bounds: must fit in an unsigned 5-bit field [0, 31]"
   else
     pure ()
@@ -303,7 +303,7 @@ def OperationPtr.verifyRISCVuimm6 {OpInfo : Type} [HasOpInfo OpInfo]
     (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 1 1
   if imm < 0 ∨ imm > 63 then
-    let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+    let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
     throw s!"{instrName} immediate out of bounds: must fit in an unsigned 6-bit field [0, 63]"
   else
     pure ()
@@ -313,7 +313,7 @@ def OperationPtr.verifyRISCVneg {OpInfo : Type} [HasOpInfo OpInfo]
     (operands results : Nat) (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn operands results
   if imm < 0 ∨ 1048575 < imm then
-    let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+    let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
     throw s!"{instrName} immediate out of bounds: must fit in an unsigned 20-bit field."
   else
     pure ()
@@ -322,7 +322,7 @@ def OperationPtr.verifyRISCVneg {OpInfo : Type} [HasOpInfo OpInfo]
 def OperationPtr.verifyRISCVRegisterTypes {OpInfo : Type} [HasOpInfo OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let opTypes := op.getOperandTypes! ctx.raw
   for i in [0:opTypes.size] do
     match (opTypes[i]!).val with

--- a/Veir/IR/Basic.lean
+++ b/Veir/IR/Basic.lean
@@ -161,7 +161,7 @@ deriving Inhabited, Repr, Hashable
 /--
 An MLIR operation.
 -/
-structure Operation (OpInfo : Type) [HasOpInfo OpInfo] where
+structure Operation (OpInfo : Type) [IsOpCode OpInfo] where
   results : Array OpResult
   -- This is the operation pointer start
   prev : Option OperationPtr
@@ -173,14 +173,14 @@ structure Operation (OpInfo : Type) [HasOpInfo OpInfo] where
   opType : OpInfo
   attrs : DictionaryAttr
   -- This should be replaced with an arbitrary user object
-  properties : HasOpInfo.propertiesOf opType
+  properties : propertiesOf opType
   blockOperands : Array BlockOperand
   regions : Array RegionPtr
   operands : Array OpOperand
 deriving Inhabited, Repr, Hashable
 
-variable {OpInfo : Type} [HasOpInfo OpInfo]
-variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {OpInfo : Type} [IsOpCode OpInfo]
+variable {Dialect : Type} [IsOpCode Dialect] [HasDialect OpInfo Dialect]
 
 namespace Operation
 
@@ -314,7 +314,7 @@ The owning context of an MLIR module.
 It contains a top-level Module operation, and a maps from pointers to
 operations, blocks, and regions.
 -/
-structure IRContext (OpInfo : Type) [HasOpInfo OpInfo] where
+structure IRContext (OpInfo : Type) [IsOpCode OpInfo] where
   operations : HashMap OperationPtr (Operation OpInfo)
   blocks : HashMap BlockPtr Block
   regions : HashMap RegionPtr Region
@@ -328,7 +328,7 @@ variable {ctx ctx' : IRContext OpInfo}
 /-! Empty objects. -/
 
 @[expose]
-def Operation.empty (opType : OpInfo) (prop : HasOpInfo.propertiesOf opType) : Operation OpInfo :=
+def Operation.empty (opType : OpInfo) (prop : propertiesOf opType) : Operation OpInfo :=
   { results := #[]
     prev := none
     next := none
@@ -1070,7 +1070,7 @@ type, in order to get the dialect-specific properties which is often easier to u
 @[inline]
 def getProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect)
     (inBounds : op.InBounds ctx := by grind)
-    (hprop : op.getOpType! ctx = opCode := by grind) : HasOpInfo.propertiesOf opCode :=
+    (hprop : op.getOpType! ctx = opCode := by grind) : propertiesOf opCode :=
   have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
   let globalProperties := h ▸ (op.get ctx (by grind)).properties
   HasDialect.toDialectProperties opCode globalProperties
@@ -1085,7 +1085,7 @@ operation's type does not match the passed `opCode`.
 -/
 @[inline]
 def getProperties! (op : OperationPtr) (ctx : IRContext OpInfo)
-    (opCode : Dialect) : HasOpInfo.propertiesOf opCode :=
+    (opCode : Dialect) : propertiesOf opCode :=
   if h : (op.get! ctx).opType = opCode then
     let globalProperties := h ▸ (op.get! ctx).properties
     HasDialect.toDialectProperties opCode globalProperties
@@ -1110,7 +1110,7 @@ The passed `opCode` can either be of the global `OpInfo` type, or the dialect-sp
 while the `Dialect` version is often easier to use when manipulating dialect-specific operations.
 -/
 def setProperties (op : OperationPtr) (ctx : IRContext OpInfo) (opCode : Dialect)
-    (newProperties : HasOpInfo.propertiesOf opCode)
+    (newProperties : propertiesOf opCode)
     (inBounds : op.InBounds ctx := by grind)
     (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   have h : (op.get ctx inBounds).opType = opCode := by grind [getOpType!]
@@ -1127,7 +1127,7 @@ while the `Dialect` version is often easier to use when manipulating dialect-spe
 This function panics if the given operation is not in bounds.
 -/
 def setProperties! {opCode : Dialect} (op : OperationPtr) (ctx : IRContext OpInfo)
-  (newProperties : HasOpInfo.propertiesOf opCode)
+  (newProperties : propertiesOf opCode)
   (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   have h : (op.get! ctx).opType = opCode := by grind [getOpType!]
   let oldOp := op.get! ctx
@@ -1136,7 +1136,7 @@ def setProperties! {opCode : Dialect} (op : OperationPtr) (ctx : IRContext OpInf
 
 @[grind =_, eq_bang ←]
 theorem setProperties!_eq_setProperties {op : OperationPtr} {opCode : Dialect}
-    (newProperties : HasOpInfo.propertiesOf opCode) (inBounds : op.InBounds ctx)
+    (newProperties : propertiesOf opCode) (inBounds : op.InBounds ctx)
     (hprop : op.getOpType! ctx = opCode) :
     op.setProperties! ctx newProperties =
     op.setProperties ctx opCode newProperties inBounds := by
@@ -1193,9 +1193,9 @@ theorem nextResult!_eq_getResult {op : OperationPtr} :
     op.nextResult! ctx = op.getResult (op.getNumResults! ctx) := by
   rfl
 
-def allocEmpty {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+def allocEmpty {Dialect : Type} [IsOpCode Dialect] [HasDialect OpInfo Dialect]
     (ctx : IRContext OpInfo) (opType : Dialect)
-    (properties : HasOpInfo.propertiesOf opType) :
+    (properties : propertiesOf opType) :
     Option (IRContext OpInfo × OperationPtr) :=
   let newOpPtr : OperationPtr := ⟨ctx.nextID⟩
   let globalProperties := HasDialect.ofDialectProperties OpInfo opType properties
@@ -2737,7 +2737,7 @@ def BlockPtr.getSuccessors! (block : BlockPtr) (ctx : IRContext OpInfo) : Array 
   | none => #[]
   | some term => term.getSuccessors! ctx
 
-def IRContext.empty (OpInfo : Type) [HasOpInfo OpInfo] : IRContext OpInfo := {
+def IRContext.empty (OpInfo : Type) [IsOpCode OpInfo] : IRContext OpInfo := {
     nextID := 0,
     operations := Std.HashMap.emptyWithCapacity,
     blocks := Std.HashMap.emptyWithCapacity,

--- a/Veir/IR/Fields.lean
+++ b/Veir/IR/Fields.lean
@@ -699,7 +699,7 @@ theorem OperationPtr.pushResult_fieldsInBounds {newResult : OpResult} {op : Oper
 theorem OperationPtr.setProperties_fieldsInBounds
     {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     {op : OperationPtr} {inBounds : op.InBounds ctx}
-    {opCode : Dialect} {newProperties : HasOpInfo.propertiesOf opCode}
+    {opCode : Dialect} {newProperties : propertiesOf opCode}
     {hprop : op.getOpType! ctx = opCode} :
     ctx.FieldsInBounds → (setProperties op ctx opCode newProperties inBounds hprop).FieldsInBounds := by
   prove_fieldsInBounds_operation ctx
@@ -724,7 +724,7 @@ attribute [local grind] Operation.empty in
 @[grind .]
 theorem OperationPtr.allocEmpty_fieldsInBounds
     {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-    {type : Dialect} {prop : HasOpInfo.propertiesOf type}
+    {type : Dialect} {prop : propertiesOf type}
     (heq : allocEmpty ctx type prop = some (ctx', ptr')) :
     ctx.FieldsInBounds → ctx'.FieldsInBounds := by
   prove_fieldsInBounds

--- a/Veir/IR/GetSet.lean
+++ b/Veir/IR/GetSet.lean
@@ -5,9 +5,9 @@ import all Veir.IR.Basic
 
 namespace Veir
 
-variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {OpInfo : Type} [IsOpCode OpInfo]
 variable {ctx ctx': IRContext OpInfo}
-variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
+variable {Dialect : Type} [IsOpCode Dialect] [HasDialect OpInfo Dialect]
 variable {opCode opCode' : Dialect}
 
 public section
@@ -53,9 +53,9 @@ setup_grind_with_get_set_definitions
 
 /- OperationPtr.allocEmpty -/
 
-variable {CreateDialect : Type} [HasOpInfo CreateDialect]
+variable {CreateDialect : Type} [IsOpCode CreateDialect]
   [HasDialect OpInfo CreateDialect]
-variable {ty : CreateDialect} {properties : HasOpInfo.propertiesOf ty}
+variable {ty : CreateDialect} {properties : propertiesOf ty}
 
 @[simp, grind =>]
 theorem BlockPtr.get!_OperationPtr_allocEmpty {block : BlockPtr}
@@ -1325,7 +1325,7 @@ theorem OpOperandPtrPtr.get!_OperationPtr_pushResult {opOperandPtr : OpOperandPt
 section OperationPtr.setProperties
 
 variable {operation' : OperationPtr}
-variable {newProperties : HasOpInfo.propertiesOf opCode}
+variable {newProperties : propertiesOf opCode}
 variable {inBounds : operation'.InBounds ctx}
 variable {hprop : operation'.getOpType! ctx = opCode}
 
@@ -1348,7 +1348,7 @@ theorem OperationPtr.get!_OperationPtr_setProperties {operation : OperationPtr} 
 
 @[grind =]
 theorem OperationPtr.getProperties!_OperationPtr_setProperties
-    {GetterDialect : Type} [HasOpInfo GetterDialect]
+    {GetterDialect : Type} [IsOpCode GetterDialect]
     [HasDialect OpInfo GetterDialect] {getterOpCode : GetterDialect}
     {operation : OperationPtr} :
     operation.getProperties!

--- a/Veir/IR/InBounds.lean
+++ b/Veir/IR/InBounds.lean
@@ -180,7 +180,7 @@ theorem OperationPtr.setBlockOperands_OpOperandPtr_InBounds_mono_ne {opOperand :
 @[grind =]
 theorem OperationPtr.setProperties_genericPtr_mono (ptr : GenericPtr)
     {opCode : Dialect} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-    {newProperties : HasOpInfo.propertiesOf opCode}
+    {newProperties : propertiesOf opCode}
     {propEq : op.getOpType! ctx = opCode} :
     ptr.InBounds (setProperties op ctx opCode newProperties h propEq) ↔ ptr.InBounds ctx := by
   grind
@@ -192,7 +192,7 @@ theorem OperationPtr.setAttributes_genericPtr_mono (ptr : GenericPtr) :
 
 variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
 variable {ty : Dialect}
-variable {properties : HasOpInfo.propertiesOf ty}
+variable {properties : propertiesOf ty}
 
 @[grind .]
 theorem OpResultPtr.allocEmpty_no_results {opResult : OpResultPtr}

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -37,8 +37,7 @@ def unknown : MemoryEffects :=
 
 end MemoryEffects
 
-class HasOpInfo (opCode: Type)
-    extends Hashable opCode, Repr opCode, Inhabited opCode where
+class IsOpCode (opCode : Type) extends Hashable opCode, Repr opCode, Inhabited opCode where
   /-- Look up an operation by its fully qualified MLIR name. -/
   fromName : ByteArray → Option opCode
   /-- Return an operation's fully qualified MLIR name. -/
@@ -67,6 +66,27 @@ class HasOpInfo (opCode: Type)
     ((try rename_i op; cases op) <;> infer_instance)
   decideEq : DecidableEq (opCode) := by
     intros opCode1 opCode2; cases opCode1 <;> cases opCode2 <;> infer_instance
+
+abbrev propertiesOf {OpCode : Type} [IsOpCode OpCode] (opCode : OpCode) :=
+  IsOpCode.propertiesOf opCode
+
+instance [IsOpCode OpCode] {op : OpCode} : Hashable (propertiesOf op) where
+  hash := IsOpCode.propertiesHash.hash
+
+instance [IsOpCode OpCode] {op : OpCode} : Inhabited (propertiesOf op) where
+  default := IsOpCode.propertiesDefault.default
+
+instance [IsOpCode OpCode] {op : OpCode} : Repr (propertiesOf op) where
+  reprPrec := IsOpCode.propertiesRepr.reprPrec
+
+instance [IsOpCode OpCode] {op : OpCode} : DecidableEq (propertiesOf op) :=
+  IsOpCode.propertiesDecideEq
+
+instance [IsOpCode OpCode] : DecidableEq OpCode :=
+  IsOpCode.decideEq
+
+class HasOpInfo (opCode: Type)
+    extends IsOpCode opCode where
   /--
   The memory effects of an operation with this opcode and these properties,
   mirroring MLIR's `MemoryEffectOpInterface::getEffects`.
@@ -110,24 +130,6 @@ class HasOpInfo (opCode: Type)
   -/
   isTerminator : opCode → Bool := fun _ => false
 
-abbrev propertiesOf {OpCode : Type} [HasOpInfo OpCode] (opCode : OpCode) :=
-  HasOpInfo.propertiesOf opCode
-
-instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
-  hash := HasOpInfo.propertiesHash.hash
-
-instance [HasOpInfo opCode] {op : opCode} : Inhabited (HasOpInfo.propertiesOf op) where
-  default := HasOpInfo.propertiesDefault.default
-
-instance [HasOpInfo opCode] {op : opCode} : Repr (HasOpInfo.propertiesOf op) where
-  reprPrec := HasOpInfo.propertiesRepr.reprPrec
-
-instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) :=
-  HasOpInfo.propertiesDecideEq
-
-instance [HasOpInfo opCode] : DecidableEq opCode :=
-  HasOpInfo.decideEq
-
 /--
 `HasDialect OpInfo Dialect` states that `OpInfo` contains the operations from
 `Dialect`.
@@ -137,7 +139,7 @@ a projection from the combined opcode type to dialect-local opcodes.
 The class also records that the dialect-local property family agree with the combined
 property family on the injected opcodes.
 -/
-class HasDialect (OpInfo Dialect : Type) [HasOpInfo OpInfo] [HasOpInfo Dialect] where
+class HasDialect (OpInfo Dialect : Type) [IsOpCode OpInfo] [IsOpCode Dialect] where
   /--
   Given a dialect opcode, get the equivalent opcode.
   `Veir.ofDialect` or a coercion should be used instead of calling this function.
@@ -153,18 +155,18 @@ class HasDialect (OpInfo Dialect : Type) [HasOpInfo OpInfo] [HasOpInfo Dialect] 
     project opInfo = some op ↔ inject op = opInfo
   /-- The equivalence between the properties of the injected opcode and the dialect opcode. -/
   properties_eq (op : Dialect) :
-    HasOpInfo.propertiesOf (inject op) = HasOpInfo.propertiesOf op
+    propertiesOf (inject op) = propertiesOf op
 
 /--
 Project a global opcode to a dialect. Returns `none` when the opcode belongs
 to another dialect.
 -/
-def toDialect? (Dialect : Type) {OpInfo : Type} [HasOpInfo OpInfo]
-    [HasOpInfo Dialect] [dialectInj : HasDialect OpInfo Dialect] (opInfo : OpInfo) :
+def toDialect? (Dialect : Type) {OpInfo : Type} [IsOpCode OpInfo]
+    [IsOpCode Dialect] [dialectInj : HasDialect OpInfo Dialect] (opInfo : OpInfo) :
     Option Dialect :=
   HasDialect.project opInfo
 
-def ofDialect {Dialect : Type} (OpInfo : Type) [HasOpInfo OpInfo] [HasOpInfo Dialect]
+def ofDialect {Dialect : Type} (OpInfo : Type) [IsOpCode OpInfo] [IsOpCode Dialect]
     [dialectInj : HasDialect OpInfo Dialect] (op : Dialect) :
     OpInfo :=
   HasDialect.inject op
@@ -174,7 +176,7 @@ We can always treat a global opcode type as a dialect of itself.
 This simplifies quite a lot of the API, since we can use a single generic function for both
 dialect-local and global opcodes.
 -/
-instance hasDialectRefl (OpInfo : Type) [HasOpInfo OpInfo] : HasDialect OpInfo OpInfo where
+instance hasDialectRefl (OpInfo : Type) [IsOpCode OpInfo] : HasDialect OpInfo OpInfo where
   inject := id
   project := some
   project_eq_some_iff _ _ := by grind
@@ -182,18 +184,18 @@ instance hasDialectRefl (OpInfo : Type) [HasOpInfo OpInfo] : HasDialect OpInfo O
 
 /-- Casting an opcode to itself is the identity. -/
 @[simp, grind =]
-theorem ofDialect_hasDialectRefl (OpInfo : Type) [HasOpInfo OpInfo] (op : OpInfo) :
+theorem ofDialect_hasDialectRefl (OpInfo : Type) [IsOpCode OpInfo] (op : OpInfo) :
     ofDialect OpInfo op = op := by rfl
 
 /-- Coercion from a dialect opcode to the global opcode type. -/
-instance {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
+instance {OpInfo : Type} {Dialect : Type} [IsOpCode OpInfo] [IsOpCode Dialect]
     [HasDialect OpInfo Dialect] (op : Dialect) :
     CoeDep Dialect op OpInfo where
   coe := ofDialect OpInfo op
 
 namespace HasDialect
 
-variable {OpInfo : Type} {Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
+variable {OpInfo : Type} {Dialect : Type} [IsOpCode OpInfo] [IsOpCode Dialect]
   [dialectInj : HasDialect OpInfo Dialect]
 
 /-- Projecting an injected dialect opcode recovers that opcode. -/
@@ -212,12 +214,12 @@ theorem ofDialect_injective {op₁ op₂ : Dialect} :
 /-- Equal global opcodes have equal dialect-local property types. -/
 theorem properties_eq_of_ofDialect_eq
     {Dialect₁ Dialect₂ : Type}
-    [HasOpInfo Dialect₁] [HasOpInfo Dialect₂]
+    [IsOpCode Dialect₁] [IsOpCode Dialect₂]
     [hasDialect₁ : HasDialect OpInfo Dialect₁]
     [hasDialect₂ : HasDialect OpInfo Dialect₂]
     {op₁ : Dialect₁} {op₂ : Dialect₂}
     (h : ofDialect OpInfo op₁ = ofDialect OpInfo op₂) :
-    HasOpInfo.propertiesOf op₁ = HasOpInfo.propertiesOf op₂ := by
+    propertiesOf op₁ = propertiesOf op₂ := by
   simp [← hasDialect₁.properties_eq op₁, ← hasDialect₂.properties_eq op₂]
   grind [ofDialect]
 
@@ -230,42 +232,42 @@ grind_pattern toDialect?_eq_some_iff =>
   toDialect? Dialect opInfo, ofDialect OpInfo op
 
 /-- Convert dialect-local properties to the global property family. -/
-def ofDialectProperties (OpInfo : Type) [HasOpInfo OpInfo] [dialectInj : HasDialect OpInfo Dialect]
-    (op : Dialect) (props : HasOpInfo.propertiesOf op) :
-    HasOpInfo.propertiesOf (opCode := OpInfo) op :=
+def ofDialectProperties (OpInfo : Type) [IsOpCode OpInfo] [dialectInj : HasDialect OpInfo Dialect]
+    (op : Dialect) (props : propertiesOf op) :
+    propertiesOf (OpCode := OpInfo) op :=
   dialectInj.properties_eq op ▸ props
 
 /-- Convert global properties of an injected opcode back to dialect-local properties. -/
 def toDialectProperties (op : Dialect)
-    (props : HasOpInfo.propertiesOf (opCode := OpInfo) op) :
-    HasOpInfo.propertiesOf op :=
+    (props : propertiesOf (OpCode := OpInfo) op) :
+    propertiesOf op :=
   (dialectInj.properties_eq op).symm ▸ props
 
 @[simp, grind =]
 theorem toDialectProperties_cast_ofDialectProperties_eq
     {Dialect₁ Dialect₂ : Type}
-    [HasOpInfo Dialect₁] [HasOpInfo Dialect₂]
+    [IsOpCode Dialect₁] [IsOpCode Dialect₂]
     [hasDialect₁ : HasDialect OpInfo Dialect₁]
     [hasDialect₂ : HasDialect OpInfo Dialect₂]
     {op₁ : Dialect₁} {op₂ : Dialect₂}
     (h : ofDialect OpInfo op₁ = ofDialect OpInfo op₂)
-    (props : HasOpInfo.propertiesOf op₁) :
+    (props : propertiesOf op₁) :
     toDialectProperties op₂ (h ▸ ofDialectProperties OpInfo op₁ props) =
       properties_eq_of_ofDialect_eq h ▸ props := by
   apply eq_of_heq
   exact (cast_heq _ _).trans ((eqRec_heq h _).trans ((cast_heq _ _).trans (cast_heq _ _).symm))
 
 /-- Coercion from a dialect property to the global property type. -/
-instance {OpInfo Dialect : Type} [HasOpInfo OpInfo] [HasOpInfo Dialect]
+instance {OpInfo Dialect : Type} [IsOpCode OpInfo] [IsOpCode Dialect]
     [HasDialect OpInfo Dialect] (x : Dialect) :
-    CoeHead (HasOpInfo.propertiesOf (opCode := OpInfo) x)
-      (HasOpInfo.propertiesOf x) where
+    CoeHead (propertiesOf (OpCode := OpInfo) x)
+      (propertiesOf x) where
   coe := HasDialect.toDialectProperties x
 
 /- Projecting an injected properties recover the original properties. -/
 @[simp, grind =]
 theorem toDialectProperties_ofDialectProperties (op : Dialect)
-    (props : HasOpInfo.propertiesOf op) :
+    (props : propertiesOf op) :
     toDialectProperties op (ofDialectProperties OpInfo op props) =
       props := by
   grind [toDialectProperties, ofDialectProperties]
@@ -273,27 +275,12 @@ theorem toDialectProperties_ofDialectProperties (op : Dialect)
 /-- A property injection into a combined property family in injective. -/
 @[simp, grind =]
 theorem ofDialectProperties_toDialectProperties (op : Dialect)
-    (props : HasOpInfo.propertiesOf (opCode := OpInfo) op) :
+    (props : propertiesOf (OpCode := OpInfo) op) :
     ofDialectProperties OpInfo op (toDialectProperties op props) =
       props := by
   grind [ofDialectProperties, toDialectProperties]
 
 end HasDialect
-
-instance [HasOpInfo opCode] {op : opCode} : Hashable (HasOpInfo.propertiesOf op) where
-  hash := HasOpInfo.propertiesHash.hash
-
-instance [HasOpInfo opCode] {op : opCode} : Inhabited (HasOpInfo.propertiesOf op) where
-  default := HasOpInfo.propertiesDefault.default
-
-instance [HasOpInfo opCode] {op : opCode} : Repr (HasOpInfo.propertiesOf op) where
-  reprPrec := HasOpInfo.propertiesRepr.reprPrec
-
-instance [HasOpInfo opCode] {op : opCode} : DecidableEq (HasOpInfo.propertiesOf op) :=
-  HasOpInfo.propertiesDecideEq
-
-instance [HasOpInfo opCode] : DecidableEq opCode :=
-  HasOpInfo.decideEq
 
 end -- public section
 

--- a/Veir/Interfaces/FoldInterfaces.lean
+++ b/Veir/Interfaces/FoldInterfaces.lean
@@ -27,7 +27,7 @@ inductive FoldDecision where
   types, and the values of its constant-defined operands (`constOperands[i] =
   some rv` iff operand `i` is known to hold the constant `rv`).
 -/
-def OpCode.foldsTo (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
+def OpCode.foldsTo (opType : OpCode) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (constOperands : Array (Option RuntimeValue))
     : Option FoldDecision := do
   guard (!opType.isConstantLike)

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -524,7 +524,7 @@ def MemoryState.llvmLoad (state : MemoryState) (addr : UInt64) (type : TypeAttr)
 
 
 
-def Arith.interpretOp' (opType : Veir.Arith) (properties : HasOpInfo.propertiesOf opType)
+def Arith.interpretOp' (opType : Veir.Arith) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -739,7 +739,7 @@ private def ModArith.binaryOperands (bw : Nat) (operands : Array RuntimeValue) :
   else
     none
 
-def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasOpInfo.propertiesOf opType)
+def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -777,7 +777,7 @@ def ModArith.interpretOp' (opType : Veir.Mod_Arith) (properties : HasOpInfo.prop
     return (#[RuntimeValue.int bw res], none)
 
 
-def Llvm.interpretOp' (opType : Veir.Llvm) (properties : HasOpInfo.propertiesOf opType)
+def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
@@ -1101,7 +1101,7 @@ def riscvLoad (mem : MemoryState) (eaddr : BitVec 64) (bytes : Nat) (ext : LoadE
     | .zeroExt => val.setWidth 64
   return (extended, mem)
 
-def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasOpInfo.propertiesOf opType)
+def Riscv.interpretOp' (opType : Veir.Riscv) (properties : propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
@@ -1490,7 +1490,7 @@ def Riscv.interpretOp' (opType : Veir.Riscv) (properties : HasOpInfo.propertiesO
     let mem ← mem.store eaddr.toNat.toUInt64 ((UInt64.ofBitVec val).toByteArrayLE.extract 0 1)
     return (#[], mem, none)
 
-def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : HasOpInfo.propertiesOf opType)
+def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : propertiesOf opType)
     (_resultTypes : Array TypeAttr) (_operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
@@ -1499,7 +1499,7 @@ def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : HasOpInfo
     let (mem, addr) := mem.alloc properties.size.value.toNat.toUInt64
     return (#[.reg ⟨.ofNat 64 addr.toNat⟩], mem, none)
 
-def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasOpInfo.propertiesOf opType)
+def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     : Interp (Array RuntimeValue × Option ControlFlowAction) :=
   match opType with
@@ -1585,7 +1585,7 @@ def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : HasOpInfo.prope
     else
       return (#[], some (.branch (operands.extract (trueSize + 1) operands.size) destFalse))
 
-def Rv64.interpretOp' (opType : Veir.Rv64) (properties : HasOpInfo.propertiesOf opType)
+def Rv64.interpretOp' (opType : Veir.Rv64) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (_operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1596,7 +1596,7 @@ def Rv64.interpretOp' (opType : Veir.Rv64) (properties : HasOpInfo.propertiesOf 
     else
       none
 
-def Cf.interpretOp' (opType : Veir.Cf) (properties : HasOpInfo.propertiesOf opType)
+def Cf.interpretOp' (opType : Veir.Cf) (properties : propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     : Interp ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1617,7 +1617,7 @@ def Cf.interpretOp' (opType : Veir.Cf) (properties : HasOpInfo.propertiesOf opTy
     | .int 1 .poison => Interp.ub
     | _ => none
 
-def Comb.interpretOp' (opType : Veir.Comb) (properties : HasOpInfo.propertiesOf opType)
+def Comb.interpretOp' (opType : Veir.Comb) (properties : propertiesOf opType)
     (operands : Array RuntimeValue) (_blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1632,7 +1632,7 @@ def Comb.interpretOp' (opType : Veir.Comb) (properties : HasOpInfo.propertiesOf 
     return (#[.int w (Veir.Data.Comb.add nl)], none)
   | _ => none
 
-def HW.interpretOp' (opType : Veir.HW) (properties : HasOpInfo.propertiesOf opType)
+def HW.interpretOp' (opType : Veir.HW) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (_blockOperands : Array BlockPtr)
     : Option ((Array RuntimeValue) × Option ControlFlowAction) :=
   match opType with
@@ -1651,7 +1651,7 @@ def HW.interpretOp' (opType : Veir.HW) (properties : HasOpInfo.propertiesOf opTy
   If any error occurs during interpretation (e.g., unknown operation, missing variable),
   returns `none`.
 -/
-def interpretOp' (opType : OpCode) (properties : HasOpInfo.propertiesOf opType)
+def interpretOp' (opType : OpCode) (properties : propertiesOf opType)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
     (mem : MemoryState)
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -17,7 +17,7 @@ namespace Veir
   it must have no memory effects at all.
 -/
 private def isFoldEvaluationCandidate
-    (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode) : Bool :=
+    (opCode : OpCode) (properties : propertiesOf opCode) : Bool :=
   HasOpInfo.getEffects opCode properties == .none
 
 /--
@@ -26,7 +26,7 @@ private def isFoldEvaluationCandidate
   UB, and `none` if the operation must not be evaluated or the interpreter
   cannot evaluate it.
 -/
-def foldEvaluate (opCode : OpCode) (properties : HasOpInfo.propertiesOf opCode)
+def foldEvaluate (opCode : OpCode) (properties : propertiesOf opCode)
     (resultTypes : Array TypeAttr) (operands : Array RuntimeValue)
     : Interp (Array RuntimeValue) := do
   if !isFoldEvaluationCandidate opCode properties then none else

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -560,10 +560,10 @@ def parseTypedValue : MlirParserM OpInfo (ByteArray × TypeAttr × Location) := 
   Currently, these properties are not stored in the IR, but we still need to parse them to be able
   to parse valid MLIR syntax.
 -/
-def parseOpProperties (opCode : OpInfo) : MlirParserM OpInfo (HasOpInfo.propertiesOf opCode) := do
+def parseOpProperties (opCode : OpInfo) : MlirParserM OpInfo (propertiesOf opCode) := do
   let propertiesStart ← getPos
   if not (← parseOptionalPunctuation "<") then
-    match HasOpInfo.fromAttrDict opCode {} with
+    match IsOpCode.fromAttrDict opCode {} with
     | .ok properties => return properties
     | .error err => throwAtCurrentPos err
   let allowUnregisteredDialect := (← get).allowUnregisteredDialect
@@ -571,7 +571,7 @@ def parseOpProperties (opCode : OpInfo) : MlirParserM OpInfo (HasOpInfo.properti
   | .ok (properties, _, parserState) =>
     set parserState
     parsePunctuation ">"
-    match HasOpInfo.fromAttrDict opCode (.ofArray properties) with
+    match IsOpCode.fromAttrDict opCode (.ofArray properties) with
     | .ok properties => return properties
     | .error err => throwAt propertiesStart err
   | .error err => throw err
@@ -581,8 +581,8 @@ Record the source operation name in the properties of a `builtin.unregistered`
 operation.
 -/
 private def optionallySetUnregisteredOpName (opCode : OpInfo)
-    (properties : HasOpInfo.propertiesOf opCode) (opName : ByteArray) :
-    HasOpInfo.propertiesOf opCode :=
+    (properties : propertiesOf opCode) (opName : ByteArray) :
+    propertiesOf opCode :=
   if h : some .unregistered = toDialect? Builtin opCode then
     have h' : ofDialect OpInfo Builtin.unregistered = opCode := by grind
     let properties : UnregisteredProperties :=
@@ -669,7 +669,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) :
 
   /- Get the operation opcode. -/
   let unregisteredOp : OpInfo := ofDialect OpInfo Builtin.unregistered
-  let opId := (HasOpInfo.fromName opName).getD unregisteredOp
+  let opId := (IsOpCode.fromName opName).getD unregisteredOp
 
   if opId = unregisteredOp then
     if !(← get).allowUnregisteredDialect then
@@ -679,7 +679,7 @@ partial def parseOptionalOp (ip : Option InsertPoint) :
   let properties ← parseOpProperties opId
   /- For `builtin.unregistered`, record the original op name in the properties so it can be
      printed back out. The properties dictionary itself has already been populated by
-     `HasOpInfo.fromAttrDict` (see `UnregisteredProperties.fromAttrDict`). -/
+     `IsOpCode.fromAttrDict` (see `UnregisteredProperties.fromAttrDict`). -/
   let properties := optionallySetUnregisteredOpName opId properties opName
   let regions ← parseOpRegions
   let attrs ← parseOpAttributes

--- a/Veir/Passes/Legalization.lean
+++ b/Veir/Passes/Legalization.lean
@@ -14,7 +14,7 @@ namespace Veir
 /--
   Sigma type for an operation plus its properties.
 -/
-abbrev OpWithProp := (op : OpCode) × (HasOpInfo.propertiesOf op)
+abbrev OpWithProp := (op : OpCode) × (propertiesOf op)
 
 /--
   Converts the types of the arguments and result of a single-result binary operation.
@@ -40,7 +40,7 @@ inductive IntegerExtKind
 /--
   Return the LLVM operation corresponding to an `IntegerExtKind`.
 -/
-def expandIntegerExtOp (type : IntegerExtKind) : ((op : OpCode) × HasOpInfo.propertiesOf op) :=
+def expandIntegerExtOp (type : IntegerExtKind) : ((op : OpCode) × propertiesOf op) :=
   match type with
   | .sign => .mk (OpCode.llvm .sext) ()
   | .zero => .mk (OpCode.llvm .zext) (.mk false)

--- a/Veir/PatternRewriter/Basic.lean
+++ b/Veir/PatternRewriter/Basic.lean
@@ -162,7 +162,7 @@ private theorem addUsersInWorklist_same_ctx :
 
 def createOp (rewriter: PatternRewriter OpInfo) (opType: OpInfo)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr)
-    (blockOperands: Array BlockPtr) (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
+    (blockOperands: Array BlockPtr) (regions: Array RegionPtr) (properties: propertiesOf opType)
     (insertionPoint: Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds rewriter.ctx.raw)
     (hblockOperands : ∀ blockOper, blockOper ∈ blockOperands → blockOper.InBounds rewriter.ctx.raw)
@@ -181,7 +181,7 @@ not be created.
 -/
 def createOp! (rewriter: PatternRewriter OpInfo) (opType: OpInfo)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr)
-    (blockOperands: Array BlockPtr) (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
+    (blockOperands: Array BlockPtr) (regions: Array RegionPtr) (properties: propertiesOf opType)
     (insertionPoint: Option InsertPoint) : Option ((PatternRewriter OpInfo) × OperationPtr) := do
   let (newCtx, op) ← WfRewriter.createOp! rewriter.ctx opType resultTypes operands blockOperands
     regions properties insertionPoint
@@ -217,7 +217,7 @@ Set the properties of an operation in place, and re-enqueue it.
 -/
 def setProperties {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : Dialect)
-    (newProps : HasOpInfo.propertiesOf opCode)
+    (newProps : propertiesOf opCode)
     (opIn : op.InBounds rewriter.ctx.raw := by grind)
     (hprop : op.getOpType! rewriter.ctx.raw = opCode := by grind)
     : PatternRewriter OpInfo :=
@@ -233,7 +233,7 @@ the property types don't match.
 -/
 def setProperties! {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
     (rewriter: PatternRewriter OpInfo) (op: OperationPtr) (opCode : Dialect)
-    (newProps : HasOpInfo.propertiesOf opCode) : PatternRewriter OpInfo :=
+    (newProps : propertiesOf opCode) : PatternRewriter OpInfo :=
   if opIn : op.InBounds rewriter.ctx.raw then
     if hprop : op.getOpType! rewriter.ctx.raw = opCode then
       rewriter.setProperties op opCode newProps opIn hprop

--- a/Veir/Rewriter/Basic.lean
+++ b/Veir/Rewriter/Basic.lean
@@ -298,7 +298,7 @@ theorem Rewriter.setAttributes_inBounds (ptr : GenericPtr) :
 @[grind .]
 theorem Rewriter.setAttributes_fieldsInBounds :
     ctx.FieldsInBounds → (setAttributes ctx op newAttrs opIn).FieldsInBounds := by
-  grind [setAttributes, OperationPtr.setAttributes_fieldsInBounds]
+  grind [setAttributes]
 
 section Rewriter.setProperties
 
@@ -313,12 +313,12 @@ while the `Dialect` version is often easier to use when manipulating dialect-spe
 -/
 def Rewriter.setProperties (ctx: IRContext OpInfo) (op: OperationPtr)
     (opCode : Dialect := by grind)
-    (newProps: HasOpInfo.propertiesOf opCode)
+    (newProps: propertiesOf opCode)
     (opIn : op.InBounds ctx := by grind)
     (hprop : op.getOpType! ctx = opCode := by grind) : IRContext OpInfo :=
   op.setProperties ctx opCode newProps opIn hprop
 
-variable {op : OperationPtr} {newProperties : HasOpInfo.propertiesOf opCode}
+variable {op : OperationPtr} {newProperties : propertiesOf opCode}
 variable {opIn : op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
 
 @[grind =]
@@ -329,7 +329,7 @@ theorem Rewriter.setProperties_inBounds (ptr : GenericPtr) :
 @[grind .]
 theorem Rewriter.setProperties_fieldsInBounds :
     ctx.FieldsInBounds → (setProperties ctx op opCode newProperties opIn hprop).FieldsInBounds := by
-  grind [setProperties, OperationPtr.setProperties_fieldsInBounds]
+  grind [setProperties]
 
 end Rewriter.setProperties
 
@@ -348,7 +348,7 @@ theorem Rewriter.setType_inBounds (ptr : GenericPtr) :
 @[grind .]
 theorem Rewriter.setType_fieldsInBounds :
     ctx.FieldsInBounds → (setType ctx value newType valueIn).FieldsInBounds := by
-  grind [setType, ValuePtr.setType_fieldsInBounds]
+  grind [setType]
 
 @[irreducible]
 def Rewriter.replaceValue? (ctx: IRContext OpInfo) (oldValue: ValuePtr) (newValue: ValuePtr)
@@ -927,14 +927,14 @@ theorem Rewriter.initBlockOperands_inBounds_mono (ptr : GenericPtr) :
 @[irreducible]
 def Rewriter.createEmptyOp {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (ctx : IRContext OpInfo) (opType : Dialect)
-    (properties : HasOpInfo.propertiesOf opType) :
+    (properties : propertiesOf opType) :
     Option (IRContext OpInfo × OperationPtr) :=
   OperationPtr.allocEmpty ctx opType properties
 
 section Rewriter.createEmptyOp
 
 variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {properties : HasOpInfo.propertiesOf opType}
+variable {opType : Dialect} {properties : propertiesOf opType}
 
 @[grind .]
 theorem Rewriter.createEmptyOp_new_inBounds
@@ -966,7 +966,7 @@ end Rewriter.createEmptyOp
 def Rewriter.createOp {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (ctx: IRContext OpInfo) (opType: Dialect)
     (resultTypes: Array TypeAttr) (operands: Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions: Array RegionPtr) (properties: HasOpInfo.propertiesOf opType)
+    (regions: Array RegionPtr) (properties: propertiesOf opType)
     (insertionPoint: Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds ctx := by grind)
     (hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds ctx := by grind)
@@ -993,7 +993,7 @@ def Rewriter.createOp {Dialect : Type} [HasOpInfo Dialect]
 section Rewriter.createOp
 
 variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {props : HasOpInfo.propertiesOf opType}
+variable {opType : Dialect} {props : propertiesOf opType}
 
 @[grind .]
 theorem Rewriter.createOp_inBounds_mono (ptr : GenericPtr)

--- a/Veir/Rewriter/GetSet/CreateOp.lean
+++ b/Veir/Rewriter/GetSet/CreateOp.lean
@@ -61,7 +61,7 @@ variable {dialectOpType : Dialect}
 variable {CreateDialect : Type} [HasOpInfo CreateDialect]
   [HasDialect OpInfo CreateDialect]
 variable {opType : CreateDialect}
-variable {properties : HasOpInfo.propertiesOf opType}
+variable {properties : propertiesOf opType}
 section Rewriter.createEmptyOp
 
 variable {op : OperationPtr}

--- a/Veir/Rewriter/GetSet/Operation.lean
+++ b/Veir/Rewriter/GetSet/Operation.lean
@@ -277,7 +277,7 @@ end Rewriter.setAttributes
 
 section Rewriter.setProperties
 
-variable {op : OperationPtr} {newProps : HasOpInfo.propertiesOf opCode}
+variable {op : OperationPtr} {newProps : propertiesOf opCode}
          {opIn : op.InBounds ctx} {hprop : op.getOpType! ctx = opCode}
 
 attribute [local grind] Rewriter.setProperties

--- a/Veir/Rewriter/WellFormed/IRContext.lean
+++ b/Veir/Rewriter/WellFormed/IRContext.lean
@@ -20,7 +20,7 @@ theorem IRContext.wellFormed_IRContext_create [HasDialect OpInfo Builtin] :
   simp only [create]
   split; grind; rename_i ctx₁ region hctx₁
   have : ctx₁.WellFormed := by
-    grind [IRContext.wellFormed_Rewriter_createRegion, IRContext.empty_wellFormed]
+    exact IRContext.wellFormed_Rewriter_createRegion IRContext.empty_wellFormed hctx₁
   split; grind; rename_i ctx₂ op' hctx₂
   have : ctx₂.WellFormed := by grind [Rewriter.createOp_WellFormed]
   split; grind; rename_i ctx₃ op'' hctx₃

--- a/Veir/Rewriter/WellFormed/Operation.lean
+++ b/Veir/Rewriter/WellFormed/Operation.lean
@@ -312,12 +312,12 @@ end setAttributes
 section setProperties
 
 variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opCode : Dialect} {newProps : HasOpInfo.propertiesOf opCode}
+variable {opCode : Dialect} {newProps : propertiesOf opCode}
 
 theorem OperationPtr.setProperties_WellFormed (ctx: IRContext OpInfo)
   (op: OperationPtr) (hctx : ctx.WellFormed) (hop : op.InBounds ctx)
   (hprop : op.getOpType! ctx = opCode := by grind)
-  (newProperties: HasOpInfo.propertiesOf opCode) :
+  (newProperties: propertiesOf opCode) :
   (op.setProperties ctx opCode newProperties hop hprop).WellFormed := by
   have ⟨h₁, h₂, h₃, h₄, h₅, h₆, h₇, h₈⟩ := hctx
   constructor
@@ -353,7 +353,7 @@ theorem OperationPtr.setProperties_WellFormed (ctx: IRContext OpInfo)
 theorem BlockPtr.opChain_OperationPtr_setProperties
     (hWf : BlockPtr.OpChain block' ctx array)
     {op : OperationPtr} (hop : op.InBounds ctx)
-    (newProps : HasOpInfo.propertiesOf opCode)
+    (newProps : propertiesOf opCode)
     (hprop : op.getOpType! ctx = opCode := by grind) :
     BlockPtr.OpChain block' (op.setProperties ctx opCode newProps hop hprop) array := by
   apply BlockPtr.OpChain_unchanged (ctx := ctx) <;> grind
@@ -653,7 +653,7 @@ theorem OperationPtr.getOperand_Rewriter_eraseOp
 section createOp
 
 variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {properties : HasOpInfo.propertiesOf opType}
+variable {opType : Dialect} {properties : propertiesOf opType}
 
 theorem Rewriter.createEmptyOp_wellFormed  (hctx : IRContext.WellFormed ctx) :
     Rewriter.createEmptyOp ctx opType properties = some (newCtx, newOp) →

--- a/Veir/Rewriter/WfRewriter/Basic.lean
+++ b/Veir/Rewriter/WfRewriter/Basic.lean
@@ -168,7 +168,7 @@ def WfRewriter.setAttributes! (wfCtx : WfIRContext OpInfo) (op : OperationPtr) (
 @[inline]
 def WfRewriter.setProperties {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo)
-    (op : OperationPtr) (opCode : Dialect) (newProps : HasOpInfo.propertiesOf opCode)
+    (op : OperationPtr) (opCode : Dialect) (newProps : propertiesOf opCode)
     (opIn : op.InBounds wfCtx.raw := by grind)
     (hprop : op.getOpType! wfCtx.raw = opCode := by grind) :
     WfIRContext OpInfo :=
@@ -181,7 +181,7 @@ property types don't match.
 -/
 def WfRewriter.setProperties! {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo)
-    (op : OperationPtr) (opCode : Dialect) (newProperties : HasOpInfo.propertiesOf opCode) :
+    (op : OperationPtr) (opCode : Dialect) (newProperties : propertiesOf opCode) :
     WfIRContext OpInfo :=
   if opIn : op.InBounds wfCtx.raw then
     if hprop : op.getOpType! wfCtx.raw = opCode then
@@ -443,7 +443,7 @@ def WfRewriter.pushBlockOperand! (wfCtx : WfIRContext OpInfo) (opPtr : Operation
 def WfRewriter.createOp {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo) (opType : Dialect)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
+    (regions : Array RegionPtr) (properties : propertiesOf opType)
     (insertionPoint : Option InsertPoint)
     (hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw := by grind)
     (hblockOperands : ∀ oper, oper ∈ blockOperands → oper.InBounds wfCtx.raw := by grind)
@@ -462,7 +462,7 @@ not be created.
 def WfRewriter.createOp! {Dialect : Type} [HasOpInfo Dialect]
     [HasDialect OpInfo Dialect] (wfCtx : WfIRContext OpInfo) (opType : Dialect)
     (resultTypes : Array TypeAttr) (operands : Array ValuePtr) (blockOperands : Array BlockPtr)
-    (regions : Array RegionPtr) (properties : HasOpInfo.propertiesOf opType)
+    (regions : Array RegionPtr) (properties : propertiesOf opType)
     (insertionPoint : Option InsertPoint)
     : Option (WfIRContext OpInfo × OperationPtr) :=
   if hoper : ∀ oper, oper ∈ operands → oper.InBounds wfCtx.raw then

--- a/Veir/Rewriter/WfRewriter/GetSet.lean
+++ b/Veir/Rewriter/WfRewriter/GetSet.lean
@@ -50,7 +50,7 @@ variable {dialectOpType : Dialect}
 variable {CreateDialect : Type} [HasOpInfo CreateDialect]
   [HasDialect OpInfo CreateDialect]
 variable {opType : CreateDialect}
-variable {properties : HasOpInfo.propertiesOf opType}
+variable {properties : propertiesOf opType}
 
 /-! ## `WfRewriter.createOp` -/
 
@@ -1069,7 +1069,7 @@ section WfRewriter.setProperties
 attribute [local grind] WfRewriter.setProperties
 
 variable {opCode : Dialect} {op : OperationPtr}
-         {newProps : HasOpInfo.propertiesOf opCode}
+         {newProps : propertiesOf opCode}
          {opIn : op.InBounds ctx.raw} {hprop : op.getOpType! ctx.raw = opCode}
 
 @[simp, grind =]

--- a/Veir/Rewriter/WfRewriter/InBounds.lean
+++ b/Veir/Rewriter/WfRewriter/InBounds.lean
@@ -169,7 +169,7 @@ theorem WfRewriter.pushBlockOperand_inBounds_mono :
 section WfRewriter.createOp
 
 variable {Dialect : Type} [HasOpInfo Dialect] [HasDialect OpInfo Dialect]
-variable {opType : Dialect} {properties : HasOpInfo.propertiesOf opType}
+variable {opType : Dialect} {properties : propertiesOf opType}
 
 @[grind →]
 theorem WfRewriter.createOp_new_inBounds (ptr : OperationPtr)

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -46,7 +46,7 @@ def Attribute.isKnownNonZero (attr : Attribute) : Bool :=
 -/
 def OperationPtr.verifyTerminatorCounts (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (successors : Nat) : Except String PUnit := do
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   if op.getNumResults ctx.raw opIn ≠ 0 then
     throw s!"{instrName}: Expected 0 results"
   if op.getNumRegions ctx.raw opIn ≠ 0 then
@@ -82,7 +82,7 @@ def OperationPtr.verifyUnconditionalBranch (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyTerminatorCounts ctx opIn 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let dest := op.getSuccessor! ctx.raw 0
   if op.getNumOperands ctx.raw opIn ≠ dest.getNumArguments! ctx.raw then
     throw s!"{instrName}: branch expected operand count {dest.getNumArguments! ctx.raw}, got {op.getNumOperands ctx.raw opIn}"
@@ -96,7 +96,7 @@ def OperationPtr.verifyOperandSegmentSizes
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (sizes : DenseArrayAttr) (expectedSegments : Nat) :
     Except String (Array Nat) := do
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   if sizes.values.size ≠ expectedSegments then
     throw s!"{instrName}: operandSegmentSizes expected {expectedSegments} entries, got {sizes.values.size}"
   let mut segmentSizes : Array Nat := #[]
@@ -113,7 +113,7 @@ def OperationPtr.verifyCondBranchOperandSegmentSizes
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (sizes : DenseArrayAttr) (fixedOperands : Nat) :
     Except String PUnit := do
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   if _ : sizes.values.size ≠ fixedOperands + 2 then
     throw s!"{instrName}: operandSegmentSizes expected {fixedOperands + 2} entries, got {sizes.values.size}"
   let mut operandSegmentSizes : Array Nat := #[]
@@ -188,7 +188,7 @@ def TypeAttr.verifyI1
 def OperationPtr.verifyPlainOpCounts (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (operands results : Nat) : Except String PUnit := do
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   if op.getNumOperands ctx.raw opIn ≠ operands then
     throw s!"{instrName}: Expected {operands} operand(s)"
   if op.getNumResults ctx.raw opIn ≠ results then
@@ -217,7 +217,7 @@ def OperationPtr.verifyIntegerBinop (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerType
     s!"{instrName}: Expected operand 0 to have integer type"
   ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyIntegerType
@@ -231,7 +231,7 @@ def OperationPtr.verifyIntegerTernop (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 3 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerType
     s!"{instrName}: Expected operand 0 to have integer type"
   ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyIntegerType
@@ -249,7 +249,7 @@ def OperationPtr.verifyIntegerUnop (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String TypeAttr := do
   op.verifyPlainOpCounts ctx opIn 1 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
   operandType.verifyIntegerType s!"{instrName}: Expected operand 0 to have integer type"
   op.verifyResultTypeMatches ctx operandType
@@ -259,7 +259,7 @@ def OperationPtr.verifyIntegerUnop (op : OperationPtr)
 def OperationPtr.verifyICmp (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerType
     s!"{instrName}: Expected operand 0 to have integer type"
   ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyIntegerType
@@ -272,7 +272,7 @@ def OperationPtr.verifySelectTypes (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 3 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyI1 s!"{instrName}: Expected i1 condition"
   let operandType ← op.verifyOperandTypesMatch ctx 1 2
     s!"{instrName}: Expected select values to have the same type"
@@ -283,7 +283,7 @@ def OperationPtr.verifyTruncTypes (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (allowByte : Bool) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 1 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
   let resultType := ((op.getResult 0).get! ctx.raw).type
   match operandType.val, resultType.val, allowByte with
@@ -303,7 +303,7 @@ def OperationPtr.verifyIntegerExtTypes (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 1 1
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
   let resultType := ((op.getResult 0).get! ctx.raw).type
   let .integerType operandInt := operandType.val
@@ -323,7 +323,7 @@ def OperationPtr.verifyIntegerExtTypes (op : OperationPtr)
 def OperationPtr.checkIsNonNullIntegerType (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
-  let instrName := String.fromUTF8! (HasOpInfo.name (op.getOpType ctx.raw opIn))
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let opTypes := op.getOperandTypes! ctx.raw
   for i in [0:opTypes.size] do
     if let .integerType intType := (opTypes[i]!).val then


### PR DESCRIPTION
`IsOpCode` now contains only the fields necessary for the core data structure, such converting from/to a string, and functions dealing with properties.

This split is necessary as some interfaces should contain references to `OperationPtr`, but `OperationPtr` is defined in a file requiring `IsOpCode`.

The important change is in `Veir/IR/OpInfo.lean`, all other changes are renaming `HasOpInfo.propertiesOf` to `IsOpCode.propertiesOf`