### PR TITLE
feat(puddle): introduce `Puddle` pattern DSL 

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -15,3 +15,4 @@ import UnitTest.ConstantValue
 import UnitTest.Evaluate
 import UnitTest.FoldDecision
 import UnitTest.SideEffectInterfaces
+import UnitTest.Puddle

--- a/UnitTest/Puddle.lean
+++ b/UnitTest/Puddle.lean
@@ -1,0 +1,21 @@
+import Veir.PatternRewriter.Puddle.Builders
+
+open Veir
+open Veir.Puddle
+
+/-- Match an arithmetic constant of a given value. -/
+def matchConstant (returnType : Handle OpCode .type) (constant : Int)
+    : MatchProg.Builder (Handle OpCode .value) := do
+  let x ← MatchProg.value returnType
+  let _ ← MatchProg.root (.arith .constant) #[] #[returnType]
+    (fun properties => properties.value.value = constant)
+  return x
+
+/-- Match an `arith.addi` whose right-hand operand is the constant zero. -/
+private def matchAddZero : MatchProg OpCode (Handle OpCode .value) :=
+  MatchProg.build do
+    let returnType ← MatchProg.type (Attr := IntegerType)
+    let x ← MatchProg.value returnType
+    let cstVal ← matchConstant returnType 0
+    let _ ← MatchProg.root (.arith .addi) #[x, cstVal] #[returnType]
+    return x

--- a/Veir.lean
+++ b/Veir.lean
@@ -11,6 +11,7 @@ import Veir.Rewriter.WfRewriter
 import Veir.PatternRewriter.Semantics
 import Veir.Printer
 import Veir.PatternRewriter.Basic
+import Veir.PatternRewriter.Puddle
 import Veir.Interfaces.FoldInterfaces
 import Veir.Interfaces.ControlFlowInterfaces
 import Veir.Passes.ArithToLLVM.Proofs

--- a/Veir/PatternRewriter/Puddle.lean
+++ b/Veir/PatternRewriter/Puddle.lean
@@ -1,0 +1,4 @@
+module
+
+public import Veir.PatternRewriter.Puddle.Definitions
+public import Veir.PatternRewriter.Puddle.Builders

--- a/Veir/PatternRewriter/Puddle/Builders.lean
+++ b/Veir/PatternRewriter/Puddle/Builders.lean
@@ -1,0 +1,152 @@
+module
+
+public import Veir.PatternRewriter.Puddle.Definitions
+
+/-!
+# Puddle Builders
+
+This file contains author-facing builders for constructing declarative Puddle rewrite patterns
+without having to manually manage handles for matched IR elements. The builders are based on a state
+monad that automatically allocates handles, allowing the use of do-notations for authoring
+match programs. In particular, the programs are built in the reverse order of the final match
+program, so the root operation is declared last, and the leaves are declared first.
+-/
+
+namespace Veir.Puddle
+
+public section
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
+/-!
+## Matcher builder
+
+`MatchProg.Builder` provides a monadic interface for authoring the matching phase of a Puddle
+pattern. Each builder operation adds one constraint and returns fresh handles for later constraints
+or for export to the following phases. Although the source reads from leaves to root, declarations
+are prepended so the finished program can be interpreted from root to leaves.
+-/
+
+/-- Internal accumulator used by `MatchProg.Builder`. -/
+structure MatchProg.BuilderState where
+  /-- The next free identifier for a handle. -/
+  nextId : Nat := 0
+  /-- Declarations in interpreter order; after a well-formed build, the root is first. -/
+  decls : List (MatchDecl OpCode) := []
+
+/--
+A stateful builder for a match program that exports a value of type `α`.
+The exported value should consist of handles needed by the creation or replacement phase.
+-/
+structure MatchProg.Builder (α : Type) where
+  /--
+  Run the builder from an explicit internal state. Should not be used directly, use
+  `MatchProg.build` instead.
+  -/
+  run : MatchProg.BuilderState → α × MatchProg.BuilderState
+
+/--
+The handles allocated for a matched operation. It contains the operation handle, an array of
+handles for its SSA results, and a handle for its concrete properties.
+-/
+structure OpHandle (opCode : OpCode) where
+  /-- The operation handle. -/
+  op : Handle OpCode .op
+  /-- The handles for each return value. -/
+  res : Array (Handle OpCode .value)
+  /-- The matched operation's concrete properties. -/
+  properties : Handle OpCode (.prop opCode)
+
+/-- Handles exported by a matched root without exposing the root's SSA results. -/
+structure RootHandle (opCode : OpCode) where
+  /-- The matched root's concrete properties. -/
+  properties : Handle OpCode (.prop opCode)
+
+/-- Monadic support for building match patterns. -/
+@[inline]
+instance MatchProg.instMonadBuilder : Monad MatchProg.Builder where
+  pure value := ⟨fun state => (value, state)⟩
+  bind action next := ⟨fun state =>
+    let (value, state) := action.run state
+    (next value).run state⟩
+
+/--
+Match a type with a given constraint.
+For ease of use, the constraint can just be expressed as a predicate on a specific type attribute,
+which can be `Attribute` if needed.
+-/
+@[expose, inline]
+def MatchProg.type (Attr : Type) [IsTypeAttr Attr] (matcher : Attr → Bool := fun _ => true) :
+    MatchProg.Builder (Handle OpCode .type) :=
+  ⟨fun state =>
+    let result := Handle.mk (OpInfo := OpCode) state.nextId
+    let matcher := fun (attr : TypeAttr) => ((attr.cast? Attr).map matcher).getD false
+    (result, {
+      nextId := state.nextId + 1
+      decls := .type matcher result :: state.decls
+    })⟩
+
+/--
+Match a value with a given type. This should be used to match values where their kind
+(i.e. whether they are block arguments or operation results) do not matter.
+-/
+@[expose, inline]
+def MatchProg.value (type : Handle OpCode .type) : MatchProg.Builder (Handle OpCode .value) :=
+  ⟨fun state =>
+    let result := Handle.mk (OpInfo := OpCode) state.nextId
+    (result, {
+      nextId := state.nextId + 1
+      decls := .value type result :: state.decls
+    })⟩
+
+/--
+Match a non-root operation given its opcode, operands, result types, and properties. The operation
+is assumed to have no block arguments or regions, but can have any attribute dictionary. Returns
+a bundle of handles that contains the operation handle, an array of handles for its SSA results,
+and a handle for its concrete properties.
+-/
+@[expose, inline]
+def MatchProg.operation (opCode : OpCode) (operands : Array (Handle OpCode .value))
+    (returnTypes : Array (Handle OpCode .type))
+    (property : PropertyMatcher opCode := fun _ => true) :
+    MatchProg.Builder (OpHandle opCode) :=
+  ⟨fun state =>
+    let op := Handle.mk (OpInfo := OpCode) state.nextId
+    let res := (Array.range returnTypes.size).map fun index =>
+      Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
+    let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
+    (⟨op, res, properties⟩, {
+      nextId := state.nextId + returnTypes.size + 2
+      decls := .operation opCode operands returnTypes property properties op res :: state.decls
+    })⟩
+
+/--
+Match a root operation given its opcode, operands, result types, and properties. This should be the
+last declaration in a Puddle match. At runtime, this is the entry point of the matcher. It returns
+a handle for accessing its concrete properties, but in particular does not return handles for its
+results or the operation itself, since those are accessible from the root through already-bound
+handles.
+-/
+@[expose, inline]
+def MatchProg.root (opCode : OpCode) (operands : Array (Handle OpCode .value))
+    (returnTypes : Array (Handle OpCode .type))
+    (property : PropertyMatcher opCode := fun _ => true) :
+    MatchProg.Builder (RootHandle opCode) :=
+  ⟨fun state =>
+    let op := Handle.mk (OpInfo := OpCode) state.nextId
+    let properties := Handle.mk (OpInfo := OpCode) (state.nextId + 1)
+    (⟨properties⟩, {
+      nextId := state.nextId + 2
+      decls := .root opCode operands returnTypes property properties op ::
+        .operation opCode operands returnTypes property properties op #[] :: state.decls
+    })⟩
+
+/-- Build a match program using `MatchProg.Builder`. -/
+@[expose, inline]
+def MatchProg.build (builder : MatchProg.Builder α) : MatchProg OpCode α :=
+  let (exports, state) := builder.run {}
+  ⟨state.decls, state.nextId, exports⟩
+
+end
+
+end Veir.Puddle

--- a/Veir/PatternRewriter/Puddle/Definitions.lean
+++ b/Veir/PatternRewriter/Puddle/Definitions.lean
@@ -1,0 +1,142 @@
+module
+
+public import Veir.GlobalOpInfo
+
+/-!
+# Puddle DSL
+
+Puddle is a small, deeply embedded DSL for describing peephole rewrites. It describes a rooted graph
+of operations to match, a sequence of operations to create, and a terminal replacement that
+replaces the root's results before the matched root is erased.
+
+The objective of Puddle is to describe rewrites in a way that makes it easier to prove their
+semantic preservation. Proving `LocalRewritePattern.Sound` requires discharging dozens of
+correctness conditions, so Puddle is designed to discharge most of them automatically or make them
+hold by construction. Additionally, Puddle's declarative source makes it much easier to reason
+about the semantic soundness of a rewrite than the imperative source of a `LocalRewritePattern`.
+
+A Puddle pattern (`Pattern`) has three phases, in this order:
+
+1. A `MatchProg` describes a rooted graph of operations. Authors build the graph bottom-up, starting
+  with free values and types and ending with the root operation. The resulting program executes
+  top-down from that root. Every matched operation must be reachable from the root and fully
+  constrained: its operands, result types, and properties must be specified.
+2. A `CreateProg` derives metadata and creates the operations that will replace the matched root.
+  Operations are created in order and inserted before the root. They may consume non-root values
+  matched in the first phase or values produced by earlier creation declarations.
+3. A `Replacement` selects, in order, the values that replace the root's results before the root is
+  erased.
+
+Puddle patterns are not meant to be constructed directly. Instead, they are built with
+`Pattern.Builder`, defined in `Veir.PatternRewriter.Puddle.Builders`.
+-/
+
+namespace Veir.Puddle
+
+public section
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
+/-!
+## Handles
+
+Handles are typed symbolic references to operations, SSA values, types, and operation properties.
+Their phantom `HandleType` prevents, for example, passing an operation handle where a value handle
+is required. During execution handles are resolved to concrete IR entities; validity proofs instead
+interpret them in the semantic model.
+-/
+
+/-- The kind of entity referenced by a `Handle`. -/
+inductive HandleType (OpInfo : Type) [HasOpInfo OpInfo] where
+/-- An operation's opcode-specific property record. -/
+| prop (opCode : OpInfo)
+/-- An operation. -/
+| op
+/-- An SSA value, which can be an operation result or block argument. -/
+| value
+/-- A VeIR IR type. -/
+| type
+
+/--
+A typed symbolic reference to an entity matched or created by a Puddle rule.
+
+Handles are not supposed to be constructed by hand, but rather allocated by builders.
+-/
+structure Handle (OpInfo : Type) [HasOpInfo OpInfo] (handleType : HandleType OpInfo) where
+  /-- The handle's rule-wide identifier. -/
+  id : Nat
+deriving Repr, DecidableEq, Inhabited
+
+/-!
+## Matcher phase
+
+`MatchDecl` is the internal declarative representation of a pattern constraint. Users should use
+the `MatchProg.Builder` API, which allocates fresh handles, rather than construct declarations
+directly.
+
+Stored matcher declarations are ordered top-down, in execution order. The first declaration marks
+the root operation; the remaining declarations constrain operations and operands recursively
+reachable from the root.
+
+Matching always proceeds from an entity already bound in the current assignment. The root
+declaration seeds the assignment with the candidate root operation; every subsequent declaration
+is anchored by an already-bound operation, SSA value, type, or metadata handle. A declaration may
+reject that binding by checking additional constraints, and it may extend the assignment with newly
+discovered operands, result types, properties, or results. Matching therefore expands outward from
+the root through already-bound handles.
+-/
+
+/--
+A predicate on an opcode-specific property record. It accepts a property when it returns `true`.
+-/
+abbrev PropertyMatcher (opCode : OpInfo) := propertiesOf opCode → Bool
+
+/-- A predicate on an IR type. It accepts a type when it returns `true`. -/
+abbrev TypeMatcher := TypeAttr → Bool
+
+/--
+A declarative matcher instruction for a Puddle pattern graph; use `MatchProg.Builder` rather than
+constructing declarations directly.
+-/
+inductive MatchDecl (OpInfo : Type) [HasOpInfo OpInfo] where
+/-- Bind `type` to the type of the already-bound value `result`. -/
+| value (type : Handle OpInfo .type) (result : Handle OpInfo .value)
+/-- Require the type bound to `result` to be accepted by `matcher`. -/
+| type (matcher : TypeMatcher) (result : Handle OpInfo .type)
+/-- Identify an operation from the already-bound `result` handle or first SSA-result handle in
+`results`, require the given opcode, operands, result types, and properties, and bind the discovered
+entities to their corresponding handles. -/
+| operation (opCode : OpInfo)
+    (operands : Array (Handle OpInfo .value))
+    (returnTypes : Array (Handle OpInfo .type))
+    (property : PropertyMatcher opCode)
+    (propertyResult : Handle OpInfo (.prop opCode))
+    (result : Handle OpInfo .op)
+    (results : Array (Handle OpInfo .value))
+/-- Mark `result` as the root operation and record its expected opcode, operands, result types, and
+properties. `MatchProg.Builder` emits a companion `operation` declaration that enforces them. -/
+| root (opCode : OpInfo)
+    (operands : Array (Handle OpInfo .value))
+    (returnTypes : Array (Handle OpInfo .type))
+    (property : PropertyMatcher opCode)
+    (propertyResult : Handle OpInfo (.prop opCode))
+    (result : Handle OpInfo .op)
+
+/--
+A match program together with the value exported by its builder. Exports typically contain handles
+used by the creation or replacement phase of a `Pattern`.
+
+Declarations are stored in execution order, starting with the root marker and continuing through
+the operation and operand constraints recursively reachable from it.
+-/
+structure MatchProg (OpInfo : Type) [HasOpInfo OpInfo] (Exports : Type) where
+  /-- Match declarations in interpreter order, beginning with a root declaration. -/
+  decls : List (MatchDecl OpInfo)
+  /-- The number of rule-wide handle identifiers reserved by the matching phase. -/
+  numHandles : Nat
+  /-- Arbitrary builder output, typically handles needed by subsequent phases. -/
+  exports : Exports
+
+end
+
+end Veir.Puddle


### PR DESCRIPTION
This introduces the `Puddle` DSL, which is meant to mimic MLIR's PDL dialect as an embedded DSL in Lean. Its objective is to allow simple reasoning over (local) rewrite patterns. By using an embedded DSL, we can write decision procedures to automatically discharge multiple fields from `LocalRewritePattern.Valid`, as well as reasoning more easily about `LocalRewritePattern.PreservesSemantics`. In particular, we can reason about semantics without having to reason about the equation lemma, or dominance, which makes things much easier.

This PR introduces the matcher DSL, as well as a do-notation-based builder, to make the creation of DAG matcher more user-friendly. The matcher DSL is a list of declarative matching instructions, with variables called `Handle`. Each handle is a reference to some part of the IR. Each instruction requires some handle to exist, constrain it, and then potentially bind a new handle. The execution of a matcher will be implemented in a following PR. 

`UnitTest/Puddle.lean` contains an example on how to build a matcher.
