### PR TITLE
feat: explicit values for boolean pass arguments

### DIFF
--- a/Test/Passes/Canonicalize/options.mlir
+++ b/Test/Passes/Canonicalize/options.mlir
@@ -1,0 +1,32 @@
+// RUN: veir-opt %s -p=canonicalize | filecheck %s --check-prefix=DEFAULT
+// RUN: veir-opt %s -p='canonicalize{mod-arith-constant=false}' | filecheck %s --check-prefix=NO-MOD
+// RUN: veir-opt %s -p='canonicalize{commutative-constant-rhs=false}' | filecheck %s --check-prefix=NO-COMMUTE
+// RUN: veir-opt %s -p='canonicalize{mod-arith-constant=false commutative-constant-rhs=false}' | filecheck %s --check-prefix=NEITHER
+
+// Both parts of canonicalize default to true and can be disabled independently.
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32) -> i32, sym_name = "main"}> ({
+    ^bb0(%x : i32):
+      // DEFAULT:      ^{{.*}}(%[[DEFAULT_X:.*]] : i32):
+      // NO-MOD:       ^{{.*}}(%[[NO_MOD_X:.*]] : i32):
+      // NO-COMMUTE:   ^{{.*}}(%[[NO_COMMUTE_X:.*]] : i32):
+      // NEITHER:      ^{{.*}}(%[[NEITHER_X:.*]] : i32):
+      %mod = "mod_arith.constant"() <{"value" = 37 : i8}> : () -> !mod_arith.int<17 : i8>
+      // DEFAULT-NEXT:    %[[DEFAULT_MOD:.*]] = "mod_arith.constant"() <{"value" = 3 : i8}>
+      // NO-MOD-NEXT:     %[[NO_MOD_MOD:.*]] = "mod_arith.constant"() <{"value" = 37 : i8}>
+      // NO-COMMUTE-NEXT: %[[NO_COMMUTE_MOD:.*]] = "mod_arith.constant"() <{"value" = 3 : i8}>
+      // NEITHER-NEXT:    %[[NEITHER_MOD:.*]] = "mod_arith.constant"() <{"value" = 37 : i8}>
+      %c = "arith.constant"() <{"value" = 5 : i32}> : () -> i32
+      // DEFAULT-NEXT:    %[[DEFAULT_C:.*]] = "arith.constant"() <{"value" = 5 : i32}>
+      // NO-MOD-NEXT:     %[[NO_MOD_C:.*]] = "arith.constant"() <{"value" = 5 : i32}>
+      // NO-COMMUTE-NEXT: %[[NO_COMMUTE_C:.*]] = "arith.constant"() <{"value" = 5 : i32}>
+      // NEITHER-NEXT:    %[[NEITHER_C:.*]] = "arith.constant"() <{"value" = 5 : i32}>
+      %add = "arith.addi"(%c, %x) : (i32, i32) -> i32
+      // DEFAULT-NEXT:    %[[DEFAULT_ADD:.*]] = "arith.addi"(%[[DEFAULT_X]], %[[DEFAULT_C]])
+      // NO-MOD-NEXT:     %[[NO_MOD_ADD:.*]] = "arith.addi"(%[[NO_MOD_X]], %[[NO_MOD_C]])
+      // NO-COMMUTE-NEXT: %[[NO_COMMUTE_ADD:.*]] = "arith.addi"(%[[NO_COMMUTE_C]], %[[NO_COMMUTE_X]])
+      // NEITHER-NEXT:    %[[NEITHER_ADD:.*]] = "arith.addi"(%[[NEITHER_C]], %[[NEITHER_X]])
+      "test.test"(%mod) : (!mod_arith.int<17 : i8>) -> ()
+      "func.return"(%add) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/ModArithToArith/mul.mlir
+++ b/Test/Passes/ModArithToArith/mul.mlir
@@ -1,5 +1,6 @@
 // RUN: veir-opt %s -p=mod-arith-to-arith | filecheck %s --check-prefix=REMUI
 // RUN: veir-opt %s -p='mod-arith-to-arith{barrett}' | filecheck %s --check-prefix=BARRETT
+// RUN: veir-opt %s -p='mod-arith-to-arith{barrett=true}' | filecheck %s --check-prefix=BARRETT
 // RUN: veir-opt %s -p='mod-arith-to-arith{pow2-width}' | filecheck %s --check-prefix=REMUI_POW2
 // RUN: veir-opt %s -p='mod-arith-to-arith{barrett pow2-width}' | filecheck %s --check-prefix=BARRETT_POW2
 

--- a/Test/Passes/pass_options.mlir
+++ b/Test/Passes/pass_options.mlir
@@ -2,9 +2,10 @@
 // RUN: not veir-opt %s -p='cse{whatever}' 2>&1 | filecheck %s --check-prefix=NO-OPTIONS
 // RUN: not veir-opt %s -p='mod-arith{pow2-width}' 2>&1 | filecheck %s --check-prefix=GROUP
 // RUN: not veir-opt %s -p='mod-arith-to-arith{pow2-width' 2>&1 | filecheck %s --check-prefix=UNCLOSED
+// RUN: not veir-opt %s -p='mod-arith-to-arith{barrett=maybe}' 2>&1 | filecheck %s --check-prefix=BAD-BOOL
 
 // A pass name in a `-p` list may be followed by a brace-enclosed, space-separated list of
-// boolean options; an option not named is off, and there is no `opt=value` form. These
+// boolean options. A bare name means true, and `name=true|false` sets an explicit value. These
 // check the diagnostics for the ways that syntax can go wrong. That the options themselves
 // take effect is covered by ModArithToArith/mul.mlir and
 // FunctionBoundaryCoercion/mod_arith_pow2_width.mlir.
@@ -16,3 +17,4 @@
 // NO-OPTIONS: pass 'cse' has no option 'whatever' (it accepts no options)
 // GROUP: pass group 'mod-arith' does not take options
 // UNCLOSED: missing closing brace in the options of pass 'mod-arith-to-arith'
+// BAD-BOOL: invalid value 'maybe' for boolean option 'barrett' of pass 'mod-arith-to-arith'

--- a/Veir/Pass.lean
+++ b/Veir/Pass.lean
@@ -17,7 +17,7 @@ public section
 structure BoolPassOption where
   /-- Human-readable help text for the option. -/
   description : String
-  /-- The option's value when it is omitted from a pipeline invocation. -/
+  /-- The option's default value. -/
   defaultValue : Bool := false
 
 /-- The boolean option values for one instance of a pass. -/

--- a/Veir/Pass.lean
+++ b/Veir/Pass.lean
@@ -1,7 +1,7 @@
 module
 
 public import Veir.Verifier
-public import Std.Data.HashSet
+public import Std.Data.HashMap
 
 /-!
   # Compilation passes
@@ -13,8 +13,15 @@ namespace Veir
 
 public section
 
-/-- The options set on one instance of a pass. Any option not in the set is `false`. -/
-abbrev PassOptions := Std.HashSet String
+/-- The declaration of a boolean pass option. -/
+structure BoolPassOption where
+  /-- Human-readable help text for the option. -/
+  description : String
+  /-- The option's value when it is omitted from a pipeline invocation. -/
+  defaultValue : Bool := false
+
+/-- The boolean option values for one instance of a pass. -/
+abbrev PassOptions := Std.HashMap String Bool
 
 /-- A compilation pass. -/
 structure Pass (OpInfo : Type) [HasOpInfo OpInfo] where
@@ -26,10 +33,9 @@ structure Pass (OpInfo : Type) [HasOpInfo OpInfo] where
   /-- Brief explanation of what the pass does, for documentation and tooling. -/
   description : String
   /--
-    The boolean options this pass accepts, mapping each option name to its help text.
-    An option that the pipeline string does not name is `false`.
+    The boolean options this pass accepts, mapping each option name to its declaration.
   -/
-  options : Std.HashMap String String := ∅
+  options : Std.HashMap String BoolPassOption := ∅
   /--
     Execute the pass over the given IR context rooted at `op`, under the options this
     instance of the pass was given.
@@ -42,23 +48,34 @@ structure Pass (OpInfo : Type) [HasOpInfo OpInfo] where
     ExceptT String IO (WfIRContext OpInfo)
 
 /--
-  Check the given option words against the options this pass accepts and return them as a
-  set. Each word names an option to turn on; there is no syntax for turning one off, since
-  every option is off unless named.
+  Check the given option words against the options this pass accepts and return their values.
+  An option word is either `name`, shorthand for `name=true`, or `name=true|false`.
+  Options not named take their declared default value.
 -/
 def Pass.parseOptions {OpInfo : Type} [HasOpInfo OpInfo]
     (pass : Pass OpInfo) (flags : List String) : Except String PassOptions := do
-  let mut enabled : PassOptions := ∅
+  let mut values : PassOptions := ∅
+  for (name, option) in pass.options.toList do
+    values := values.insert name option.defaultValue
   for flag in flags do
-    unless pass.options.contains flag do
+    let (name, value?) ← match flag.splitOn "=" with
+      | [name] => pure (name, none)
+      | [name, value] => pure (name, some value)
+      | _ => throw s!"malformed boolean option '{flag}' for pass '{pass.name}'"
+    unless pass.options.contains name do
       let known := String.intercalate ", " (pass.options.keys.toArray.qsort (· < ·)).toList
       let known := if known.isEmpty then "it accepts no options" else s!"it accepts: {known}"
-      throw s!"pass '{pass.name}' has no option '{flag}' ({known})"
-    enabled := enabled.insert flag
-  return enabled
+      throw s!"pass '{pass.name}' has no option '{name}' ({known})"
+    let value ← match value? with
+      | none | some "true" => pure true
+      | some "false" => pure false
+      | some value =>
+          throw s!"invalid value '{value}' for boolean option '{name}' of pass '{pass.name}'"
+    values := values.insert name value
+  return values
 
 /--
-  Split one pipeline element, either `name` or `name{flag1 flag2 ...}`, into the name and
+  Split one pipeline element, either `name` or `name{option1 option2 ...}`, into the name and
   the (possibly empty) list of option words.
 -/
 def splitPipelineElement (s : String) : Except String (String × List String) := do
@@ -81,9 +98,10 @@ namespace PassPipeline
 
 /--
   Parse a comma-separated list of pipeline elements into a `PassPipeline`, looking each
-  name up in `registry`. An element is either `name` or `name{flag1 flag2 ...}`, where the
-  flags are boolean options accepted by that pass. Returns an error if a name does not
-  exist in the registry, or if an element requests an option the pass does not accept.
+  name up in `registry`. An element is either `name` or `name{option1 option2 ...}`, where the
+  options are accepted boolean options in `name` or `name=true|false` form. Returns an error if
+  a name does not exist in the registry, or if an element requests an option the pass does not
+  accept.
 -/
 def ofString? {OpInfo : Type} [HasOpInfo OpInfo]
     (registry : Std.HashMap String (Pass OpInfo)) (s : String) :

--- a/Veir/Passes/Canonicalize.lean
+++ b/Veir/Passes/Canonicalize.lean
@@ -45,12 +45,15 @@ def commutativeConstantRHS (rewriter : PatternRewriter OpCode) (op : OperationPt
 
 /-! ## Pass implementation -/
 
-def CanonicalizePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
+def CanonicalizePass.impl (options : PassOptions) (ctx : WfIRContext OpCode)
+    (op : OperationPtr) (_ : op.InBounds ctx.raw) :
     ExceptT String IO (WfIRContext OpCode) := do
-  let pattern := RewritePattern.GreedyRewritePattern #[
-    canonicalizeModArithConstant,
-    commutativeConstantRHS
-  ]
+  let mut patterns : Array (RewritePattern OpCode) := #[]
+  if (options.get? "mod-arith-constant").getD true then
+    patterns := patterns.push canonicalizeModArithConstant
+  if (options.get? "commutative-constant-rhs").getD true then
+    patterns := patterns.push commutativeConstantRHS
+  let pattern := RewritePattern.GreedyRewritePattern patterns
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying canonicalization patterns"
   | some ctx => pure ctx
@@ -58,6 +61,13 @@ def CanonicalizePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op
 public def CanonicalizePass : Pass OpCode :=
   { name := "canonicalize"
     description := "Rewrite operations into a canonical form."
-    run := fun _ => CanonicalizePass.impl }
+    options := .ofList [
+      ("mod-arith-constant",
+        { description := "Reduce modular constants to their canonical representatives."
+          defaultValue := true }),
+      ("commutative-constant-rhs",
+        { description := "Move constants to the right side of commutative operations."
+          defaultValue := true })]
+    run := CanonicalizePass.impl }
 
 end Veir

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -118,7 +118,9 @@ public def CoerceFunctionBoundariesToRiscvRegPass : Pass OpCode :=
 public def CoerceModArithFunctionBoundariesPass : Pass OpCode :=
   { name := "coerce-mod-arith-function-boundaries"
     description := "Coerce `!mod_arith.int` function boundaries to their storage integer type."
-    options := .ofList [("pow2-width", "Widen the storage integer type to a power-of-two bitwidth.")]
+    options := .ofList [
+      ("pow2-width", { description := "Widen the storage integer type to a power-of-two bitwidth." })]
     run := fun options =>
       CoerceFunctionBoundariesPass.impl
-        (.modArithToInt (if options.contains "pow2-width" then Nat.nextPowerOfTwo else id)) }
+        (.modArithToInt
+          (if (options.get? "pow2-width").getD false then Nat.nextPowerOfTwo else id)) }

--- a/Veir/Passes/ModArithToArith.lean
+++ b/Veir/Passes/ModArithToArith.lean
@@ -344,11 +344,11 @@ public def ModArithToArithPass : Pass OpCode :=
   { name := "mod-arith-to-arith"
     description := "Lower mod_arith operations to the arith dialect."
     options := .ofList [
-      ("barrett", "Use Barrett reduction instead of `arith.remui` for reduction."),
-      ("pow2-width", "Use power-of-two bitwidths for the lowered integer types.")]
+      ("barrett", { description := "Use Barrett reduction instead of `arith.remui` for reduction." }),
+      ("pow2-width", { description := "Use power-of-two bitwidths for the lowered integer types." })]
     run := fun options =>
       ModArithToArithPass.impl
-        (if options.contains "pow2-width" then Nat.nextPowerOfTwo else id)
-        (if options.contains "barrett" then .barrett else .full) }
+        (if (options.get? "pow2-width").getD false then Nat.nextPowerOfTwo else id)
+        (if (options.get? "barrett").getD false then .barrett else .full) }
 
 end Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -76,8 +76,9 @@ def passOptionsUsage : String :=
     (!·.options.isEmpty)
   String.intercalate "\n" (withOptions.flatMap fun pass =>
     s!"    {pass.name}:" ::
-      (pass.options.toList.toArray.qsort (·.1 < ·.1)).toList.map fun (name, description) =>
-        s!"      {name}: {description}")
+      (pass.options.toList.toArray.qsort (·.1 < ·.1)).toList.map fun (name, option) =>
+        let defaultValue := if option.defaultValue then "true" else "false"
+        s!"      {name} (default: {defaultValue}): {option.description}")
 
 /--
   Arguments for the `veir-opt` command-line tool, parsed from the CLI.
@@ -113,8 +114,9 @@ def expandPassGroups (pipeline : String) : Except String String := do
   Parse the `-p` flags to construct a pass pipeline.
   `-p` takes a comma-separated list of pass names and pass-group names; a group name
   (see `passGroups`) expands in place to its member passes. A pass name may be followed by
-  a brace-enclosed, space-separated list of boolean options, as in `pass{opt1 opt2}`; every
-  option not listed is off. The flag may appear any number of times; the resulting pipeline
+  a brace-enclosed, space-separated list of boolean options, as in
+  `pass{opt1 opt2=false}`. Bare option names mean `true`; omitted options take their declared
+  defaults. The flag may appear any number of times; the resulting pipeline
   is the concatenation of their passes, in the order the flags appear on the command line.
   Returns an error if a flag is malformed, if any name is neither a pass nor a group, or if
   a pass is given an option it does not accept.
@@ -197,8 +199,9 @@ def main (args : List String) : IO Unit := do
     IO.eprintln s!"Error: {errMsg}"
     IO.eprintln "Usage: veir-opt <filename> [-p=\"pass1,pass2,...\"]... [--allow-unregistered-dialect] [--disable-verifiers]"
     IO.eprintln "  -p may be repeated; passes run in the order the flags appear."
-    IO.eprintln "  A pass name may be followed by boolean options: pass{opt1 opt2}."
-    IO.eprintln "  Options not listed are off. The passes taking options are:"
+    IO.eprintln "  A pass name may be followed by boolean options: pass{opt1 opt2=false}."
+    IO.eprintln "  Bare option names mean true; omitted options take their declared defaults."
+    IO.eprintln "  The passes taking options are:"
     IO.eprintln passOptionsUsage
     IO.eprintln "  A pass list may also contain pass-group names, which expand in place:"
     IO.eprintln passGroupsUsage


### PR DESCRIPTION
just a simple change: instead of a pass argument always implicitly setting a boolean to true, they can now be set to either true or false.

the immediate use case I have for this is canonicalization. I want to make its components turned on by default, but they can be disabled by setting them to false. thus, when canonicalization does constant folding (PR for this is ready to go except for this PR), we can avoid breaking a lot of test cases by turning off the folder.