### PR TITLE
feat: Expand PBV examples to cover sign and zero extensions

### DIFF
--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -53,7 +53,7 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
--- Step 1: Bound widths to the provided blast width 
+-- Step 1: Bound widths to the provided blast width
   have r_le_bw : r <= 8 := by grind
   have q_le_bw : q <= 8 := by grind
   have p_le_bw : p <= 8 := by grind
@@ -102,30 +102,31 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   (hpq : p < q) :
   (x.zeroExtend q).signExtend r = x.zeroExtend r
   := by
--- Step 1
+-- Step 1: Bound widths to the provided blast width
   have r_le_bw : r <= 8 := by grind
   have q_le_bw : q <= 8 := by grind
   have p_le_bw : p <= 8 := by grind
--- Step 2-3
+-- Step 2-3: Introduce mask to replace `w` Nat var
   apply width_elim 8 r
   intro mr h_mr
   apply width_elim 8 q
   intro mq h_mq
   apply width_elim 8 p
   intro mp h_mp
--- Step 4:
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
   revert x
   apply var_elim 8 p p_le_bw
   intro x h_xmp
--- Step 5:
+-- Step 5: Convert width hypothesis to mask hypothesis
   have mr_mask := isMask_of_eq_maskOfWidth h_mr
   have mq_mask := isMask_of_eq_maskOfWidth h_mq
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
-  -- Translate the condition on the natural number width
-  -- into a fact about the bitvector masks
+-- Step 5B: Translate the condition on the natural number width
+--   into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
--- Step 6:
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff r_le_bw,
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
@@ -142,7 +143,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     ← h_mq,
     ← h_mp,
   ] at h_xmp ⊢
--- Step 7:
+-- Step 7: Drop the Nat 'p', 'q', 'r'
   clear h_mp h_mq h_mr
   clear hr hqr hpq r_le_bw q_le_bw p_le_bw
   clear p q r

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -125,16 +125,16 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 6:
   simp only [
     eq_iff r_le_bw,
-    setWidth_signExtend r_le_bw,        -- Push `setWidth` down signExtend
-    msb_toMask q_le_bw,                 -- Replace the sign bit test with a mask test
+    setWidth_signExtend r_le_bw,   -- Push `setWidth` down signExtend
+    msb_toMask q_le_bw,            -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,
     BitVec.zeroExtend_eq_setWidth,
-    signBitOfMask,                    -- Unfold, else `bv_decide` abstracts it away
+    signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
-    q_le_bw,                                 -- Lets simp discharge the `v ≤ o` side condition
-                                             -- of `setWidth_signExtend`
+    q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition
+                                   -- of `setWidth_signExtend`
     ← h_mr,
     ← h_mq,
     ← h_mp,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -53,30 +53,31 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
--- Step 1
+-- Step 1: Bound widths to the provided blast width 
   have r_le_bw : r <= 8 := by grind
   have q_le_bw : q <= 8 := by grind
   have p_le_bw : p <= 8 := by grind
--- Step 2-3
+-- Step 2-3: Introduce mask to replace `w` Nat var
   apply width_elim 8 r
   intro mr h_mr
   apply width_elim 8 q
   intro mq h_mq
   apply width_elim 8 p
   intro mp h_mp
--- Step 4:
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
   revert x
   apply var_elim 8 p p_le_bw
   intro x h_xmp
--- Step 5:
+-- Step 5: Convert width hypothesis to mask hypothesis
   have mr_mask := isMask_of_eq_maskOfWidth h_mr
   have mq_mask := isMask_of_eq_maskOfWidth h_mq
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
-  -- Translate the condition on the natural number width
-  -- into a fact about the bitvector masks
+-- Step 5B: Translate the condition on the natural number width
+--   into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
--- Step 6:
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff r_le_bw,
     setWidth_setWidth r_le_bw,
@@ -88,7 +89,7 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
     ← h_mq,
     ← h_mp,
   ] at h_xmp ⊢
--- Step 7:
+-- Step 7: Drop the Nat 'p', 'q', 'r'
   clear h_mp h_mq h_mr
   clear hr hqr hpq r_le_bw q_le_bw p_le_bw
   clear p q r

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -89,6 +89,8 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   ] at h_xmp ⊢
 -- Step 7:
   clear h_mp h_mq h_mr
+  clear hr hqr hpq r_le_bw q_le_bw p_le_bw
+  clear p q r
 -- Step 8:
   bv_decide
 
@@ -123,7 +125,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 6:
   simp only [
     eq_iff r_le_bw,
-    setWidth_signExtend r_le_bw, -- Push `setWidth` down signExtend
+    setWidth_signExtend r_le_bw,        -- Push `setWidth` down signExtend
     msb_toMask q_le_bw,                 -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
@@ -132,12 +134,14 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     signBitOfMask,                    -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
     q_le_bw,                                 -- Lets simp discharge the `v ≤ o` side condition
-                                             -- of `pbv_setWidth_signExtend`
+                                             -- of `setWidth_signExtend`
     ← h_mr,
     ← h_mq,
     ← h_mp,
   ] at h_xmp ⊢
 -- Step 7:
   clear h_mp h_mq h_mr
+  clear hr hqr hpq r_le_bw q_le_bw p_le_bw
+  clear p q r
 -- Step 8:
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -75,7 +75,7 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   -- Translate the condition on the natural number width
   -- into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
-  simp only [IsMask] at mr_mask mq_mask mp_mask
+  simp only [isMask_eq] at mr_mask mq_mask mp_mask
 -- Step 6:
   simp only [
     eq_iff r_le_bw,
@@ -123,11 +123,11 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   -- Translate the condition on the natural number width
   -- into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
-  simp only [IsMask] at mr_mask mq_mask mp_mask
+  simp only [isMask_eq] at mr_mask mq_mask mp_mask
 -- Step 6:
   simp only [
     eq_iff r_le_bw,
-    setWidth_signExtend_eq_and_maskOfWidth r_le_bw,  -- Push `setWidth` down signExtend
+    setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
@@ -135,8 +135,8 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
-    q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition
-                                   -- of `setWidth_signExtend`
+    q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
+                                   -- `setWidth_signExtend_eq_and_maskOfWidth`
     ← h_mr,
     ← h_mq,
     ← h_mp,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -46,3 +46,98 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   clear w
 -- Step 8: Bitblast!
   bv_decide
+
+theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
+  (hr : r <= 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+-- Step 1
+  have r_le_bw : r <= 8 := by grind
+  have q_le_bw : q <= 8 := by grind
+  have p_le_bw : p <= 8 := by grind
+-- Step 2-3
+  apply width_elim 8 r
+  intro mr h_mr
+  apply width_elim 8 q
+  intro mq h_mq
+  apply width_elim 8 p
+  intro mp h_mp
+-- Step 4:
+  revert x
+  apply var_elim 8 p p_le_bw
+  intro x h_xmp
+-- Step 5:
+  have mr_mask := isMask_of_eq_maskOfWidth h_mr
+  have mq_mask := isMask_of_eq_maskOfWidth h_mq
+  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+  -- Translate the condition on the natural number width
+  -- into a fact about the bitvector masks
+  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+-- Step 6:
+  simp only [
+    eq_iff r_le_bw,
+    setWidth_setWidth r_le_bw,
+    setWidth_setWidth p_le_bw,
+    setWidth_setWidth q_le_bw,
+    BitVec.zeroExtend_eq_setWidth,
+    BitVec.setWidth_eq,
+    ← h_mr,
+    ← h_mq,
+    ← h_mp,
+  ] at h_xmp ⊢
+-- Step 7:
+  clear h_mp h_mq h_mr
+-- Step 8:
+  bv_decide
+
+theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
+  (hr : r <= 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+-- Step 1
+  have r_le_bw : r <= 8 := by grind
+  have q_le_bw : q <= 8 := by grind
+  have p_le_bw : p <= 8 := by grind
+-- Step 2-3
+  apply width_elim 8 r
+  intro mr h_mr
+  apply width_elim 8 q
+  intro mq h_mq
+  apply width_elim 8 p
+  intro mp h_mp
+-- Step 4:
+  revert x
+  apply var_elim 8 p p_le_bw
+  intro x h_xmp
+-- Step 5:
+  have mr_mask := isMask_of_eq_maskOfWidth h_mr
+  have mq_mask := isMask_of_eq_maskOfWidth h_mq
+  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+  -- Translate the condition on the natural number width
+  -- into a fact about the bitvector masks
+  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+-- Step 6:
+  simp only [
+    eq_iff r_le_bw,
+    setWidth_signExtend r_le_bw, -- Push `setWidth` down signExtend
+    msb_toMask q_le_bw,                 -- Replace the sign bit test with a mask test
+    setWidth_setWidth r_le_bw,
+    setWidth_setWidth q_le_bw,
+    setWidth_setWidth p_le_bw,
+    BitVec.zeroExtend_eq_setWidth,
+    signBitOfMask,                    -- Unfold, else `bv_decide` abstracts it away
+    BitVec.setWidth_eq,
+    q_le_bw,                                 -- Lets simp discharge the `v ≤ o` side condition
+                                             -- of `pbv_setWidth_signExtend`
+    ← h_mr,
+    ← h_mq,
+    ← h_mp,
+  ] at h_xmp ⊢
+-- Step 7:
+  clear h_mp h_mq h_mr
+-- Step 8:
+  bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -124,7 +124,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --   into a fact about the bitvector masks
-  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -47,6 +47,8 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 8: Bitblast!
   bv_decide
 
+/-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
+    which is a single zero extension to `r`, for all widths `p < q < r ≤ 8` -/
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (hqr : q < r)
@@ -75,7 +77,7 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --   into a fact about the bitvector masks
-  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
@@ -93,9 +95,12 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   clear h_mp h_mq h_mr
   clear hr hqr hpq r_le_bw q_le_bw p_le_bw
   clear p q r
--- Step 8:
+-- Step 8: Bitblast!
   bv_decide
 
+/-- Manual trace of a zero extension to `q` followed by a sign extension to `r`,
+    which is a single zero extension to `r`, since `p < q` leaves the sign bit
+    of the intermediate value clear -/
 theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (hqr : q < r)
@@ -130,7 +135,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   simp only [
     eq_iff r_le_bw,
     setWidth_signExtend_eq_and_maskOfWidth,                -- Push `setWidth` down signExtend
-    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,  -- Replace the sign bit test with a mask test
+    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,  -- Sign bit test becomes a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,
@@ -147,5 +152,5 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   clear h_mp h_mq h_mr
   clear hr hqr hpq r_le_bw q_le_bw p_le_bw
   clear p q r
--- Step 8:
+-- Step 8: Bitblast!
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -48,15 +48,15 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   bv_decide
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r <= 8)
+  (hr : r ≤ 8)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
 -- Step 1: Bound widths to the provided blast width
-  have r_le_bw : r <= 8 := by grind
-  have q_le_bw : q <= 8 := by grind
-  have p_le_bw : p <= 8 := by grind
+  have r_le_bw : r ≤ 8 := by grind
+  have q_le_bw : q ≤ 8 := by grind
+  have p_le_bw : p ≤ 8 := by grind
 -- Step 2-3: Introduce mask to replace `w` Nat var
   apply width_elim 8 r
   intro mr h_mr
@@ -97,15 +97,15 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   bv_decide
 
 theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
-  (hr : r <= 8)
+  (hr : r ≤ 8)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).signExtend r = x.zeroExtend r
   := by
 -- Step 1: Bound widths to the provided blast width
-  have r_le_bw : r <= 8 := by grind
-  have q_le_bw : q <= 8 := by grind
-  have p_le_bw : p <= 8 := by grind
+  have r_le_bw : r ≤ 8 := by grind
+  have q_le_bw : q ≤ 8 := by grind
+  have p_le_bw : p ≤ 8 := by grind
 -- Step 2-3: Introduce mask to replace `w` Nat var
   apply width_elim 8 r
   intro mr h_mr
@@ -129,8 +129,8 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff r_le_bw,
-    setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
-    msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
+    setWidth_signExtend_eq_and_maskOfWidth,                -- Push `setWidth` down signExtend
+    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,  -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -75,6 +75,7 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   -- Translate the condition on the natural number width
   -- into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  simp only [IsMask] at mr_mask mq_mask mp_mask
 -- Step 6:
   simp only [
     eq_iff r_le_bw,
@@ -122,11 +123,12 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   -- Translate the condition on the natural number width
   -- into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  simp only [IsMask] at mr_mask mq_mask mp_mask
 -- Step 6:
   simp only [
     eq_iff r_le_bw,
-    setWidth_signExtend r_le_bw,   -- Push `setWidth` down signExtend
-    msb_toMask q_le_bw,            -- Replace the sign bit test with a mask test
+    setWidth_signExtend_eq_and_maskOfWidth r_le_bw,  -- Push `setWidth` down signExtend
+    msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,

--- a/Veir/Data/PBV/Lemmas.lean
+++ b/Veir/Data/PBV/Lemmas.lean
@@ -22,4 +22,21 @@ theorem setWidth_inj {w o : Nat} (h : w ≤ o) {a b : BitVec w}
     (hab : a.setWidth o = b.setWidth o) : a = b := by
   simpa [h] using congrArg (BitVec.setWidth w) hab
 
+/-- Widening and truncating back is the identity. -/
+theorem setWidth_setWidth_eq_self_of_le {w o : Nat} (h : w ≤ o) (x : BitVec w) :
+    (x.setWidth o).setWidth w = x := by
+  apply eq_of_toNat_eq
+  rw [toNat_setWidth, toNat_setWidth_of_le h, Nat.mod_eq_of_lt x.isLt]
+
+theorem ushiftRight_one_le {o : Nat} (m : BitVec o) : m >>> 1 ≤ m := by
+  rw [le_def, toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
+  exact Nat.div_le_self _ _
+
+theorem twoPow_ne_zero {o k : Nat} (h : k < o) : twoPow o k ≠ 0#o := by
+  intro hcontra
+  have hn := congrArg BitVec.toNat hcontra
+  rw [toNat_twoPow, toNat_zero,
+    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by omega) h)] at hn
+  exact absurd hn (Nat.ne_of_gt (Nat.two_pow_pos k))
+
 end BitVec

--- a/Veir/Data/PBV/Lemmas.lean
+++ b/Veir/Data/PBV/Lemmas.lean
@@ -22,10 +22,12 @@ theorem setWidth_inj {w o : Nat} (h : w ≤ o) {a b : BitVec w}
     (hab : a.setWidth o = b.setWidth o) : a = b := by
   simpa [h] using congrArg (BitVec.setWidth w) hab
 
+/-- Shifting right by one can only decrease a bitvector. -/
 theorem ushiftRight_one_le {o : Nat} (m : BitVec o) : m >>> 1 ≤ m := by
   rw [le_def, toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
   exact Nat.div_le_self _ _
 
+/-- A power of two that is in bounds of the width is a non-zero bitvector. -/
 theorem twoPow_ne_zero {o k : Nat} (h : k < o) : twoPow o k ≠ 0#o := by
   intro hcontra
   have hn := congrArg BitVec.toNat hcontra

--- a/Veir/Data/PBV/Lemmas.lean
+++ b/Veir/Data/PBV/Lemmas.lean
@@ -30,7 +30,7 @@ theorem twoPow_ne_zero {o k : Nat} (h : k < o) : twoPow o k ≠ 0#o := by
   intro hcontra
   have hn := congrArg BitVec.toNat hcontra
   rw [toNat_twoPow, toNat_zero,
-    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by omega) h)] at hn
+    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by lia) h)] at hn
   exact absurd hn (Nat.ne_of_gt (Nat.two_pow_pos k))
 
 end BitVec

--- a/Veir/Data/PBV/Lemmas.lean
+++ b/Veir/Data/PBV/Lemmas.lean
@@ -22,12 +22,6 @@ theorem setWidth_inj {w o : Nat} (h : w ≤ o) {a b : BitVec w}
     (hab : a.setWidth o = b.setWidth o) : a = b := by
   simpa [h] using congrArg (BitVec.setWidth w) hab
 
-/-- Widening and truncating back is the identity. -/
-theorem setWidth_setWidth_eq_self_of_le {w o : Nat} (h : w ≤ o) (x : BitVec w) :
-    (x.setWidth o).setWidth w = x := by
-  apply eq_of_toNat_eq
-  rw [toNat_setWidth, toNat_setWidth_of_le h, Nat.mod_eq_of_lt x.isLt]
-
 theorem ushiftRight_one_le {o : Nat} (m : BitVec o) : m >>> 1 ≤ m := by
   rw [le_def, toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
   exact Nat.div_le_self _ _

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -40,6 +40,20 @@ theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
   subst hm
   exact isMask_maskOfWidth
 
+theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
+  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by omega) h
+  have : 0 < 2 ^ w₁ := Nat.two_pow_pos w₁
+  omega
+
+/-- Strict width order becomes strict mask order. -/
+theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw : w₁ < w₂) : m₁ < m₂ := by
+  subst hm₁; subst hm₂
+  exact maskOfWidth_lt_maskOfWidth h₁ h₂ hw
+
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :
     (x &&& maskOfWidth o w).toNat = x.toNat % 2 ^ w := by

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -81,7 +81,7 @@ the index 'i' is inbounds of `o` and `w`. -/
   grind only
 
 /-- The 'i'th bit of `maskOfWidth o w` is enabled iff
-the index 'i' is inbounds of `o` and `w`. -/
+the index 'i' is inbounds of `w`. -/
 @[simp] theorem getElem_maskOfWidth {o w : Nat} (i : Nat) (hi : i < o) :
     (maskOfWidth o w)[i] = decide (i < w) := by
   rw [← BitVec.getLsbD_eq_getElem, getLsbD_maskOfWidth]
@@ -94,7 +94,7 @@ the index 'i' is inbounds of `o` and `w`. -/
 /-! ## The sign bit helpers -/
 
 /-- `signBitOfMask m` keeps only the top bit of the mask `m`.
-This is used to extract the sign bit of a width `m` bitvector. -/
+This is used to extract the sign bit of a width `o` bitvector. -/
 @[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
 
 /-- The zero bitvector, which is the mask of width `0`, has no sign bit. -/

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -24,8 +24,8 @@ def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 /-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
 theorem isMask_eq {o : Nat} (m : BitVec o) :
     IsMask m = (m &&& (m + 1#o) = 0#o) := by
-    unfold IsMask
-    rfl
+  unfold IsMask
+  rfl
 
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by
@@ -47,7 +47,7 @@ theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
   subst hm
   exact isMask_maskOfWidth
 
-/-- maskOfWidth is monotone with respect to unsigned bitvec comparison. -/
+/-- `maskOfWidth` is monotone with respect to unsigned bitvec comparison. -/
 theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
   rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
@@ -73,15 +73,15 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
 
-/-- The 'i'th bit of `maskOfWidth o w` is enabled iff
-the index 'i' is inbounds of `o` and `w`. -/
+/-- The `i`th bit of `maskOfWidth o w` is enabled iff
+the index `i` is inbounds of `o` and `w`. -/
 @[simp] theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :
     (maskOfWidth o w).getLsbD i = (decide (i < w) && decide (i < o)) := by
   rw [maskOfWidth, BitVec.getLsbD_ofNat, Nat.testBit_two_pow_sub_one]
   grind only
 
-/-- The 'i'th bit of `maskOfWidth o w` is enabled iff
-the index 'i' is inbounds of `w`. -/
+/-- The `i`th bit of `maskOfWidth o w` is enabled iff
+the index `i` is inbounds of `w`. -/
 @[simp] theorem getElem_maskOfWidth {o w : Nat} (i : Nat) (hi : i < o) :
     (maskOfWidth o w)[i] = decide (i < w) := by
   rw [← BitVec.getLsbD_eq_getElem, getLsbD_maskOfWidth]
@@ -101,10 +101,8 @@ This is used to extract the sign bit of a width `o` bitvector. -/
 @[simp] theorem signBitOfMask_zero {o : Nat} : signBitOfMask (0#o) = 0#o := by
   simp [signBitOfMask]
 
-/--
-The `Nat` denotation of `signBitOfMask` of a mask of width `w`
-is given by `2^w` minus `2^(w - 1)`.
--/
+/-- The `Nat` denotation of `signBitOfMask` of a mask of width `w`
+is given by `2^w` minus `2^(w - 1)`. -/
 theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (signBitOfMask (maskOfWidth o w)).toNat = 2 ^ w - 2 ^ (w - 1) := by
   rw [signBitOfMask, BitVec.toNat_sub_of_le (BitVec.ushiftRight_one_le _),

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -34,26 +34,26 @@ theorem isMask_maskOfWidth {o w : Nat} :
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- The mask constraint: the only fact about `m` surviving abstraction.
-Unfold the IsMask def here to simplify use in the proof. -/
+/-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
+    (hm : m = maskOfWidth o w) : IsMask m := by
   subst hm
   exact isMask_maskOfWidth
 
+/-- maskOfWidth is monotone with respect to unsigned bitvec comparison. -/
 theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
   rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by omega) h
-  have : 0 < 2 ^ w₁ := Nat.two_pow_pos w₁
-  omega
+  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
+  have : 0 < 2 ^ w₁ := by grind
+  lia
 
 /-- Strict width order becomes strict mask order. -/
 theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
     (hw : w₁ < w₂) : m₁ < m₂ := by
-  subst hm₁; subst hm₂
-  exact maskOfWidth_lt_maskOfWidth h₁ h₂ hw
+  subst m₁ m₂
+  grind only [maskOfWidth_lt_maskOfWidth]
 
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :
@@ -67,25 +67,34 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
 
-theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :
+/-- The 'i'th bit of `maskOfWidth o w` is enabled iff 
+the index 'i' is inbounds of `o` and `w`. -/
+@[simp] theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :
     (maskOfWidth o w).getLsbD i = (decide (i < w) && decide (i < o)) := by
   rw [maskOfWidth, BitVec.getLsbD_ofNat, Nat.testBit_two_pow_sub_one]
-  exact Bool.and_comm _ _
+  grind only
 
-theorem getElem_maskOfWidth {o w : Nat} (i : Nat) (hi : i < o) :
+/-- The 'i'th bit of `maskOfWidth o w` is enabled iff 
+the index 'i' is inbounds of `o` and `w`. -/
+@[simp] theorem getElem_maskOfWidth {o w : Nat} (i : Nat) (hi : i < o) :
     (maskOfWidth o w)[i] = decide (i < w) := by
   rw [← BitVec.getLsbD_eq_getElem, getLsbD_maskOfWidth]
-  simp [hi]
+  grind only
 
-theorem maskOfWidth_zero (o : Nat) : maskOfWidth o 0 = 0#o := by
+/-- Mask of width 0 is the zero bitvector. -/
+@[simp] theorem maskOfWidth_zero (o : Nat) : maskOfWidth o 0 = 0#o := by
   simp [maskOfWidth]
 
 /-! ## The sign bit helpers -/
 
-/-- `signBitOfMask m` keeps only the top bit of the mask `m`, i.e. the sign bit of the width `m`
-represents. -/
+/-- `signBitOfMask m` keeps only the top bit of the mask `m`.
+This is used to extract the sign bit of a width `m` bitvector. -/
 @[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
 
+/--
+The nat denotation of `sigOfBitMask` of a mask of width `w`
+is given by `2^w` minus `2^w - 1`.
+-/
 theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (signBitOfMask (maskOfWidth o w)).toNat = 2 ^ w - 2 ^ (w - 1) := by
   rw [signBitOfMask, BitVec.toNat_sub_of_le (BitVec.ushiftRight_one_le _),
@@ -93,20 +102,26 @@ theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
     toNat_maskOfWidth h, Nat.shiftRight_eq_div_pow, Nat.pow_one]
   rcases Nat.eq_zero_or_pos w with rfl | hw
   · simp
-  · have h2 : 2 ^ w = 2 * 2 ^ (w - 1) := by
-      obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by omega⟩
-      rw [Nat.pow_succ, Nat.add_sub_cancel]
-      omega
+  · have hpow : 2 ^ w = 2 * 2 ^ (w - 1) := by
+      obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by grind⟩
+      lia
     have h3 : 0 < 2 ^ (w - 1) := Nat.two_pow_pos _
     lia
 
-theorem signBitOfMask_maskOfWidth_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) :
+/-- The sign bit of a mask of non-zero width `w` is `the bitvector `2^(w - 1)`. -/
+@[simp] theorem signBitOfMask_maskOfWidth_eq_zero {o w : Nat} :
+    signBitOfMask (maskOfWidth o 0) = 0#o := by
+  apply BitVec.eq_of_toNat_eq
+  rw [toNat_signBitOfMask_maskOfWidth (by lia)]
+  grind only [= BitVec.toNat_ofNat, = BitVec.toNat_zero]
+
+/-- The sign bit of a mask of non-zero width `w` is `the bitvector `2^(w - 1)`. -/
+@[simp] theorem signBitOfMask_maskOfWidth_eq_twoPow_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) :
     signBitOfMask (maskOfWidth o w) = BitVec.twoPow o (w - 1) := by
   apply BitVec.eq_of_toNat_eq
   rw [toNat_signBitOfMask_maskOfWidth h, BitVec.toNat_twoPow,
-    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by omega) (by omega : w - 1 < o))]
-  have h2 : 2 ^ w = 2 * 2 ^ (w - 1) := by
+    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by lia) (by lia : w - 1 < o))]
+  have hpow : 2 ^ w = 2 * 2 ^ (w - 1) := by
     obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by omega⟩
-    rw [Nat.pow_succ, Nat.add_sub_cancel]
-    omega
-  omega
+    lia
+  lia

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -4,9 +4,10 @@ public import Veir.Data.PBV.Lemmas
 
 /-! # Masks as bitvector variables constrained by `m &&& (m + 1) = 0`.
 
-A width `w` is represented by the mask `2^w - 1` of the blast width, and the
-constraint `m &&& (m + 1) = 0` is the only fact about that mask the bitblaster
-is given. See `Veir.Data.PBV` for the pipeline this step belongs to.
+A width `w` is represented by the mask `2^w - 1` of the blast width, and it is
+encoded as a bitvector constraint `m &&& (m + 1) = 0` which the bitblaster
+can reason about. Other relations between bitwidths are encoded as bitvector
+inequalities and equalities.
 -/
 
 namespace Veir.Data.PBV
@@ -58,7 +59,6 @@ theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂
 theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
     (hw : w₁ < w₂) : m₁ < m₂ := by
-  subst m₁ m₂
   grind only [maskOfWidth_lt_maskOfWidth]
 
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -20,6 +20,10 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
 @[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
+/-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
+theorem isMask_eq {o : Nat} (m : BitVec o) :
+    IsMask m = (m &&& (m + 1#o) = 0#o) := rfl
+
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by
   rw [maskOfWidth, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
@@ -91,9 +95,13 @@ the index 'i' is inbounds of `o` and `w`. -/
 This is used to extract the sign bit of a width `m` bitvector. -/
 @[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
 
+/-- The zero bitvector, which is the mask of width `0`, has no sign bit. -/
+@[simp] theorem signBitOfMask_zero {o : Nat} : signBitOfMask (0#o) = 0#o := by
+  simp [signBitOfMask]
+
 /--
-The nat denotation of `sigOfBitMask` of a mask of width `w`
-is given by `2^w` minus `2^w - 1`.
+The nat denotation of `signBitOfMask` of a mask of width `w`
+is given by `2^w` minus `2^(w - 1)`.
 -/
 theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (signBitOfMask (maskOfWidth o w)).toNat = 2 ^ w - 2 ^ (w - 1) := by
@@ -108,14 +116,7 @@ theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
     have h3 : 0 < 2 ^ (w - 1) := Nat.two_pow_pos _
     lia
 
-/-- The sign bit of a mask of non-zero width `w` is `the bitvector `2^(w - 1)`. -/
-@[simp] theorem signBitOfMask_maskOfWidth_eq_zero {o w : Nat} :
-    signBitOfMask (maskOfWidth o 0) = 0#o := by
-  apply BitVec.eq_of_toNat_eq
-  rw [toNat_signBitOfMask_maskOfWidth (by lia)]
-  grind only [= BitVec.toNat_ofNat, = BitVec.toNat_zero]
-
-/-- The sign bit of a mask of non-zero width `w` is `the bitvector `2^(w - 1)`. -/
+/-- The sign bit of a mask of non-zero width `w` is the bitvector `2^(w - 1)`. -/
 @[simp] theorem signBitOfMask_maskOfWidth_eq_twoPow_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) :
     signBitOfMask (maskOfWidth o w) = BitVec.twoPow o (w - 1) := by
   apply BitVec.eq_of_toNat_eq

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -71,14 +71,14 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
 
-/-- The 'i'th bit of `maskOfWidth o w` is enabled iff 
+/-- The 'i'th bit of `maskOfWidth o w` is enabled iff
 the index 'i' is inbounds of `o` and `w`. -/
 @[simp] theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :
     (maskOfWidth o w).getLsbD i = (decide (i < w) && decide (i < o)) := by
   rw [maskOfWidth, BitVec.getLsbD_ofNat, Nat.testBit_two_pow_sub_one]
   grind only
 
-/-- The 'i'th bit of `maskOfWidth o w` is enabled iff 
+/-- The 'i'th bit of `maskOfWidth o w` is enabled iff
 the index 'i' is inbounds of `o` and `w`. -/
 @[simp] theorem getElem_maskOfWidth {o w : Nat} (i : Nat) (hi : i < o) :
     (maskOfWidth o w)[i] = decide (i < w) := by
@@ -111,7 +111,7 @@ theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
   rcases Nat.eq_zero_or_pos w with rfl | hw
   · simp
   · have hpow : 2 ^ w = 2 * 2 ^ (w - 1) := by
-      obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by grind⟩
+      obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by lia⟩
       lia
     have h3 : 0 < 2 ^ (w - 1) := Nat.two_pow_pos _
     lia
@@ -123,6 +123,6 @@ theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
   rw [toNat_signBitOfMask_maskOfWidth h, BitVec.toNat_twoPow,
     Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by lia) (by lia : w - 1 < o))]
   have hpow : 2 ^ w = 2 * 2 ^ (w - 1) := by
-    obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by omega⟩
+    obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by lia⟩
     lia
   lia

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -102,7 +102,7 @@ This is used to extract the sign bit of a width `m` bitvector. -/
   simp [signBitOfMask]
 
 /--
-The nat denotation of `signBitOfMask` of a mask of width `w`
+The `Nat` denotation of `signBitOfMask` of a mask of width `w`
 is given by `2^w` minus `2^(w - 1)`.
 -/
 theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -81,15 +81,14 @@ theorem maskOfWidth_zero (o : Nat) : maskOfWidth o 0 = 0#o := by
 
 /-! ## The sign bit helpers -/
 
+/-- `signBitOfMask m` keeps only the top bit of the mask `m`, i.e. the sign bit of the width `m`
+represents. -/
 @[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
-
-theorem ushiftRight_one_le {o : Nat} (m : BitVec o) : m >>> 1 ≤ m := by
-  rw [BitVec.le_def, BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
-  exact Nat.div_le_self _ _
 
 theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (signBitOfMask (maskOfWidth o w)).toNat = 2 ^ w - 2 ^ (w - 1) := by
-  rw [signBitOfMask, BitVec.toNat_sub_of_le (ushiftRight_one_le _), BitVec.toNat_ushiftRight,
+  rw [signBitOfMask, BitVec.toNat_sub_of_le (BitVec.ushiftRight_one_le _),
+    BitVec.toNat_ushiftRight,
     toNat_maskOfWidth h, Nat.shiftRight_eq_div_pow, Nat.pow_one]
   rcases Nat.eq_zero_or_pos w with rfl | hw
   · simp
@@ -99,13 +98,6 @@ theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
       omega
     have h3 : 0 < 2 ^ (w - 1) := Nat.two_pow_pos _
     omega
-
-theorem twoPow_ne_zero {o k : Nat} (h : k < o) : BitVec.twoPow o k ≠ 0#o := by
-  intro hcontra
-  have hn := congrArg BitVec.toNat hcontra
-  rw [BitVec.toNat_twoPow, BitVec.toNat_zero,
-    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by omega) h)] at hn
-  exact absurd hn (Nat.ne_of_gt (Nat.two_pow_pos k))
 
 theorem signBitOfMask_maskOfWidth_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) :
     signBitOfMask (maskOfWidth o w) = BitVec.twoPow o (w - 1) := by
@@ -117,18 +109,3 @@ theorem signBitOfMask_maskOfWidth_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) 
     rw [Nat.pow_succ, Nat.add_sub_cancel]
     omega
   omega
-
-theorem msb_toMask {w o : Nat} (h : w ≤ o) :
-    ∀ (a : BitVec w),
-      a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
-  intro a
-  rcases Nat.eq_zero_or_pos w with rfl | hw
-  · -- `BitVec 0` has no bits, so both sides are `false`.
-    rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by omega)]
-    rw [maskOfWidth_zero, signBitOfMask]
-    simp
-  · rw [signBitOfMask_maskOfWidth_of_pos h hw, BitVec.and_twoPow, BitVec.getLsbD_setWidth,
-      BitVec.msb_eq_getLsbD_last]
-    have hlt : w - 1 < o := by omega
-    simp only [hlt, decide_true, Bool.true_and]
-    cases a.getLsbD (w - 1) <;> simp [twoPow_ne_zero hlt]

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -18,7 +18,7 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
 /-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
-def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
+@[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -34,9 +34,10 @@ theorem isMask_maskOfWidth {o w : Nat} :
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- The mask constraint: the only fact about `m` surviving abstraction. -/
+/-- The mask constraint: the only fact about `m` surviving abstraction.
+Unfold the IsMask def here to simplify use in the proof. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : IsMask m := by
+    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   exact isMask_maskOfWidth
 
@@ -97,7 +98,7 @@ theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
       rw [Nat.pow_succ, Nat.add_sub_cancel]
       omega
     have h3 : 0 < 2 ^ (w - 1) := Nat.two_pow_pos _
-    omega
+    lia
 
 theorem signBitOfMask_maskOfWidth_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) :
     signBitOfMask (maskOfWidth o w) = BitVec.twoPow o (w - 1) := by

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -65,3 +65,70 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
     a.setWidth o = b &&& maskOfWidth o w := by
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
+
+theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :
+    (maskOfWidth o w).getLsbD i = (decide (i < w) && decide (i < o)) := by
+  rw [maskOfWidth, BitVec.getLsbD_ofNat, Nat.testBit_two_pow_sub_one]
+  exact Bool.and_comm _ _
+
+theorem getElem_maskOfWidth {o w : Nat} (i : Nat) (hi : i < o) :
+    (maskOfWidth o w)[i] = decide (i < w) := by
+  rw [← BitVec.getLsbD_eq_getElem, getLsbD_maskOfWidth]
+  simp [hi]
+
+theorem maskOfWidth_zero (o : Nat) : maskOfWidth o 0 = 0#o := by
+  simp [maskOfWidth]
+
+/-! ## The sign bit helpers -/
+
+def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
+
+theorem ushiftRight_one_le {o : Nat} (m : BitVec o) : m >>> 1 ≤ m := by
+  rw [BitVec.le_def, BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
+  exact Nat.div_le_self _ _
+
+theorem toNat_signBitOfMask_maskOfWidth {o w : Nat} (h : w ≤ o) :
+    (signBitOfMask (maskOfWidth o w)).toNat = 2 ^ w - 2 ^ (w - 1) := by
+  rw [signBitOfMask, BitVec.toNat_sub_of_le (ushiftRight_one_le _), BitVec.toNat_ushiftRight,
+    toNat_maskOfWidth h, Nat.shiftRight_eq_div_pow, Nat.pow_one]
+  rcases Nat.eq_zero_or_pos w with rfl | hw
+  · simp
+  · have h2 : 2 ^ w = 2 * 2 ^ (w - 1) := by
+      obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by omega⟩
+      rw [Nat.pow_succ, Nat.add_sub_cancel]
+      omega
+    have h3 : 0 < 2 ^ (w - 1) := Nat.two_pow_pos _
+    omega
+
+theorem twoPow_ne_zero {o k : Nat} (h : k < o) : BitVec.twoPow o k ≠ 0#o := by
+  intro hcontra
+  have hn := congrArg BitVec.toNat hcontra
+  rw [BitVec.toNat_twoPow, BitVec.toNat_zero,
+    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by omega) h)] at hn
+  exact absurd hn (Nat.ne_of_gt (Nat.two_pow_pos k))
+
+theorem signBitOfMask_maskOfWidth_of_pos {o w : Nat} (h : w ≤ o) (hw : 0 < w) :
+    signBitOfMask (maskOfWidth o w) = BitVec.twoPow o (w - 1) := by
+  apply BitVec.eq_of_toNat_eq
+  rw [toNat_signBitOfMask_maskOfWidth h, BitVec.toNat_twoPow,
+    Nat.mod_eq_of_lt (Nat.pow_lt_pow_right (by omega) (by omega : w - 1 < o))]
+  have h2 : 2 ^ w = 2 * 2 ^ (w - 1) := by
+    obtain ⟨w', rfl⟩ : ∃ w', w = w' + 1 := ⟨w - 1, by omega⟩
+    rw [Nat.pow_succ, Nat.add_sub_cancel]
+    omega
+  omega
+
+theorem msb_toMask {w o : Nat} (h : w ≤ o) :
+    ∀ (a : BitVec w),
+      a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
+  intro a
+  rcases Nat.eq_zero_or_pos w with rfl | hw
+  · -- `BitVec 0` has no bits, so both sides are `false`.
+    rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by omega)]
+    rw [maskOfWidth_zero, signBitOfMask]
+    simp
+  · rw [signBitOfMask_maskOfWidth_of_pos h hw, BitVec.and_twoPow, BitVec.getLsbD_setWidth,
+      BitVec.msb_eq_getLsbD_last]
+    have hlt : w - 1 < o := by omega
+    simp only [hlt, decide_true, Bool.true_and]
+    cases a.getLsbD (w - 1) <;> simp [twoPow_ne_zero hlt]

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -81,7 +81,7 @@ theorem maskOfWidth_zero (o : Nat) : maskOfWidth o 0 = 0#o := by
 
 /-! ## The sign bit helpers -/
 
-def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
+@[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
 
 theorem ushiftRight_one_le {o : Nat} (m : BitVec o) : m >>> 1 ≤ m := by
   rw [BitVec.le_def, BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -18,11 +18,13 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
 /-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
-@[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
+def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
 /-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
 theorem isMask_eq {o : Nat} (m : BitVec o) :
-    IsMask m = (m &&& (m + 1#o) = 0#o) := rfl
+    IsMask m = (m &&& (m + 1#o) = 0#o) := by
+    unfold IsMask
+    rfl
 
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -40,3 +40,26 @@ theorem setWidth_add {w o : Nat} (h : w ≤ o) :
   refine setWidth_eq_and_maskOfWidth h ?_
   rw [BitVec.toNat_add, BitVec.toNat_setWidth_of_le h, BitVec.toNat_setWidth_of_le h,
     Nat.mod_mod_pow_of_le h, BitVec.toNat_add]
+
+/-- Sign extension: fill above the source width `v` with the sign bit, then mask to the target
+width. -/
+theorem setWidth_signExtend {t o : Nat} (_h : t ≤ o) :
+    ∀ {v : Nat} (a : BitVec v), v ≤ o →
+      (a.signExtend t).setWidth o
+        = ((a.setWidth o) ||| (cond a.msb (~~~(maskOfWidth o v)) 0#o)) &&& maskOfWidth o t := by
+  intro v a hv
+  apply BitVec.eq_of_getLsbD_eq
+  intro i _
+  rw [BitVec.getLsbD_setWidth, BitVec.getLsbD_signExtend, BitVec.getLsbD_and,
+    BitVec.getLsbD_or, BitVec.getLsbD_setWidth, getLsbD_maskOfWidth]
+  by_cases hiv : i < v
+  · -- Below the source width: the sign fill is masked out, so the bit is `a`'s own.
+    have hio : i < o := by omega
+    have hmask : (maskOfWidth o v)[i] = true := by
+      rw [getElem_maskOfWidth i hio]; simp [hiv]
+    cases hmsb : a.msb <;>
+      simp [hiv, hio, hmask, Bool.and_comm]
+  · -- At or above the source width: `a` has no bit here, so the result is the sign bit.
+    rw [BitVec.getLsbD_of_ge a i (by omega)]
+    cases hmsb : a.msb <;>
+      simp [hiv, getLsbD_maskOfWidth, Bool.and_comm]

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -54,12 +54,12 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t o : Nat} :
     BitVec.getLsbD_or, BitVec.getLsbD_setWidth, getLsbD_maskOfWidth]
   by_cases hiv : i < v
   · -- Below the source width: the sign fill is masked out.
-    have hio : i < o := by omega
+    have hio : i < o := by lia
     have hmask : (maskOfWidth o v)[i] = true := by
       rw [getElem_maskOfWidth i hio]; simp [hiv]
     cases hmsb : a.msb <;> grind
   · -- At or above the source width: `a` has no bit here, so the result is the sign bit.
-    rw [BitVec.getLsbD_of_ge a i (by omega)]
+    rw [BitVec.getLsbD_of_ge a i (by lia)]
     cases hmsb : a.msb <;>
       simp [hiv, getLsbD_maskOfWidth, Bool.and_comm]
 
@@ -73,13 +73,13 @@ theorem msb_eq_and_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
   intro a
   rcases Nat.eq_zero_or_pos w with rfl | hw
   · -- `BitVec 0` has no bits, so both sides are `false`.
-    rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by omega)]
+    rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by lia)]
     simp
-  · rw [signBitOfMask_maskOfWidth_eq_twoPow_of_pos h hw, 
+  · rw [signBitOfMask_maskOfWidth_eq_twoPow_of_pos h hw,
       BitVec.and_twoPow, BitVec.getLsbD_setWidth,
       BitVec.msb_eq_getLsbD_last]
     have hlt : w - 1 < o := by lia
     simp only [hlt, decide_true, Bool.true_and]
     cases a.getLsbD (w - 1)
-    · simp 
+    · simp
     · simp [BitVec.twoPow_ne_zero hlt]

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -43,7 +43,7 @@ theorem setWidth_add {w o : Nat} (h : w ≤ o) :
 
 /-- Sign extension fills above the source width `v` with the sign bit,
 and then masks to the target width. -/
-theorem setWidth_signExtend_eq_and_maskOfWidth {t o : Nat} (_h : t ≤ o) :
+theorem setWidth_signExtend_eq_and_maskOfWidth {t o : Nat} :
     ∀ {v : Nat} (a : BitVec v), v ≤ o →
       (a.signExtend t).setWidth o
         = ((a.setWidth o) ||| (cond a.msb (~~~(maskOfWidth o v)) 0#o)) &&& maskOfWidth o t := by
@@ -74,7 +74,6 @@ theorem msb_eq_and_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
   rcases Nat.eq_zero_or_pos w with rfl | hw
   · -- `BitVec 0` has no bits, so both sides are `false`.
     rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by omega)]
-    rw [maskOfWidth_zero, signBitOfMask]
     simp
   · rw [signBitOfMask_maskOfWidth_eq_twoPow_of_pos h hw, 
       BitVec.and_twoPow, BitVec.getLsbD_setWidth,

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -43,11 +43,11 @@ theorem setWidth_add {w o : Nat} (h : w ≤ o) :
 
 /-- Sign extension fills above the source width `v` with the sign bit,
 and then masks to the target width. -/
-theorem setWidth_signExtend_eq_and_maskOfWidth {t o : Nat} :
-    ∀ {v : Nat} (a : BitVec v), v ≤ o →
+theorem setWidth_signExtend_eq_and_maskOfWidth {t v o: Nat} (hvo : v ≤ o) :
+    ∀ (a : BitVec v),
       (a.signExtend t).setWidth o
         = ((a.setWidth o) ||| (cond a.msb (~~~(maskOfWidth o v)) 0#o)) &&& maskOfWidth o t := by
-  intro v a hv
+  intro a
   apply BitVec.eq_of_getLsbD_eq
   intro i _
   rw [BitVec.getLsbD_setWidth, BitVec.getLsbD_signExtend, BitVec.getLsbD_and,

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -63,3 +63,22 @@ theorem setWidth_signExtend {t o : Nat} (_h : t ≤ o) :
     rw [BitVec.getLsbD_of_ge a i (by omega)]
     cases hmsb : a.msb <;>
       simp [hiv, getLsbD_maskOfWidth, Bool.and_comm]
+
+/-! ### The sign bit: a test against the mask's top bit -/
+
+/-- `a.msb` is the only width-dependent test `signExtend` leaves behind; replace it by a test
+against the top bit of `w`'s mask, which the bitblaster can see. -/
+theorem msb_toMask {w o : Nat} (h : w ≤ o) :
+    ∀ (a : BitVec w),
+      a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
+  intro a
+  rcases Nat.eq_zero_or_pos w with rfl | hw
+  · -- `BitVec 0` has no bits, so both sides are `false`.
+    rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by omega)]
+    rw [maskOfWidth_zero, signBitOfMask]
+    simp
+  · rw [signBitOfMask_maskOfWidth_of_pos h hw, BitVec.and_twoPow, BitVec.getLsbD_setWidth,
+      BitVec.msb_eq_getLsbD_last]
+    have hlt : w - 1 < o := by omega
+    simp only [hlt, decide_true, Bool.true_and]
+    cases a.getLsbD (w - 1) <;> simp [BitVec.twoPow_ne_zero hlt]

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -43,7 +43,7 @@ theorem setWidth_add {w o : Nat} (h : w ≤ o) :
 
 /-- Sign extension fills above the source width `v` with the sign bit,
 and then masks to the target width. -/
-theorem setWidth_signExtend_eq_and_maskOfWidth {t v o: Nat} (hvo : v ≤ o) :
+theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
     ∀ (a : BitVec v),
       (a.signExtend t).setWidth o
         = ((a.setWidth o) ||| (cond a.msb (~~~(maskOfWidth o v)) 0#o)) &&& maskOfWidth o t := by

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -41,9 +41,9 @@ theorem setWidth_add {w o : Nat} (h : w ≤ o) :
   rw [BitVec.toNat_add, BitVec.toNat_setWidth_of_le h, BitVec.toNat_setWidth_of_le h,
     Nat.mod_mod_pow_of_le h, BitVec.toNat_add]
 
-/-- Sign extension: fill above the source width `v` with the sign bit, then mask to the target
-width. -/
-theorem setWidth_signExtend {t o : Nat} (_h : t ≤ o) :
+/-- Sign extension fills above the source width `v` with the sign bit,
+and then masks to the target width. -/
+theorem setWidth_signExtend_eq_and_maskOfWidth {t o : Nat} (_h : t ≤ o) :
     ∀ {v : Nat} (a : BitVec v), v ≤ o →
       (a.signExtend t).setWidth o
         = ((a.setWidth o) ||| (cond a.msb (~~~(maskOfWidth o v)) 0#o)) &&& maskOfWidth o t := by
@@ -53,12 +53,11 @@ theorem setWidth_signExtend {t o : Nat} (_h : t ≤ o) :
   rw [BitVec.getLsbD_setWidth, BitVec.getLsbD_signExtend, BitVec.getLsbD_and,
     BitVec.getLsbD_or, BitVec.getLsbD_setWidth, getLsbD_maskOfWidth]
   by_cases hiv : i < v
-  · -- Below the source width: the sign fill is masked out, so the bit is `a`'s own.
+  · -- Below the source width: the sign fill is masked out.
     have hio : i < o := by omega
     have hmask : (maskOfWidth o v)[i] = true := by
       rw [getElem_maskOfWidth i hio]; simp [hiv]
-    cases hmsb : a.msb <;>
-      simp [hiv, hio, hmask, Bool.and_comm]
+    cases hmsb : a.msb <;> grind
   · -- At or above the source width: `a` has no bit here, so the result is the sign bit.
     rw [BitVec.getLsbD_of_ge a i (by omega)]
     cases hmsb : a.msb <;>
@@ -66,9 +65,9 @@ theorem setWidth_signExtend {t o : Nat} (_h : t ≤ o) :
 
 /-! ### The sign bit: a test against the mask's top bit -/
 
-/-- `a.msb` is the only width-dependent test `signExtend` leaves behind; replace it by a test
-against the top bit of `w`'s mask, which the bitblaster can see. -/
-theorem msb_toMask {w o : Nat} (h : w ≤ o) :
+/-- `a.msb` can be implemented by masking the sign bit,
+which are definitions the bitblaster can see. -/
+theorem msb_eq_and_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
     ∀ (a : BitVec w),
       a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
   intro a
@@ -77,8 +76,11 @@ theorem msb_toMask {w o : Nat} (h : w ≤ o) :
     rw [BitVec.msb_eq_getLsbD_last, BitVec.getLsbD_of_ge _ _ (by omega)]
     rw [maskOfWidth_zero, signBitOfMask]
     simp
-  · rw [signBitOfMask_maskOfWidth_of_pos h hw, BitVec.and_twoPow, BitVec.getLsbD_setWidth,
+  · rw [signBitOfMask_maskOfWidth_eq_twoPow_of_pos h hw, 
+      BitVec.and_twoPow, BitVec.getLsbD_setWidth,
       BitVec.msb_eq_getLsbD_last]
-    have hlt : w - 1 < o := by omega
+    have hlt : w - 1 < o := by lia
     simp only [hlt, decide_true, Bool.true_and]
-    cases a.getLsbD (w - 1) <;> simp [BitVec.twoPow_ne_zero hlt]
+    cases a.getLsbD (w - 1)
+    · simp 
+    · simp [BitVec.twoPow_ne_zero hlt]

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -67,7 +67,7 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o: Nat} (hvo : v ≤ o) :
 
 /-- `a.msb` can be implemented by masking the sign bit,
 which are definitions the bitblaster can see. -/
-theorem msb_eq_and_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
+theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
     ∀ (a : BitVec w),
       a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
   intro a


### PR DESCRIPTION
This PR introduces some more examples of the bounded parametric bitvector solving technique for the zero and sign extension cases.
- Theorems for translating about `Nat` width constraints into `BitVec` are added in `Mask.lean`
- `Push.lean` contains theorems regarding sign bits