### PR TITLE
chore: Move `verifyRISCVRegisterTypes` to dialect-local verification

### DIFF
--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -340,6 +340,7 @@ containing the `riscv` dialect.
 def Riscv.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
     [HasDialect OpInfo Riscv] (opType : Riscv) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyRISCVRegisterTypes ctx opIn
   match opType with
   | .li => do
     op.verifyPlainOpCounts ctx opIn 0 1

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -167,8 +167,6 @@ def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
       (fun msg => if opName.isEmpty || msg.startsWith opName then msg else s!"{opName}: {msg}")
       (do
         op.verifyLocalInvariants ctx opIn
-        if let .riscv _ := opType then
-          op.verifyRISCVRegisterTypes ctx opIn
         match (op.get ctx.raw opIn).parent with
         | some _ => op.verifyTerminatorPosition ctx opIn
         | none => pure ()))


### PR DESCRIPTION
`verifyRISCVRegisterTypes` was called in the global opcode verifier, which we are in the process on making dialect-agnostic.