### PR TITLE
feat: creates `FunctionOpInterface` in `HasOpInfo`

### DIFF
--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -56,11 +56,6 @@ def Func.getEffects
 def Func.isConstantLike (_op : Func) : Bool :=
   false
 
-def Func.isFunctionLike (op : Func) : Bool :=
-  match op with
-  | .func => true
-  | .call | .return => false
-
 def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
   true
 
@@ -77,6 +72,16 @@ instance : IsOpCode Func where
   propertiesOf := Func.propertiesOf
   fromAttrDict := Func.fromAttrDict
   toAttrDict := Func.toAttrDict
+
+def Func.functionInterface? (op : Func) : Option (FunctionOpInterface (Func.propertiesOf op)) :=
+  match op with
+  | .func =>
+    some
+      { getSymName := fun props => props.sym_name
+        getFunctionType := fun props => props.function_type
+        setFunctionType := fun props functionType =>
+          { props with function_type := functionType } }
+  | _ => none
 
 /--
 Check that a `func.return` returns the declared result types of its enclosing
@@ -130,7 +135,7 @@ instance : HasOpInfo Func where
   verifyLocalInvariants := Func.verifyLocalInvariants
   getEffects := Func.getEffects
   isConstantLike := Func.isConstantLike
-  isFunctionLike := Func.isFunctionLike
+  functionInterface? := Func.functionInterface?
   hasSSADominance := Func.hasSSADominance
   isTerminator := Func.isTerminator
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -315,11 +315,6 @@ def Llvm.isConstantLike (op : Llvm) : Bool :=
   | .mlir__constant | .mlir__poison | .mlir__addressof => true
   | _ => false
 
-def Llvm.isFunctionLike (op : Llvm) : Bool :=
-  match op with
-  | .func => true
-  | _ => false
-
 def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
   true
 
@@ -336,6 +331,16 @@ instance : IsOpCode Llvm where
   propertiesOf := Llvm.propertiesOf
   fromAttrDict := Llvm.fromAttrDict
   toAttrDict := Llvm.toAttrDict
+
+def Llvm.functionInterface? (op : Llvm) : Option (FunctionOpInterface (Llvm.propertiesOf op)) :=
+  match op with
+  | .func =>
+    some
+      { getSymName := fun props => props.sym_name
+        getFunctionType := fun props => props.function_type
+        setFunctionType := fun props functionType =>
+          { props with function_type := functionType } }
+  | _ => none
 
 /-- Whether `n` is a valid LLVM alignment: a strictly positive power of two. -/
 def isValidLLVMAlignment (n : Int) : Bool :=
@@ -658,7 +663,7 @@ instance : HasOpInfo Llvm where
   verifyLocalInvariants := Llvm.verifyLocalInvariants
   getEffects := Llvm.getEffects
   isConstantLike := Llvm.isConstantLike
-  isFunctionLike := Llvm.isFunctionLike
+  functionInterface? := Llvm.functionInterface?
   hasSSADominance := Llvm.hasSSADominance
   isTerminator := Llvm.isTerminator
 

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -168,32 +168,6 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | .pdl op => PDL.isConstantLike op
   | .test op => Test.isConstantLike op
 
-/--
-  Does this `OpCode` act like a function, i.e. a symbol whose single
-  region is the function body, with the signature carried in a
-  `function_type` property?
-
-  Dialects that do not override isFunctionLike default to false
-  for all operations.
--/
-def OpCode.isFunctionLike (opCode : OpCode) : Bool :=
-  match opCode with
-  | .arith op => HasOpInfo.isFunctionLike op
-  | .llvm op => HasOpInfo.isFunctionLike op
-  | .riscv op => HasOpInfo.isFunctionLike op
-  | .riscv_cf op => HasOpInfo.isFunctionLike op
-  | .riscv_stack op => HasOpInfo.isFunctionLike op
-  | .rv64 op => HasOpInfo.isFunctionLike op
-  | .mod_arith op => HasOpInfo.isFunctionLike op
-  | .cf op => HasOpInfo.isFunctionLike op
-  | .comb op => HasOpInfo.isFunctionLike op
-  | .hw op => HasOpInfo.isFunctionLike op
-  | .builtin op => HasOpInfo.isFunctionLike op
-  | .func op => HasOpInfo.isFunctionLike op
-  | .datapath op => HasOpInfo.isFunctionLike op
-  | .pdl op => HasOpInfo.isFunctionLike op
-  | .test op => HasOpInfo.isFunctionLike op
-
 def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String (_propertiesOf opCode) :=
   match opCode with
@@ -243,6 +217,25 @@ instance : IsOpCode OpCode where
   fromAttrDict := Properties.fromAttrDict
   toAttrDict := Properties.toAttrDict
 
+/-- Function-interface information assembled from the registered dialects. -/
+def OpCode.functionInterface? (opCode : OpCode) : Option (FunctionOpInterface (_propertiesOf opCode)) :=
+  match opCode with
+  | .arith op => HasOpInfo.functionInterface? op
+  | .llvm op => HasOpInfo.functionInterface? op
+  | .riscv op => HasOpInfo.functionInterface? op
+  | .riscv_cf op => HasOpInfo.functionInterface? op
+  | .riscv_stack op => HasOpInfo.functionInterface? op
+  | .rv64 op => HasOpInfo.functionInterface? op
+  | .mod_arith op => HasOpInfo.functionInterface? op
+  | .cf op => HasOpInfo.functionInterface? op
+  | .comb op => HasOpInfo.functionInterface? op
+  | .hw op => HasOpInfo.functionInterface? op
+  | .builtin op => HasOpInfo.functionInterface? op
+  | .func op => HasOpInfo.functionInterface? op
+  | .datapath op => HasOpInfo.functionInterface? op
+  | .pdl op => HasOpInfo.functionInterface? op
+  | .test op => HasOpInfo.functionInterface? op
+
 #generate_has_dialect_instances OpCode
 
 @[expose]
@@ -269,7 +262,7 @@ instance : HasOpInfo OpCode where
   verifyLocalInvariants := OpCode.verifyLocalInvariants
   getEffects := OpCode.getEffects
   isConstantLike := OpCode.isConstantLike
-  isFunctionLike := OpCode.isFunctionLike
+  functionInterface? := OpCode.functionInterface?
   getRegionKind := OpCode.getRegionKind
   hasSSADominance := OpCode.hasSSADominance
   hasNoTerminator := OpCode.hasNoTerminator

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -42,6 +42,15 @@ def unknown : MemoryEffects :=
 
 end MemoryEffects
 
+/-- Information exposed by operations that behave like functions. -/
+structure FunctionOpInterface (Properties : Type) where
+  /-- Return the symbol name of the function. -/
+  getSymName : Properties → StringAttr
+  /-- Return the type of the function. -/
+  getFunctionType : Properties → FunctionType
+  /-- Return the properties with the function type replaced. -/
+  setFunctionType : Properties → FunctionType → Properties
+
 class HasOpInfo (opCode: Type)
     extends IsOpCode opCode where
   /--
@@ -68,10 +77,10 @@ class HasOpInfo (opCode: Type)
   -/
   isConstantLike : opCode → Bool := fun _ => false
   /--
-  Whether an operation with this opcode acts like a function: a symbol
-  whose single region is the function body.
+  Information about operations that act like functions.
   -/
-  isFunctionLike : opCode → Bool := fun _ => false
+  functionInterface? : (op : opCode) → Option (FunctionOpInterface (propertiesOf op)) :=
+    fun _ => none
   /--
   Return the kind of the indexed region inside an operation with this opcode.
   This mirrors MLIR's `RegionKindInterface` default: regions are SSACFG unless

--- a/Veir/Interfaces/FunctionInterfaces.lean
+++ b/Veir/Interfaces/FunctionInterfaces.lean
@@ -1,6 +1,5 @@
 module
 
-public import Veir.GlobalOpInfo
 public import Veir.Rewriter.WfRewriter
 
 /-!
@@ -16,33 +15,27 @@ https://github.com/llvm/llvm-project/blob/main/mlir/include/mlir/Interfaces/Func
 
 namespace Veir
 
+variable {OpCode : Type} [HasOpInfo OpCode]
+
 public section
 
 /-- Whether this operation acts like a function. -/
-def OperationPtr.isFunctionLike {OpInfo : Type} [HasOpInfo OpInfo]
-    (op : OperationPtr) (ctx : IRContext OpInfo) : Bool :=
-  HasOpInfo.isFunctionLike (op.getOpType! ctx)
+def OperationPtr.isFunctionLike (op : OperationPtr) (ctx : IRContext OpCode) : Bool :=
+  (HasOpInfo.functionInterface? (op.getOpType! ctx)).isSome
 
 namespace FunctionOpInterface
 
 /-- Returns the symbol name of the function. -/
-def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr :=
-  match funcOp.getOpType! raw with
-  | .func .func =>
-    some (funcOp.getProperties! raw Func.func : FuncFuncProperties).sym_name
-  | .llvm .func =>
-    some (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).sym_name
-  | _ => none
+def getSymName? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option StringAttr := do
+  let opType := funcOp.getOpType! raw
+  let interface ← HasOpInfo.functionInterface? opType
+  return interface.getSymName (funcOp.getProperties! raw opType)
 
 /-- Returns the type of the function. -/
-def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) :
-    Option FunctionType :=
-  match funcOp.getOpType! raw with
-  | .func .func =>
-    some (funcOp.getProperties! raw Func.func : FuncFuncProperties).function_type
-  | .llvm .func =>
-    some (funcOp.getProperties! raw Llvm.func : LLVMFuncProperties).function_type
-  | _ => none
+def getFunctionType? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option FunctionType := do
+  let opType := funcOp.getOpType! raw
+  let interface ← HasOpInfo.functionInterface? opType
+  return interface.getFunctionType (funcOp.getProperties! raw opType)
 
 /-!
 ## Body Handling
@@ -65,6 +58,7 @@ theorem getFunctionBody!_eq_getFunctionBody {funcOp : OperationPtr} {raw : IRCon
   grind [getFunctionBody, getFunctionBody!]
 
 theorem getFunctionBody!_inBounds
+    {raw : IRContext OpCode}
     (ctxInBounds : raw.FieldsInBounds)
     (opInBounds : funcOp.InBounds raw)
     (hasRegion : 0 < funcOp.getNumRegions! raw) :
@@ -81,32 +75,24 @@ def getEntryBlock? (funcOp : OperationPtr) (raw : IRContext OpCode) : Option Blo
 ## Type Attribute Handling
 -/
 
-/-- Sets the function type to the given input/output type lists.
-    `llvm.func` is canonicalized to the `.llvmFunctionType` spelling, regardless of
-    which spelling the original attribute used. -/
-def setFunctionType (wfCtx : WfIRContext OpCode) (funcOp : OperationPtr)
+/-- Sets the function type to the given input/output type lists. -/
+def setFunctionTypeInBounds (wfCtx : WfIRContext OpCode) (funcOp : OperationPtr)
     (inputs outputs : Array Attribute)
     (opInBounds : funcOp.InBounds wfCtx.raw := by grind) : WfIRContext OpCode :=
   let opType := funcOp.getOpType! wfCtx.raw
-  if h : opType = ofDialect OpCode Func.func then
-    let props : FuncFuncProperties := funcOp.getProperties! wfCtx.raw Func.func
-    let newProps : FuncFuncProperties := { props with function_type := { inputs, outputs } }
-    WfRewriter.setProperties wfCtx funcOp Func.func newProps opInBounds
-  else if h : opType = ofDialect OpCode Llvm.func then
-    let props : LLVMFuncProperties := funcOp.getProperties! wfCtx.raw Llvm.func
-    let newProps : LLVMFuncProperties := { props with function_type := { inputs, outputs } }
-    WfRewriter.setProperties wfCtx funcOp Llvm.func newProps opInBounds
-  else
-    wfCtx
+  match HasOpInfo.functionInterface? opType with
+  | none => wfCtx
+  | some interface =>
+    let props := funcOp.getProperties! wfCtx.raw opType
+    let newProps := interface.setFunctionType props { inputs, outputs }
+    WfRewriter.setProperties wfCtx funcOp opType newProps opInBounds
 
 /-- Sets the function type to the given input/output type lists, panicking if the op
-    is out of bounds.
-    `llvm.func` is canonicalized to the `.llvmFunctionType` spelling, regardless of
-    which spelling the original attribute used. -/
+    is out of bounds. -/
 def setFunctionType! (c : WfIRContext OpCode) (funcOp : OperationPtr)
     (inputs outputs : Array Attribute) : WfIRContext OpCode :=
   if opInBounds : funcOp.InBounds c.raw then
-    setFunctionType c funcOp inputs outputs opInBounds
+    setFunctionTypeInBounds c funcOp inputs outputs opInBounds
   else
     panic "FunctionOpInterface.setFunctionType! failed: operation is out of bounds"
 

--- a/Veir/MIRPrinter.lean
+++ b/Veir/MIRPrinter.lean
@@ -1,5 +1,6 @@
 module
 
+public import Veir.GlobalOpInfo
 public import Veir.Interfaces.FunctionInterfaces
 
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Verifier.Lemmas
+public import Veir.GlobalOpInfo
 public import Veir.Interfaces.FunctionInterfaces
 
 import all Veir.Verifier.Basic


### PR DESCRIPTION
`FunctionOpInterface` was only partially implemented in `HasOpInfo`, and only contained `isFunctionLike`. This PR bundles `getSymName` and `getFunctionType` into the same structure, that can be queried from an `HasOpInfo`.