### PR TITLE
feat(PBV): Introduce basic tactic to solve bounded parametric bitvector formulas automatically

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -16,3 +16,4 @@ import UnitTest.Evaluate
 import UnitTest.FoldDecision
 import UnitTest.SideEffectInterfaces
 import UnitTest.Puddle
+import UnitTest.BoundedBitblasting.BoundedBitblasting

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -1,0 +1,7 @@
+import Veir.Meta.PBVDecide
+
+example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+  pbv_decide 13
+  · bv_decide
+  · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -5,3 +5,15 @@ example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   pbv_decide 13
   · bv_decide
   · grind
+
+example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
+  x + y + z = y + x + z := by
+  pbv_decide 13
+  · bv_decide
+  · grind
+
+example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+  pbv_decide 13
+  · bv_decide
+  · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -2,18 +2,18 @@ import Veir.Meta.PBVDecide
 
 example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
-  pbv_decide 13
+  pbv_decide 4
   · bv_decide
   · grind
 
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
-  pbv_decide 13
+  pbv_decide 4
   · bv_decide
   · grind
 
 example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
-  pbv_decide 13
+  pbv_decide 4
   · bv_decide
   · grind

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -43,7 +43,7 @@ theorem isMask_maskOfWidth {o w : Nat} :
 
 /-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
+    (hm : m = maskOfWidth o w) : IsMask m := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -43,7 +43,7 @@ theorem isMask_maskOfWidth {o w : Nat} :
 
 /-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : IsMask m := by
+    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -30,11 +30,13 @@ syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 
 @[tactic pbvDecide]
 def evalPbvDecide : Tactic := fun stx => do
-  let out ← pbvTranslate (← getMainGoal) stx[0].toNat
-  replaceMainGoal [out]
+  match stx with
+  | `(tactic| pbv_decide $n:num) => do
+      replaceMainGoal [← pbvTranslate (← getMainGoal) n.getNat]
+  | _ => throwUnsupportedSyntax
 
 
 
 theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
-  pbv_decide 9
+  pbv_decide 13

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -34,11 +34,9 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
     let width_var ← getFVarFromUserName widthName
 
   -- Assert that the width variable is less than the width bound
-    let width_le_bound_expr := mkAppN (Expr.const `Nat.le []) #[width_var, mkNatLit bound]
-    let width_le_bound ← mkFreshExprMVar width_le_bound_expr
+    let width_le_bound ← mkFreshExprMVar (mkAppN (Expr.const `Nat.le []) #[width_var, mkNatLit bound])
 
     let mut out_goal := g_no_w
-
     let mut hyps : Array FVarId := #[]
 
     for ldecl in ← getLCtx do
@@ -46,9 +44,10 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
         -- Find the BitVec {width_expr} variables
         if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
           logInfo s!"Applying var_elim to {ldecl.userName}"
+          -- Revert to expose forall with the BitVec
           let (var_hyp, goal) ← out_goal.revert #[ldecl.fvarId]
           let some oldvar_name := var_hyp[0]? | throwError "reverting shuold produce a var"
-          -- not providing the `hwo` hypothesis but seems to work?
+
           let applied := mkAppN var_elim_theorem #[mkNatLit bound, width_var, width_le_bound]
           let out ← goal.apply applied
           let some goal := out[0]? | throwError "var_elim should generate a goal"
@@ -56,20 +55,29 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           let name ← oldvar_name.getUserName
           let (_new_var, goal) ← goal.intro (name)
           let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
+
           -- Add the mask hypothesis to the running list
           hyps := hyps.push new_hyp
 
           out_goal := goal
     return (out_goal, width_le_bound, hyps)
 
+-- -- IsMask theorem
+  let (g_no_w_no_v) ← g_no_w_no_v.withContext do
+    let hyp_expr ← mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar mask_hyp]
+    let type ← inferType hyp_expr
+    let (_new_hyps, goal) ← g_no_w_no_v.assertHypotheses #[{ userName := Name.mkSimple "test", type := type, value := hyp_expr}]
+    return goal
+
 -- Simp and push theorems
   let final_goal ← g_no_w_no_v.withContext do
     let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
     let others := #[``BitVec.setWidth_eq]
 
+    let mut simpThms : SimpTheoremsArray := #[]
+
     -- push theorems that need to be partially evealuted with the right
     -- symbolic width and concrete bound width
-    let mut simpThms : SimpTheoremsArray := #[]
     for n in push_th do
       let push_thm ← mkAppM n #[w_expr]
       simpThms ← simpThms.addTheorem (.other n) push_thm
@@ -87,13 +95,39 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
     -- add the mask constraint as an inverse theorem, to remove `setWidths` from the goal
     simpThms ← simpThms.modifyM 0 fun thms => thms.add (.other mask_hyp.name) #[] (mkFVar mask_hyp) (inv := true)
 
+    -- apply simp
     let ctx ← Simp.mkContext (simpTheorems := simpThms)
-
     let (result, _) ← simpTarget g_no_w_no_v ctx
-
     let some goal_out := result | throwError "goal solved by simp"
 
+    let mut goal_out := goal_out
+
+    -- replace all occurences of `maskOfWidth` in the hypotheses
+    -- (hacky?) reverse because when a hypothesis is rewritten all hyps that come after it change FVarID
+    -- by reversing the `hyp` stays unchanged as the rewrites are applied
+    for hyp in hyps.reverse do
+      logInfo s!"rewriting {← hyp.getUserName}"
+      let test ← goal_out.rewrite (← hyp.getType) (.fvar mask_hyp) true
+      let replaced ← goal_out.replaceLocalDecl hyp test.eNew test.eqProof
+      -- logInfo (← replaced.mvarId.getType)
+      goal_out := replaced.mvarId
+
+    -- clear `maskOfWidth` hypothesis
+    goal_out ← goal_out.clear mask_hyp
+
+    -- clear "w" dependencies
+    let w_decl ← getLocalDeclFromUserName widthName
+
+    -- let mut goal := goal_out
+
+    -- (← getLCtx).foldlM (fun goal => do (fun localDecl => do
+    --   unless localDecl.fvarId == w_decl.fvarId do
+    --     if (← localDeclDependsOn localDecl w_decl.fvarId) then
+    --       goal ← goal.clear localDecl.fvarId
+    -- ))
+
     return goal_out
+
 
   return [final_goal, w_expr.mvarId!]
 
@@ -111,6 +145,7 @@ def evalPbvDecide : Tactic := fun stx => do
 theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 13
+
   bv_decide
   grind
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -5,30 +5,47 @@ open Lean Elab Tactic Meta
 
 namespace Veir.Data.PBV
 
+def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
+  logInfo s!"Deciding with bound {bound}"
+
 -- Start by only trying to apply width elim, and generating some new hyps
 -- The width_elim has type:  (o w : Nat) (Q : Prop) (h : ∀ (m : BitVec o), m = maskOfWidth o w → Q) : Q
 -- so, will "feed" the current o w and goal (Q) and it will generate a new hole with the hypothesis and the Q
-def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
-  logInfo ("Deciding with bound")
   let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
-  let (out, widthName) ← g.withContext do
+  let (g_no_w, widthName) ← g.withContext do
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
           logInfo m!"Found a var! {ldecl.userName}"
           let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
           let out ← g.apply applied
-          let some g_out := out[0]? | throwError "Shuold have a goal here"
+          let some out := out[0]? | throwError "Shuold have a goal here"
+          return (out, ldecl.userName)
 
-          return (g_out, ldecl.userName)
     throwError "haven't thought about this yet"
 
   let mask_name := Name.mkSimple s!"m{widthName}"
-  let (mask, g_out) ← out.intro mask_name
-  let (mask_hyp, g_out) ← g_out.intro (Name.mkSimple s!"h_{mask_name}")
+  let (mask, g_no_w) ← g_no_w.intro mask_name
+  let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
-  logInfo (toString width_elim_theorem)
-  return g_out
+-- Not do var elim
+  let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
+
+  let g_no_w_no_v ← g_no_w.withContext do
+    let width_var ← getFVarFromUserName widthName
+
+    logInfo (width_var)
+
+    for ldecl in ← getLCtx do
+      unless ldecl.isImplementationDetail do
+        -- Find the BitVec {width_expr} variables
+        if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
+          logInfo s!"Applying var_elim to {ldecl.userName}"
+          let (var_hyp, goal) ← g_no_w.revert #[ldecl.fvarId]
+          return goal
+    throwError "Shouldn't get here"
+
+  return g_no_w_no_v
 
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -5,141 +5,148 @@ open Lean Elab Tactic Meta Simp
 
 namespace Veir.Data.PBV
 
-def pbvTranslate (g : MVarId) (bound : Nat) : MetaM (List MVarId) := do
-  logInfo s!"Deciding with bound {bound}"
+structure WidthInfo where
+  /-- The local decl corresponding to this width variable. -/
+  widthNatLocalDecl : LocalDecl
+  /-- The fvar corresponding to the new mask variable for this width. -/
+  widthMaskFvar : FVarId
+  /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
+  widthMaskHypFvar : FVarId
+  /-- The hypothesis that the width variable is less than the bmc bound. -/
+  hypWidthLeBound : MVarId
 
--- Apply width_elim
+def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
+  info.widthNatLocalDecl.fvarId
+
+def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
+  .fvar info.widthFvarId
+
+/--
+Read-only configuration for the tactic.
+-/
+structure PbvTranslateContext where
+  /-- the bound upto which we want to bitblast our widths. -/
+   bmcBound : Nat
+
+/-- Find the local declaration of the (single) width variable,
+and eliminate it, producing the mask variable, and the masking contstraint.
+-/
+def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
   let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
-  let (g_no_w, widthName) ← g.withContext do
+  g.withContext do
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
           logInfo m!"Applying width_elim to {ldecl.userName}"
-          let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
-          let out ← g.apply applied
-          let some out := out[0]? | throwError "width_elim should generate a goal"
-          -- TODO, for multiwidth this needs to loop
-          return (out, ldecl.userName)
-
-    throwError "No width variables were found"
-
-  let mask_name := Name.mkSimple s!"m{widthName}"
-  let (_mask, g_no_w) ← g_no_w.intro mask_name
-  let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
-
--- Apply var_elim
-  let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
-
-  let (g_no_w_no_v, w_expr, hyps) ← g_no_w.withContext do
-    let width_var ← getFVarFromUserName widthName
-
-  -- Assert that the width variable is less than the width bound
-    let width_le_bound ← mkFreshExprMVar (mkAppN (Expr.const `Nat.le []) #[width_var, mkNatLit bound])
-
-    let mut out_goal := g_no_w
-    let mut hyps : Array FVarId := #[]
-
-    for ldecl in ← getLCtx do
-      unless ldecl.isImplementationDetail do
-        -- Find the BitVec {width_expr} variables
-        if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
-          logInfo s!"Applying var_elim to {ldecl.userName}"
-          -- Revert to expose forall with the BitVec
-          let (var_hyp, goal) ← out_goal.revert #[ldecl.fvarId]
-          let some oldvar_name := var_hyp[0]? | throwError "reverting shuold produce a var"
-
-          let applied := mkAppN var_elim_theorem #[mkNatLit bound, width_var, width_le_bound]
-          let out ← goal.apply applied
-          let some goal := out[0]? | throwError "var_elim should generate a goal"
-
-          let name ← oldvar_name.getUserName
-          let (_new_var, goal) ← goal.intro (name)
-          let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
-
-          -- Add the mask hypothesis to the running list
-          hyps := hyps.push new_hyp
-
-          out_goal := goal
-    return (out_goal, width_le_bound, hyps)
-
--- IsMask theorem
-  let (g_no_w_no_v) ← g_no_w_no_v.withContext do
-    let hyp_expr ← mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar mask_hyp]
-    let type ← inferType hyp_expr
-    let (_new_hyps, goal) ← g_no_w_no_v.assertHypotheses #[{ userName := Name.mkSimple "test", type := type, value := hyp_expr}]
-    return goal
-
--- Simp and push theorems
-  let final_goal ← g_no_w_no_v.withContext do
-    let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
-    let others := #[``BitVec.setWidth_eq]
-
-    let mut simpThms : SimpTheoremsArray := #[]
-
-    -- push theorems that need to be partially evealuted with the right
-    -- symbolic width and concrete bound width
-    for n in push_th do
-      let push_thm ← mkAppM n #[w_expr]
-      simpThms ← simpThms.addTheorem (.other n) push_thm
-
-    -- other theorems that don't need bounds
-    for n in others do
-      let thm ← mkConstWithFreshMVarLevels n
-      simpThms ← simpThms.addTheorem (.other n) thm
-
-    -- the hypotheses enforcing the variables to "behave" like they have a certain width
-    for h in hyps do
-      let thm := mkFVar h
-      simpThms ← simpThms.addTheorem (.other h.name) thm
-
-    -- add the mask constraint as an inverse theorem, to remove `setWidths` from the goal
-    simpThms ← simpThms.modifyM 0 fun thms => thms.add (.other mask_hyp.name) #[] (mkFVar mask_hyp) (inv := true)
-
-    -- apply simp
-    let ctx ← Simp.mkContext (simpTheorems := simpThms)
-    let (result, _) ← simpTarget g_no_w_no_v ctx
-    let some goal_out := result | throwError "goal solved by simp"
-
-    let mut goal_out := goal_out
-
-    -- replace all occurences of `maskOfWidth` in the hypotheses
-    -- (hacky?) reverse because when a hypothesis is rewritten all hyps that come after it change FVarID
-    -- by reversing the `hyp` stays unchanged as the rewrites are applied
-    for hyp in hyps.reverse do
-      logInfo s!"rewriting {← hyp.getUserName}"
-      let test ← goal_out.rewrite (← hyp.getType) (.fvar mask_hyp) true
-      let replaced ← goal_out.replaceLocalDecl hyp test.eNew test.eqProof
-      -- logInfo (← replaced.mvarId.getType)
-      goal_out := replaced.mvarId
-
-    -- clear `maskOfWidth` hypothesis
-    goal_out ← goal_out.clear mask_hyp
-    return goal_out
+          let applied := mkAppN width_elim_theorem #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
+          let [g] ← g.withContext do g.apply applied | throwError "width_elim should generate a goal"
+          let widthName := ldecl.userName
+          let maskName := Name.mkSimple s!"m{widthName}"
+          let (mask, g) ← g.withContext do g.intro maskName
+          let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+          let hypWidthLeBound <- g.withContext do
+            mkFreshExprMVar (mkAppN (Expr.const `Nat.le [])
+              #[Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
+          g.withContext <| check hypWidthLeBound
+          let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
+          let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+          let info : WidthInfo := {
+            widthNatLocalDecl := ldecl,
+            widthMaskFvar := mask,
+            widthMaskHypFvar := maskHyp
+            hypWidthLeBound := hypWidthLeBound.mvarId!
+          }
+          return (g, info)
+    throwError "unable to find a valid width variable."
 
 
--- Clear the last Nat hypotheses
-  let final_goal ← final_goal.withContext do
-    let w_decl ← getLocalDeclFromUserName widthName
+structure BitVecInfo where
+  bvVar : FVarId
+  bvHyp : FVarId
 
-    let dependant ← (← getLCtx).foldrM (init := (#[] : Array LocalDecl )) fun localDecl acc => do
-      if localDecl.fvarId == w_decl.fvarId then
-        return acc
-      if (← localDeclDependsOn localDecl w_decl.fvarId) then
-        -- goal ← goal.clear localDecl.fvarId
-        logInfo s!"{localDecl.userName} depends on {w_decl.userName }"
-        return acc.push localDecl
-      else
-        return acc
+structure BitVecInfos where
+  infos : Array BitVecInfo := #[]
 
-    let mut goal := final_goal
-    for hyp in dependant do
-      goal ← goal.clear hyp.fvarId
+def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
+  { this with infos := this.infos.push val }
 
-    goal ← goal.clear w_decl.fvarId
 
-    return goal
 
-  return [final_goal, w_expr.mvarId!]
+#check isMask_of_eq_maskOfWidth
+/--
+Analyze a single local decl, and try to introduce it as a bitvec variable in our larger universe
+if it is in fact a bitvec variable.
+-/
+def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
+      (infos : BitVecInfos) (ldecl : LocalDecl) :
+      MetaM (MVarId × BitVecInfos) := g.withContext do
+  unless ldecl.isImplementationDetail do
+    -- Find the BitVec {width_expr} variables
+    -- | TODO: replace defeq with syntactic eq, there are helpers in Lean/Meta or Lean/Tactic
+    -- inside the bv_decide implementation.
+    if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) widthInfo.widthFvar) then
+      -- Revert to expose forall with the BitVec
+      let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
+      let (List.cons g _) ← g.withContext <|  g.apply <| ← mkAppM ``var_elim
+          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBound]
+        | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
+      let name ← oldVar.getUserName
+      let (bvVar, g) ← g.intro name
+      let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
+      return (g, infos.push { bvVar, bvHyp})
+  return (g, infos)
+
+
+def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) : MetaM (MVarId × BitVecInfos) := do
+  let decls : LocalContext ← g.withContext getLCtx
+  decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
+    introVar ctx widthInfo g infos ldecl
+
+def addPushTheorems (g : MVarId)
+    (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+  let thms := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
+  let mut simp := simp
+  for thm in thms do
+    let push_thm ← g.withContext do mkAppM thm #[.mvar widthInfo.hypWidthLeBound]
+    simp ← simp.addTheorem (.other thm) push_thm
+  return simp
+
+
+def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
+  -- throwError s!"Deciding with bound {ctx.bmcBound}"
+  let (g, widthInfo) ← introMaskWidths ctx g
+  -- Introduce bitvector variables
+  let (g, bvInfos) ← introVars ctx g widthInfo
+  g.withContext do check (← g.getType)
+  logInfo m!"intro mask widths done. {g}"
+  let mut simpThmsArray : SimpTheoremsArray := #[]
+  simpThmsArray ← addPushTheorems g widthInfo simpThmsArray
+  logInfo m!"added push theorems."
+
+  -- other theorems that don't need bounds
+  let others := #[``BitVec.setWidth_eq]
+  for n in others do
+    let thm ← mkConstWithFreshMVarLevels n
+    simpThmsArray ← simpThmsArray.addTheorem (.other n) thm
+
+  -- the hypotheses enforcing the variables to "behave" like they have a certain width
+  for info in bvInfos.infos do
+    simpThmsArray ← g.withContext do simpThmsArray.addTheorem (.other info.bvHyp.name) (mkFVar info.bvHyp)
+
+  -- TODO: make this cleaner by collecting them all into a single array.
+  let simpThms : SimpTheorems := {}
+  let simpThms ← g.withContext do
+    simpThms.add (.other widthInfo.widthMaskHypFvar.name)
+      #[] (mkFVar widthInfo.widthMaskHypFvar) (inv := true)
+  simpThmsArray := simpThmsArray.push simpThms
+
+  -- apply simp
+  let simpCtx ← Simp.mkContext (simpTheorems := simpThmsArray)
+  let (some g, _) ← g.withContext do simpTarget g simpCtx
+    | throwError "goal solved by simp"
+  logInfo m!"rewritten using simp theorems. {g}"
+
+  return [g, widthInfo.hypWidthLeBound]
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 
@@ -147,7 +154,8 @@ syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 def evalPbvDecide : Tactic := fun stx => do
   match stx with
   | `(tactic| pbv_decide $n:num) => do
-      replaceMainGoal (← pbvTranslate (← getMainGoal) n.getNat)
+      let ctx : PbvTranslateContext := { bmcBound := n.getNat }
+      replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
 
 
@@ -157,9 +165,3 @@ theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   pbv_decide 13
   · bv_decide
   · grind
-
--- theorem trace_add_test (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
---   x + y = y + x + 0 := by
---   pbv_decide 13
---   bv_decide
---   grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -29,12 +29,10 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
   let (_mask, g_no_w) ← g_no_w.intro mask_name
   let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
-  let mut hyps := #[mask_hyp]
-
 -- Now do var elim
   let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
 
-  let (g_no_w_no_v, w_expr, new_hyps) ← g_no_w.withContext do
+  let (g_no_w_no_v, w_expr, hyps) ← g_no_w.withContext do
     let width_var ← getFVarFromUserName widthName
 
   -- Assert that the width variable is less than the width bound
@@ -66,8 +64,6 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           out_goal := goal
     return (out_goal, width_le_bound, hyps)
 
-  hyps := hyps ++ new_hyps
-
 -- Simp and push theorems
   let final_goal ← g_no_w_no_v.withContext do
     let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
@@ -85,11 +81,13 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
       let thm ← mkConstWithFreshMVarLevels n
       simpThms ← simpThms.addTheorem (.other n) thm
 
-    -- the hypothesis
+    -- the hypotheses enforcing the variables to "behave" like they have a certain width
     for h in hyps do
-      logInfo (← h.getUserName)
       let thm := mkFVar h
       simpThms ← simpThms.addTheorem (.other h.name) thm
+
+    -- add the mask constraint as an inverse theorem, to remove `setWidths` from the goal
+    simpThms ← simpThms.modifyM 0 fun thms => thms.add (.other mask_hyp.name) #[] (mkFVar mask_hyp) (inv := true)
 
     let ctx ← Simp.mkContext (simpTheorems := simpThms)
 
@@ -117,3 +115,9 @@ theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   pbv_decide 13
   bv_decide
   grind
+
+-- theorem trace_add_test (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
+--   x + y = y + x + 0 := by
+--   pbv_decide 13
+--   bv_decide
+--   grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -138,7 +138,7 @@ def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheorem
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
+Add BitVecInfos theorems to the Simp theorem context that don't need special bindings.
 -/
 def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -160,7 +160,7 @@ def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
   return simp.push simpThms
 
 /--
-Run simp on an MVarId given a set of simp theorems
+Run simp on an MVarId given a set of simp theorems.
 -/
 def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.withContext do
   let simpCtx ← Simp.mkContext (simpTheorems := simp)

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -170,6 +170,14 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
 
   return [g, widthInfo.hypWidthLeBound]
 
+/--
+`pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
+parametric bitvector formula, containing a single width parameter, into a
+concrete width formula. The tactic generates two goals: the first, containing
+the desired concrete width formula that can be decided using `bv_decide`; the
+second containing a side-goal to prove that the width parameter is bounded
+by the provided bound.
+-/
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 
 @[tactic pbvDecide]
@@ -179,17 +187,3 @@ def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
-
-
-
-theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
-  pbv_decide 13
-  · bv_decide
-  · grind
-
-theorem trace_add (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
-  x + y + z = y + x + z := by
-  pbv_decide 13
-  · bv_decide
-  · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -59,12 +59,10 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           out_goal := goal
     return (out_goal, width_le_bound)
 
-  let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth]
-
-  let curried_push := push_th.map (mkAppM · #[w_expr])
+-- Simp and push theorems
+  let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
 
   let mut simpThms : SimpTheoremsArray := #[]
-
   for n in push_th do
     let push_thm ← mkAppM n #[w_expr]
     simpThms ← simpThms.addTheorem (.other n) push_thm
@@ -73,10 +71,9 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
 
   let (result, _) ← simpTarget g_no_w_no_v ctx
 
-  let some goal_out := result | throwError "solved everything!"
+  let some goal_out := result | throwError "solved everything?"
 
   return [goal_out, w_expr.mvarId!]
-
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -42,24 +42,23 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
     let width_le_bound ← mkFreshExprMVar width_le_bound_expr
     logInfo (width_le_bound)
 
-    let mut out_goals := #[width_le_bound.mvarId!]
+    let mut out_goal := g_no_w
 
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         -- Find the BitVec {width_expr} variables
         if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
           logInfo s!"Applying var_elim to {ldecl.userName}"
-          let (var_hyp, goal) ← g_no_w.revert #[ldecl.fvarId]
+          let (var_hyp, goal) ← out_goal.revert #[ldecl.fvarId]
           logInfo (← goal.getType)
           -- not providing the `hwo` hypothesis but seems to work?
           let applied := mkAppN var_elim_theorem #[mkNatLit bound, width_var, width_le_bound]
           let out ← goal.apply applied
           let some goal := out[0]? | throwError "ahhhh"
-          out_goals := out_goals.push goal
-          return out_goals
-    throwError "Shouldn't get here"
+          out_goal := goal
+    return [out_goal, width_le_bound.mvarId!]
 
-  return g_no_w_no_v.toList
+  return g_no_w_no_v
 
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -126,7 +126,8 @@ def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheorem
 /--
 Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
 -/
-def addBvInfos (g : MVarId) (bvInfos : BitVecInfos) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
+  (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
   for info in bvInfos.infos do
       simp ← simp.addTheorem (.other info.bvHyp.name) (mkFVar info.bvHyp)
@@ -135,7 +136,8 @@ def addBvInfos (g : MVarId) (bvInfos : BitVecInfos) (simp : SimpTheoremsArray) :
 /--
 Add width mask hypothesis
 -/
-def addWidthHyp (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
+  (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   -- TODO: make this cleaner by collecting them all into a single array.
   let simpThms : SimpTheorems := {}
   let simpThms ← do

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -2,7 +2,6 @@ import Lean
 import Veir.Data.PBV
 
 open Lean Elab Tactic Meta Simp
-
 namespace Veir.Data.PBV
 
 structure WidthInfo where

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -1,6 +1,6 @@
 module
 
-public import Lean
+public meta import Lean
 public import Veir.Data.PBV
 
 open Lean Elab Tactic Meta Simp
@@ -9,7 +9,7 @@ namespace Veir.Data.PBV
 /--
 Information about the width variable and associated hypotheses.
 -/
-structure WidthInfo where
+meta structure WidthInfo where
   /-- The LocalDecl corresponding to this width variable. -/
   widthNatLocalDecl : LocalDecl
   /-- The FVarId corresponding to the new mask variable for this width. -/
@@ -28,7 +28,7 @@ meta def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
 /--
 Read-only configuration for the tactic.
 -/
-structure PbvTranslateContext where
+meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
@@ -68,7 +68,7 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
 /--
 Pair of local facts about the converted `BitVec` variables.
 -/
-structure BitVecInfo where
+meta structure BitVecInfo where
   /-- The FVarId corresponding to the new concrete-width variable. -/
   bvVar : FVarId
   /-- The FVarId of the hypothesis encoding the mask constraint on the variable. -/
@@ -77,7 +77,7 @@ structure BitVecInfo where
 /--
 Store information for all translated `BitVec`s.
 -/
-structure BitVecInfos where
+meta structure BitVecInfos where
   /-- The Array containing facts about each variable. -/
   infos : Array BitVecInfo := #[]
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -12,16 +12,18 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
   logInfo ("Deciding with bound")
   let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
   let out ← g.withContext do
-    let mut width_vars : Array FVarId := #[]
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
           logInfo m!"Found a var! {ldecl.userName}"
-          width_vars := width_vars.push ldecl.fvarId
-    return width_vars
+          let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
+          return ← g.apply applied
+    throwError "haven't thought about this yet"
+
+  let some new_g := out[0]? | throwError "Shuold have a goal here"
 
   logInfo (toString width_elim_theorem)
-  return g
+  return new_g
 
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -32,16 +32,14 @@ structure PbvTranslateContext where
 and eliminate it, producing the mask variable, and the masking contstraint.
 -/
 def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
-  let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
   g.withContext do
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
-          logInfo m!"Applying width_elim to {ldecl.userName}"
-          let applied := mkAppN width_elim_theorem #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
-          let [g] ← g.withContext do g.apply applied | throwError "width_elim should generate a goal"
-          let widthName := ldecl.userName
-          let maskName := Name.mkSimple s!"m{widthName}"
+          let [g] ← g.withContext do
+            g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
+            | throwError "width_elim should generate a goal"
+          let maskName := Name.mkSimple s!"m{ldecl.userName}"
           let (mask, g) ← g.withContext do g.intro maskName
           let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
           let hypWidthLeBound <- g.withContext do
@@ -70,9 +68,6 @@ structure BitVecInfos where
 def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
-
-
-#check isMask_of_eq_maskOfWidth
 /--
 Analyze a single local decl, and try to introduce it as a bitvec variable in our larger universe
 if it is in fact a bitvec variable.
@@ -96,12 +91,19 @@ def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
       return (g, infos.push { bvVar, bvHyp})
   return (g, infos)
 
-
+/--
+Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
+hypotheses.
+-/
 def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) : MetaM (MVarId × BitVecInfos) := do
   let decls : LocalContext ← g.withContext getLCtx
   decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
     introVar ctx widthInfo g infos ldecl
 
+/--
+Add the harcoded push theorems to the Simp theorem context, bind each application to the
+concrete blast width (`o`) and parametric width (`w`).
+-/
 def addPushTheorems (g : MVarId)
     (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let thms := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
@@ -111,40 +113,55 @@ def addPushTheorems (g : MVarId)
     simp ← simp.addTheorem (.other thm) push_thm
   return simp
 
+/--
+Add theorems to the Simp theorem context that don't need special bindings
+-/
+def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+  let others := #[``BitVec.setWidth_eq]
+  let mut simp := simp
+  for n in others do
+    simp ← simp.addTheorem (.other n) (mkConst n [])
+  return simp
+
+/--
+Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
+-/
+def addBvInfos (g : MVarId) (bvInfos : BitVecInfos) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+  let mut simp := simp
+  for info in bvInfos.infos do
+      simp ← simp.addTheorem (.other info.bvHyp.name) (mkFVar info.bvHyp)
+  return simp
+
+/--
+Add width mask hypothesis
+-/
+def addWidthHyp (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+  -- TODO: make this cleaner by collecting them all into a single array.
+  let simpThms : SimpTheorems := {}
+  let simpThms ← do
+    simpThms.add (.other widthInfo.widthMaskHypFvar.name)
+      #[] (mkFVar widthInfo.widthMaskHypFvar) (inv := true)
+  return simp.push simpThms
+
+/--
+Run simp on an MVarId given a set of simp theorems
+-/
+def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.withContext do
+  let simpCtx ← Simp.mkContext (simpTheorems := simp)
+  let (some g, _) ← g.withContext do simpTarget g simpCtx
+    | throwError "goal solved by simp"
+  return g
 
 def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   let (g, widthInfo) ← introMaskWidths ctx g
   -- Introduce bitvector variables
   let (g, bvInfos) ← introVars ctx g widthInfo
-  g.withContext do check (← g.getType)
-  logInfo m!"intro mask widths done. {g}"
-  let mut simpThmsArray : SimpTheoremsArray := #[]
-  simpThmsArray ← addPushTheorems g widthInfo simpThmsArray
-  logInfo m!"added push theorems."
-
-  -- other theorems that don't need bounds
-  let others := #[``BitVec.setWidth_eq]
-  for n in others do
-    let thm ← mkConstWithFreshMVarLevels n
-    simpThmsArray ← simpThmsArray.addTheorem (.other n) thm
-
-  -- the hypotheses enforcing the variables to "behave" like they have a certain width
-  for info in bvInfos.infos do
-    simpThmsArray ← g.withContext do simpThmsArray.addTheorem (.other info.bvHyp.name) (mkFVar info.bvHyp)
-
-  -- TODO: make this cleaner by collecting them all into a single array.
-  let simpThms : SimpTheorems := {}
-  let simpThms ← g.withContext do
-    simpThms.add (.other widthInfo.widthMaskHypFvar.name)
-      #[] (mkFVar widthInfo.widthMaskHypFvar) (inv := true)
-  simpThmsArray := simpThmsArray.push simpThms
-
-  -- apply simp
-  let simpCtx ← Simp.mkContext (simpTheorems := simpThmsArray)
-  let (some g, _) ← g.withContext do simpTarget g simpCtx
-    | throwError "goal solved by simp"
-  logInfo m!"rewritten using simp theorems. {g}"
+  -- Run simp
+  let g ← applySimp g <| ← addPushTheorems g widthInfo
+                      <| ← addOtherTheorems g
+                      <| ← addBvInfos g bvInfos
+                      <| ← addWidthHyp g widthInfo #[]
 
   return [g, widthInfo.hypWidthLeBound]
 
@@ -162,6 +179,12 @@ def evalPbvDecide : Tactic := fun stx => do
 
 theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
+  pbv_decide 13
+  · bv_decide
+  · grind
+
+theorem trace_add (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
+  x + y + z= y + x +z := by
   pbv_decide 13
   · bv_decide
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -8,9 +8,7 @@ namespace Veir.Data.PBV
 def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
   logInfo s!"Deciding with bound {bound}"
 
--- Start by only trying to apply width elim, and generating some new hyps
--- The width_elim has type:  (o w : Nat) (Q : Prop) (h : ∀ (m : BitVec o), m = maskOfWidth o w → Q) : Q
--- so, will "feed" the current o w and goal (Q) and it will generate a new hole with the hypothesis and the Q
+-- Apply width_elim
   let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
   let (g_no_w, widthName) ← g.withContext do
     for ldecl in ← getLCtx do
@@ -19,17 +17,17 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           logInfo m!"Applying width_elim to {ldecl.userName}"
           let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
           let out ← g.apply applied
-          let some out := out[0]? | throwError "Shuold have a goal here"
-          -- TODO, this shuold loop over all widths
+          let some out := out[0]? | throwError "width_elim should generate a goal"
+          -- TODO, for multiwidth this needs to loop
           return (out, ldecl.userName)
 
-    throwError "haven't thought about this yet"
+    throwError "No width variables were found"
 
   let mask_name := Name.mkSimple s!"m{widthName}"
   let (_mask, g_no_w) ← g_no_w.intro mask_name
   let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
--- Now do var elim
+-- Apply var_elim
   let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
 
   let (g_no_w_no_v, w_expr, hyps) ← g_no_w.withContext do
@@ -49,12 +47,12 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
         if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
           logInfo s!"Applying var_elim to {ldecl.userName}"
           let (var_hyp, goal) ← out_goal.revert #[ldecl.fvarId]
+          let some oldvar_name := var_hyp[0]? | throwError "reverting shuold produce a var"
           -- not providing the `hwo` hypothesis but seems to work?
           let applied := mkAppN var_elim_theorem #[mkNatLit bound, width_var, width_le_bound]
           let out ← goal.apply applied
-          let some goal := out[0]? | throwError "ahhhh"
+          let some goal := out[0]? | throwError "var_elim should generate a goal"
 
-          let some oldvar_name := var_hyp[0]? | throwError "no var name?"
           let name ← oldvar_name.getUserName
           let (_new_var, goal) ← goal.intro (name)
           let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
@@ -93,7 +91,7 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
 
     let (result, _) ← simpTarget g_no_w_no_v ctx
 
-    let some goal_out := result | throwError "solved everything?"
+    let some goal_out := result | throwError "goal solved by simp"
 
     return goal_out
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -28,10 +28,12 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
   let (mask, g_no_w) ← g_no_w.intro mask_name
   let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
+  let mut hyps := #[mask_hyp]
+
 -- Now do var elim
   let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
 
-  let (g_no_w_no_v, w_expr) ← g_no_w.withContext do
+  let (g_no_w_no_v, w_expr, new_hyps) ← g_no_w.withContext do
     let width_var ← getFVarFromUserName widthName
 
   -- Assert that the width variable is less than the width bound
@@ -39,6 +41,8 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
     let width_le_bound ← mkFreshExprMVar width_le_bound_expr
 
     let mut out_goal := g_no_w
+
+    let mut hyps : Array FVarId := #[]
 
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
@@ -53,27 +57,48 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
 
           let some oldvar_name := var_hyp[0]? | throwError "no var name?"
           let name ← oldvar_name.getUserName
-          let (new_var, goal) ← goal.intro (name)
+          let (_new_var, goal) ← goal.intro (name)
           let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
 
+          hyps := hyps.push new_hyp
+
           out_goal := goal
-    return (out_goal, width_le_bound)
+    return (out_goal, width_le_bound, hyps)
+
+  hyps := hyps ++ new_hyps
 
 -- Simp and push theorems
-  let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
+  let final_goal ← g_no_w_no_v.withContext do
+    let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
+    let others := #[``BitVec.setWidth_eq]
 
-  let mut simpThms : SimpTheoremsArray := #[]
-  for n in push_th do
-    let push_thm ← mkAppM n #[w_expr]
-    simpThms ← simpThms.addTheorem (.other n) push_thm
+    -- push theorems that need to be partially evealuted with the right
+    -- symbolic width and concrete bound width
+    let mut simpThms : SimpTheoremsArray := #[]
+    for n in push_th do
+      let push_thm ← mkAppM n #[w_expr]
+      simpThms ← simpThms.addTheorem (.other n) push_thm
 
-  let ctx ← Simp.mkContext (simpTheorems := simpThms)
+    -- other theorems that don't need bounds
+    for n in others do
+      let thm ← mkConstWithFreshMVarLevels n
+      simpThms ← simpThms.addTheorem (.other n) thm
 
-  let (result, _) ← simpTarget g_no_w_no_v ctx
+    -- the hypothesis
+    for h in hyps do
+      logInfo (← h.getUserName)
+      let thm := mkFVar h
+      simpThms ← simpThms.addTheorem (.other h.name) thm
 
-  let some goal_out := result | throwError "solved everything?"
+    let ctx ← Simp.mkContext (simpTheorems := simpThms)
 
-  return [goal_out, w_expr.mvarId!]
+    let (result, _) ← simpTarget g_no_w_no_v ctx
+
+    let some goal_out := result | throwError "solved everything?"
+
+    return goal_out
+
+  return [final_goal, w_expr.mvarId!]
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -20,12 +20,13 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
           let out ← g.apply applied
           let some out := out[0]? | throwError "Shuold have a goal here"
+          -- TODO, this shuold loop over all widths
           return (out, ldecl.userName)
 
     throwError "haven't thought about this yet"
 
   let mask_name := Name.mkSimple s!"m{widthName}"
-  let (mask, g_no_w) ← g_no_w.intro mask_name
+  let (_mask, g_no_w) ← g_no_w.intro mask_name
   let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
   let mut hyps := #[mask_hyp]
@@ -59,7 +60,7 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           let name ← oldvar_name.getUserName
           let (_new_var, goal) ← goal.intro (name)
           let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
-
+          -- Add the mask hypothesis to the running list
           hyps := hyps.push new_hyp
 
           out_goal := goal

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -193,7 +193,7 @@ The tactic generates two goals:
 2. A side-goal to prove that the width parameter is bounded by the provided
 bound, this should be solvable by grind.
 -/
-syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num)? : tactic
+syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num) : tactic
 
 @[tactic pbvDecide]
 public meta def evalPbvDecide : Tactic := fun stx => do

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -5,7 +5,7 @@ open Lean Elab Tactic Meta Simp
 
 namespace Veir.Data.PBV
 
-def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
+def pbvTranslate (g : MVarId) (bound : Nat) : MetaM (List MVarId) := do
   logInfo s!"Deciding with bound {bound}"
 
 -- Apply width_elim

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -11,19 +11,24 @@ namespace Veir.Data.PBV
 def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
   logInfo ("Deciding with bound")
   let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
-  let out ← g.withContext do
+  let (out, widthName) ← g.withContext do
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
           logInfo m!"Found a var! {ldecl.userName}"
           let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
-          return ← g.apply applied
+          let out ← g.apply applied
+          let some g_out := out[0]? | throwError "Shuold have a goal here"
+
+          return (g_out, ldecl.userName)
     throwError "haven't thought about this yet"
 
-  let some new_g := out[0]? | throwError "Shuold have a goal here"
+  let mask_name := Name.mkSimple s!"m{widthName}"
+  let (mask, g_out) ← out.intro mask_name
+  let (mask_hyp, g_out) ← g_out.intro (Name.mkSimple s!"h_{mask_name}")
 
   logInfo (toString width_elim_theorem)
-  return new_g
+  return g_out
 
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -187,7 +187,7 @@ parametric bitvector formula, containing a single width parameter, into a
 concrete width formula. The tactic generates two goals: the first, containing
 the desired concrete width formula that can be decided using `bv_decide`; the
 second containing a side-goal to prove that the width parameter is bounded
-by the provided bound.
+by the provided bound, this should be solvable by grind.
 -/
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -36,16 +36,20 @@ def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × 
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
+          -- Apply ``width_elim
           let [g] ← g.withContext do
             g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
             | throwError "width_elim should generate a goal"
+          -- Intros
           let maskName := Name.mkSimple s!"m{ldecl.userName}"
           let (mask, g) ← g.withContext do g.intro maskName
           let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+          -- Define bounding conditions
           let hypWidthLeBound <- g.withContext do
             mkFreshExprMVar (mkAppN (Expr.const `Nat.le [])
               #[Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
           g.withContext <| check hypWidthLeBound
+          -- Assert the BitVec mask constraint
           let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
           let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
           let info : WidthInfo := {
@@ -77,14 +81,14 @@ def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
       MetaM (MVarId × BitVecInfos) := g.withContext do
   unless ldecl.isImplementationDetail do
     -- Find the BitVec {width_expr} variables
-    -- | TODO: replace defeq with syntactic eq, there are helpers in Lean/Meta or Lean/Tactic
-    -- inside the bv_decide implementation.
-    if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) widthInfo.widthFvar) then
+    if Expr.equal ldecl.type (mkApp (mkConst ``BitVec) widthInfo.widthFvar) then
       -- Revert to expose forall with the BitVec
       let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
-      let (List.cons g _) ← g.withContext <|  g.apply <| ← mkAppM ``var_elim
+      -- Apply ``var_elim
+      let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
           #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBound]
         | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
+      -- Intros
       let name ← oldVar.getUserName
       let (bvVar, g) ← g.intro name
       let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
@@ -186,7 +190,7 @@ theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   · grind
 
 theorem trace_add (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
-  x + y + z= y + x +z := by
+  x + y + z = y + x + z := by
   pbv_decide 13
   · bv_decide
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -183,7 +183,7 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
 
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
-parametric bitvector formula, containing a single width parameter, into a
+parametric bitvector formula, containing a single-width parameter, into a
 concrete width formula.
 
 The tactic generates two goals:

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -5,7 +5,7 @@ open Lean Elab Tactic Meta
 
 namespace Veir.Data.PBV
 
-def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
+def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
   logInfo s!"Deciding with bound {bound}"
 
 -- Start by only trying to apply width elim, and generating some new hyps
@@ -16,7 +16,7 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
         if ← isDefEq ldecl.type (mkConst ``Nat) then
-          logInfo m!"Found a var! {ldecl.userName}"
+          logInfo m!"Applying width_elim to {ldecl.userName}"
           let applied := mkAppN width_elim_theorem #[mkNatLit bound, ldecl.toExpr, ← g.getType]
           let out ← g.apply applied
           let some out := out[0]? | throwError "Shuold have a goal here"
@@ -28,13 +28,21 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
   let (mask, g_no_w) ← g_no_w.intro mask_name
   let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
+
+
 -- Not do var elim
   let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
 
   let g_no_w_no_v ← g_no_w.withContext do
     let width_var ← getFVarFromUserName widthName
-
     logInfo (width_var)
+
+  -- Assert that the width variable is less than the width bound
+    let width_le_bound_expr := mkAppN (Expr.const `Nat.le []) #[width_var, mkNatLit bound]
+    let width_le_bound ← mkFreshExprMVar width_le_bound_expr
+    logInfo (width_le_bound)
+
+    let mut out_goals := #[width_le_bound.mvarId!]
 
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
@@ -42,10 +50,16 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
         if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
           logInfo s!"Applying var_elim to {ldecl.userName}"
           let (var_hyp, goal) ← g_no_w.revert #[ldecl.fvarId]
-          return goal
+          logInfo (← goal.getType)
+          -- not providing the `hwo` hypothesis but seems to work?
+          let applied := mkAppN var_elim_theorem #[mkNatLit bound, width_var, width_le_bound]
+          let out ← goal.apply applied
+          let some goal := out[0]? | throwError "ahhhh"
+          out_goals := out_goals.push goal
+          return out_goals
     throwError "Shouldn't get here"
 
-  return g_no_w_no_v
+  return g_no_w_no_v.toList
 
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
@@ -54,7 +68,7 @@ syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 def evalPbvDecide : Tactic := fun stx => do
   match stx with
   | `(tactic| pbv_decide $n:num) => do
-      replaceMainGoal [← pbvTranslate (← getMainGoal) n.getNat]
+      replaceMainGoal (← pbvTranslate (← getMainGoal) n.getNat)
   | _ => throwUnsupportedSyntax
 
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -1,5 +1,7 @@
-import Lean
-import Veir.Data.PBV
+module
+
+public import Lean
+public import Veir.Data.PBV
 
 open Lean Elab Tactic Meta Simp
 namespace Veir.Data.PBV
@@ -17,10 +19,10 @@ structure WidthInfo where
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBound : MVarId
 
-def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
+meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
   info.widthNatLocalDecl.fvarId
 
-def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
+meta def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
   .fvar info.widthFvarId
 
 /--
@@ -33,7 +35,7 @@ structure PbvTranslateContext where
 /-- Find the local declaration of the (single) width variable,
 and eliminate it, producing the mask variable, and the masking constraint.
 -/
-def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
+meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
   g.withContext do
     for ldecl in ← getLCtx do
       unless ldecl.isImplementationDetail do
@@ -79,14 +81,14 @@ structure BitVecInfos where
   /-- The Array containing facts about each variable. -/
   infos : Array BitVecInfo := #[]
 
-def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
+meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
 /--
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
+meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
       (infos : BitVecInfos) (ldecl : LocalDecl) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   unless ldecl.isImplementationDetail do
@@ -109,7 +111,7 @@ def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
 Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
 hypotheses.
 -/
-def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) : MetaM (MVarId × BitVecInfos) := do
+meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) : MetaM (MVarId × BitVecInfos) := do
   let decls : LocalContext ← g.withContext getLCtx
   decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
     introVar ctx widthInfo g infos ldecl
@@ -118,7 +120,7 @@ def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) :
 Add the hardcoded push theorems to the Simp theorem context, bind each application to the
 concrete blast width (`o`) and parametric width (`w`).
 -/
-def addPushTheorems (g : MVarId)
+meta def addPushTheorems (g : MVarId)
     (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let thms := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
   let mut simp := simp
@@ -130,7 +132,7 @@ def addPushTheorems (g : MVarId)
 /--
 Add theorems to the Simp theorem context that don't need special bindings
 -/
-def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+meta def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let others := #[``BitVec.setWidth_eq]
   let mut simp := simp
   for n in others do
@@ -140,7 +142,7 @@ def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheorem
 /--
 Add BitVecInfos theorems to the Simp theorem context that don't need special bindings.
 -/
-def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
+meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
   for info in bvInfos.infos do
@@ -150,7 +152,7 @@ def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
 /--
 Add width mask hypothesis
 -/
-def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
+meta def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   -- TODO: make this cleaner by collecting them all into a single array.
   let simpThms : SimpTheorems := {}
@@ -162,13 +164,13 @@ def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
 /--
 Run simp on an MVarId given a set of simp theorems.
 -/
-def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.withContext do
+meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.withContext do
   let simpCtx ← Simp.mkContext (simpTheorems := simp)
   let (some g, _) ← g.withContext do simpTarget g simpCtx
     | throwError "goal solved by simp"
   return g
 
-def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
+meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   let (g, widthInfo) ← introMaskWidths ctx g
   -- Introduce bitvector variables
@@ -194,7 +196,7 @@ bound, this should be solvable by grind.
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 
 @[tactic pbvDecide]
-def evalPbvDecide : Tactic := fun stx => do
+public meta def evalPbvDecide : Tactic := fun stx => do
   match stx with
   | `(tactic| pbv_decide $n:num) => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -27,7 +27,7 @@ def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
 Read-only configuration for the tactic.
 -/
 structure PbvTranslateContext where
-  /-- the bound upto which we want to bitblast our widths. -/
+  /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
 /-- Find the local declaration of the (single) width variable,

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -1,0 +1,38 @@
+import Lean
+import Veir.Data.PBV
+
+open Lean Elab Tactic Meta
+
+namespace Veir.Data.PBV
+
+-- Start by only trying to apply width elim, and generating some new hyps
+-- The width_elim has type:  (o w : Nat) (Q : Prop) (h : ∀ (m : BitVec o), m = maskOfWidth o w → Q) : Q
+-- so, will "feed" the current o w and goal (Q) and it will generate a new hole with the hypothesis and the Q
+def pbvTranslate (g : MVarId) (bound : Nat) : TacticM MVarId := do
+  logInfo ("Deciding with bound")
+  let width_elim_theorem ← mkConstWithFreshMVarLevels ``width_elim
+  let out ← g.withContext do
+    let mut width_vars : Array FVarId := #[]
+    for ldecl in ← getLCtx do
+      unless ldecl.isImplementationDetail do
+        if ← isDefEq ldecl.type (mkConst ``Nat) then
+          logInfo m!"Found a var! {ldecl.userName}"
+          width_vars := width_vars.push ldecl.fvarId
+    return width_vars
+
+  logInfo (toString width_elim_theorem)
+  return g
+
+
+syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
+
+@[tactic pbvDecide]
+def evalPbvDecide : Tactic := fun stx => do
+  let out ← pbvTranslate (← getMainGoal) stx[0].toNat
+  replaceMainGoal [out]
+
+
+
+theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+  pbv_decide 9

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -48,7 +48,7 @@ def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × 
             mkFreshExprMVar (mkAppN (Expr.const `Nat.le [])
               #[Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
           g.withContext <| check hypWidthLeBound
-          -- Assert the BitVec mask constraint
+          -- Assert the BitVec mask constraint.
           let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
           let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
           let info : WidthInfo := {
@@ -73,15 +73,15 @@ def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
 
 /--
 Analyze a single local decl, and try to introduce it as a bitvec variable in our larger universe
-if it is in fact a bitvec variable.
+if it is in fact a `BitVec` variable.
 -/
 def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
       (infos : BitVecInfos) (ldecl : LocalDecl) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   unless ldecl.isImplementationDetail do
-    -- Find the BitVec {width_expr} variables
+    -- Find the BitVec {width_expr} variables.
     if Expr.equal ldecl.type (mkApp (mkConst ``BitVec) widthInfo.widthFvar) then
-      -- Revert to expose forall with the BitVec
+      -- Revert to expose forall with the BitVec.
       let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
       -- Apply ``var_elim
       let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
@@ -104,7 +104,7 @@ def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) :
     introVar ctx widthInfo g infos ldecl
 
 /--
-Add the harcoded push theorems to the Simp theorem context, bind each application to the
+Add the hardcoded push theorems to the Simp theorem context, bind each application to the
 concrete blast width (`o`) and parametric width (`w`).
 -/
 def addPushTheorems (g : MVarId)

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -1,7 +1,7 @@
 import Lean
 import Veir.Data.PBV
 
-open Lean Elab Tactic Meta
+open Lean Elab Tactic Meta Simp
 
 namespace Veir.Data.PBV
 
@@ -28,19 +28,15 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
   let (mask, g_no_w) ← g_no_w.intro mask_name
   let (mask_hyp, g_no_w) ← g_no_w.intro (Name.mkSimple s!"h_{mask_name}")
 
-
-
 -- Now do var elim
   let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
 
-  let g_no_w_no_v ← g_no_w.withContext do
+  let (g_no_w_no_v, w_expr) ← g_no_w.withContext do
     let width_var ← getFVarFromUserName widthName
-    logInfo (width_var)
 
   -- Assert that the width variable is less than the width bound
     let width_le_bound_expr := mkAppN (Expr.const `Nat.le []) #[width_var, mkNatLit bound]
     let width_le_bound ← mkFreshExprMVar width_le_bound_expr
-    logInfo (width_le_bound)
 
     let mut out_goal := g_no_w
 
@@ -61,9 +57,25 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
 
           out_goal := goal
-    return [out_goal, width_le_bound.mvarId!]
+    return (out_goal, width_le_bound)
 
-  return g_no_w_no_v
+  let push_th := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth]
+
+  let curried_push := push_th.map (mkAppM · #[w_expr])
+
+  let mut simpThms : SimpTheoremsArray := #[]
+
+  for n in push_th do
+    let push_thm ← mkAppM n #[w_expr]
+    simpThms ← simpThms.addTheorem (.other n) push_thm
+
+  let ctx ← Simp.mkContext (simpTheorems := simpThms)
+
+  let (result, _) ← simpTarget g_no_w_no_v ctx
+
+  let some goal_out := result | throwError "solved everything!"
+
+  return [goal_out, w_expr.mvarId!]
 
 
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
@@ -80,3 +92,5 @@ def evalPbvDecide : Tactic := fun stx => do
 theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 13
+  bv_decide
+  grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -193,7 +193,7 @@ The tactic generates two goals:
 2. A side-goal to prove that the width parameter is bounded by the provided
 bound, this should be solvable by grind.
 -/
-syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
+syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num)? : tactic
 
 @[tactic pbvDecide]
 public meta def evalPbvDecide : Tactic := fun stx => do

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -62,7 +62,7 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
           out_goal := goal
     return (out_goal, width_le_bound, hyps)
 
--- -- IsMask theorem
+-- IsMask theorem
   let (g_no_w_no_v) ← g_no_w_no_v.withContext do
     let hyp_expr ← mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar mask_hyp]
     let type ← inferType hyp_expr
@@ -114,20 +114,30 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
 
     -- clear `maskOfWidth` hypothesis
     goal_out ← goal_out.clear mask_hyp
-
-    -- clear "w" dependencies
-    let w_decl ← getLocalDeclFromUserName widthName
-
-    -- let mut goal := goal_out
-
-    -- (← getLCtx).foldlM (fun goal => do (fun localDecl => do
-    --   unless localDecl.fvarId == w_decl.fvarId do
-    --     if (← localDeclDependsOn localDecl w_decl.fvarId) then
-    --       goal ← goal.clear localDecl.fvarId
-    -- ))
-
     return goal_out
 
+
+-- Clear the last Nat hypotheses
+  let final_goal ← final_goal.withContext do
+    let w_decl ← getLocalDeclFromUserName widthName
+
+    let dependant ← (← getLCtx).foldrM (init := (#[] : Array LocalDecl )) fun localDecl acc => do
+      if localDecl.fvarId == w_decl.fvarId then
+        return acc
+      if (← localDeclDependsOn localDecl w_decl.fvarId) then
+        -- goal ← goal.clear localDecl.fvarId
+        logInfo s!"{localDecl.userName} depends on {w_decl.userName }"
+        return acc.push localDecl
+      else
+        return acc
+
+    let mut goal := final_goal
+    for hyp in dependant do
+      goal ← goal.clear hyp.fvarId
+
+    goal ← goal.clear w_decl.fvarId
+
+    return goal
 
   return [final_goal, w_expr.mvarId!]
 
@@ -145,9 +155,8 @@ def evalPbvDecide : Tactic := fun stx => do
 theorem trace_add_comm (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 13
-
-  bv_decide
-  grind
+  · bv_decide
+  · grind
 
 -- theorem trace_add_test (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 --   x + y = y + x + 0 := by

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -184,10 +184,12 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula, containing a single width parameter, into a
-concrete width formula. The tactic generates two goals: the first, containing
-the desired concrete width formula that can be decided using `bv_decide`; the
-second containing a side-goal to prove that the width parameter is bounded
-by the provided bound, this should be solvable by grind.
+concrete width formula.
+
+The tactic generates two goals:
+1. The desired concrete width formula that can be decided using `bv_decide`
+2. A side-goal to prove that the width parameter is bounded by the provided
+bound, this should be solvable by grind.
 -/
 syntax (name := pbvDecide) "pbv_decide" optConfig (ppSpace colGt num)? : tactic
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -4,10 +4,13 @@ import Veir.Data.PBV
 open Lean Elab Tactic Meta Simp
 namespace Veir.Data.PBV
 
+/--
+Information about the width variable and associated hypotheses.
+-/
 structure WidthInfo where
-  /-- The local decl corresponding to this width variable. -/
+  /-- The LocalDecl corresponding to this width variable. -/
   widthNatLocalDecl : LocalDecl
-  /-- The fvar corresponding to the new mask variable for this width. -/
+  /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
   widthMaskHypFvar : FVarId
@@ -28,7 +31,7 @@ structure PbvTranslateContext where
    bmcBound : Nat
 
 /-- Find the local declaration of the (single) width variable,
-and eliminate it, producing the mask variable, and the masking contstraint.
+and eliminate it, producing the mask variable, and the masking constraint.
 -/
 def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
   g.withContext do
@@ -43,7 +46,7 @@ def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × 
           let maskName := Name.mkSimple s!"m{ldecl.userName}"
           let (mask, g) ← g.withContext do g.intro maskName
           let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
-          -- Define bounding conditions
+          -- Define bounding conditions.
           let hypWidthLeBound <- g.withContext do
             mkFreshExprMVar (mkAppN (Expr.const `Nat.le [])
               #[Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
@@ -60,19 +63,27 @@ def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × 
           return (g, info)
     throwError "unable to find a valid width variable."
 
-
+/--
+Pair of local facts about the converted `BitVec` variables.
+-/
 structure BitVecInfo where
+  /-- The FVarId corresponding to the new concrete-width variable. -/
   bvVar : FVarId
+  /-- The FVarId of the hypothesis encoding the mask constraint on the variable. -/
   bvHyp : FVarId
 
+/--
+Store information for all translated `BitVec`s.
+-/
 structure BitVecInfos where
+  /-- The Array containing facts about each variable. -/
   infos : Array BitVecInfo := #[]
 
 def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
 /--
-Analyze a single local decl, and try to introduce it as a bitvec variable in our larger universe
+Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
 def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -30,7 +30,7 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
 
 
 
--- Not do var elim
+-- Now do var elim
   let var_elim_theorem ← mkConstWithFreshMVarLevels ``var_elim
 
   let g_no_w_no_v ← g_no_w.withContext do
@@ -50,11 +50,16 @@ def pbvTranslate (g : MVarId) (bound : Nat) : TacticM (List MVarId) := do
         if ← isDefEq ldecl.type (mkApp (mkConst ``BitVec) width_var) then
           logInfo s!"Applying var_elim to {ldecl.userName}"
           let (var_hyp, goal) ← out_goal.revert #[ldecl.fvarId]
-          logInfo (← goal.getType)
           -- not providing the `hwo` hypothesis but seems to work?
           let applied := mkAppN var_elim_theorem #[mkNatLit bound, width_var, width_le_bound]
           let out ← goal.apply applied
           let some goal := out[0]? | throwError "ahhhh"
+
+          let some oldvar_name := var_hyp[0]? | throwError "no var name?"
+          let name ← oldvar_name.getUserName
+          let (new_var, goal) ← goal.intro (name)
+          let (new_hyp, goal) ← goal.intro (Name.mkSimple s!"h_m{name}")
+
           out_goal := goal
     return [out_goal, width_le_bound.mvarId!]
 


### PR DESCRIPTION
This PR introduces a basic tactic `pbv_decide` to translate a bounded single parametric-width bitvector formula into a concrete-width formula amenable to bit-blasting.  
- The tactic broadly follows the steps outlined in `PBV.lean` and applies the `width_elim` and `var_elim` theorems followed by running `simp` with the theorems from `Push.lean`.
  - At the moment addition is the only supported operation.
-  Added a test in UnitTest to exercise the tactic.
  