### PR TITLE
feat: Move `verifyLocalInvariants` to `HasOpInfo`

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -128,15 +128,12 @@ def Arith.hasSSADominance (_op : Arith) (_index : Nat) : Bool :=
 
 #generate_dialect Arith
 
-instance : HasOpInfo Arith where
+instance : IsOpCode Arith where
   fromName := Arith.fromName
   name := Arith.name
   propertiesOf := Arith.propertiesOf
   fromAttrDict := Arith.fromAttrDict
   toAttrDict := Arith.toAttrDict
-  getEffects := Arith.getEffects
-  isConstantLike := Arith.isConstantLike
-  hasSSADominance := Arith.hasSSADominance
 
 /--
 Materialize integer results of folded arithmetic operations as `arith.constant`.
@@ -160,7 +157,7 @@ two results. The low result always matches the operand type; the high result
 is either an `i1` overflow flag (`addui_extended` / `subui_extended`) or
 another value of the operand type (`mulsi_extended` / `mului_extended`).
 -/
-def OperationPtr.verifyArithExtendedOp {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyArithExtendedOp {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (secondResultIsI1 : Bool) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 2
@@ -184,7 +181,7 @@ Verify the local invariants of an `arith` operation in any operation-info type
 containing the `arith` dialect.
 -/
 @[expose]
-def Arith.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Arith]
+def Arith.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInfo Arith]
     (opType : Arith) (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -234,6 +231,12 @@ def Arith.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect O
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyTruncTypes ctx opIn false
     pure ()
+
+instance : HasOpInfo Arith where
+  verifyLocalInvariants := Arith.verifyLocalInvariants
+  getEffects := Arith.getEffects
+  isConstantLike := Arith.isConstantLike
+  hasSSADominance := Arith.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -65,24 +65,19 @@ def Builtin.hasNoTerminator (op : Builtin) (_index : Nat) : Bool :=
 
 #generate_dialect Builtin
 
-instance : HasOpInfo Builtin where
+instance : IsOpCode Builtin where
   fromName := Builtin.fromName
   name := Builtin.name
   propertiesOf := Builtin.propertiesOf
   fromAttrDict := Builtin.fromAttrDict
   toAttrDict := Builtin.toAttrDict
-  getEffects := Builtin.getEffects
-  isConstantLike := Builtin.isConstantLike
-  getRegionKind := Builtin.getRegionKind
-  hasSSADominance := Builtin.hasSSADominance
-  hasNoTerminator := Builtin.hasNoTerminator
 
 /--
 Verify the local invariants of a `builtin` operation in any operation-info type
 containing the `builtin` dialect.
 -/
 @[expose]
-def Builtin.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Builtin.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Builtin] (opType : Builtin) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -100,6 +95,14 @@ def Builtin.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+
+instance : HasOpInfo Builtin where
+  verifyLocalInvariants := Builtin.verifyLocalInvariants
+  getEffects := Builtin.getEffects
+  isConstantLike := Builtin.isConstantLike
+  getRegionKind := Builtin.getRegionKind
+  hasSSADominance := Builtin.hasSSADominance
+  hasNoTerminator := Builtin.hasNoTerminator
 
 end
 

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -56,22 +56,18 @@ def Cf.isTerminator (_op : Cf) : Bool :=
 
 #generate_dialect Cf
 
-instance : HasOpInfo Cf where
+instance : IsOpCode Cf where
   fromName := Cf.fromName
   name := Cf.name
   propertiesOf := Cf.propertiesOf
   fromAttrDict := Cf.fromAttrDict
   toAttrDict := Cf.toAttrDict
-  getEffects := Cf.getEffects
-  isConstantLike := Cf.isConstantLike
-  hasSSADominance := Cf.hasSSADominance
-  isTerminator := Cf.isTerminator
 
 /--
 Verify the local invariants of a `cf` operation in any operation-info type
 containing the `cf` dialect.
 -/
-def Cf.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo Cf]
+def Cf.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInfo Cf]
     (opType : Cf) (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -85,6 +81,13 @@ def Cf.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpIn
     if props.branch_weights.values.size ≠ 2 && props.branch_weights.values.size ≠ 0 then
       throw "Expected 0 or 2 branch weights"
     op.verifyCondBranchOperandSegmentSizes ctx opIn props.operandSegmentSizes 1
+
+instance : HasOpInfo Cf where
+  verifyLocalInvariants := Cf.verifyLocalInvariants
+  getEffects := Cf.getEffects
+  isConstantLike := Cf.isConstantLike
+  hasSSADominance := Cf.hasSSADominance
+  isTerminator := Cf.isTerminator
 
 end
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -75,15 +75,12 @@ def Comb.hasSSADominance (_op : Comb) (_index : Nat) : Bool :=
 
 #generate_dialect Comb
 
-instance : HasOpInfo Comb where
+instance : IsOpCode Comb where
   fromName := Comb.fromName
   name := Comb.name
   propertiesOf := Comb.propertiesOf
   fromAttrDict := Comb.fromAttrDict
   toAttrDict := Comb.toAttrDict
-  getEffects := Comb.getEffects
-  isConstantLike := Comb.isConstantLike
-  hasSSADominance := Comb.hasSSADominance
 
 /-- CIRCT combinational folds use the HW dialect's integer constant. -/
 def Comb.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo HW]
@@ -99,7 +96,7 @@ def Comb.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpIn
 Verify the local invariants of a `comb` operation in any operation-info type
 containing the `comb` dialect.
 -/
-def Comb.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Comb.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Comb] (opType : Comb) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -130,6 +127,12 @@ def Comb.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
   | .mux => do
     op.verifyPlainOpCounts ctx opIn 3 1
     pure ()
+
+instance : HasOpInfo Comb where
+  verifyLocalInvariants := Comb.verifyLocalInvariants
+  getEffects := Comb.getEffects
+  isConstantLike := Comb.isConstantLike
+  hasSSADominance := Comb.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -42,22 +42,19 @@ def Datapath.hasSSADominance (_op : Datapath) (_index : Nat) : Bool :=
 
 #generate_dialect Datapath
 
-instance : HasOpInfo Datapath where
+instance : IsOpCode Datapath where
   fromName := Datapath.fromName
   name := Datapath.name
   propertiesOf := Datapath.propertiesOf
   fromAttrDict := Datapath.fromAttrDict
   toAttrDict := Datapath.toAttrDict
-  getEffects := Datapath.getEffects
-  isConstantLike := Datapath.isConstantLike
-  hasSSADominance := Datapath.hasSSADominance
 
 /--
 Verify the local invariants of a `datapath` operation in any operation-info
 type containing the `datapath` dialect.
 -/
 @[expose]
-def Datapath.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Datapath.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Datapath] (opType : Datapath) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -87,6 +84,12 @@ def Datapath.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
     pure ()
+
+instance : HasOpInfo Datapath where
+  verifyLocalInvariants := Datapath.verifyLocalInvariants
+  getEffects := Datapath.getEffects
+  isConstantLike := Datapath.isConstantLike
+  hasSSADominance := Datapath.hasSSADominance
 
 end
 

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -73,23 +73,18 @@ def Func.isTerminator (op : Func) : Bool :=
 
 #generate_dialect Func
 
-instance : HasOpInfo Func where
+instance : IsOpCode Func where
   fromName := Func.fromName
   name := Func.name
   propertiesOf := Func.propertiesOf
   fromAttrDict := Func.fromAttrDict
   toAttrDict := Func.toAttrDict
-  getEffects := Func.getEffects
-  isConstantLike := Func.isConstantLike
-  isFunctionLike := Func.isFunctionLike
-  hasSSADominance := Func.hasSSADominance
-  isTerminator := Func.isTerminator
 
 /--
 Check that a `func.return` returns the declared result types of its enclosing
 `func.func`.
 -/
-def OperationPtr.verifyFuncReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyFuncReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Func] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   let funcOp ← op.getEnclosingFunctionOp ctx "func.return"
@@ -113,7 +108,7 @@ Verify the local invariants of a `func` operation in any operation-info type
 containing the `func` dialect.
 -/
 @[expose]
-def Func.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Func.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Func] (opType : Func) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -141,6 +136,14 @@ def Func.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
   | .return => do
     op.verifyTerminatorCounts ctx opIn 0
     op.verifyFuncReturnTypes ctx opIn
+
+instance : HasOpInfo Func where
+  verifyLocalInvariants := Func.verifyLocalInvariants
+  getEffects := Func.getEffects
+  isConstantLike := Func.isConstantLike
+  isFunctionLike := Func.isFunctionLike
+  hasSSADominance := Func.hasSSADominance
+  isTerminator := Func.isTerminator
 
 end
 

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -68,22 +68,18 @@ def HW.isTerminator (op : HW) : Bool :=
 
 #generate_dialect HW
 
-instance : HasOpInfo HW where
+instance : IsOpCode HW where
   fromName := HW.fromName
   name := HW.name
   propertiesOf := HW.propertiesOf
   fromAttrDict := HW.fromAttrDict
   toAttrDict := HW.toAttrDict
-  getEffects := HW.getEffects
-  isConstantLike := HW.isConstantLike
-  hasSSADominance := HW.hasSSADominance
-  isTerminator := HW.isTerminator
 
 /--
 Verify the local invariants of an `hw` operation in any operation-info type
 containing the `hw` dialect.
 -/
-def HW.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def HW.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo HW] (opType : HW) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -113,6 +109,13 @@ def HW.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo
       some (.of HW.constant (HWConstantProperties.mk (IntegerAttr.mk value.toInt intType)))
     else none
   | _, _ => none
+
+instance : HasOpInfo HW where
+  verifyLocalInvariants := HW.verifyLocalInvariants
+  getEffects := HW.getEffects
+  isConstantLike := HW.isConstantLike
+  hasSSADominance := HW.hasSSADominance
+  isTerminator := HW.isTerminator
 
 end
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -332,24 +332,19 @@ def Llvm.isTerminator (op : Llvm) : Bool :=
 
 #generate_dialect Llvm
 
-instance : HasOpInfo Llvm where
+instance : IsOpCode Llvm where
   fromName := Llvm.fromName
   name := Llvm.name
   propertiesOf := Llvm.propertiesOf
   fromAttrDict := Llvm.fromAttrDict
   toAttrDict := Llvm.toAttrDict
-  getEffects := Llvm.getEffects
-  isConstantLike := Llvm.isConstantLike
-  isFunctionLike := Llvm.isFunctionLike
-  hasSSADominance := Llvm.hasSSADominance
-  isTerminator := Llvm.isTerminator
 
 /-- Whether `n` is a valid LLVM alignment: a strictly positive power of two. -/
 def isValidLLVMAlignment (n : Int) : Bool :=
   decide (0 < n) && (n.toNat &&& (n.toNat - 1)) == 0
 
 /-- Check an `llvm.return` against its enclosing `llvm.func`'s declared results. -/
-def OperationPtr.verifyLLVMFuncReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyLLVMFuncReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Llvm] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (funcOp : OperationPtr) : Except String PUnit := do
   let props : Llvm.propertiesOf .func := funcOp.getProperties! ctx.raw Llvm.func
@@ -369,7 +364,7 @@ def OperationPtr.verifyLLVMFuncReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
       throw s!"llvm.return operand {i} type does not match the function's declared result type"
 
 /-- Check an `llvm.return` against its `llvm.mlir.global`'s `global_type`. -/
-def OperationPtr.verifyLLVMGlobalReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyLLVMGlobalReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Llvm] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (globalOp : OperationPtr) : Except String PUnit := do
   let globalType :=
@@ -384,7 +379,7 @@ def OperationPtr.verifyLLVMGlobalReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
 Check an `llvm.return`'s operands against its enclosing `llvm.func` or
 `llvm.mlir.global`.
 -/
-def OperationPtr.verifyLLVMReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyLLVMReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Llvm] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   let enclosingOp ← op.getEnclosingFunctionOp ctx "llvm.return"
@@ -395,7 +390,7 @@ def OperationPtr.verifyLLVMReturnTypes {OpInfo : Type} [HasOpInfo OpInfo]
   | some .mlir__global => op.verifyLLVMGlobalReturnTypes ctx opIn enclosingOp
   | _ => badEnclosure
 
-def OperationPtr.verifyLLVMShift {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyLLVMShift {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
@@ -407,7 +402,7 @@ def OperationPtr.verifyLLVMShift {OpInfo : Type} [HasOpInfo OpInfo]
   op.verifyResultTypeMatches ctx ((op.getOperand! ctx.raw 0).getType! ctx.raw)
     s!"{instrName}: Expected result type to match first operand type"
 
-def OperationPtr.verifyLLVMICmp {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyLLVMICmp {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
@@ -425,7 +420,7 @@ def OperationPtr.verifyLLVMICmp {OpInfo : Type} [HasOpInfo OpInfo]
 Verify the local invariants of an `llvm` operation in any operation-info type
 containing the `llvm` dialect.
 -/
-def Llvm.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Llvm] (opType : Llvm) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -669,6 +664,14 @@ def Llvm.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpIn
         (LLVMConstantProperties.mk (.float (FloatAttr.mk value floatType))))
     else none
   | _, _ => none
+
+instance : HasOpInfo Llvm where
+  verifyLocalInvariants := Llvm.verifyLocalInvariants
+  getEffects := Llvm.getEffects
+  isConstantLike := Llvm.isConstantLike
+  isFunctionLike := Llvm.isFunctionLike
+  hasSSADominance := Llvm.hasSSADominance
+  isTerminator := Llvm.isTerminator
 
 end
 

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -55,15 +55,12 @@ def Mod_Arith.hasSSADominance (_op : Mod_Arith) (_index : Nat) : Bool :=
 
 #generate_dialect Mod_Arith
 
-instance : HasOpInfo Mod_Arith where
+instance : IsOpCode Mod_Arith where
   fromName := Mod_Arith.fromName
   name := Mod_Arith.name
   propertiesOf := Mod_Arith.propertiesOf
   fromAttrDict := Mod_Arith.fromAttrDict
   toAttrDict := Mod_Arith.toAttrDict
-  getEffects := Mod_Arith.getEffects
-  isConstantLike := Mod_Arith.isConstantLike
-  hasSSADominance := Mod_Arith.hasSSADominance
 
 /--
 Materialize concrete modular-integer fold results.
@@ -91,7 +88,7 @@ def TypeAttr.verifyModArithType (ty : TypeAttr) (msg : String) : Except String M
     pure type
   | type => throw s!"{msg} but found {type} instead."
 
-def OperationPtr.verifyModArithBinOp {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyModArithBinOp {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 2 1
@@ -102,7 +99,7 @@ def OperationPtr.verifyModArithBinOp {OpInfo : Type} [HasOpInfo OpInfo]
     s!"{instrName}: Expected result type to match operand type"
   let _ ← operandType.verifyModArithType s!"{instrName}: Expected ModArithType"
 
-def OperationPtr.verifyModArithConstantOp {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyModArithConstantOp {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Mod_Arith] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 0 1
@@ -119,7 +116,7 @@ def OperationPtr.verifyModArithConstantOp {OpInfo : Type} [HasOpInfo OpInfo]
 Verify the local invariants of a `mod_arith` operation in any operation-info
 type containing the `mod_arith` dialect.
 -/
-def Mod_Arith.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Mod_Arith.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Mod_Arith] (opType : Mod_Arith) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -129,3 +126,9 @@ def Mod_Arith.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
   | .constant => do
     op.verifyModArithConstantOp ctx opIn
     pure ()
+
+instance : HasOpInfo Mod_Arith where
+  verifyLocalInvariants := Mod_Arith.verifyLocalInvariants
+  getEffects := Mod_Arith.getEffects
+  isConstantLike := Mod_Arith.isConstantLike
+  hasSSADominance := Mod_Arith.hasSSADominance

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -151,17 +151,12 @@ def PDL.isTerminator (op : PDL) : Bool :=
 
 #generate_dialect PDL
 
-instance : HasOpInfo PDL where
+instance : IsOpCode PDL where
   fromName := PDL.fromName
   name := PDL.name
   propertiesOf := PDL.propertiesOf
   fromAttrDict := PDL.fromAttrDict
   toAttrDict := PDL.toAttrDict
-  getEffects := PDL.getEffects
-  isConstantLike := PDL.isConstantLike
-  hasSSADominance := PDL.hasSSADominance
-  hasNoTerminator := PDL.hasNoTerminator
-  isTerminator := PDL.isTerminator
 
 /--
   The element kind of a PDL handle type, treating a non-range handle as a range
@@ -184,7 +179,7 @@ TODO: An unconstrained `pdl.type` needs a use that binds it, but that invariant
 only applies inside the matcher body of a `pdl.pattern`, which is not modelled
 yet.
 -/
-def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpInfo PDL]
+def PDL.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInfo PDL]
     (opType : PDL) (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -466,6 +461,14 @@ def PDL.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
     op.verifyPlainOpCounts ctx opIn 0 1
     op.verifyResultTypeMatches ctx (PDL.RangeType.mk .type : TypeAttr)
       "Expected the result to be of type '!pdl.range<type>'"
+
+instance : HasOpInfo PDL where
+  verifyLocalInvariants := PDL.verifyLocalInvariants
+  getEffects := PDL.getEffects
+  isConstantLike := PDL.isConstantLike
+  hasSSADominance := PDL.hasSSADominance
+  hasNoTerminator := PDL.hasNoTerminator
+  isTerminator := PDL.isTerminator
 
 end
 

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -248,15 +248,12 @@ def Riscv.hasSSADominance (_op : Riscv) (_index : Nat) : Bool :=
 
 #generate_dialect Riscv
 
-instance : HasOpInfo Riscv where
+instance : IsOpCode Riscv where
   fromName := Riscv.fromName
   name := Riscv.name
   propertiesOf := Riscv.propertiesOf
   fromAttrDict := Riscv.fromAttrDict
   toAttrDict := Riscv.toAttrDict
-  getEffects := Riscv.getEffects
-  isConstantLike := Riscv.isConstantLike
-  hasSSADominance := Riscv.hasSSADominance
 
 /--
 Materialize register-valued fold results as `riscv.li`. A register always holds
@@ -270,7 +267,7 @@ def Riscv.materializeConstant {OpInfo : Type} [HasOpInfo OpInfo] [HasDialect OpI
       (RISCVImmediateProperties.mk (IntegerAttr.mk value.val.toInt (IntegerType.mk 64))))
   | _, _ => none
 
-def OperationPtr.verifyRISCVimm12 {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyRISCVimm12 {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (operands results : Nat) (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn operands results
@@ -284,7 +281,7 @@ def OperationPtr.verifyRISCVimm12 {OpInfo : Type} [HasOpInfo OpInfo]
 Check that a shift-amount/bit-index immediate fits in an unsigned 5-bit field
 `[0, 31]`.
 -/
-def OperationPtr.verifyRISCVuimm5 {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyRISCVuimm5 {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 1 1
@@ -298,7 +295,7 @@ def OperationPtr.verifyRISCVuimm5 {OpInfo : Type} [HasOpInfo OpInfo]
 Check that a shift-amount/bit-index immediate fits in an unsigned 6-bit field
 `[0, 63]`.
 -/
-def OperationPtr.verifyRISCVuimm6 {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyRISCVuimm6 {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn 1 1
@@ -308,7 +305,7 @@ def OperationPtr.verifyRISCVuimm6 {OpInfo : Type} [HasOpInfo OpInfo]
   else
     pure ()
 
-def OperationPtr.verifyRISCVneg {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyRISCVneg {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)
     (operands results : Nat) (imm : Int) : Except String PUnit := do
   op.verifyPlainOpCounts ctx opIn operands results
@@ -319,7 +316,7 @@ def OperationPtr.verifyRISCVneg {OpInfo : Type} [HasOpInfo OpInfo]
     pure ()
 
 /-- Ensure that every operand and result has type `!riscv.reg`. -/
-def OperationPtr.verifyRISCVRegisterTypes {OpInfo : Type} [HasOpInfo OpInfo]
+def OperationPtr.verifyRISCVRegisterTypes {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
@@ -337,7 +334,7 @@ def OperationPtr.verifyRISCVRegisterTypes {OpInfo : Type} [HasOpInfo OpInfo]
 Verify the local invariants of a `riscv` operation in any operation-info type
 containing the `riscv` dialect.
 -/
-def Riscv.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Riscv.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Riscv] (opType : Riscv) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   op.verifyRISCVRegisterTypes ctx opIn
@@ -478,6 +475,12 @@ def Riscv.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
   | .sltz | .sgtz => do
     op.verifyPlainOpCounts ctx opIn 1 1
     pure ()
+
+instance : HasOpInfo Riscv where
+  verifyLocalInvariants := Riscv.verifyLocalInvariants
+  getEffects := Riscv.getEffects
+  isConstantLike := Riscv.isConstantLike
+  hasSSADominance := Riscv.hasSSADominance
 
 end
 

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -70,22 +70,18 @@ def Riscv_Cf.isTerminator (_op : Riscv_Cf) : Bool :=
 
 #generate_dialect Riscv_Cf
 
-instance : HasOpInfo Riscv_Cf where
+instance : IsOpCode Riscv_Cf where
   fromName := Riscv_Cf.fromName
   name := Riscv_Cf.name
   propertiesOf := Riscv_Cf.propertiesOf
   fromAttrDict := Riscv_Cf.fromAttrDict
   toAttrDict := Riscv_Cf.toAttrDict
-  getEffects := Riscv_Cf.getEffects
-  isConstantLike := Riscv_Cf.isConstantLike
-  hasSSADominance := Riscv_Cf.hasSSADominance
-  isTerminator := Riscv_Cf.isTerminator
 
 /--
 Verify the local invariants of a `riscv_cf` operation in any operation-info
 type containing the `riscv_cf` dialect.
 -/
-def Riscv_Cf.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Riscv_Cf.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Riscv_Cf] (opType : Riscv_Cf) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -131,6 +127,13 @@ def Riscv_Cf.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
     let sizes := (op.getProperties! ctx.raw Riscv_Cf.bnez).operandSegmentSizes
     op.verifyCondBranchOperandSegmentSizes ctx opIn sizes 1
     pure ()
+
+instance : HasOpInfo Riscv_Cf where
+  verifyLocalInvariants := Riscv_Cf.verifyLocalInvariants
+  getEffects := Riscv_Cf.getEffects
+  isConstantLike := Riscv_Cf.isConstantLike
+  hasSSADominance := Riscv_Cf.hasSSADominance
+  isTerminator := Riscv_Cf.isTerminator
 
 end
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -48,21 +48,18 @@ def Riscv_Stack.hasSSADominance (_op : Riscv_Stack) (_index : Nat) : Bool :=
 
 #generate_dialect Riscv_Stack
 
-instance : HasOpInfo Riscv_Stack where
+instance : IsOpCode Riscv_Stack where
   fromName := Riscv_Stack.fromName
   name := Riscv_Stack.name
   propertiesOf := Riscv_Stack.propertiesOf
   fromAttrDict := Riscv_Stack.fromAttrDict
   toAttrDict := Riscv_Stack.toAttrDict
-  getEffects := Riscv_Stack.getEffects
-  isConstantLike := Riscv_Stack.isConstantLike
-  hasSSADominance := Riscv_Stack.hasSSADominance
 
 /--
 Verify the local invariants of a `riscv_stack` operation in any operation-info
 type containing the `riscv_stack` dialect.
 -/
-def Riscv_Stack.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Riscv_Stack.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Riscv_Stack] (opType : Riscv_Stack) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
@@ -82,6 +79,12 @@ def Riscv_Stack.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
     if alignment &&& (alignment - 1) ≠ 0 then
       throw "alignment must be a positive power of two"
     pure ()
+
+instance : HasOpInfo Riscv_Stack where
+  verifyLocalInvariants := Riscv_Stack.verifyLocalInvariants
+  getEffects := Riscv_Stack.getEffects
+  isConstantLike := Riscv_Stack.isConstantLike
+  hasSSADominance := Riscv_Stack.hasSSADominance
 
 end
 

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -42,27 +42,30 @@ def Rv64.hasSSADominance (_op : Rv64) (_index : Nat) : Bool :=
 
 #generate_dialect Rv64
 
-instance : HasOpInfo Rv64 where
+instance : IsOpCode Rv64 where
   fromName := Rv64.fromName
   name := Rv64.name
   propertiesOf := Rv64.propertiesOf
   fromAttrDict := Rv64.fromAttrDict
   toAttrDict := Rv64.toAttrDict
-  getEffects := Rv64.getEffects
-  isConstantLike := Rv64.isConstantLike
-  hasSSADominance := Rv64.hasSSADominance
 
 /--
 Verify the local invariants of an `rv64` operation in any operation-info type
 containing the `rv64` dialect.
 -/
-def Rv64.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+def Rv64.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Rv64] (opType : Rv64) (op : OperationPtr)
     (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   match opType with
   | .get_register => do
     op.verifyPlainOpCounts ctx opIn 0 1
     pure ()
+
+instance : HasOpInfo Rv64 where
+  verifyLocalInvariants := Rv64.verifyLocalInvariants
+  getEffects := Rv64.getEffects
+  isConstantLike := Rv64.isConstantLike
+  hasSSADominance := Rv64.hasSSADominance
 
 end
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -236,12 +236,37 @@ def Properties.toAttrDict
   | .pdl op, props => PDL.toAttrDict op props
   | .test op, props => Test.toAttrDict op props
 
-instance : HasOpInfo OpCode where
+instance : IsOpCode OpCode where
   fromName := OpCode.fromName
   name := OpCode.name
   propertiesOf := _propertiesOf
   fromAttrDict := Properties.fromAttrDict
   toAttrDict := Properties.toAttrDict
+
+#generate_has_dialect_instances OpCode
+
+@[expose]
+def OpCode.verifyLocalInvariants (opCode : OpCode) (op : OperationPtr)
+    (ctx : WfIRContext OpCode) (opIn : op.InBounds ctx.raw) : Except String Unit :=
+  match opCode with
+  | .builtin opType => Builtin.verifyLocalInvariants opType op ctx opIn
+  | .arith opType => Arith.verifyLocalInvariants opType op ctx opIn
+  | .datapath opType => Datapath.verifyLocalInvariants opType op ctx opIn
+  | .func opType => Func.verifyLocalInvariants opType op ctx opIn
+  | .cf opType => Cf.verifyLocalInvariants opType op ctx opIn
+  | .pdl opType => PDL.verifyLocalInvariants opType op ctx opIn
+  | .test .test => pure ()
+  | .llvm opType => Llvm.verifyLocalInvariants opType op ctx opIn
+  | .mod_arith opType => Mod_Arith.verifyLocalInvariants opType op ctx opIn
+  | .riscv opType => Riscv.verifyLocalInvariants opType op ctx opIn
+  | .riscv_cf opType => Riscv_Cf.verifyLocalInvariants opType op ctx opIn
+  | .riscv_stack opType => Riscv_Stack.verifyLocalInvariants opType op ctx opIn
+  | .rv64 opType => Rv64.verifyLocalInvariants opType op ctx opIn
+  | .comb opType => Comb.verifyLocalInvariants opType op ctx opIn
+  | .hw opType => HW.verifyLocalInvariants opType op ctx opIn
+
+instance : HasOpInfo OpCode where
+  verifyLocalInvariants := OpCode.verifyLocalInvariants
   getEffects := OpCode.getEffects
   isConstantLike := OpCode.isConstantLike
   isFunctionLike := OpCode.isFunctionLike
@@ -249,8 +274,6 @@ instance : HasOpInfo OpCode where
   hasSSADominance := OpCode.hasSSADominance
   hasNoTerminator := OpCode.hasNoTerminator
   isTerminator := OpCode.isTerminator
-
-#generate_has_dialect_instances OpCode
 
 /--
 Ask the dialect of `opCode` how to represent a folded

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.IR.OpCode
+public import Veir.IR.WellFormed
 
 namespace Veir
 
@@ -43,6 +44,16 @@ end MemoryEffects
 
 class HasOpInfo (opCode: Type)
     extends IsOpCode opCode where
+  /--
+  Verify the local invariants of an operation. This typically includes checking
+  that the number of operands, successors, results, and regions match the
+  expected values for the operation type, as well as checking that referenced
+  types are in bounds.
+  -/
+  verifyLocalInvariants :
+    (opType : opCode) → (op : OperationPtr) → (ctx : WfIRContext opCode) →
+    (opIn : op.InBounds ctx.raw) → Except String PUnit :=
+      fun _ _ _ _ => pure ()
   /--
   The memory effects of an operation with this opcode and these properties,
   mirroring MLIR's `MemoryEffectOpInterface::getEffects`.
@@ -91,6 +102,13 @@ class HasOpInfo (opCode: Type)
   Does this OpCode count as an MLIR basic block terminator?
   -/
   isTerminator : opCode → Bool := fun _ => false
+
+/-- Verify the local invariants of an operation using its opcode interface. -/
+@[inline]
+abbrev OperationPtr.verifyLocalInvariants {OpInfo : Type} [HasOpInfo OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) :
+    Except String PUnit :=
+  HasOpInfo.verifyLocalInvariants (op.getOpType ctx.raw opIn) op ctx opIn
 
 end -- public section
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -11,31 +11,6 @@ namespace Veir
 
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 
-
-/--
-  Verify local invariants of an operation.
-  This typically includes checking that the number of operands, successors, results, and regions
-  match the expected values for the given operation type.
-  This also checks that the given types are in bounds.
--/
-def OperationPtr.verifyLocalInvariants (op : OperationPtr) (ctx : WfIRContext OpCode) (opIn : op.InBounds ctx.raw) : Except String PUnit :=
-  match op.getOpType ctx.raw opIn with
-  | .builtin opType => Builtin.verifyLocalInvariants opType op ctx opIn
-  | .arith opType => Arith.verifyLocalInvariants opType op ctx opIn
-  | .datapath opType => Datapath.verifyLocalInvariants opType op ctx opIn
-  | .func opType => Func.verifyLocalInvariants opType op ctx opIn
-  | .cf opType => Cf.verifyLocalInvariants opType op ctx opIn
-  | .pdl opType => PDL.verifyLocalInvariants opType op ctx opIn
-  | .test .test => pure ()
-  | .llvm opType => Llvm.verifyLocalInvariants opType op ctx opIn
-  | .mod_arith opType => Mod_Arith.verifyLocalInvariants opType op ctx opIn
-  | .riscv opType => Riscv.verifyLocalInvariants opType op ctx opIn
-  | .riscv_cf opType => Riscv_Cf.verifyLocalInvariants opType op ctx opIn
-  | .riscv_stack opType => Riscv_Stack.verifyLocalInvariants opType op ctx opIn
-  | .rv64 opType => Rv64.verifyLocalInvariants opType op ctx opIn
-  | .comb opType => Comb.verifyLocalInvariants opType op ctx opIn
-  | .hw opType => HW.verifyLocalInvariants opType op ctx opIn
-
 /--
   Return the kind of this region.
 -/
@@ -179,6 +154,10 @@ def WfIRContext.verify (ctx : WfIRContext OpCode) : Except String Unit := do
   ctx.verifyLLVMGlobalSymbols
   ctx.verifyPDLPatternBodies
 
+attribute [simp] OpCode.verifyLocalInvariants HasOpInfo.verifyLocalInvariants
+  OperationPtr.verifyLocalInvariants
+  Llvm.verifyLocalInvariants Arith.verifyLocalInvariants Mod_Arith.verifyLocalInvariants
+
 /--
 Assert that the IR context satisfies its structural and local invariants.
 -/
@@ -278,7 +257,8 @@ theorem OperationPtr.Verified.arith_constant {op : OperationPtr} {opInBounds}
     op.getNumRegions! ctx.raw = 0 ∧
     ((op.getResult 0).get! ctx.raw).type =
       ⟨(op.getProperties! ctx.raw Arith.constant).value.type, (by grind)⟩ := by
-  simp only [Verified, verifyLocalInvariants, Arith.verifyLocalInvariants,
+  simp only [Verified, verifyLocalInvariants, HasOpInfo.verifyLocalInvariants,
+    OpCode.verifyLocalInvariants, Arith.verifyLocalInvariants,
     ← getOpType!_eq_getOpType, opType, ne_eq,
     bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure, Except.pure, dite_not,
     ite_not] at opVerify
@@ -293,7 +273,9 @@ theorem OperationPtr.Verified.llvm_mlir__constant_resultType {op : OperationPtr}
     (hProp : (op.getProperties! ctx.raw Llvm.mlir__constant).value = .integer intAttr) :
     ∃ intTy : IntegerType, ((op.getResult 0).get! ctx.raw).type.val = .integerType intTy := by
   rw [Verified] at opVerify
-  simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType] at opVerify
+  simp only [verifyLocalInvariants, HasOpInfo.verifyLocalInvariants,
+    OpCode.verifyLocalInvariants, Llvm.verifyLocalInvariants,
+    ← getOpType!_eq_getOpType, opType] at opVerify
   replace opVerify := Except.ok_of_bind_ok opVerify
   simp only [verifyPlainOpCounts, hProp, ne_eq, bind, Except.bind, throw, throwThe,
     MonadExceptOf.throw, pure, Except.pure] at opVerify
@@ -345,7 +327,7 @@ theorem OperationPtr.Verified.llvm_icmp {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .icmp) :
     op.IsVerifiedIcmp ctx :=
   op.verifyLLVMICmp_eq_ok <| op.verifyLLVMICmp_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [OperationPtr.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
 
 /--
   Every integer binary operation's `Verified.*` lemma: given that the operation is verified and
@@ -376,7 +358,7 @@ theorem OperationPtr.Verified.llvm_select {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .select) :
     op.IsVerifiedSelect ctx :=
   op.verifySelectTypes_eq_ok <| op.verifySelectTypes_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [← getOpType!_eq_getOpType, opType]
 
 /--
   Structural facts guaranteed by a successful `verifyLLVMShift` check. Unlike `IsVerifiedIntegerBinop`
@@ -423,147 +405,127 @@ private theorem OperationPtr.Verified.llvmShift {op : OperationPtr} {opInBounds}
 theorem OperationPtr.Verified.llvm_shl {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .shl) :
     op.IsVerifiedLLVMShift ctx := OperationPtr.Verified.llvmShift opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_lshr {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .lshr) :
     op.IsVerifiedLLVMShift ctx := OperationPtr.Verified.llvmShift opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_addi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .addi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_andi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .andi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_ceildivsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .ceildivsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_ceildivui {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .ceildivui) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_divsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .divsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_divui {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .divui) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_floordivsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .floordivsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_maxsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .maxsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_maxui {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .maxui) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_minsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .minsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_minui {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .minui) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_muli {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .muli) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_ori {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .ori) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_remsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .remsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_remui {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .remui) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_shli {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .shli) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_shrsi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .shrsi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_shrui {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .shrui) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_subi {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .subi) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.arith_xori {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .arith .xori) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_and {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .and) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_or {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .or) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_xor {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .xor) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 /--
   Structural facts guaranteed by the verifier for `llvm.mlir.constant`: no operands, one
@@ -576,7 +538,8 @@ theorem OperationPtr.Verified.llvm_mlir__constant {op : OperationPtr} {opInBound
     op.getNumOperands! ctx.raw = 0 ∧
     op.getNumSuccessors! ctx.raw = 0 ∧
     op.getNumRegions! ctx.raw = 0 := by
-  simp only [Verified, verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType,
+  simp only [Verified, verifyLocalInvariants, HasOpInfo.verifyLocalInvariants,
+    OpCode.verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType,
     verifyPlainOpCounts, ne_eq, bind, Except.bind, throw, throwThe, MonadExceptOf.throw, pure,
     Except.pure] at opVerify
   grind
@@ -584,58 +547,58 @@ theorem OperationPtr.Verified.llvm_mlir__constant {op : OperationPtr} {opInBound
 theorem OperationPtr.Verified.llvm_intr__smax {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__smax) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__smin {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__smin) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__umax {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__umax) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__umin {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__umin) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__usub__sat {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .intr__usub__sat) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__uadd__sat {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .intr__uadd__sat) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__sadd__sat {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .intr__sadd__sat) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__ssub__sat {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .intr__ssub__sat) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__sshl__sat {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .intr__sshl__sat) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_intr__ushl__sat {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .llvm .intr__ushl__sat) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 /--
   Reduce a verified integer unary operation to a successful `verifyIntegerUnop` check.
@@ -662,7 +625,7 @@ theorem OperationPtr.Verified.llvm_intr__bitreverse {op : OperationPtr} {opInBou
     (opType : op.getOpType! ctx.raw = .llvm .intr__bitreverse) :
     op.IsVerifiedIntegerUnop ctx := by
   obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [← getOpType!_eq_getOpType, opType]
   exact op.verifyIntegerUnop_eq_ok hty
 
 /-- Structural facts from the verifier for a verified `llvm.intr.ctlz`. -/
@@ -670,7 +633,7 @@ theorem OperationPtr.Verified.llvm_intr__ctlz {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__ctlz) :
     op.IsVerifiedIntegerUnop ctx := by
   obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [← getOpType!_eq_getOpType, opType]
   exact op.verifyIntegerUnop_eq_ok hty
 
 /-- Structural facts from the verifier for a verified `llvm.intr.cttz`. -/
@@ -678,7 +641,7 @@ theorem OperationPtr.Verified.llvm_intr__cttz {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__cttz) :
     op.IsVerifiedIntegerUnop ctx := by
   obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [← getOpType!_eq_getOpType, opType]
   exact op.verifyIntegerUnop_eq_ok hty
 
 /-- Structural facts from the verifier for a verified `llvm.intr.ctpop`. -/
@@ -686,8 +649,9 @@ theorem OperationPtr.Verified.llvm_intr__ctpop {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__ctpop) :
     op.IsVerifiedIntegerUnop ctx := by
   obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [← getOpType!_eq_getOpType, opType]
   exact op.verifyIntegerUnop_eq_ok hty
+
 
 /-- Structural facts from the verifier for a verified `llvm.intr.abs`. Its verifier arm is exactly
     the shared `verifyIntegerUnop >>= pure` shape (the `is_int_min_poison` property is not checked
@@ -696,8 +660,9 @@ theorem OperationPtr.Verified.llvm_intr__abs {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__abs) :
     op.IsVerifiedIntegerUnop ctx := by
   obtain ⟨ty, hty⟩ := op.verifyIntegerUnop_ok_of_Verified opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+    simp [← getOpType!_eq_getOpType, opType]
   exact op.verifyIntegerUnop_eq_ok hty
+
 
 /-- Structural facts from the verifier for a verified `llvm.intr.bswap`. Unlike the other unary
     intrinsics, `bswap`'s verifier arm performs an extra bitwidth check *after* the shared
@@ -707,7 +672,8 @@ theorem OperationPtr.Verified.llvm_intr__bswap {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__bswap) :
     op.IsVerifiedIntegerUnop ctx := by
   rw [Verified] at opVerify
-  simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType] at opVerify
+  simp only [verifyLocalInvariants, HasOpInfo.verifyLocalInvariants, OpCode.verifyLocalInvariants,
+    Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType] at opVerify
   replace opVerify := Except.ok_of_bind_ok opVerify
   simp only [bind, Except.bind] at opVerify
   obtain ⟨ty, hty⟩ : ∃ ty, op.verifyIntegerUnop ctx opInBounds = .ok ty := by
@@ -750,13 +716,13 @@ private theorem OperationPtr.Verified.integerTernop {op : OperationPtr} {opInBou
 theorem OperationPtr.Verified.llvm_intr__fshl {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__fshl) :
     op.IsVerifiedIntegerTernop ctx := OperationPtr.Verified.integerTernop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 /-- Structural facts from the verifier for a verified `llvm.intr.fshr`. -/
 theorem OperationPtr.Verified.llvm_intr__fshr {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .intr__fshr) :
     op.IsVerifiedIntegerTernop ctx := OperationPtr.Verified.integerTernop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 /--
   Reduce a verified integer extension operation to a successful `verifyIntegerExtTypes` check.
@@ -792,53 +758,53 @@ private theorem OperationPtr.Verified.integerExtop {op : OperationPtr} {opInBoun
 theorem OperationPtr.Verified.llvm_sext {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .sext) :
     op.IsVerifiedIntegerExtop ctx := OperationPtr.Verified.integerExtop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 /-- Structural facts from the verifier for a verified `llvm.zext`. -/
 theorem OperationPtr.Verified.llvm_zext {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .zext) :
     op.IsVerifiedIntegerExtop ctx := OperationPtr.Verified.integerExtop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_add {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .add) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_sub {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .sub) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_ashr {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .ashr) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_mul {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .mul) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_sdiv {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .sdiv) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_udiv {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .udiv) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_srem {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .srem) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.llvm_urem {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .llvm .urem) :
     op.IsVerifiedIntegerBinop ctx := OperationPtr.Verified.integerBinop opVerify <| by
-    simp only [verifyLocalInvariants, Llvm.verifyLocalInvariants, ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 /- Verified ModArith Op Lemmas -/
 
@@ -883,20 +849,17 @@ private theorem OperationPtr.Verified.modArithBinop {op : OperationPtr} {opInBou
 theorem OperationPtr.Verified.mod_arith_add {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .mod_arith .add) :
     op.IsVerifiedModArithBinop ctx := OperationPtr.Verified.modArithBinop opVerify <| by
-    simp only [verifyLocalInvariants, Mod_Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.mod_arith_mul {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .mod_arith .mul) :
     op.IsVerifiedModArithBinop ctx := OperationPtr.Verified.modArithBinop opVerify <| by
-    simp only [verifyLocalInvariants, Mod_Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 theorem OperationPtr.Verified.mod_arith_sub {op : OperationPtr} {opInBounds}
     (opVerify : op.Verified ctx opInBounds) (opType : op.getOpType! ctx.raw = .mod_arith .sub) :
     op.IsVerifiedModArithBinop ctx := OperationPtr.Verified.modArithBinop opVerify <| by
-    simp only [verifyLocalInvariants, Mod_Arith.verifyLocalInvariants,
-      ← getOpType!_eq_getOpType, opType]
+  simp [← getOpType!_eq_getOpType, opType]
 
 def OperationPtr.IsVerifiedModArithConstant (op : OperationPtr) (ctx : WfIRContext OpCode) : Prop :=
   op.getNumOperands! ctx.raw = 0 ∧
@@ -916,7 +879,8 @@ theorem OperationPtr.Verified.mod_arith_constant {op : OperationPtr} {opInBounds
     (opVerify : op.Verified ctx opInBounds)
     (opType : op.getOpType! ctx.raw = .mod_arith .constant) :
     op.IsVerifiedModArithConstant ctx := by
-  simp only [Verified, verifyLocalInvariants, Mod_Arith.verifyLocalInvariants,
+  simp only [Verified, verifyLocalInvariants, HasOpInfo.verifyLocalInvariants,
+    OpCode.verifyLocalInvariants, Mod_Arith.verifyLocalInvariants,
     ← getOpType!_eq_getOpType, opType] at opVerify
   have h : op.verifyModArithConstantOp ctx opInBounds = .ok () := by
     cases hb : op.verifyModArithConstantOp ctx opInBounds with
@@ -938,7 +902,8 @@ theorem OperationPtr.Verified.func_func {op : OperationPtr} {opInBounds}
     op.getNumResults! ctx.raw = 0 ∧
     op.getNumSuccessors! ctx.raw = 0 ∧
     op.getNumRegions! ctx.raw = 1 := by
-  simp only [Verified, verifyLocalInvariants, Func.verifyLocalInvariants,
+  simp only [Verified, verifyLocalInvariants, HasOpInfo.verifyLocalInvariants,
+    OpCode.verifyLocalInvariants, Func.verifyLocalInvariants,
     ← getOpType!_eq_getOpType, opType, ne_eq, bind, Except.bind, throw,
     throwThe, MonadExceptOf.throw, pure, Except.pure, ite_not] at opVerify
   grind

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -17,7 +17,7 @@ namespace Veir
 
 public section
 
-variable {OpInfo : Type} [HasOpInfo OpInfo]
+variable {OpInfo : Type} [IsOpCode OpInfo]
 
 /--
   Type compatibility for values forwarded to block arguments or returned from


### PR DESCRIPTION
This continues the work of making everything use a generic `OpCode` type, rather than the specialized one that contains all dialects.

This also exposes the reason why we split `IsOpCode` and `HasOpInfo`, as here the verifier requires `IsOpCode`, and the verifier needs to be put in an `HasOpInfo.