### PR TITLE
feat(puddle): Add creation and replacement to patterns

### DIFF
--- a/UnitTest/Puddle.lean
+++ b/UnitTest/Puddle.lean
@@ -6,16 +6,34 @@ open Veir.Puddle
 /-- Match an arithmetic constant of a given value. -/
 def matchConstant (returnType : Handle OpCode .type) (constant : Int)
     : MatchProg.Builder (Handle OpCode .value) := do
-  let x ← MatchProg.value returnType
-  let _ ← MatchProg.root (.arith .constant) #[] #[returnType]
+  let op ← MatchProg.operation (.arith .constant) #[] #[returnType]
     (fun properties => properties.value.value = constant)
-  return x
+  return op.res[0]!
 
-/-- Match an `arith.addi` whose right-hand operand is the constant zero. -/
-private def matchAddZero : MatchProg OpCode (Handle OpCode .value) :=
-  MatchProg.build do
-    let returnType ← MatchProg.type (Attr := IntegerType)
-    let x ← MatchProg.value returnType
-    let cstVal ← matchConstant returnType 0
-    let _ ← MatchProg.root (.arith .addi) #[x, cstVal] #[returnType]
-    return x
+/-- Rewrite `x + 0` to `x`. -/
+private def addZero : Pattern OpCode :=
+  Pattern.Builder
+    (do
+      let returnType ← MatchProg.type (Attr := IntegerType)
+      let x ← MatchProg.value returnType
+      let cstVal ← matchConstant returnType 0
+      let _ ← MatchProg.root (.arith .addi) #[x, cstVal] #[returnType]
+      return x)
+    pure
+    (fun x => x)
+
+/-- Rewrite `x * 2` to `x + x`. -/
+private def mulTwo : Pattern OpCode :=
+  Pattern.Builder
+    (do
+      let returnType ← MatchProg.type (Attr := IntegerType)
+      let x ← MatchProg.value returnType
+      let cstVal ← matchConstant returnType 2
+      let _ ← MatchProg.root (.arith .muli) #[x, cstVal] #[returnType]
+      return (returnType, x))
+    (fun (returnType, x) => do
+      let properties ← CreateProg.property (.arith .addi)
+        (default : propertiesOf (.arith .addi : OpCode))
+      let add ← CreateProg.operation (.arith .addi) #[x, x] #[returnType] properties
+      return add)
+    (fun result => result)

--- a/Veir/PatternRewriter/Puddle/Builders.lean
+++ b/Veir/PatternRewriter/Puddle/Builders.lean
@@ -147,6 +147,119 @@ def MatchProg.build (builder : MatchProg.Builder α) : MatchProg OpCode α :=
   let (exports, state) := builder.run {}
   ⟨state.decls, state.nextId, exports⟩
 
+/-!
+## Creation builder
+
+`CreateProg.Builder` provides `do` notation for the creation phase. Each call to
+`CreateProg` builder functions appends a logical step and returns fresh handles that later steps may
+consume.
+-/
+
+/-- The operation and SSA-result handles introduced by a creation declaration. -/
+structure CreatedOpHandle where
+  /-- The newly-created operation. -/
+  op : Handle OpCode .op
+  /-- Its result values, in result order. -/
+  res : Array (Handle OpCode .value)
+
+/-- Coerce an operation-and-results bundle to its operation handle. -/
+instance : Coe CreatedOpHandle (Handle OpCode .op) where
+  coe := fun handle => handle.op
+
+/-- Internal accumulator used by `CreateProg.Builder`. -/
+structure CreateProg.BuilderState where
+  /-- The next free pattern-wide handle identifier. -/
+  nextId : Nat := 0
+  /-- Declarations in reverse construction order. -/
+  decls : List (CreateDecl OpCode) := []
+
+/-- A stateful builder for an ordered creation program that exports a value of type `α`. -/
+structure CreateProg.Builder (α : Type) where
+  /-- Run the builder from an explicit internal state. -/
+  run : CreateProg.BuilderState → α × CreateProg.BuilderState
+
+/-- Monadic support for composing creation declarations in program order. -/
+@[inline]
+instance CreateProg.instMonadBuilder : Monad CreateProg.Builder where
+  pure value := ⟨fun state => (value, state)⟩
+  bind action next := ⟨fun state =>
+    let (value, state) := action.run state
+    (next value).run state⟩
+
+/--
+Append a concrete property record to the creation program and return the handle bound to it.
+-/
+@[expose, inline]
+def CreateProg.property (opCode : OpCode) (value : propertiesOf opCode) :
+    CreateProg.Builder (Handle OpCode (.prop opCode)) :=
+  ⟨fun state =>
+    let result := Handle.mk (OpInfo := OpCode) state.nextId
+    (result, {
+      nextId := state.nextId + 1
+      decls := .property opCode value result :: state.decls
+    })⟩
+
+/-- Append an operation to the creation program and return handles for it and its results. -/
+@[expose, inline]
+def CreateProg.operation (opCode : OpCode) (operands : Array (Handle OpCode .value))
+    (resultTypes : Array (Handle OpCode .type))
+    (properties : Handle OpCode (.prop opCode)) : CreateProg.Builder CreatedOpHandle :=
+  ⟨fun state =>
+    let op := Handle.mk (OpInfo := OpCode) state.nextId
+    let res := (Array.range resultTypes.size).map fun index =>
+      Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
+    (⟨op, res⟩, {
+      nextId := state.nextId + resultTypes.size + 1
+      decls := .operation opCode operands resultTypes properties op res :: state.decls
+    })⟩
+
+/-- Build a creation program using the matcher's exports and continuing its handle numbering. -/
+@[expose, inline]
+def CreateProg.build (matcher : MatchProg OpCode α)
+    (builder : α → CreateProg.Builder β) : CreateProg OpCode β :=
+  let (exports, state) := (builder matcher.exports).run { nextId := matcher.numHandles }
+  /- The creation declaration are reversed, since they are collected in opposite order. -/
+  ⟨state.decls.reverse, state.nextId, exports⟩
+
+/-- Build a creation program with no declarations, forwarding `matcher.exports` unchanged. -/
+@[expose, inline]
+def CreateProg.empty (matcher : MatchProg OpCode α) : CreateProg OpCode α :=
+  CreateProg.build matcher pure
+
+/-! ## Replacement and pattern builders -/
+
+/-- Allow passing a single value handle directly as a replacement. -/
+instance : Coe (Handle OpInfo .value) (Replacement OpInfo) where
+  coe := fun value => ⟨#[value]⟩
+
+/-- Allow passing an array of value handles directly as a replacement. -/
+instance : Coe (Array (Handle OpInfo .value)) (Replacement OpInfo) where
+  coe := Replacement.mk
+
+/-- Allow replacing the root with all results of a newly-created operation. -/
+instance : Coe CreatedOpHandle (Replacement OpCode) where
+  coe := fun operation => ⟨operation.res⟩
+
+/--
+Build a puddle pattern by composing its three phases.
+
+`matcherBuilder` is executed first. Its exported `α` is passed to `creationBuilder`, whose exported
+`β` is then passed to `replacementBuilder`.
+-/
+@[expose, inline]
+def Pattern.Builder (matcherBuilder : MatchProg.Builder α)
+    (creationBuilder : α → CreateProg.Builder β)
+    (replacementBuilder : β → Replacement OpCode) : Pattern OpCode :=
+  let matcher := MatchProg.build matcherBuilder
+  let creation := CreateProg.build matcher creationBuilder
+  {
+    Exports := α
+    matcher := matcher
+    CreationExports := β
+    creation := creation
+    replacement := replacementBuilder creation.exports
+  }
+
 end
 
 end Veir.Puddle

--- a/Veir/PatternRewriter/Puddle/Definitions.lean
+++ b/Veir/PatternRewriter/Puddle/Definitions.lean
@@ -137,6 +137,85 @@ structure MatchProg (OpInfo : Type) [HasOpInfo OpInfo] (Exports : Type) where
   /-- Arbitrary builder output, typically handles needed by subsequent phases. -/
   exports : Exports
 
+/-!
+## Creation phase
+
+After a successful match, the creation phase may create new operations. Operations are created in
+declaration order, and their results can be used by later declarations or by the terminal
+replacement.
+
+Created operations may consume matched values or earlier-created values. Their result types and
+properties must be already-bound metadata handles. Those handles may come from the matcher or an
+earlier property declaration.
+-/
+
+/-- An internal declarative instruction in a creation program. -/
+inductive CreateDecl (OpInfo : Type) [HasOpInfo OpInfo] where
+/-- Bind a concrete property record to `result` for use by a later operation declaration. -/
+| property (opCode : OpInfo) (value : propertiesOf opCode) (result : Handle OpInfo (.prop opCode))
+/--
+Create an operation, resolving its operands, result types, and properties, and bind the newly
+created operation and SSA results to `result` and `results`.
+-/
+| operation (opCode : OpInfo) (operands : Array (Handle OpInfo .value))
+    (resultTypes : Array (Handle OpInfo .type))
+    (properties : Handle OpInfo (.prop opCode))
+    (result : Handle OpInfo .op)
+    (results : Array (Handle OpInfo .value))
+
+/--
+The ordered creation phase of a Puddle rule.
+
+Each declaration may consume metadata or values bound during matching or by earlier creation
+declarations. Every input must resolve through an already-bound handle. The creation builder starts
+allocating immediately after the matcher's handle range; `numHandles` records the first unused
+pattern-wide handle identifier after creation.
+-/
+structure CreateProg (OpInfo : Type) [HasOpInfo OpInfo] (Exports : Type) where
+  /-- Creation declarations in execution order. -/
+  decls : List (CreateDecl OpInfo)
+  /-- The first unused rule-wide handle identifier after the creation program. -/
+  numHandles : Nat
+  /-- Arbitrary builder output, typically handles needed by the replacement phase. -/
+  exports : Exports
+
+/-!
+## Replacement
+
+A terminal replacement specifies the SSA values that replace the matched root operation's results.
+Each selected handle may denote a non-root matched value or a value produced during creation.
+Execution will fail if the replacement differs in length from the root's result count or if the
+replacement includes one of the root's own results.
+-/
+
+/-- Value handles that replace the root operation's results. -/
+structure Replacement (OpInfo : Type) [HasOpInfo OpInfo] where
+  /-- The replacement values, in root-result order. -/
+  values : Array (Handle OpInfo .value)
+
+/-!
+## Puddle Pattern
+
+A Puddle rule packages its match program, ordered creation program, and terminal replacement. The
+exports types are used to pass handles between phases. The pattern is not meant to be constructed
+directly; use `Pattern.Builder` instead.
+-/
+
+/--
+A complete declarative Puddle rewrite pattern. Prefer constructing one with `Pattern.Builder`.
+-/
+structure Pattern (OpInfo : Type) [HasOpInfo OpInfo] where
+  /-- The type of data (usually handles) exported by the matching phase. -/
+  Exports : Type
+  /-- The graph pattern matched against a candidate root operation. -/
+  matcher : MatchProg OpInfo Exports
+  /-- The type of data (usually handles) exported by the creation phase. -/
+  CreationExports : Type
+  /-- The creation program run after a successful match. -/
+  creation : CreateProg OpInfo CreationExports
+  /-- Values used to replace the root's results. -/
+  replacement : Replacement OpInfo
+
 end
 
 end Veir.Puddle


### PR DESCRIPTION
This PR adds the second part of the Puddle embedded DSL.

It contains the definitions for the rewrite part of the pattern. It is split in two parts:
* Directly after the matching phase, there is the creation phase, which creates a sequence of new operations.
* Then, after the creation phase, a single instruction specifies which values should replace the original root operaiton matched in the matching phase.

Similar to the match phase, we define a monadic interface to define the creation phase. We also define a monadic interface for the entire pattern, which composes the 3 different phases.