### PR TITLE
chore: Remove dependency between `Printer` and `OpCode`

### DIFF
--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -1,5 +1,6 @@
 import Veir.Parser.MlirParser
 import Veir.Printer
+import Veir.GlobalOpInfo
 
 open Veir
 open Veir.Parser
@@ -13,7 +14,7 @@ def testParseOp (s : String) : IO Unit :=
     match ParserState.fromInput (s.toByteArray) with
     | .ok parser =>
       match parseTopLevelOp.run (MlirParserState.fromContext ctx) parser with
-      | .ok (op, state, _) => Printer.printOperation state.ctx op
+      | .ok (op, state, _) => Printer.printOperation state.ctx.raw op
       | .error err => .error (toString err)
     | .error err => .error (toString err)
   | none => .error "internal error: failed to create IR context"

--- a/Veir/Benchmarks.lean
+++ b/Veir/Benchmarks.lean
@@ -5,6 +5,7 @@ public import Veir.GlobalOpInfo
 
 import Veir.Printer
 
+meta import Veir.GlobalOpInfo
 meta import Veir.PatternRewriter.Basic
 meta import Veir.Printer
 
@@ -497,7 +498,7 @@ def rewriteWorklist (program: WfIRContext OpCode) (_topOp : OperationPtr) (rewri
 
 def print (program: Option (WfIRContext OpCode × OperationPtr)) : IO Unit := do
   if let some (ctx, topOp) := program then
-    Printer.printModule ctx topOp
+    Printer.printModule ctx.raw topOp
 
 def time {α : Type} (name: String) (f: Unit → IO α) (quiet: Bool) : IO α := do
   let startTime ← IO.monoNanosNow

--- a/Veir/Printer.lean
+++ b/Veir/Printer.lean
@@ -1,7 +1,7 @@
 module
 
-public import Veir.GlobalOpInfo
-
+public import Veir.IR.Basic
+public import Veir.Dialects.Builtin.OpInfo
 import Veir.Rewriter.Basic
 
 open Veir
@@ -10,17 +10,7 @@ public section
 
 namespace Veir.Printer
 
-def opName (opType: Nat) : String :=
-  match opType with
-  | 0 => "builtin.module"
-  | 1 => "arith.constant"
-  | 2 => "arith.addi"
-  | 3 => "return"
-  | 4 => "arith.muli"
-  | 5 => "arith.andi"
-  | 6 => "arith.subi"
-  | 99 => "test.test"
-  | _ => "UNREGISTERED"
+variable {OpCode : Type} [IsOpCode OpCode] [HasDialect OpCode Builtin]
 
 def printIndent (identFactor: Nat) : IO Unit :=
   match identFactor with
@@ -110,7 +100,7 @@ def printOpAttrDict (ctx : IRContext OpCode) (op : OperationPtr) : IO Unit := do
 def printOpProperties (ctx : IRContext OpCode) (op : OperationPtr) : IO Unit := do
   let opType := (op.get! ctx).opType
   let properties := op.getProperties! ctx opType
-  let attrDict := Properties.toAttrDict opType properties
+  let attrDict := IsOpCode.toAttrDict opType properties
   if attrDict.size = 0 then return
   IO.print " <"
   IO.print (DictionaryAttr.fromArray attrDict.toArray)
@@ -176,10 +166,10 @@ partial def printOperation (ctx: IRContext OpCode) (op: OperationPtr) (indent: N
   printOpResults ctx op
   /- Unregistered operations store their original operation name in the properties. -/
   let nameBytes : ByteArray :=
-    match opStruct.opType with
-    | .builtin .unregistered =>
+    match toDialect? Builtin opStruct.opType with
+    | some Builtin.unregistered =>
       (op.getProperties! ctx Builtin.unregistered).opName
-    | _ => opStruct.opType.name
+    | _ => IsOpCode.name opStruct.opType
   IO.print s!"\"{String.fromUTF8! nameBytes}\""
   printOpOperands ctx op
   printBlockOperands ctx op

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -218,4 +218,4 @@ def main (args : List String) : IO Unit := do
         IO.eprintln s!"Error: {errMsg}"
         IO.Process.exit 1
       | .ok finalCtx =>
-        Veir.Printer.printOperation finalCtx op
+        Veir.Printer.printOperation finalCtx.raw op


### PR DESCRIPTION
The printer can now take any `OpInfo` as long as it has `Builtin` in it.