### PR TITLE
chore: make `Interp` an inductive with `.ok`/`.ub`/`.fail`

### DIFF
--- a/UnitTest/Evaluate.lean
+++ b/UnitTest/Evaluate.lean
@@ -10,8 +10,8 @@ private def i32 : TypeAttr := IntegerType.mk 32
 
 private def testEvaluateAddi : String := Id.run do
   let operands : Array RuntimeValue := #[.int 32 (.val 7), .int 32 (.val 8)]
-  let some (.ok results) :=
-    (foldEvaluate (.arith .addi) default #[i32] operands : Option (UBOr (Array RuntimeValue)))
+  let .ok results :=
+    (foldEvaluate (.arith .addi) default #[i32] operands : Interp (Array RuntimeValue))
     | return "arith.addi did not evaluate"
   let result? : Option RuntimeValue := results[0]?
   let some (.int 32 (.val value)) := result?
@@ -31,8 +31,8 @@ info: "ok"
     UB into poison is the client's policy decision, not this layer's. -/
 private def testEvaluateUB : String := Id.run do
   let operands : Array RuntimeValue := #[.int 32 (.val 5), .int 32 (.val 0)]
-  let some .ub :=
-    (foldEvaluate (.arith .divsi) default #[i32] operands : Option (UBOr (Array RuntimeValue)))
+  let .ub :=
+    (foldEvaluate (.arith .divsi) default #[i32] operands : Interp (Array RuntimeValue))
     | return "arith.divsi by zero did not report UB"
   return "ok"
 
@@ -42,12 +42,12 @@ info: "ok"
 #guard_msgs in
 #eval! testEvaluateUB
 
-/-- An operation the interpreter does not implement evaluates to `none`. The
+/-- An operation the interpreter does not implement evaluates to `.fail`. The
     `datapath` dialect models hardware structures with no runtime semantics of
     their own to evaluate against. -/
 private def testEvaluateUninterpreted : String := Id.run do
   let operands : Array RuntimeValue := #[.int 32 (.val 13), .int 32 (.val 7)]
-  let none := (foldEvaluate (.datapath .compress) () #[i32, i32] operands : Option (UBOr (Array RuntimeValue)))
+  let .fail := (foldEvaluate (.datapath .compress) () #[i32, i32] operands : Interp (Array RuntimeValue))
     | return "an uninterpreted operation was evaluated"
   return "ok"
 
@@ -62,8 +62,8 @@ info: "ok"
 private def testEvaluateModArithAdd : String := Id.run do
   let m17 : TypeAttr := ModArithType.mk (IntegerAttr.mk 17 (IntegerType.mk 32))
   let operands : Array RuntimeValue := #[.int 32 (.val 13), .int 32 (.val 7)]
-  let some (.ok results) :=
-    (foldEvaluate (.mod_arith .add) () #[m17] operands : Option (UBOr (Array RuntimeValue)))
+  let .ok results :=
+    (foldEvaluate (.mod_arith .add) () #[m17] operands : Interp (Array RuntimeValue))
     | return "mod_arith.add did not evaluate"
   let result? : Option RuntimeValue := results[0]?
   let some (.int 32 (.val value)) := result?

--- a/Veir/Interfaces/ConstantLikeInterfaces.lean
+++ b/Veir/Interfaces/ConstantLikeInterfaces.lean
@@ -36,9 +36,9 @@ def ValuePtr.constantValue (val : ValuePtr) (ctx : IRContext OpCode) : Option Ru
   -- makes interpreting against an empty operand array and an empty memory
   -- produce exactly the value the operation materializes.
   if res.op.getNumOperands! ctx ≠ 0 then none else
-  match (res.op.interpret ctx #[] .empty : Option (UBOr _)) with
-  | some (.ok (results, _, none)) => results[res.index]?
-  | some .ub => RuntimeValue.getPoisonForType (val.getType! ctx)
+  match res.op.interpret ctx #[] .empty with
+  | .ok (results, _, none) => results[res.index]?
+  | .ub => RuntimeValue.getPoisonForType (val.getType! ctx)
   | _ => none
 
 end

--- a/Veir/Interfaces/FoldInterfaces.lean
+++ b/Veir/Interfaces/FoldInterfaces.lean
@@ -40,7 +40,8 @@ private def foldByEvaluation (opType : OpCode) (properties : propertiesOf opType
     (resultTypes : Array TypeAttr) (constOperands : Array (Option RuntimeValue))
     : Option (Array FoldResult) := do
   let values ← constOperands.mapM id
-  match ← (foldEvaluate opType properties resultTypes values : Option (UBOr _)) with
+  match foldEvaluate opType properties resultTypes values with
+  | .fail => none
   | .ok results => return results.map .useConstant
   | .ub => allResultsPoison resultTypes
 

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -317,56 +317,51 @@ inductive ControlFlowAction where
   | branch (vals : Array RuntimeValue) (dest : BlockPtr)
 
 /--
-  Wrapper for interpreter step results: either a successful value `ok` or the
-  program has triggered undefined behaviour (`ub`). UB is a property of the
-  execution, not of any value, so it lives here rather than inside `RuntimeValue`
-  or `LLVM.Int`.
+  The interpreter monad. An interpretation step has three outcomes. UB is a property
+  of the execution, not of any value, so it lives here rather than inside
+  `RuntimeValue` or `LLVM.Int`.
 -/
-inductive UBOr (α : Type) where
-  | ok : α → UBOr α
-  | ub : UBOr α
+inductive Interp (α : Type) where
+  /-- Interpreter could not proceed (malformed IR, unsupported op). -/
+  | fail
+  /-- Execution triggered undefined behaviour. -/
+  | ub
+  /-- Successful execution producing `a`. -/
+  | ok (a : α)
 deriving Inhabited
 
 @[expose]
-def UBOr.map {α β : Type} (f : α → β) : UBOr α → UBOr β
-  | .ok a => .ok (f a)
+def Interp.map {α β : Type} (f : α → β) : Interp α → Interp β
+  | .fail => .fail
   | .ub => .ub
+  | .ok a => .ok (f a)
 
-@[simp, grind =]
-theorem UBOr.map_ok : UBOr.map f (.ok a) = .ok (f a) := by grind [UBOr.map]
-
-@[simp, grind =]
-theorem UBOr.map_ub : UBOr.map f .ub = .ub := by grind [UBOr.map]
-
-/--
-  The interpreter monad. `Option (UBOr α)` has three states:
-  - `some (.ok x)` — successful execution producing `x`.
-  - `some .ub`     — execution triggered undefined behaviour.
-  - `none`         — interpreter could not proceed (malformed IR, unsupported op).
--/
-@[expose]
-def Interp (α : Type) : Type := Option (UBOr α)
-
-@[expose]
-def Interp.map {α β : Type} (f : α → β) : Interp α → Interp β :=
-  Option.map (UBOr.map f)
+@[simp, grind =] theorem Interp.map_fail : Interp.map f .fail = .fail := rfl
+@[simp, grind =] theorem Interp.map_ub : Interp.map f .ub = .ub := rfl
+@[simp, grind =] theorem Interp.map_ok : Interp.map f (.ok a) = .ok (f a) := rfl
 
 instance : Monad Interp where
-  pure x := (some (.ok x) : Option (UBOr _))
-  bind x f := match (x : Option (UBOr _)) with
-    | none => none
-    | some .ub => some .ub
-    | some (.ok a) => f a
+  pure x := .ok x
+  bind x f := match x with
+    | .fail => .fail
+    | .ub => .ub
+    | .ok a => f a
 
 instance : MonadLift Option Interp where
   monadLift
-    | none => none
-    | some v => some (.ok v)
+    | none => .fail
+    | some v => .ok v
 
-instance : Inhabited (Interp α) := ⟨(none : Option (UBOr α))⟩
+@[simp, grind =] theorem Interp.pure_eq (a : α) : (pure a : Interp α) = .ok a := rfl
+@[simp, grind =] theorem Interp.bind_ok (a : α) (f : α → Interp β) :
+    (Interp.ok a >>= f) = f a := rfl
+@[simp, grind =] theorem Interp.bind_ub (f : α → Interp β) :
+    ((.ub : Interp α) >>= f) = .ub := rfl
+@[simp, grind =] theorem Interp.bind_fail (f : α → Interp β) :
+    ((.fail : Interp α) >>= f) = .fail := rfl
+@[simp, grind =] theorem Interp.liftOption_none : ((none : Option α) : Interp α) = .fail := rfl
+@[simp, grind =] theorem Interp.liftOption_some (a : α) : ((some a : Option α) : Interp α) = .ok a := rfl
 
-/-- Signal undefined behaviour from inside the interpreter monad. -/
-@[inline] def Interp.ub : Interp α := some .ub
 
 /--
   Signal UB if the divisor `b` of an unsigned division or remainder could be
@@ -1027,8 +1022,8 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
   | .alloca => do
     let [.int _ (.val count)] := operands.toList | none
     let size ← match properties.elem_type.val with
-    | Attribute.integerType { bitwidth := bw } => some (.ok (bw / 8))
-    | .llvmPointerType _ => some (.ok 8)
+    | Attribute.integerType { bitwidth := bw } => .ok ((bw / 8))
+    | .llvmPointerType _ => .ok (8)
     | _ => none
     let totalSize := (size * count.toNat).toUInt64
     let (mem, addr) := mem.alloc totalSize
@@ -1062,18 +1057,18 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
     let [⟨type, _⟩] := resultTypes.toList | none
     let result ← do match val, type with
       | .int bw1 val', .integerType ⟨bw2⟩ =>
-          if bw1 ≠ bw2 then none else some (.ok val)
+          if bw1 ≠ bw2 then .fail else .ok (val)
       | .int bw1 val', .byteType ⟨bw2⟩ =>
-          if bw1 ≠ bw2 then none else some (.ok (.byte bw1 $ LLVM.Byte.fromInt val'))
+          if bw1 ≠ bw2 then .fail else .ok ((.byte bw1 $ LLVM.Byte.fromInt val'))
       | .byte bw1 val', .byteType ⟨bw2⟩ =>
-          if bw1 ≠ bw2 then none else some (.ok val)
+          if bw1 ≠ bw2 then .fail else .ok (val)
       | .byte bw1 val', .integerType ⟨bw2⟩ =>
-          if bw1 ≠ bw2 then none else some (.ok (.int bw1 $ val'.toInt))
+          if bw1 ≠ bw2 then .fail else .ok ((.int bw1 $ val'.toInt))
       | .byte bw val', .llvmPointerType _ =>
-          if h : bw = 64 then some (.ok (.addr (val'.cast h).toUInt64)) else none
-      | .addr val', .llvmPointerType _ => some (.ok val)
+          if h : bw = 64 then .ok ((.addr (val'.cast h).toUInt64)) else .fail
+      | .addr val', .llvmPointerType _ => .ok (val)
       | .addr val', .byteType ⟨bw⟩ =>
-          if h : bw = 64 then some (.ok (.byte 64 $ LLVM.Byte.fromUInt64 val')) else none
+          if h : bw = 64 then .ok ((.byte 64 $ LLVM.Byte.fromUInt64 val')) else .fail
       | _, _ => none
     return (#[result], mem, none)
   | _ => none
@@ -1808,14 +1803,14 @@ def interpretBlockCFG (blockPtr : BlockPtr) (values : Array RuntimeValue) {ctx :
     (state : InterpreterState ctx) (blockInBounds : blockPtr.InBounds ctx.raw := by grind) :
     Interp (InterpreterState ctx × Array RuntimeValue) := do
   match interpretBlock blockPtr values state blockInBounds with
-  | some (.ok (state, .return res)) => some (.ok (state, res))
-  | some (.ok (state, .branch res succ)) =>
+  | .ok (state, .return res) => .ok (state, res)
+  | .ok (state, .branch res succ) =>
     if h : succ.InBounds ctx.raw then
       interpretBlockCFG succ res state h
     else
-      none
-  | some .ub => Interp.ub
-  | none => none
+      .fail
+  | .ub => .ub
+  | .fail => .fail
 partial_fixpoint
 
 /--

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -59,10 +59,10 @@ theorem interpretOp'_eq_interpretOp'_other_memory
 theorem interpretOp'_eq_ok_implies_memory_eq (h : op.Pure ctx) :
       interpretOp' (op.getOpType! ctx) (op.getProperties! ctx (op.getOpType! ctx))
         (op.getResultTypes! ctx) operands (op.getSuccessors! ctx) memory₁ =
-          some (.ok (resValues, memory₂, cf)) →
+          .ok (resValues, memory₂, cf) →
       memory₁ = memory₂ := by
   rw [h operands memory₁ memory₁]
-  simp only [Interp.map, Option.map, Interp, UBOr.map]
+  simp only [Interp.map]
   grind
 
 end OperationPtr.Pure
@@ -75,13 +75,13 @@ equivalent to saying that the results of interpreting `op` on the given `state` 
 -/
 def InterpreterState.EquationHolds {ctx : WfIRContext OpCode} (state : InterpreterState ctx)
     (op : OperationPtr) (inBounds : op.InBounds ctx.raw := by grind) : Prop :=
-  ∃ controlFlow, interpretOp op state = some (.ok (state, controlFlow))
+  ∃ controlFlow, interpretOp op state = .ok (state, controlFlow)
 
 theorem interpretOp_equationHolds_self
     {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom)
     (inBounds : op.InBounds ctx.raw) :
     op.Pure ctx →
-    interpretOp op state = some (.ok (state', controlFlow)) →
+    interpretOp op state = .ok (state', controlFlow) →
     state'.EquationHolds op := by
   simp only [InterpreterState.EquationHolds]
   grind [OperationPtr.Pure.interpretOp'_eq_ok_implies_memory_eq, interpretOp_some_iff]
@@ -90,7 +90,7 @@ theorem interpretOp_equationHolds_other
     {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} (ctxDom : ctx.Dom)
     {inBounds₁ : op₁.InBounds ctx.raw} {inBounds₂ : op₂.InBounds ctx.raw} :
     op₂.Pure ctx →
-    interpretOp op₁ state inBounds₁ = some (.ok (state', cf₁)) →
+    interpretOp op₁ state inBounds₁ = .ok (state', cf₁) →
     op₂.dominates op₁ ctx →
     state.EquationHolds op₂ →
     state'.EquationHolds op₂ := by
@@ -105,7 +105,7 @@ theorem interpretOp_equationHolds_other
   simp only [VariableState.getOperandValues_setResultValues?_of_dominates ctxDom hDom hResValues₁]
   simp only [hOperandValues₂, OperationPtr.interpret]
   rw [OperationPtr.Pure.interpretOp'_eq_interpretOp'_other_memory op₂Pure memory₂]
-  simp only [hInterp₂', Interp.map, Option.map, UBOr.map]
+  simp only [hInterp₂', Interp.map]
   by_cases hOp : op₂ = op₁
   · grind
   · have := VariableState.setResultValues?_comm hOp hResValues₂ hResValues₁
@@ -132,7 +132,7 @@ theorem interpretOp_equationLemmaAt {ctx : WfIRContext OpCode} {opInBounds} {sta
     (ctxDom : ctx.Dom)
     (stateWf : state.EquationLemmaAt (InsertPoint.before op) opInBounds)
     (opHasParent : (op.get! ctx.raw).parent = some block) :
-    interpretOp op state = some (.ok (state', controlFlow)) →
+    interpretOp op state = .ok (state', controlFlow) →
     state'.EquationLemmaAt (InsertPoint.after op ctx.raw block) := by
   intro hInterp
   simp only [InterpreterState.EquationLemmaAt] at stateWf ⊢
@@ -194,7 +194,7 @@ theorem interpretOp_DefinesDominating {ctx : WfIRContext OpCode} {opInBounds}
     (ctxDom : ctx.Dom) {state state' : InterpreterState ctx}
     (stateDom : state.DefinesDominating (InsertPoint.before op) opInBounds)
     (opHasParent : (op.get! ctx.raw).parent = some block) :
-    interpretOp op state = some (.ok (state', controlFlow)) →
+    interpretOp op state = .ok (state', controlFlow) →
     state'.DefinesDominating (InsertPoint.after op ctx.raw block) := by
   intro hinterp
   simp only [InterpreterState.DefinesDominating] at stateDom ⊢
@@ -256,46 +256,46 @@ theorem InterpreterState.EquationLemmaAt.setArgumentValues?_succ_entry (ctxDom :
 
 /-- Interpreting a verified operation never fails on a state satisfying `DefinesDominating` at the
 operation's location. -/
-theorem InterpreterState.DefinesDominating.interpretOp_ne_none
+theorem InterpreterState.DefinesDominating.interpretOp_ne_fail
     (ctxDom : ctx.Dom) {state : InterpreterState ctx}
     (stateDom : state.DefinesDominating (InsertPoint.before op) ipInBounds)
     (opVerif : op.Verified ctx opInBounds) :
-    ∃ state', interpretOp op state opInBounds = some state' := by
+    interpretOp op state opInBounds ≠ .fail := by
   simp only [interpretOp]
   have ⟨operandValues, hOperandValues⟩ := stateDom.exists_getOperandValues_eq_some ctxDom
   simp only [hOperandValues]
   have hconforms : RuntimeValue.ArrayConforms operandValues (op.getOperandTypes! ctx.raw) := by
     grind [VariableState.getOperandValues_conforms]
-  have ⟨resValues, hresValues⟩ := exists_interpretOp'_eq_some opVerif hconforms state.memory
-  simp only [hresValues, bind]
-  rcases resValues with ⟨resValues, mem', act⟩ | _
-  · simp only [liftM, monadLift, MonadLift.monadLift, pure, Interp]
+  have hne := interpretOp'_ne_fail opVerif hconforms state.memory
+  rcases hresValues : op.interpret ctx operandValues state.memory with _ | _ | ⟨resValues, mem', act⟩
+  · exact absurd hresValues hne
+  · simp
+  · simp only [liftM, monadLift, MonadLift.monadLift]
     have := interpretOp'_results_conform opVerif hconforms hresValues
     have ⟨v, hv⟩ :=
       (VariableState.setResultValues?_isSome_iff_conforms state.variables opInBounds).mp this
     simp [hv]
-  · simp [Interp]
 
-/-- `interpretOpList` never fails (returns `none`) on a slice of an operation chain given a verified
+/-- `interpretOpList` never fails (returns `.fail`) on a slice of an operation chain given a verified
 and well-dominated context, on an interpreter state containing all values dominating the first
 operation in the slice. -/
-theorem InterpreterState.DefinesDominating.interpretOpList_ne_none
+theorem InterpreterState.DefinesDominating.interpretOpList_ne_fail
     (ctxVerif : ctx.Verified) (ctxDom : ctx.Dom) {block : BlockPtr}
     (hChain : block.OpChainSlice ctx.raw ops)
     {state : InterpreterState ctx}
     (stateDom : ∀ head, (hhead : ops.head? = some head) →
       state.DefinesDominating (.before head) (by grind [List.mem_of_head? hhead])) :
-    interpretOpList ops state ≠ none := by
+    interpretOpList ops state ≠ .fail := by
   induction ops generalizing state with
   | nil => simp
   | cons a l ih =>
     have hDom : state.DefinesDominating (.before a) := stateDom a (by simp)
     obtain ⟨headInBounds, headParent, headNext, hChainTail⟩ := hChain
     simp only [interpretOpList_cons]
-    rcases hi : interpretOp a state (by grind) with _ | (⟨s, act⟩ | _)
-    · grind [InterpreterState.DefinesDominating.interpretOp_ne_none ctxDom]
-    · grind [interpretOp_DefinesDominating ctxDom hDom headParent hi]
+    rcases hi : interpretOp a state (by grind) with _ | _ | ⟨s, act⟩
+    · grind [InterpreterState.DefinesDominating.interpretOp_ne_fail ctxDom]
     · simp
+    · grind [interpretOp_DefinesDominating ctxDom hDom headParent hi]
 
 /-- If the equation lemma holds at the point *before* an operation chain, interpreting the chain
 keeps the equation lemma valid at the point *after* the chain. -/
@@ -306,7 +306,7 @@ theorem interpretOpList_equationLemmaAt {ctx : WfIRContext OpCode}
     (eqLemma : state.EquationLemmaAt (.before fstOp) (by
       grind [List.head?_eq_getElem?, hChain.inBounds_of_mem]))
     (hLastElem : ops.getLast? = some lastOp)
-    (hrun : interpretOpList ops state (by grind) = some (.ok (state', none))) :
+    (hrun : interpretOpList ops state (by grind) = .ok (state', none)) :
     state'.EquationLemmaAt (InsertPoint.after lastOp ctx.raw block) := by
   induction ops generalizing state fstOp with
   | nil => grind
@@ -315,12 +315,12 @@ theorem interpretOpList_equationLemmaAt {ctx : WfIRContext OpCode}
     have : head = fstOp := by grind
     subst head
     simp only [interpretOpList_cons] at hrun
-    rcases hi : interpretOp fstOp state headInBounds with _ | (⟨s, act⟩ | _) <;>
+    rcases hi : interpretOp fstOp state headInBounds with _ | _ | ⟨s, act⟩ <;>
       simp only [hi] at hrun
     · simp at hrun
+    · grind
     · have hAfter := interpretOp_equationLemmaAt ctxDom eqLemma headParent hi
       cases tail <;> grind
-    · grind
 
 /-- If `DefinesDominating` holds at the point *before* an operation chain, interpreting the chain
 keeps `DefinesDominating` at the point *after* the chain. -/
@@ -331,7 +331,7 @@ theorem interpretOpList_DefinesDominating {ctx : WfIRContext OpCode}
     (stateDom : state.DefinesDominating (.before fstOp) (by
       grind [List.head?_eq_getElem?, hChain.inBounds_of_mem]))
     (hLastElem : ops.getLast? = some lastOp)
-    (hrun : interpretOpList ops state (by grind) = some (.ok (state', none))) :
+    (hrun : interpretOpList ops state (by grind) = .ok (state', none)) :
     state'.DefinesDominating (InsertPoint.after lastOp ctx.raw block) := by
   induction ops generalizing state fstOp with
   | nil => simp at hLastElem
@@ -339,12 +339,12 @@ theorem interpretOpList_DefinesDominating {ctx : WfIRContext OpCode}
     obtain ⟨headInBounds, headParent, headNext, hChainTail⟩ := hChain
     obtain rfl : a = fstOp := by simpa using head
     simp only [interpretOpList_cons] at hrun
-    rcases hi : interpretOp a state headInBounds with _ | (⟨s, act⟩ | _) <;>
+    rcases hi : interpretOp a state headInBounds with _ | _ | ⟨s, act⟩ <;>
       simp only [hi] at hrun
     · simp at hrun
+    · grind
     · cases act
       case none =>
         have hAfter := interpretOp_DefinesDominating ctxDom stateDom headParent hi
         cases tail <;> grind
       case some cf => grind
-    · grind

--- a/Veir/Interpreter/Evaluate.lean
+++ b/Veir/Interpreter/Evaluate.lean
@@ -23,7 +23,7 @@ private def isFoldEvaluationCandidate
 /--
   Evaluate an operation with the interpreter, given the runtime values of its
   operands. Returns the result values, `Interp.ub` if the operation triggers
-  UB, and `none` if the operation must not be evaluated or the interpreter
+  UB, and `Interp.fail` if the operation must not be evaluated or the interpreter
   cannot evaluate it.
 -/
 def foldEvaluate (opCode : OpCode) (properties : propertiesOf opCode)

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -281,10 +281,10 @@ theorem interpretOp'_opType_cast
 
 theorem interpretOp_some_iff {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx}
   {inBounds : op.InBounds ctx.raw} :
-  interpretOp op state inBounds = some (.ok (state', cf)) ↔
+  interpretOp op state inBounds = .ok (state', cf) ↔
   ∃ operandValues resValues mem' varState',
     (state.variables.getOperandValues op) = some operandValues ∧
-    op.interpret ctx operandValues state.memory = some (.ok (resValues, mem', cf)) ∧
+    op.interpret ctx operandValues state.memory = .ok (resValues, mem', cf) ∧
     state.variables.setResultValues? op resValues = some varState' ∧
     state' = ⟨varState', mem'⟩ := by
   simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]
@@ -298,9 +298,9 @@ setting the result values in the state succeeds.
 theorem interpretOp_ok_iff_of_getOperandValues_eq_some
   {ctx : WfIRContext OpCode} {state state' : InterpreterState ctx} {inBounds : op.InBounds ctx.raw}
   (hoperandValues : state.variables.getOperandValues op = some operandValues) :
-  interpretOp op state inBounds = some (.ok (state', cf)) ↔
+  interpretOp op state inBounds = .ok (state', cf) ↔
   ∃ resValues,
-    op.interpret ctx operandValues state.memory = some (.ok (resValues, state'.memory, cf)) ∧
+    op.interpret ctx operandValues state.memory = .ok (resValues, state'.memory, cf) ∧
     state.variables.setResultValues? op resValues = some state'.variables := by
   simp only [interpretOp, hoperandValues, bind, pure, liftM, monadLift, MonadLift.monadLift]
   grind [cases InterpreterState]
@@ -311,10 +311,10 @@ and that the underlying `interpretOp'` call triggered `ub`.
 -/
 theorem interpretOp_ub_iff {ctx : WfIRContext OpCode} {state : InterpreterState ctx}
   {inBounds : op.InBounds ctx.raw} :
-  interpretOp op state inBounds = some .ub ↔
+  interpretOp op state inBounds = .ub ↔
   ∃ operandValues,
     (state.variables.getOperandValues op) = some operandValues ∧
-    op.interpret ctx operandValues state.memory = some .ub := by
+    op.interpret ctx operandValues state.memory = .ub := by
   simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]
   grind
 
@@ -323,8 +323,8 @@ the variable state. -/
 theorem interpretOp_ub_iff_op_interpret_of_getOperandValues_eq_some
   {ctx : WfIRContext OpCode} {state : InterpreterState ctx} {inBounds : op.InBounds ctx.raw}
   (hoperandValues : state.variables.getOperandValues op = some operandValues) :
-  interpretOp op state inBounds = some .ub ↔
-  op.interpret ctx.raw operandValues state.memory = some .ub := by
+  interpretOp op state inBounds = .ub ↔
+  op.interpret ctx.raw operandValues state.memory = .ub := by
   simp only [interpretOp, bind, pure, liftM, monadLift, MonadLift.monadLift]
   grind
 
@@ -510,9 +510,9 @@ theorem interpretOp_forward
     {ctx : WfIRContext OpCode} {op : OperationPtr} {state : InterpreterState ctx}
     {inBounds : op.InBounds ctx.raw} {vals results : Array RuntimeValue} {mem' : MemoryState}
     (hVals : state.variables.getOperandValues op = some vals)
-    (hInterp : op.interpret ctx vals state.memory = some (.ok (results, mem', none)))
+    (hInterp : op.interpret ctx vals state.memory = .ok (results, mem', none))
     (hConf : RuntimeValue.ArrayConforms results (op.getResultTypes! ctx.raw)) :
-    ∃ state', interpretOp op state inBounds = some (.ok (state', none)) ∧
+    ∃ state', interpretOp op state inBounds = .ok (state', none) ∧
       state'.memory = mem' ∧
       state.variables.setResultValues? op results = some state'.variables := by
   obtain ⟨varState', hSet⟩ :=
@@ -528,33 +528,33 @@ variable {state : InterpreterState ctx}
 
 @[simp, grind =]
 theorem interpretOpList_nil :
-    interpretOpList [] state inBounds = some (.ok (state, none)) := by
+    interpretOpList [] state inBounds = .ok (state, none) := by
   simp [interpretOpList, pure]
 
 theorem interpretOpList_cons :
     interpretOpList (op :: l) state inBounds =
     match interpretOp op state with
-    | none => none
-    | some .ub => some .ub
-    | some (.ok (state', none)) => interpretOpList l state' (by grind)
-    | some (.ok (state', some cf)) => some (.ok (state', some cf)) := by
+    | .fail => .fail
+    | .ub => .ub
+    | .ok (state', none) => interpretOpList l state' (by grind)
+    | .ok (state', some cf) => .ok (state', some cf) := by
   simp [interpretOpList, bind, pure]
   grind
 
 theorem interpretOpList_append :
     interpretOpList (l₁ ++ l₂) state inBounds =
     match interpretOpList l₁ state (by grind) with
-    | some (.ok (state', none)) => interpretOpList l₂ state' (by grind)
-    | some (.ok (state', some cf)) => some (.ok (state', some cf))
-    | some .ub => some .ub
-    | none => none := by
+    | .ok (state', none) => interpretOpList l₂ state' (by grind)
+    | .ok (state', some cf) => .ok (state', some cf)
+    | .ub => .ub
+    | .fail => .fail := by
   induction l₁ generalizing state
   · simp
   · grind [interpretOpList_cons]
 
 @[simp, grind =]
 theorem interpretTerminatedOpList_nil :
-    interpretTerminatedOpList [] state inBounds = none := by
+    interpretTerminatedOpList [] state inBounds = .fail := by
   simp [interpretTerminatedOpList, interpretOpList_nil, bind]
 
 theorem interpretTerminatedOpList_cons {ctx : WfIRContext OpCode}
@@ -563,20 +563,20 @@ theorem interpretTerminatedOpList_cons {ctx : WfIRContext OpCode}
     {inBounds : ∀ op' ∈ op :: l, op'.InBounds ctx.raw} :
     interpretTerminatedOpList (op :: l) state inBounds =
     match interpretOp op state with
-    | none => none
-    | some .ub => some .ub
-    | some (.ok (state', none)) => interpretTerminatedOpList l state' (by grind)
-    | some (.ok (state', some cf)) => some (.ok (state', cf)) := by
+    | .fail => .fail
+    | .ub => .ub
+    | .ok (state', none) => interpretTerminatedOpList l state' (by grind)
+    | .ok (state', some cf) => .ok (state', cf) := by
   simp [interpretTerminatedOpList, interpretOpList_cons, bind, pure]
   grind
 
 theorem interpretTerminatedOpList_append :
     interpretTerminatedOpList (l₁ ++ l₂) state inBounds =
     match interpretOpList l₁ state (by grind) with
-    | some (.ok (state', none)) => interpretTerminatedOpList l₂ state' (by grind)
-    | some (.ok (state', some cf))=> some (.ok (state', cf))
-    | some .ub => some .ub
-    | none => none := by
+    | .ok (state', none) => interpretTerminatedOpList l₂ state' (by grind)
+    | .ok (state', some cf)=> .ok (state', cf)
+    | .ub => .ub
+    | .fail => .fail := by
   simp [interpretTerminatedOpList, interpretOpList_append, bind, pure]
   grind
 
@@ -584,10 +584,10 @@ theorem interpretOpChain_of_next!_eq_some {state' : InterpreterState ctx}
     (hnext : (op.get! ctx.raw).next = some op') :
     interpretOpChain op state' inBounds =
     match interpretOp op state' (by grind) with
-    | none => none
-    | some .ub => some .ub
-    | some (.ok (state'', none)) => interpretOpChain op' state'' (by grind)
-    | some (.ok (state'', some cf)) => some (.ok (state'', cf)) := by
+    | .fail => .fail
+    | .ub => .ub
+    | .ok (state'', none) => interpretOpChain op' state'' (by grind)
+    | .ok (state'', some cf) => .ok (state'', cf) := by
   rw [interpretOpChain]
   simp [bind, pure]
   grind
@@ -596,10 +596,10 @@ theorem interpretOpChain_of_next!_eq_none {state' : InterpreterState ctx}
     (hnext : (op.get! ctx.raw).next = none) :
     interpretOpChain op state' inBounds =
     match interpretOp op state' (by grind) with
-    | none => none
-    | some .ub => some .ub
-    | some (.ok (_, none)) => none
-    | some (.ok (state'', some cf)) => some (.ok (state'', cf)) := by
+    | .fail => .fail
+    | .ub => .ub
+    | .ok (_, none) => .fail
+    | .ok (state'', some cf) => .ok (state'', cf) := by
   rw [interpretOpChain]
   simp [bind, pure]
   grind
@@ -638,11 +638,11 @@ end interpretOpList
 
 /-- An operation that verifies does not fail interpretation as long as the operands conform to
 the declared operand types. -/
-axiom exists_interpretOp'_eq_some {ctx : WfIRContext OpCode} {op : OperationPtr}
+axiom interpretOp'_ne_fail {ctx : WfIRContext OpCode} {op : OperationPtr}
     {opInBounds : op.InBounds ctx.raw} (opVerify : OperationPtr.Verified ctx op opInBounds)
     (operandConforms : RuntimeValue.ArrayConforms operands (op.getOperandTypes! ctx.raw))
     (mem : MemoryState) :
-  ∃ res, op.interpret ctx.raw operands mem = some res
+  op.interpret ctx.raw operands mem ≠ .fail
 
 axiom interpretOp'_monotone
     (opType : OpCode) (properties : propertiesOf opType) (resultTypes : Array TypeAttr)
@@ -661,7 +661,7 @@ A successful operation interpretation returns result values that conform to the 
 axiom interpretOp'_results_conform {ctx : WfIRContext OpCode}
     {opInBounds : op.InBounds ctx.raw} (opVerif : op.Verified ctx opInBounds)
     (conforms : RuntimeValue.ArrayConforms operands (op.getOperandTypes! ctx.raw))
-    (h : op.interpret ctx.raw operands mem = some (.ok (vals, mem', act))) :
+    (h : op.interpret ctx.raw operands mem = .ok (vals, mem', act)) :
     RuntimeValue.ArrayConforms vals (op.getResultTypes! ctx.raw)
 
 /--
@@ -670,7 +670,7 @@ provided successor blocks.
 -/
 axiom interpretOp'_branch_dest_mem
     (h : interpretOp' opType properties resultTypes operands blockOperands mem
-      = some (.ok (vals, mem', some (.branch res dest)))) :
+      = .ok (vals, mem', some (.branch res dest))) :
     dest ∈ blockOperands
 
 /--
@@ -680,7 +680,7 @@ operation successors.
 theorem interpretOp_branch_dest_mem_getSuccessors!
     {ctx : WfIRContext OpCode} {op : OperationPtr} {state state' : InterpreterState ctx}
     {inBounds : op.InBounds ctx.raw} {res : Array RuntimeValue} {dest : BlockPtr}
-    (h : interpretOp op state inBounds = some (.ok (state', some (.branch res dest)))) :
+    (h : interpretOp op state inBounds = .ok (state', some (.branch res dest))) :
     dest ∈ op.getSuccessors! ctx.raw := by
   obtain ⟨operandValues, resValues, mem', varState', hOperand, hInterp', hSetRes, hStateEq⟩ :=
     interpretOp_some_iff.mp h

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -76,17 +76,17 @@ def FunctionResult.isRefinedBy (source target : MemoryState × Array RuntimeValu
 /--
 An interpretation result `source` is refined by `target` given a refinement relation `R`
 on the underlying values. This asserts:
-* every well-defined outcome `some (.ok a)` of `source` must be matched by an outcome
-  `some (.ok b)` of `target` with `R a b`;
-* when `source` is undefined behaviour (`some .ub`) or failed interpretation (`none`), `target`
+* every well-defined outcome `.ok a` of `source` must be matched by an outcome
+  `.ok b` of `target` with `R a b`;
+* when `source` is undefined behaviour (`.ub`) or failed interpretation (`.fail`), `target`
   is unconstrained
 -/
 @[expose]
 def Interp.isRefinedBy (R : α → β → Prop) (source : Interp α) (target : Interp β) : Prop :=
   match source, target with
-  | some (.ok a), some (.ok b) => R a b
-  | some .ub, _ => True
-  | none, _ => True
+  | .ok a, .ok b => R a b
+  | .ub, _ => True
+  | .fail, _ => True
   | _, _ => False
 
 /--

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -53,9 +53,9 @@ theorem FunctionResult.isRefinedBy_refl (r : MemoryState × Array RuntimeValue) 
   simp [FunctionResult.isRefinedBy]
 
 @[simp, grind .]
-theorem Interp.isRefinedBy_refl_of_ne_none {α : Type} {R : α → α → Prop}
-    (hR : ∀ a, R a a) (x : Interp α) (neNone : x ≠ none) : Interp.isRefinedBy R x x := by
-  rcases x with _ | (x | _) <;> grind [Interp.isRefinedBy]
+theorem Interp.isRefinedBy_refl_of_ne_fail {α : Type} {R : α → α → Prop}
+    (hR : ∀ a, R a a) (x : Interp α) (neFail : x ≠ .fail) : Interp.isRefinedBy R x x := by
+  rcases x with _ | _ | x <;> grind [Interp.isRefinedBy]
 
 @[simp, grind .]
 theorem VariableState.isRefinedBy_refl
@@ -173,23 +173,23 @@ theorem RuntimeValue.reg_of_isRefinedBy {v : Data.RISCV.Reg} {tv : RuntimeValue}
 
 /-! ## Interp refinements -/
 
-/-- `none` is refined by any value. -/
+/-- `fail` is refined by any value. -/
 @[simp, grind .]
-theorem Interp.isRefinedBy_none_target :
-    Interp.isRefinedBy R none target := by
+theorem Interp.isRefinedBy_fail_target :
+    Interp.isRefinedBy R .fail target := by
   simp [Interp.isRefinedBy]
 
 /-- `ub` is refined by any value. -/
 @[simp, grind .]
 theorem Interp.isRefinedBy_ub_target :
-    Interp.isRefinedBy R (some .ub) target := by
+    Interp.isRefinedBy R (.ub) target := by
   simp only [Interp.isRefinedBy]
 
 /-- `ok` is only refined by `ok` values that satisfy the given refinement relation. -/
 @[simp, grind =]
 theorem Interp.isRefinedBy_ok_target_iff :
-    Interp.isRefinedBy R (some (.ok sourceRes)) target ↔
-    ∃ targetRes, target = some (.ok targetRes) ∧ R sourceRes targetRes := by
+    Interp.isRefinedBy R (.ok sourceRes) target ↔
+    ∃ targetRes, target = .ok targetRes ∧ R sourceRes targetRes := by
   simp only [Interp.isRefinedBy]
   rcases target with _ | (_ | _) <;> grind
 

--- a/Veir/Interpreter/Refinement/Monotonicity.lean
+++ b/Veir/Interpreter/Refinement/Monotonicity.lean
@@ -107,7 +107,7 @@ theorem interpretOp_monotone
       (interpretOp op state opIn)
       (interpretOp op' state' opIn') := by
   -- If the source interpretation fails, then the refinement is trivial
-  by_cases hsource : interpretOp op state opIn = none; simp [hsource, Interp.isRefinedBy]
+  by_cases hsource : interpretOp op state opIn = .fail; simp [hsource, Interp.isRefinedBy]
   -- Source/target operands are defined, and memory is equal.
   have ⟨operands, hSrcOps⟩ : ∃ operands, state.variables.getOperandValues op = some operands := by
     grind [interpretOp]
@@ -123,9 +123,11 @@ theorem interpretOp_monotone
                     op.interpret ctx.raw operands' state.memory := by
      grind [interpretOp'_opType_cast, cases ValueMapping.PreservesOperation]
   /- Do a case analysis on the source interpretation -/
-  rcases hsrc : interpretOp op state opIn with _ | (⟨state₂, act⟩ | _)
+  rcases hsrc : interpretOp op state opIn with _ | _ | ⟨state₂, act⟩
   · -- If the source interpretation fails, then the refinement is trivial
     simp [Interp.isRefinedBy]
+  · /- If the source interpretation returns UB, then the refinement holds trivially. -/
+    simp
   · /- If the source interpretation returns a new state, we need to prove that (1) the target
        interpretation also returns a new state, and (2) the new states are in the refinement relation. -/
     simp only [Interp.isRefinedBy_ok_target_iff, Prod.exists]
@@ -138,11 +140,9 @@ theorem interpretOp_monotone
     simp only [interpretOp, hTgtOps, bind, hinterp'Tgt, liftM, monadLift, MonadLift.monadLift]
     have := interpretOp'_results_conform (opInBounds := opIn') opVerif' (VariableState.getOperandValues_conforms hTgtOps) hinterp'Tgt
     have ⟨v, hv⟩ := (VariableState.setResultValues?_isSome_iff_conforms state'.variables opIn').mp this
-    simp only [Interp, hv, pure, Option.some.injEq, UBOr.ok.injEq, Prod.mk.injEq]
+    simp only [hv, Interp.pure_eq, Interp.ok.injEq, Prod.mk.injEq]
     have stateVarRef : state.variables.isRefinedBy state'.variables mapping := by grind [InterpreterState.isRefinedBy]
     grind [InterpreterState.isRefinedBy, VariableState.setResultValues?_isRefinedBy stateVarRef resValuesRef, cases ValueMapping.PreservesOperation]
-  · /- If the source interpretation returns UB, then the refinement holds trivially. -/
-    simp
 
 
 /-!
@@ -171,16 +171,18 @@ theorem interpretOpList_mono
         r₁.1.isRefinedBy r₂.1 mapping ∧ ControlFlowAction.optionIsRefinedBy r₁.2 r₂.2)
       (interpretOpList ops state) (interpretOpList ops state') := by
   induction ops generalizing state state' with
-  | nil => simpa [Interp]
+  | nil => simpa using hState
   | cons a l ih =>
     /- Refinement of the state after interpreting the head operation `a`. -/
     have refinesHead := interpretOp_monotone (opsInBounds a (by grind)) (opsInBounds' a (by grind))
       hState (hPreserves a (by grind)) (by grind)
     simp only [interpretOpList_cons]
     /- Case analysis on the interpretation of the head operation `a` in the source. -/
-    rcases hsrc : interpretOp a state (opsInBounds a (by grind)) with _ | (⟨s, act⟩ | _)
-    · /- Source operation fails: interpreting the list returns `none`, refinement is trivial. -/
+    rcases hsrc : interpretOp a state (opsInBounds a (by grind)) with _ | _ | ⟨s, act⟩
+    · /- Source operation fails: interpreting the list returns `.fail`, refinement is trivial. -/
       simp [Interp.isRefinedBy]
+    · /- Source operation is UB, which is refined by anything. -/
+      simp
     · /- Source operation succeeds with new state `s` and action `act`. This means that the target
       operation also succeeds with a refined state `s'` and action `act'`. -/
       simp only [hsrc, Interp.isRefinedBy_ok_target_iff] at refinesHead
@@ -200,9 +202,7 @@ theorem interpretOpList_mono
         /- A control-flow action: the list stops here for both the source and the target. -/
         have ⟨cf', hact', hcfRef⟩ : ∃ cf', act' = some cf' ∧ cf.isRefinedBy cf' := by grind
         subst hact'
-        simp [Interp, hsRef, ControlFlowAction.optionIsRefinedBy, hcfRef]
-    · /- Source operation is UB, which is refined by anything. -/
-      simp
+        simp [hsRef, ControlFlowAction.optionIsRefinedBy, hcfRef]
 
 /-- `interpretTerminatedOpList` is monotone under a *cross-context* interpreter-state refinement,
 over an *identical* list of operations. The proof is derived from `interpretOpList_monotone`, as
@@ -223,8 +223,9 @@ theorem interpretTerminatedOpList_mono
       (interpretTerminatedOpList ops state) (interpretTerminatedOpList ops state') := by
   have hList := interpretOpList_mono ctx'Verif opsInBounds opsInBounds' hState hFrame
   simp only [interpretTerminatedOpList, bind]
-  rcases hsrc : interpretOpList ops state (by grind) with _ | (⟨s, act⟩ | _)
+  rcases hsrc : interpretOpList ops state (by grind) with _ | _ | ⟨s, act⟩
   · simp [Interp.isRefinedBy]
+  · exact Interp.isRefinedBy_ub_target
   · simp only [hsrc, Interp.isRefinedBy_ok_target_iff] at hList
     obtain ⟨⟨s', act'⟩, htgt, hsRef, hactRef⟩ := hList
     simp only [htgt]
@@ -239,6 +240,5 @@ theorem interpretTerminatedOpList_mono
         cases act' <;> simp_all [ControlFlowAction.optionIsRefinedBy]
       subst hact'
       exact ⟨hsRef, hcfRef⟩
-  · exact Interp.isRefinedBy_ub_target
 
 end Veir

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -86,9 +86,9 @@ def main (args : List String) : IO Unit := do
         let result := bind (interpretFunction (ctx := ctx) mainOp #[] MemoryState.empty (by sorry))
                            (fun (_, r) => pure r)
         match result with
-        | some (.ok results) => IO.println s!"Program output: {results}"
-        | some .ub => IO.println "Undefined behavior"
-        | none =>
+        | .ok results => IO.println s!"Program output: {results}"
+        | .ub => IO.println "Undefined behavior"
+        | .fail =>
           IO.eprintln "Error while interpreting module"
           IO.Process.exit 1
       | .error errMsg =>


### PR DESCRIPTION
Lean 4.33 has become stricter about the use of semireducible definitions, which makes `simp` and `grind` more fragile. This PR reduces our reliance on semireducible definitions by lifting `UBOr` into `Interp`.

`Interp α` was a semireducible `def` for `Option (UBOr α)`, so statements mixing an `Interp`-typed position with an `Option` constructor (`interpretOpList ops state ≠ none`, `… = some (.ok r)`) were only type-correct once `Interp` unfolded, which `simp`, `grind` and instance synthesis will not do at their reducible transparency. This replaces the `def` with a three-constructor inductive — `.ok` / `.ub` / `.fail`, with `UBOr` folded into it — so those goals are genuinely typed at `Interp` and the constructor lemmas apply directly.

This prepares for the Lean 4.33 upgrade in #1255.
