### PR TITLE
fix: require function names and types in `llvm.func` and `func.func`

### DIFF
--- a/Test/LLVM/invalid_icmp_predicate.mlir
+++ b/Test/LLVM/invalid_icmp_predicate.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() ({
+  "func.func"() <{sym_name = "foo", function_type = (i64, i64) -> ()}> ({
     ^bb0(%a: i64, %b: i64):
       %r = "llvm.icmp"(%a, %b) <{"predicate" = 11 : i64}> : (i64, i64) -> i1
   }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_invalid.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s -p=isel-riscv64 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  "func.func"()  <{function_type = (i32, i32, i64) -> ()}> ({
+  "func.func"()  <{sym_name = "foo", function_type = (i32, i32, i64) -> ()}> ({
     ^bb0(%a: i32, %b: i32, %c: i64):
         %r_0 = "llvm.icmp"(%a, %b) <{"predicate" = 0 : i64}> : (i32, i32) -> i1
         %r_2 = "llvm.icmp"(%a, %b) <{"predicate" = 2 : i64}> : (i32, i32) -> i1

--- a/Test/Verifier/func_func_missing_sym_name.mlir
+++ b/Test/Verifier/func_func_missing_sym_name.mlir
@@ -7,4 +7,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: func.func: Expected symbol name
+// CHECK: func.func: missing 'sym_name' property

--- a/Test/Verifier/func_return_missing_function_type.mlir
+++ b/Test/Verifier/func_return_missing_function_type.mlir
@@ -1,10 +1,10 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() ({
+  "func.func"() <{sym_name = "f"}> ({
   ^bb0():
     "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: func.return: Expected enclosing func.func to have a function_type attribute
+// CHECK: func.func: missing 'function_type' property

--- a/Test/Verifier/llvm_func_missing_sym_name.mlir
+++ b/Test/Verifier/llvm_func_missing_sym_name.mlir
@@ -7,4 +7,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.func: Expected symbol name
+// CHECK: llvm.func: missing 'sym_name' property

--- a/Test/Verifier/terminator_not_last.mlir
+++ b/Test/Verifier/terminator_not_last.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 
 "builtin.module"() ({
-  "func.func"() <{function_type = () -> ()}> ({
+  "func.func"() <{sym_name = "foo", function_type = () -> ()}> ({
   ^bb0():
     "func.return"() : () -> ()
     %0 = "arith.constant"() <{"value" = 0 : i32}> : () -> i32

--- a/UnitTest/DataFlowFramework/DeadCodeAnalysis.lean
+++ b/UnitTest/DataFlowFramework/DeadCodeAnalysis.lean
@@ -63,7 +63,7 @@ private def testTopLevelAndFunctionEntryBlocksLive : String :=
   run
     r#""builtin.module"() ({
 ^bb0:
-  "func.func"() ({
+  "func.func"() <{sym_name = "f", function_type = () -> ()}> ({
   ^entry:
   }) : () -> ()
 }) : () -> ()"#

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -42,10 +42,8 @@ def Func.toAttrDict
     dict
   | .func => Id.run do
     let mut dict := Std.HashMap.ofList props.extra.entries.toList
-    if let some sym_name := props.sym_name then
-      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
-    if let some function_type := props.function_type then
-      dict := dict.insert "function_type".toUTF8 function_type
+    dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    dict := dict.insert "function_type".toUTF8 (.functionType props.function_type)
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
@@ -91,10 +89,7 @@ def OperationPtr.verifyFuncReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
   let some .func := toDialect? Func (funcOp.getOpType! ctx.raw)
     | throw "Expected func.return to be enclosed by func.func"
   let props : Func.propertiesOf .func := funcOp.getProperties! ctx.raw Func.func
-  let some functionType := props.function_type
-    | throw "Expected enclosing func.func to have a function_type attribute"
-  let .functionType functionType := functionType.val
-    | throw "Expected enclosing func.func to have a function_type attribute"
+  let functionType := props.function_type
   let outputs := functionType.outputs
   if op.getNumOperands ctx.raw opIn ≠ outputs.size then
     throw s!"Expected func.return to have {outputs.size} operand(s)"
@@ -121,12 +116,6 @@ def Func.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       throw "Expected 0 results"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    let props : Func.propertiesOf .func := op.getProperties! ctx.raw Func.func
-    match props.function_type with
-    | some ⟨.functionType _, _⟩ => pure ()
-    | _ => throw "Expected function type"
-    if props.sym_name.isNone then
-      throw "Expected symbol name"
   | .call => do
     if op.getNumRegions ctx.raw opIn ≠ 0 then
       throw "Expected 0 regions"

--- a/Veir/Dialects/Func/Properties.lean
+++ b/Veir/Dialects/Func/Properties.lean
@@ -8,27 +8,27 @@ namespace Veir
 public section
 
 /--
-  Properties of `func.func`. The `sym_name` attribute is modelled explicitly;
-  all other attributes are preserved verbatim in `extra`.
+  Properties of `func.func`. Its required `sym_name` and `function_type`
+  attributes are modelled explicitly; all other attributes are preserved
+  verbatim in `extra`.
 -/
 structure FuncFuncProperties where
-  sym_name : Option StringAttr
-  function_type : Option TypeAttr
+  sym_name : StringAttr
+  function_type : FunctionType
   extra : DictionaryAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def FuncFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String FuncFuncProperties := do
   let symName ← match attrDict["sym_name".toUTF8]? with
-    | some (.stringAttr s) => pure (some s)
+    | some (.stringAttr s) => pure s
     | some attr => throw s!"func.func: expected 'sym_name' to be a string attribute, but got {attr}"
-    | none => pure none
+    | none => throw "func.func: missing 'sym_name' property"
   let funcType ← match attrDict["function_type".toUTF8]? with
+    | some (.functionType ft) => pure ft
     | some attr =>
-      if _ : attr.isType = false then
-        throw "func.func: expected 'function_type' to be a type attribute"
-      else pure (some attr.asType)
-    | none => pure none
+      throw s!"func.func: expected 'function_type' to be a function type, but got {attr}"
+    | none => throw "func.func: missing 'function_type' property"
   let extra := DictionaryAttr.fromArray
     (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8 && k ≠ "function_type".toUTF8)
   return { sym_name := symName, function_type := funcType, extra }

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -270,10 +270,8 @@ def Llvm.toAttrDict
     dict
   | .func => Id.run do
     let mut dict := Std.HashMap.ofList props.extra.entries.toList
-    if let some sym_name := props.sym_name then
-      dict := dict.insert "sym_name".toUTF8 (.stringAttr sym_name)
-    if let some function_type := props.function_type then
-      dict := dict.insert "function_type".toUTF8 function_type
+    dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    dict := dict.insert "function_type".toUTF8 (.llvmFunctionType props.function_type)
     dict
   | .module_flags =>
     (Std.HashMap.emptyWithCapacity 3).insert
@@ -348,10 +346,7 @@ def OperationPtr.verifyLLVMFuncReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Llvm] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) (funcOp : OperationPtr) : Except String PUnit := do
   let props : Llvm.propertiesOf .func := funcOp.getProperties! ctx.raw Llvm.func
-  let some functionType := props.function_type
-    | throw "Expected enclosing llvm.func to have a function_type attribute"
-  let .llvmFunctionType functionType := functionType.val
-    | throw "Expected enclosing llvm.func to have a function_type attribute"
+  let functionType := props.function_type
   -- A single `llvm.void` result corresponds to no return operands.
   let outputs := match functionType.outputs with
     | #[.llvmVoidType _] => #[]
@@ -617,12 +612,6 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       throw "Expected 1 region"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
-    let props : Llvm.propertiesOf .func := op.getProperties! ctx.raw Llvm.func
-    match props.function_type with
-    | some ⟨.llvmFunctionType _, _⟩ => pure ()
-    | _ => throw "Expected function type"
-    if props.sym_name.isNone then
-      throw "Expected symbol name"
   | .fadd | .fsub | .fmul | .fdiv | .frem => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 2 1

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -441,28 +441,27 @@ def LLVMCallProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
   return { callee, extra }
 
 /--
-  Properties of `llvm.func`. The `sym_name` and `function_type` attributes are
-  modelled explicitly; all other attributes (e.g. `CConv`, `linkage`, `visibility_`)
-  are preserved verbatim in `extra`.
+  Properties of `llvm.func`. Its required `sym_name` and `function_type`
+  attributes are modelled explicitly; all other attributes (e.g. `CConv`,
+  `linkage`, `visibility_`) are preserved verbatim in `extra`.
 -/
 structure LLVMFuncProperties where
-  sym_name : Option StringAttr
-  function_type : Option TypeAttr
+  sym_name : StringAttr
+  function_type : FunctionType
   extra : DictionaryAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def LLVMFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String LLVMFuncProperties := do
   let symName ← match attrDict["sym_name".toUTF8]? with
-    | some (.stringAttr s) => pure (some s)
+    | some (.stringAttr s) => pure s
     | some attr => throw s!"llvm.func: expected 'sym_name' to be a string attribute, but got {attr}"
-    | none => pure none
+    | none => throw "llvm.func: missing 'sym_name' property"
   let funcType ← match attrDict["function_type".toUTF8]? with
+    | some (.llvmFunctionType ft) => pure ft
     | some attr =>
-      if _ : attr.isType = false then
-        throw "llvm.func: expected 'function_type' to be a type attribute"
-      else pure (some attr.asType)
-    | none => pure none
+      throw s!"llvm.func: expected 'function_type' to be an LLVM function type, but got {attr}"
+    | none => throw "llvm.func: missing 'function_type' property"
   let extra := DictionaryAttr.fromArray
     (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8 && k ≠ "function_type".toUTF8)
   return { sym_name := symName, function_type := funcType, extra }

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -29,25 +29,19 @@ namespace FunctionOpInterface
 def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr :=
   match funcOp.getOpType! raw with
   | .func .func =>
-    (funcOp.getProperties! raw Func.func : FuncFuncProperties).sym_name
+    some (funcOp.getProperties! raw Func.func : FuncFuncProperties).sym_name
   | .llvm .func =>
-    (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).sym_name
+    some (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).sym_name
   | _ => none
 
 /-- Returns the type of the function. -/
 def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
-    Option FunctionType := do
+    Option FunctionType :=
   match funcOp.getOpType! raw with
   | .func .func =>
-    let ta ← (funcOp.getProperties! raw Func.func : FuncFuncProperties).function_type
-    match ta.val with
-    | .functionType ft => some ft
-    | _ => none
+    some (funcOp.getProperties! raw Func.func : FuncFuncProperties).function_type
   | .llvm .func =>
-    let ta ← (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).function_type
-    match ta.val with
-    | .llvmFunctionType ft => some ft
-    | _ => none
+    some (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).function_type
   | _ => none
 
 /-!
@@ -95,14 +89,12 @@ def setFunctionType (wfCtx : WfIRContext OpCode) (funcOp : OperationPtr)
     (opInBounds : funcOp.InBounds wfCtx.raw := by grind) : WfIRContext OpCode :=
   let opType := funcOp.getOpType! wfCtx.raw
   if h : opType = ofDialect OpCode Func.func then
-    let ftType : TypeAttr := ⟨.functionType { inputs, outputs }, by simp⟩
     let props : FuncFuncProperties := funcOp.getProperties! wfCtx.raw Func.func
-    let newProps : FuncFuncProperties := { props with function_type := some ftType }
+    let newProps : FuncFuncProperties := { props with function_type := { inputs, outputs } }
     WfRewriter.setProperties wfCtx funcOp Func.func newProps opInBounds
   else if h : opType = ofDialect OpCode Llvm.func then
-    let ftType : TypeAttr := ⟨.llvmFunctionType { inputs, outputs }, by simp⟩
     let props : LLVMFuncProperties := funcOp.getProperties! wfCtx.raw Llvm.func
-    let newProps : LLVMFuncProperties := { props with function_type := some ftType }
+    let newProps : LLVMFuncProperties := { props with function_type := { inputs, outputs } }
     WfRewriter.setProperties wfCtx funcOp Llvm.func newProps opInBounds
   else
     wfCtx


### PR DESCRIPTION
`llvm.func` and `func.func` properties were not requiring their function type or `sym_name` to be present.  This PR makes them mandatory in the propreties, and also fixes their type to be function types rather than arbitrary types.