### PR TITLE
chore: Remove `dominates` and `properlyDominates` axioms

### DIFF
--- a/Veir/Dominance.lean
+++ b/Veir/Dominance.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Rewriter.InsertPoint
+public import Veir.Dominance.Basic
 
 /-!
   # Dominance
@@ -21,30 +22,12 @@ variable {OpInfo : Type} [HasOpInfo OpInfo]
 variable {ctx : WfIRContext OpInfo}
 variable {op op₁ op₂ : OperationPtr}
 
-/-!
-## Definition of Dominance
--/
-
-/--
-  The dominance relation between operations.
-  An operation `op` dominates itself.
--/
-axiom OperationPtr.dominates (op₁ op₂ : OperationPtr) (ctx : WfIRContext OpInfo) : Prop
-
-/--
-  The proper dominance relation between operations.
-  An operation `op` does not properly dominate itself.
--/
-def OperationPtr.properlyDominates (op₁ op₂ : OperationPtr) (ctx : WfIRContext OpInfo) : Prop :=
-  op₁.dominates op₂ ctx ∧ op₁ ≠ op₂
-
 /--
   An operation `op₁` properly dominates an operation `op₂` if it dominates it
   and the operations are not equal.
 -/
-theorem OperationPtr.properlyDominates_def :
-    op₁.properlyDominates op₂ ctx ↔ op₁.dominates op₂ ctx ∧ op₁ ≠ op₂ := by
-  grind [properlyDominates]
+axiom OperationPtr.properlyDominates_def :
+    op₁.ProperlyDominates op₂ ctx true ↔ op₁.Dominates op₂ ctx ∧ op₁ ≠ op₂
 
 /--
   The dominance relation between an operation and an insertion point.
@@ -63,23 +46,21 @@ axiom ValuePtr.dominatesIp (val : ValuePtr) (ip : InsertPoint) (ctx : WfIRContex
 /--
 An operation `op₁` dominates an operation `op₂` if it properly dominates it.
 -/
-theorem OperationPtr.dominates_of_properlyDominates :
-    op₁.properlyDominates op₂ ctx → op₁.dominates op₂ ctx := by
-  grind [properlyDominates]
+axiom OperationPtr.dominates_of_properlyDominates :
+    op₁.ProperlyDominates op₂ ctx true → op₁.Dominates op₂ ctx
 
 /--
 An operation dominates itself.
 -/
 @[grind .]
-axiom OperationPtr.dominates_refl : op.dominates op ctx
+axiom OperationPtr.dominates_refl : op.Dominates op ctx
 
 /--
 An operation `op₁` dominates an operation `op₂` if and only if
 `op₁` properly dominates `op₂` or if `op₁` is `op₂`.
 -/
-theorem OperationPtr.dominates_iff_properlyDominates_or_eq :
-    op₁.dominates op₂ ctx ↔ op₁.properlyDominates op₂ ctx ∨ op₁ = op₂ := by
-  grind [OperationPtr.properlyDominates]
+axiom OperationPtr.dominates_iff_properlyDominates_or_eq :
+    op₁.Dominates op₂ ctx ↔ op₁.ProperlyDominates op₂ ctx true ∨ op₁ = op₂
 
 /--
 An operation `op₁` dominates the program point after a given operation `op₂` if it
@@ -87,14 +68,14 @@ either dominates the `op₂`, or is `op₂`.
 -/
 axiom OperationPtr.dominatesIp_iff :
     op₁.dominatesIp (InsertPoint.after op₂ ctx.raw block op₂HasParent op₂InBounds) ctx ↔
-    op₁.dominates op₂ ctx
+    op₁.Dominates op₂ ctx
 
 /--
 An operation `op₁` dominates the program point before `op₂` if it properly dominates `op₂`.
 -/
 @[simp]
 axiom OperationPtr.dominatesIp_before :
-  op₁.dominatesIp (.before op₂) ctx ↔ op₁.properlyDominates op₂ ctx
+  op₁.dominatesIp (.before op₂) ctx ↔ op₁.ProperlyDominates op₂ ctx true
 
 grind_pattern OperationPtr.dominatesIp_before => op₁.dominatesIp (.before op₂) ctx
 
@@ -102,15 +83,15 @@ grind_pattern OperationPtr.dominatesIp_before => op₁.dominatesIp (.before op�
 Proper dominance between operations is transitive.
 -/
 axiom OperationPtr.properlyDominates_trans {op₃ : OperationPtr} :
-  op₁.properlyDominates op₂ ctx → op₂.properlyDominates op₃ ctx →
-  op₁.properlyDominates op₃ ctx
+  op₁.ProperlyDominates op₂ ctx true → op₂.ProperlyDominates op₃ ctx true →
+  op₁.ProperlyDominates op₃ ctx true
 
 /--
 A value dominating the program point before an operation `op₁` also dominates the program
 point before any operation `op₂` properly dominated by `op₁`.
 -/
 axiom ValuePtr.dominatesIp_before_of_properlyDominates {value : ValuePtr} :
-  value.dominatesIp (InsertPoint.before op₁) ctx → op₁.properlyDominates op₂ ctx →
+  value.dominatesIp (InsertPoint.before op₁) ctx → op₁.ProperlyDominates op₂ ctx true →
   value.dominatesIp (InsertPoint.before op₂) ctx
 
 /--
@@ -118,9 +99,9 @@ If an operation `op₁` dominates an operation `op₂`, it dominates the operati
 if it exists.
 -/
 axiom OperationPtr.dominates_next :
-  op₁.dominates op₂ ctx →
+  op₁.Dominates op₂ ctx →
   (op₂.get! ctx.raw).next = some op₂Next →
-  op₁.dominates op₂Next ctx
+  op₁.Dominates op₂Next ctx
 
 /-!
 ## Programs Satisfying Dominance Invariants
@@ -142,7 +123,7 @@ def WfIRContext.Dom (ctx : WfIRContext OpInfo) : Prop :=
 Operands of an operation are not results of dominated operations.
 -/
 axiom IRContext.Dom.value_not_in_results_of_forall_in_operands_of_dominates (ctxDom : ctx.Dom) :
-    op₁.dominates op₂ ctx →
+    op₁.Dominates op₂ ctx →
     ∀ (value : ValuePtr), value ∈ op₁.getOperands! ctx.raw →
     value ∉ op₂.getResults! ctx.raw
 
@@ -153,7 +134,7 @@ operation `op₂`, then `op₁` properly dominates `op₂`.
 axiom OperationPtr.properlyDominates_of_definingOp?_of_mem_getOperands! (ctxDom : ctx.Dom) :
   value.definingOp? = some op₁ →
   value ∈ op₂.getOperands! ctx.raw →
-  op₁.properlyDominates op₂ ctx
+  op₁.ProperlyDominates op₂ ctx true
 
 grind_pattern OperationPtr.properlyDominates_of_definingOp?_of_mem_getOperands! =>
   ctx.Dom, value.definingOp?, some op₂, op₁.getOperands! ctx.raw

--- a/Veir/Interpreter/EquationLemma.lean
+++ b/Veir/Interpreter/EquationLemma.lean
@@ -91,7 +91,7 @@ theorem interpretOp_equationHolds_other
     {inBounds₁ : op₁.InBounds ctx.raw} {inBounds₂ : op₂.InBounds ctx.raw} :
     op₂.Pure ctx →
     interpretOp op₁ state inBounds₁ = .ok (state', cf₁) →
-    op₂.dominates op₁ ctx →
+    op₂.Dominates op₁ ctx →
     state.EquationHolds op₂ →
     state'.EquationHolds op₂ := by
   intro op₂Pure hInterp₁ hDom

--- a/Veir/Interpreter/Lemmas.lean
+++ b/Veir/Interpreter/Lemmas.lean
@@ -412,7 +412,7 @@ theorem VariableState.setResultValues?_setArgumentValues?_comm :
   grind [getVar?_setResultValues?, getVar?_setArgumentValues?]
 
 theorem VariableState.getVar?_setResultValues?_operand_of_dominates
-    (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
+    (ctxDom : ctx.Dom) (hdom : op'.Dominates op ctx) :
     value ∈ op'.getOperands! ctx.raw →
     varState.setResultValues? op resValues inBounds = some varState' →
     varState'.getVar? value =
@@ -430,7 +430,7 @@ theorem VariableState.getVar?_setResultValues?_operand_of_dominates
 
 @[grind =>]
 theorem VariableState.getOperandValues_setResultValues?_of_dominates
-    (ctxDom : ctx.Dom) (hdom : op'.dominates op ctx) :
+    (ctxDom : ctx.Dom) (hdom : op'.Dominates op ctx) :
     varState.setResultValues? op resValues inBounds = some varState' →
     varState'.getOperandValues op' = varState.getOperandValues op' := by
   intro h


### PR DESCRIPTION
These were already implemented in a different file, so we use these definitions instead. The actual definitions were named `Dominates` and `ProperlyDominates`, so we also do a renaming.