### PR TITLE
feat: build the `IsVerified*` type specs with `Attribute.asType`

### DIFF
--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -1375,6 +1375,14 @@ theorem TypeAttr.inj {attr1 attr2 : TypeAttr} :
 def Attribute.asType (attr : Attribute) (isType : attr.isType := by grind) : TypeAttr :=
   ⟨attr, isType⟩
 
+/-- `Attribute.asType` is the identity on the underlying attribute. Stated so that `simp` and
+`grind` can see through it without unfolding the semireducible `TypeAttr`. -/
+@[simp, grind =]
+theorem Attribute.asType_val {attr : Attribute} {isType : attr.isType} :
+    (attr.asType isType).val = attr := by
+  unfold Attribute.asType
+  rfl
+
 /-!
   ## Coercion instances to TypeAttr
 

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -237,7 +237,7 @@ theorem OperationPtr.Verified.arith_constant {op : OperationPtr} {opInBounds}
     op.getNumSuccessors! ctx.raw = 0 ∧
     op.getNumRegions! ctx.raw = 0 ∧
     ((op.getResult 0).get! ctx.raw).type =
-      ⟨(op.getProperties! ctx.raw Arith.constant).value.type, (by grind)⟩ := by
+      Attribute.asType (op.getProperties! ctx.raw Arith.constant).value.type (by grind) := by
   simp only [Verified, verifyLocalInvariants, HasOpInfo.verifyLocalInvariants,
     OpCode.verifyLocalInvariants, Arith.verifyLocalInvariants,
     ← getOpType!_eq_getOpType, opType, ne_eq,
@@ -797,9 +797,9 @@ def OperationPtr.IsVerifiedModArithBinop (op : OperationPtr) (ctx : WfIRContext 
   ∃ modArithType,
     modArithType.modulus.value > 0 ∧
     modArithType.modulus.value < 2 ^ modArithType.modulus.type.bitwidth ∧
-    ((op.getResult 0).get! ctx.raw).type = ⟨.modArithType modArithType, (by grind)⟩ ∧
-    ((op.getOperand! ctx.raw 0).getType! ctx.raw) = ⟨.modArithType modArithType, (by grind)⟩ ∧
-    ((op.getOperand! ctx.raw 1).getType! ctx.raw) = ⟨.modArithType modArithType, (by grind)⟩
+    ((op.getResult 0).get! ctx.raw).type = Attribute.asType (.modArithType modArithType) (by grind) ∧
+    ((op.getOperand! ctx.raw 0).getType! ctx.raw) = Attribute.asType (.modArithType modArithType) (by grind) ∧
+    ((op.getOperand! ctx.raw 1).getType! ctx.raw) = Attribute.asType (.modArithType modArithType) (by grind)
 
 
 private theorem OperationPtr.verifyModArithBinOp_eq_ok {ctx : WfIRContext OpCode} {op : OperationPtr}
@@ -848,7 +848,7 @@ def OperationPtr.IsVerifiedModArithConstant (op : OperationPtr) (ctx : WfIRConte
   op.getNumSuccessors! ctx.raw = 0 ∧
   op.getNumRegions! ctx.raw = 0 ∧
   ∃ modArithType,
-    ((op.getResult 0).get! ctx.raw).type = ⟨.modArithType modArithType, (by grind)⟩ ∧
+    ((op.getResult 0).get! ctx.raw).type = Attribute.asType (.modArithType modArithType) (by grind) ∧
     modArithType.modulus.value > 0 ∧
     modArithType.modulus.value < 2 ^ modArithType.modulus.type.bitwidth ∧
     -(2 ^ (modArithType.modulus.type.bitwidth - 1) : Int)

--- a/Veir/Verifier/Lemmas.lean
+++ b/Veir/Verifier/Lemmas.lean
@@ -20,11 +20,11 @@ def OperationPtr.IsVerifiedIntegerBinop
   op.getNumRegions! ctx.raw = 0 ∧
   ∃ integerType,
     ((op.getResult 0).get! ctx.raw).type =
-      ⟨.integerType integerType, (by grind)⟩ ∧
+      Attribute.asType (.integerType integerType) (by grind) ∧
     ((op.getOperand! ctx.raw 0).getType! ctx.raw) =
-      ⟨.integerType integerType, (by grind)⟩ ∧
+      Attribute.asType (.integerType integerType) (by grind) ∧
     ((op.getOperand! ctx.raw 1).getType! ctx.raw) =
-      ⟨.integerType integerType, (by grind)⟩
+      Attribute.asType (.integerType integerType) (by grind)
 
 /-- Extract structural facts from a successful `verifyIntegerBinop` check. -/
 theorem OperationPtr.verifyIntegerBinop_eq_ok
@@ -77,7 +77,7 @@ def OperationPtr.IsVerifiedIntegerUnop
   ((op.getResult 0).get! ctx.raw).type =
     (op.getOperand! ctx.raw 0).getType! ctx.raw ∧
   ∃ integerType isT,
-    ((op.getResult 0).get! ctx.raw).type = ⟨.integerType integerType, isT⟩
+    ((op.getResult 0).get! ctx.raw).type = Attribute.asType (.integerType integerType) isT
 
 /-- Extract structural facts from a successful `verifyIntegerUnop` check. -/
 theorem OperationPtr.verifyIntegerUnop_eq_ok
@@ -102,13 +102,13 @@ def OperationPtr.IsVerifiedIntegerTernop
   op.getNumRegions! ctx.raw = 0 ∧
   ∃ integerType,
     ((op.getResult 0).get! ctx.raw).type =
-      ⟨.integerType integerType, (by grind)⟩ ∧
+      Attribute.asType (.integerType integerType) (by grind) ∧
     ((op.getOperand! ctx.raw 0).getType! ctx.raw) =
-      ⟨.integerType integerType, (by grind)⟩ ∧
+      Attribute.asType (.integerType integerType) (by grind) ∧
     ((op.getOperand! ctx.raw 1).getType! ctx.raw) =
-      ⟨.integerType integerType, (by grind)⟩ ∧
+      Attribute.asType (.integerType integerType) (by grind) ∧
     ((op.getOperand! ctx.raw 2).getType! ctx.raw) =
-      ⟨.integerType integerType, (by grind)⟩
+      Attribute.asType (.integerType integerType) (by grind)
 
 /-- Extract structural facts from a successful `verifyIntegerTernop` check. -/
 theorem OperationPtr.verifyIntegerTernop_eq_ok
@@ -133,9 +133,9 @@ def OperationPtr.IsVerifiedIntegerExtop
   op.getNumRegions! ctx.raw = 0 ∧
   ∃ operandType resultType,
     ((op.getOperand! ctx.raw 0).getType! ctx.raw) =
-      ⟨.integerType operandType, (by grind)⟩ ∧
+      Attribute.asType (.integerType operandType) (by grind) ∧
     ((op.getResult 0).get! ctx.raw).type =
-      ⟨.integerType resultType, (by grind)⟩ ∧
+      Attribute.asType (.integerType resultType) (by grind) ∧
     operandType.bitwidth < resultType.bitwidth
 
 /-- Extract structural facts from a successful `verifyIntegerExtTypes` check. -/


### PR DESCRIPTION
Lean 4.33 does not reduce subtypes anymore in `simp` and `grind`.  This PR avoids breakage in the Lean 4.33 update in #1255.
