### PR TITLE
chore: Move `getRegionKind` to `HasOpInfo`

### DIFF
--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -46,6 +46,11 @@ def Builtin.getEffects
 def Builtin.isConstantLike (_op : Builtin) : Bool :=
   false
 
+def Builtin.getRegionKind (op : Builtin) (_index : Nat) : RegionKind :=
+  match op with
+  | .module | .unregistered => .Graph
+  | _ => .SSACFG
+
 def Builtin.hasSSADominance (op : Builtin) (_index : Nat) : Bool :=
   match op with
   | .module | .unregistered => false
@@ -68,6 +73,7 @@ instance : HasOpInfo Builtin where
   toAttrDict := Builtin.toAttrDict
   getEffects := Builtin.getEffects
   isConstantLike := Builtin.isConstantLike
+  getRegionKind := Builtin.getRegionKind
   hasSSADominance := Builtin.hasSSADominance
   hasNoTerminator := Builtin.hasNoTerminator
 

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -34,6 +34,9 @@ def Test.getEffects
 def Test.isConstantLike (_op : Test) : Bool :=
   false
 
+def Test.getRegionKind (_op : Test) (_index : Nat) : RegionKind :=
+  .Graph
+
 def Test.hasSSADominance (_op : Test) (_index : Nat) : Bool :=
   false
 
@@ -50,6 +53,7 @@ instance : HasOpInfo Test where
   toAttrDict := Test.toAttrDict
   getEffects := Test.getEffects
   isConstantLike := Test.isConstantLike
+  getRegionKind := Test.getRegionKind
   hasSSADominance := Test.hasSSADominance
   hasNoTerminator := Test.hasNoTerminator
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -54,22 +54,26 @@ def OpCode.getEffects (opCode : OpCode) (props : _propertiesOf opCode) : MemoryE
   | .pdl op, props => PDL.getEffects op props
   | .test op, props => Test.getEffects op props
 
-inductive RegionKind where
-| SSACFG
-| Graph
-deriving Inhabited, Repr, DecidableEq
-
 /--
   Return the kind of the region with the given index inside this operation.
-  This mirrors MLIR's RegionKindInterface default: regions are SSACFG unless
-  the operation is known to define graph regions.
 -/
-def OpCode.getRegionKind (opCode : OpCode) (_index : Nat) : RegionKind :=
+def OpCode.getRegionKind (opCode : OpCode) (index : Nat) : RegionKind :=
   match opCode with
-  | .builtin .module
-  | .builtin .unregistered
-  | .test .test => .Graph
-  | _ => .SSACFG
+  | .arith op => HasOpInfo.getRegionKind op index
+  | .llvm op => HasOpInfo.getRegionKind op index
+  | .riscv op => HasOpInfo.getRegionKind op index
+  | .riscv_cf op => HasOpInfo.getRegionKind op index
+  | .riscv_stack op => HasOpInfo.getRegionKind op index
+  | .rv64 op => HasOpInfo.getRegionKind op index
+  | .mod_arith op => HasOpInfo.getRegionKind op index
+  | .cf op => HasOpInfo.getRegionKind op index
+  | .comb op => HasOpInfo.getRegionKind op index
+  | .hw op => HasOpInfo.getRegionKind op index
+  | .builtin op => HasOpInfo.getRegionKind op index
+  | .func op => HasOpInfo.getRegionKind op index
+  | .datapath op => HasOpInfo.getRegionKind op index
+  | .pdl op => HasOpInfo.getRegionKind op index
+  | .test op => HasOpInfo.getRegionKind op index
 
 /--
   Whether definitions in the indexed region of this opcode must dominate
@@ -241,6 +245,7 @@ instance : HasOpInfo OpCode where
   getEffects := OpCode.getEffects
   isConstantLike := OpCode.isConstantLike
   isFunctionLike := OpCode.isFunctionLike
+  getRegionKind := OpCode.getRegionKind
   hasSSADominance := OpCode.hasSSADominance
   hasNoTerminator := OpCode.hasNoTerminator
   isTerminator := OpCode.isTerminator

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -7,6 +7,11 @@ namespace Veir
 
 public section
 
+inductive RegionKind where
+| SSACFG
+| Graph
+deriving Inhabited, Repr, DecidableEq
+
 /-- The memory effects an operation may have. -/
 structure MemoryEffects where
   /-- The operation may dereference memory, without necessarily mutating it. -/
@@ -105,6 +110,12 @@ class HasOpInfo (opCode: Type)
   whose single region is the function body.
   -/
   isFunctionLike : opCode → Bool := fun _ => false
+  /--
+  Return the kind of the indexed region inside an operation with this opcode.
+  This mirrors MLIR's `RegionKindInterface` default: regions are SSACFG unless
+  the operation is known to define graph regions.
+  -/
+  getRegionKind : opCode → Nat → RegionKind := fun _ _ => .SSACFG
   /--
   Whether definitions in the indexed region must dominate their uses. A false
   result denotes graph-style semantics, where only a single block can be in the


### PR DESCRIPTION
This is in the continuation of moving interfaces to `HasOpInfo`, so that we can have more file that do not depend on the specialized `OpCode`, and instead work on a generic `OpInfo` directly.