### PR TITLE
fix(dataflow): Dominance facts now attach directly to BlockPtrs instead of InsertPoints

### DIFF
--- a/UnitTest/DataFlowFramework/Dominance.lean
+++ b/UnitTest/DataFlowFramework/Dominance.lean
@@ -2,6 +2,7 @@ import UnitTest.DataFlowFramework.Helpers
 
 import Veir.Analysis.DataFlow.DominanceAnalysis
 import Veir.IR.Dominance
+import Veir.Rewriter.WfRewriter.Basic
 
 open Std (HashSet)
 open Veir
@@ -75,11 +76,10 @@ Compare `BlockPtr.immediateDominator?` against the expected block label.
 private def compareImmediateDominator
     (recovered : RecoveredNames)
     (expected : ExpectedBlockDominators)
-    (dfCtx : DataFlowContext)
-    (irCtx : WfIRContext OpCode) : MismatchReport := Id.run do
+    (dfCtx : DataFlowContext) : MismatchReport := Id.run do
   let some block := recovered.blocks[expected.name]?
     | return #[s!"idom {expected.name}: missing block label"]
-  let some observedIDom := block.immediateDominator? dfCtx irCtx
+  let some observedIDom := block.immediateDominator? dfCtx
     | return #[s!"idom {expected.name}: expected immediate dominator {expected.immediateDom}, observed none"]
   let some expectedIDom := recovered.blocks[expected.immediateDom]?
     | return #[s!"idom {expected.name}: missing block label {expected.immediateDom}"]
@@ -126,7 +126,7 @@ private def compareDominators
     (irCtx : WfIRContext OpCode) : MismatchReport := Id.run do
   let some block := recovered.blocks[expected.name]?
     | return #[s!"dominators {expected.name}: missing block label"]
-  let observedFact? := block.getDominatorFact? dfCtx irCtx
+  let observedFact? := block.getDominatorFact? dfCtx
   match expected.doms.isEmpty, observedFact? with
   | true, none =>
       return #[]
@@ -149,7 +149,7 @@ private def compareNamedDominators
   let mut report := #[]
   for expected in expectations do
     report := report ++ compareDominators recovered expected dfCtx irCtx
-    report := report ++ compareImmediateDominator recovered expected dfCtx irCtx
+    report := report ++ compareImmediateDominator recovered expected dfCtx
   report
 
 /-- Resolve a named SSA value to the operation that defines it. -/
@@ -570,6 +570,44 @@ def testOpDomSameRegionTwoBlocks : String :=
      , { dominator := "outer", dominated := "entry", dominates := true,  properDom := true  }
      , { dominator := "outer", dominated := "exit",  dominates := true,  properDom := true  }
      ]
+
+/-
+  Test: dominance facts remain usable after deleting the first operation of an
+  intermediate block without changing the CFG.
+-/
+def testDomAfterFirstOpErasure : String :=
+  let mlir := r#""builtin.module"() ({
+^bb0:
+  %dominator = "test.test"() : () -> i32
+  "test.test"() [^bb1] : () -> ()
+^bb1:
+  %erased = "test.test"() : () -> i32
+  "test.test"() [^bb2] : () -> ()
+^bb2:
+  %dominated = "test.test"() : () -> i32
+  "test.test"() : () -> ()
+}) : () -> ()"#
+  runWithAnalyses mlir #[Veir.DominanceAnalysis] (fun top dfCtx parserState => Id.run do
+    let .ok recovered := recoverNames top parserState.ctx mlir
+      | return #["failed to recover names"]
+    let some dominator := getNamedOperation? recovered "dominator"
+      | return #["missing dominator operation"]
+    let some erased := getNamedOperation? recovered "erased"
+      | return #["missing operation to erase"]
+    let some dominated := getNamedOperation? recovered "dominated"
+      | return #["missing dominated operation"]
+    let some entryBlock := recovered.blocks["bb0"]?
+      | return #["missing entry block"]
+    let some middleBlock := recovered.blocks["bb1"]?
+      | return #["missing intermediate block"]
+
+    let newCtx := WfRewriter.eraseOp! parserState.ctx erased
+    let mut report := #[]
+    if !dominator.properlyDominates dominated dfCtx newCtx then
+      report := report.push "operation dominance was invalidated by erasing the first op of a block"
+    if middleBlock.immediateDominator? dfCtx ≠ some entryBlock then
+      report := report.push "intermediate block lost its immediate dominator fact"
+    report)
 /--
 info: "ok"
 -/
@@ -635,5 +673,11 @@ info: "ok"
 -/
 #guard_msgs in
 #eval! testOpDomSameRegionTwoBlocks
+
+/--
+info: "ok"
+-/
+#guard_msgs in
+#eval! testDomAfterFirstOpErasure
 
 end DominanceAnalysis

--- a/Veir/Analysis/DataFlow/DominanceAnalysis.lean
+++ b/Veir/Analysis/DataFlow/DominanceAnalysis.lean
@@ -31,7 +31,7 @@ estimate. Each recomputation either preserves the estimate or moves it upward
 in the dominator tree (note that this is monotonic!), and the process repeats
 until the facts reach a fixpoint.
 
-In VeIR, dominator facts are attached to block entry `InsertPoint`s. A separate
+In VeIR, dominator facts are attached to `BlockPtr`s. A separate
 region metadata fact stores the postorder numbering needed by `intersect`, and
 the ordinary dataflow worklist is used to revisit dependent successors until the
 immediate dominator facts reach a fixpoint.
@@ -40,14 +40,13 @@ immediate dominator facts reach a fixpoint.
 namespace BlockPtr
 
 /--
-Look up the dominator fact stored at the entry insertion point of `block`.
+Look up the dominator fact stored on `block`.
 
-Returns `none` when dominance analysis has not attached a dominator fact to that
-block entry.
+Returns `none` when dominance analysis has not attached a dominator fact to the block.
 -/
-def getDominatorFact? [FactSpec .dominator] (block : BlockPtr) (dfCtx : DataFlowContext)
-    (irCtx : WfIRContext OpCode) : Option DominatorFact :=
-  dfCtx.getFact? .dominator (.InsertPoint (InsertPoint.atStart! block irCtx.raw))
+def getDominatorFact? [FactSpec .dominator]
+    (block : BlockPtr) (dfCtx : DataFlowContext) : Option DominatorFact :=
+  dfCtx.getFact? .dominator (.BlockPtr block)
 
 /--
 Return the immediate dominator currently recorded for `block`.
@@ -56,9 +55,9 @@ This is just `block.getDominatorFact?` projected to its `iDom` field, so it
 returns `none` when the fact is missing or when the fact has no immediate
 dominator yet.
 -/
-def getIDom? [FactSpec .dominator] (block : BlockPtr) (dfCtx : DataFlowContext)
-    (irCtx : WfIRContext OpCode) : Option BlockPtr :=
-  block.getDominatorFact? dfCtx irCtx >>= (·.iDom)
+def getIDom? [FactSpec .dominator]
+    (block : BlockPtr) (dfCtx : DataFlowContext) : Option BlockPtr :=
+  block.getDominatorFact? dfCtx >>= (·.iDom)
 
 end BlockPtr
 
@@ -72,8 +71,7 @@ not been attached to that entry block.
 -/
 def getRegionMetadataFact? [FactSpec .regionMetadata] (region : RegionPtr) (dfCtx : DataFlowContext)
     (irCtx : WfIRContext OpCode) : Option RegionMetadataFact :=
-  (region.get! irCtx.raw).firstBlock >>= 
-    dfCtx.getFact? .regionMetadata ∘ (InsertPoint.atStart! · irCtx.raw)
+  (region.get! irCtx.raw).firstBlock >>= dfCtx.getFact? .regionMetadata ∘ .BlockPtr
 
 end RegionPtr
 
@@ -158,7 +156,7 @@ private def initializeRegion
   let (postOrder, postOrderIndex) := collectPostOrder region irCtx
   let reversePostOrder := postOrder.reverse
   dfCtx :=
-    dfCtx.modifyFact .regionMetadata (InsertPoint.atStart! entry irCtx.raw) fun fact =>
+    dfCtx.modifyFact .regionMetadata (.BlockPtr entry) fun fact =>
       fact.setPostOrderIndex postOrderIndex
 
   for block in reversePostOrder do
@@ -166,7 +164,7 @@ private def initializeRegion
     if let some terminator := (block.get! irCtx.raw).lastOp then
       for succ in terminator.getSuccessors! irCtx.raw do
         dependents := dependents.push (InsertPoint.atStart! succ irCtx.raw, kind)
-    dfCtx := dfCtx.modifyFact .dominator (InsertPoint.atStart! block irCtx.raw) fun fact =>
+    dfCtx := dfCtx.modifyFact .dominator (.BlockPtr block) fun fact =>
       (fact.setDependents dependents).setIDom
         (if block = entry then some entry else none)
     dfCtx := dfCtx.enqueue (InsertPoint.atStart! block irCtx.raw, kind)
@@ -207,15 +205,14 @@ both cursors coincide.
 private def intersect
     (block1 block2 : BlockPtr)
     (postOrderIndex : HashMap BlockPtr Nat)
-    (dfCtx : DataFlowContext)
-    (irCtx : WfIRContext OpCode) : BlockPtr := Id.run do
+    (dfCtx : DataFlowContext) : BlockPtr := Id.run do
   let mut finger1 := block1
   let mut finger2 := block2
   while finger1 ≠ finger2 do
     while postOrderIndex[finger1]! < postOrderIndex[finger2]! do
-      finger1 := (finger1.getIDom? dfCtx irCtx).get!
+      finger1 := (finger1.getIDom? dfCtx).get!
     while postOrderIndex[finger2]! < postOrderIndex[finger1]! do
-      finger2 := (finger2.getIDom? dfCtx irCtx).get!
+      finger2 := (finger2.getIDom? dfCtx).get!
   finger1
 
 /--
@@ -244,22 +241,22 @@ private def computeImmediateDominator
     let predOp := predUseStruct.owner
     let some predBlock := (predOp.get! irCtx.raw).parent
       | continue
-    let some _ := predBlock.getIDom? dfCtx irCtx
+    let some _ := predBlock.getIDom? dfCtx
       | continue
     newIDom :=
       match newIDom with
       | none => predBlock
       | some idom =>
-          intersect predBlock idom metadata.postOrderIndex dfCtx irCtx
+          intersect predBlock idom metadata.postOrderIndex dfCtx
 
   newIDom
 
 /--
 Visit one dominator work item.
 
-Only block entry insertion points carry dominator facts. Non-entry insertion points
-are ignored. For a block entry, recompute the block's current immediate dominator
-candidate and update the fact stored at that entry when the candidate changes.
+Only block entry insertion points schedule dominance work. Non-entry insertion points are ignored.
+For a block entry, recompute the block's current immediate dominator candidate and update the fact
+stored on that block when the candidate changes.
 -/
 def visit
     (point : InsertPoint)
@@ -273,8 +270,7 @@ def visit
     match computeImmediateDominator block dfCtx irCtx with
     | none => dfCtx
     | some newIDom => 
-      let anchor := InsertPoint.atStart! block irCtx.raw
-      dfCtx.modifyFactAndPropagate .dominator anchor (fun fact =>
+      dfCtx.modifyFactAndPropagate .dominator (.BlockPtr block) (fun fact =>
        (fact.setIDom (some newIDom), some newIDom ≠ fact.iDom)) irCtx
 
 end DominanceAnalysis

--- a/Veir/Analysis/DataFlow/Facts.lean
+++ b/Veir/Analysis/DataFlow/Facts.lean
@@ -37,12 +37,16 @@ The control flow graph positions and SSA values where dataflow facts are attache
 -/
 inductive LatticeAnchor
   | InsertPoint (point : InsertPoint)
+  | BlockPtr (block : BlockPtr)
   | ValuePtr (value : ValuePtr)
   | CFGEdge (edge : CFGEdge)
 deriving BEq, Hashable
 
 instance : Coe InsertPoint LatticeAnchor where
   coe := .InsertPoint
+
+instance : Coe BlockPtr LatticeAnchor where
+  coe := .BlockPtr
 
 /-!
 # Analyses and facts

--- a/Veir/IR/Dominance.lean
+++ b/Veir/IR/Dominance.lean
@@ -40,7 +40,7 @@ private partial def BlockPtr.dominatesWithinRegion
   if dominator = block then
     true
   else
-    let some idom := block.getIDom? dfCtx irCtx | return false
+    let some idom := block.getIDom? dfCtx | return false
     idom ≠ block && dominatesWithinRegion dominator idom dfCtx irCtx
 
 
@@ -137,9 +137,8 @@ initialized this block.
 def immediateDominator?
     [FactSpec .dominator]
     (block : BlockPtr)
-    (dfCtx : DataFlowContext)
-    (irCtx : WfIRContext OpCode) : Option BlockPtr :=
-  block.getIDom? dfCtx irCtx
+    (dfCtx : DataFlowContext) : Option BlockPtr :=
+  block.getIDom? dfCtx
 
 /--
 Dominance query between two blocks, where a block dominates itself.


### PR DESCRIPTION
Also added a test to show it fixing a bug (when the first operation of a block is erased, it'd invalidate dominance facts. This is now no longer the case).