### PR TITLE
feat(PBV): Expand tactic to handle multiple widths

### DIFF
--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -1,19 +1,47 @@
 import Veir.Meta.PBVDecide
 
+/-- Commutativity of addition -/
 example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
 
+/-- Commutativity of addition for three variables -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
   pbv_decide 4
   · bv_decide
   · grind
 
-example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
-  pbv_decide 4
+-- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
+--   x + y = y + x := by
+--   pbv_decide 4
+--   · bv_decide
+--   · grind
+
+/-- Zero extending a zero extension-/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
   · bv_decide
+  · grind
+  · grind
+  · grind
+
+/-- Sign extending a zero extensions -/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
+  · grind
   · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -14,12 +14,6 @@ example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
--- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
---   x + y = y + x := by
---   pbv_decide 4
---   · bv_decide
---   · grind
-
 /-- Zero extending a zero extension-/
 example (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)

--- a/Veir/Data/PBV.lean
+++ b/Veir/Data/PBV.lean
@@ -49,7 +49,7 @@ which we wish to prove it, the tactic performs the following steps:
 
 * `Veir.Data.PBV.Lemmas` — `Nat` and `BitVec` lemmas used by the translation.
 * `Veir.Data.PBV.Elim` — steps 3 and 4: `width_elim` and `var_elim`.
-* `Veir.Data.PBV.Mask` — step 5: `maskOfWidth`, `IsMask`, the mask constraint.
+* `Veir.Data.PBV.Mask` — step 5: `maskOfWidth`, the mask constraint.
 * `Veir.Data.PBV.Push` — step 6: pushing `setWidth` from the root to its leaves.
 * `Veir.Data.PBV.Examples` — a manual trace of the whole pipeline.
 

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -34,7 +34,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
-      eq_iff 4,             -- Introduce `setWidth` to goal
+      eq_iff (o := 4),             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add
       setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
@@ -75,22 +75,21 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  have bv_p_lt_q := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
     eq_iff (o := 8),
+    setWidth_setWidth (o := 8),
+    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
-    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
-    setWidth_setWidth r_le_bw,
-    setWidth_setWidth q_le_bw,
-    setWidth_setWidth p_le_bw,
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
+    p_le_bw,
     r_le_bw,
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
-  ]  at h_xmp ⊢
+  ] at h_xmp ⊢
 -- Step 7: Drop the Nat 'p', 'q', 'r'
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -137,7 +137,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,
     setWidth_setWidth,
-    signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
+    signBitOfMask_eq,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
     p_le_bw,
     r_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -34,7 +34,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
-      eq_iff w_le_bw,             -- Introduce `setWidth` to goal
+      eq_iff 4,             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add
       setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
@@ -43,56 +43,6 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 8: Bitblast!
   bv_decide
 
-/-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
-    which is a single zero extension to `r`, for all widths `p < q < r ≤ 8` -/
-theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
--- Step 1: Bound widths to the provided blast width
-  have r_le_bw : r ≤ 8 := by grind
-  have q_le_bw : q ≤ 8 := by grind
-  have p_le_bw : p ≤ 8 := by grind
--- Step 2-3: Introduce mask to replace `w` Nat var
-  apply width_elim 8 r
-  intro mr h_mr
-  apply width_elim 8 q
-  intro mq h_mq
-  apply width_elim 8 p
-  intro mp h_mp
--- Step 4: Eliminate the parametric bv var of width `w`
---         enforcing width constraint with mask
-  revert x
-  apply var_elim 8 p p_le_bw
-  intro x h_xmp
--- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := isMask_of_eq_maskOfWidth h_mr
-  have mq_mask := isMask_of_eq_maskOfWidth h_mq
-  have mp_mask := isMask_of_eq_maskOfWidth h_mp
--- Step 5B: Translate the condition on the natural number width
---   into a fact about the bitvector masks
-  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
-  simp only [isMask_eq] at mr_mask mq_mask mp_mask
--- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [
-    eq_iff r_le_bw,
-    setWidth_setWidth r_le_bw,
-    setWidth_setWidth p_le_bw,
-    setWidth_setWidth q_le_bw,
-    BitVec.zeroExtend_eq_setWidth,
-    BitVec.setWidth_eq,
-    ← h_mr,
-    ← h_mq,
-    ← h_mp,
-  ] at h_xmp ⊢
--- Step 7: Drop the Nat 'p', 'q', 'r'
-  clear h_mp h_mq h_mr
-  clear hr hqr hpq r_le_bw q_le_bw p_le_bw
-  clear p q r
--- Step 8: Bitblast!
-  bv_decide
 
 /-- Manual trace of a zero extension to `q` followed by a sign extension to `r`,
     which is a single zero extension to `r`, since `p < q` leaves the sign bit
@@ -125,28 +75,27 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --   into a fact about the bitvector masks
-  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  -- have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
+  revert hpq hqr
+
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [
-    eq_iff r_le_bw,
-    setWidth_signExtend_eq_and_maskOfWidth,                -- Push `setWidth` down signExtend
-    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,  -- Sign bit test becomes a mask test
+  simp  only [
+    eq_iff (o := 8),
+    nat_lt_nat_eq_mask_lt_mask (o := 8),
+    setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
+    msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
+    h_mq, h_mr, h_mp,
+    p_le_bw,
+    r_le_bw,
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
-    ← h_mr,
-    ← h_mq,
-    ← h_mp,
-  ] at h_xmp ⊢
+  ]  at h_xmp ⊢
 -- Step 7: Drop the Nat 'p', 'q', 'r'
-  clear h_mp h_mq h_mr
-  clear hr hqr hpq r_le_bw q_le_bw p_le_bw
-  clear p q r
--- Step 8: Bitblast!
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -35,15 +35,11 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
       eq_iff w_le_bw,             -- Introduce `setWidth` to goal
-      setWidth_add w_le_bw,       -- Push `setWidth` down add
-      setWidth_setWidth w_le_bw,  -- Push `setWidth` down setWidth
+      setWidth_add,       -- Push `setWidth` down add
+      setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
-      ← h_mw]                     -- Replace mask with nat with bv constraint
+      w_le_bw]                     -- Replace mask with nat with bv constraint
       at h_xmw h_ymw ⊢
--- Step 7: Drop the Nat `w`
-  clear hw
-  clear w_le_bw h_mw
-  clear w
 -- Step 8: Bitblast!
   bv_decide
 

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -74,15 +74,13 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mq_mask := isMask_of_eq_maskOfWidth h_mq
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
---   into a fact about the bitvector masks
-  -- have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+--          into a fact about the bitvector masks
+  have le_pq := mask_lt_mask 8 p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
-  revert hpq hqr
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
     eq_iff (o := 8),
-    nat_lt_nat_eq_mask_lt_mask (o := 8),
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -76,7 +76,6 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
-  simp only [isMask_eq] at mr_mask mq_mask mp_mask
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
@@ -89,8 +88,6 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
-    h_mq, h_mr, h_mp,
-    p_le_bw,
     r_le_bw,
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -81,7 +81,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   simp  only [
     eq_iff (o := 8),
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
-    msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
+    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -77,6 +77,8 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 --          into a fact about the bitvector masks
   have bv_p_lt_q := h_pq
   revert bv_p_lt_q
+  have bv_q_lt_r := h_qr
+  revert bv_q_lt_r
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
@@ -128,7 +130,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp  only [
+  simp only [
     eq_iff (o := 8),
     Nat_lt_eq_Mask_lt (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -50,7 +50,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (h_qr : q < r)
-  (h_pq : (p + 1) - 1 < q) :
+  (h_pq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
 -- Step 1: Bound widths to the provided blast width
@@ -76,12 +76,13 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have bv_p_lt_q := h_pq
-  simp [Nat_lt_eq_Mask_lt (o := 8), p_le_bw, q_le_bw] at bv_p_lt_q
+  revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp  only [
+  simp only [
     eq_iff (o := 8),
-    setWidth_setWidth (o := 8),
+    Nat_lt_eq_Mask_lt (o := 8),
+    setWidth_setWidth,
     BitVec.zeroExtend_eq_setWidth,
     BitVec.setWidth_eq,
     p_le_bw,
@@ -123,15 +124,17 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_p_lt_q := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  have bv_p_lt_q := hpq
+  revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
     eq_iff (o := 8),
-    setWidth_setWidth (o := 8),
+    Nat_lt_eq_Mask_lt (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,
+    setWidth_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
     p_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -44,6 +44,54 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   bv_decide
 
 
+/-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
+    which is a single zero extension to `r`, since `p < q`.
+-/
+theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (h_qr : q < r)
+  (h_pq : (p + 1) - 1 < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+-- Step 1: Bound widths to the provided blast width
+  have r_le_bw : r ≤ 8 := by grind
+  have q_le_bw : q ≤ 8 := by grind
+  have p_le_bw : p ≤ 8 := by grind
+-- Step 2-3: Introduce mask to replace `w` Nat var
+  apply width_elim 8 r
+  intro mr h_mr
+  apply width_elim 8 q
+  intro mq h_mq
+  apply width_elim 8 p
+  intro mp h_mp
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
+  revert x
+  apply var_elim 8 p p_le_bw
+  intro x h_xmp
+-- Step 5: Convert width hypothesis to mask hypothesis
+  have mr_mask := isMask_of_eq_maskOfWidth h_mr
+  have mq_mask := isMask_of_eq_maskOfWidth h_mq
+  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+-- Step 5B: Translate the condition on the natural number width
+--          into a fact about the bitvector masks
+  have bv_p_lt_q := h_pq
+  simp [Nat_lt_eq_Mask_lt (o := 8), p_le_bw, q_le_bw] at bv_p_lt_q
+
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
+  simp  only [
+    eq_iff (o := 8),
+    setWidth_setWidth (o := 8),
+    BitVec.zeroExtend_eq_setWidth,
+    BitVec.setWidth_eq,
+    p_le_bw,
+    r_le_bw,
+    q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
+                                   -- `setWidth_signExtend_eq_and_maskOfWidth`
+  ] at h_xmp ⊢
+-- Step 8: BitBlast!
+  bv_decide
+
 /-- Manual trace of a zero extension to `q` followed by a sign extension to `r`,
     which is a single zero extension to `r`, since `p < q` leaves the sign bit
     of the intermediate value clear -/
@@ -91,5 +139,5 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
   ] at h_xmp ⊢
--- Step 7: Drop the Nat 'p', 'q', 'r'
+-- Step 8: BitBlast!
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -31,7 +31,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   apply var_elim 4 w w_le_bw
   intro y h_ymw
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mw_mask := isMask_of_eq_maskOfWidth h_mw
+  have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
       eq_iff (o := 4),             -- Introduce `setWidth` to goal
@@ -70,9 +70,9 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   apply var_elim 8 p p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := isMask_of_eq_maskOfWidth h_mr
-  have mq_mask := isMask_of_eq_maskOfWidth h_mq
-  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+  have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
+  have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
+  have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have bv_p_lt_q := h_pq
@@ -121,9 +121,9 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   apply var_elim 8 p p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := isMask_of_eq_maskOfWidth h_mr
-  have mq_mask := isMask_of_eq_maskOfWidth h_mq
-  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+  have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
+  have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
+  have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have bv_p_lt_q := hpq

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -83,7 +83,7 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
-    Nat_lt_eq_Mask_lt (o := 8),
+    lt_eq_lt_of_eq_maskOfWidth (o := 8),
     setWidth_setWidth,
     BitVec.zeroExtend_eq_setWidth,
     BitVec.setWidth_eq,
@@ -132,7 +132,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
-    Nat_lt_eq_Mask_lt (o := 8),
+    lt_eq_lt_of_eq_maskOfWidth (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -75,7 +75,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have le_pq := mask_lt_mask 8 p_le_bw q_le_bw h_mp h_mq hpq
+  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -84,7 +84,12 @@ the index `i` is inbounds of `w`. -/
 
 /-- `signBitOfMask m` keeps only the top bit of the mask `m`.
 This is used to extract the sign bit of a width `o` bitvector. -/
-@[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
+def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
+
+theorem signBitOfMask_eq {o : Nat} (m : BitVec o) :
+    signBitOfMask m = m - (m >>> 1) := by
+  unfold signBitOfMask
+  rfl
 
 /-- The zero bitvector, which is the mask of width `0`, has no sign bit. -/
 @[simp] theorem signBitOfMask_zero {o : Nat} : signBitOfMask (0#o) = 0#o := by

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -41,10 +41,9 @@ theorem isMask_maskOfWidth {o w : Nat} :
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- The mask constraint: the only fact about `m` surviving abstraction.
-Unfold the IsMask def here to simplify use in the proof. -/
+/-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
+    (hm : m = maskOfWidth o w) : IsMask m := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -19,7 +19,7 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
 /-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
-@[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
+def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
 /-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
 theorem isMask_eq {o : Nat} (m : BitVec o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -55,11 +55,6 @@ theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂
   have : 0 < 2 ^ w₁ := by grind
   lia
 
-/-- Strict width order becomes strict mask order. -/
-theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw : w₁ < w₂) : m₁ < m₂ := by
-  grind only [maskOfWidth_lt_maskOfWidth]
 
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -21,12 +21,6 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
 def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
-/-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
-theorem isMask_eq {o : Nat} (m : BitVec o) :
-    IsMask m = (m &&& (m + 1#o) = 0#o) := by
-  unfold IsMask
-  rfl
-
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by
   rw [maskOfWidth, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
@@ -43,7 +37,7 @@ theorem isMask_maskOfWidth {o w : Nat} :
 
 /-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : IsMask m := by
+    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -41,9 +41,10 @@ theorem isMask_maskOfWidth {o w : Nat} :
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- The mask constraint: the only fact about `m` surviving abstraction. -/
+/-- The mask constraint: the only fact about `m` surviving abstraction.
+Unfold the IsMask def here to simplify use in the proof. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : IsMask m := by
+    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -19,7 +19,7 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
 /-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
-def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
+@[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
 /-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
 theorem isMask_eq {o : Nat} (m : BitVec o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -17,10 +17,6 @@ public section
 /-- `maskOfWidth o w : BitVec o` has its low `w` bits set. -/
 def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
-/-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
-operations removing the dependency on `k` and allowing it to be bitblasted. -/
-def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
-
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by
   rw [maskOfWidth, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
@@ -28,27 +24,15 @@ theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
   have h2 : 0 < 2 ^ w := Nat.two_pow_pos w
   lia
 
-/-- Soundness: every real mask satisfies the constraint. -/
-theorem isMask_maskOfWidth {o w : Nat} :
-    IsMask (maskOfWidth o w) := by
-  simp [IsMask, maskOfWidth, BitVec.ofNat_add_ofNat, ← BitVec.ofNat_and,
-    Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
-    Nat.and_two_pow_sub_one_eq_mod]
-
-/-- The mask constraint: the only fact about `m` surviving abstraction. -/
-theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
+/-- The mask constraint: the only fact about `m` surviving abstraction. This
+encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector operations
+removing the dependency on `k` and allowing it to be bitblasted. -/
+theorem maskOfWidth_and_add_one_eq_zero {o w : Nat} {m : BitVec o}
     (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
-  exact isMask_maskOfWidth
-
-/-- `maskOfWidth` is monotone with respect to unsigned bitvec comparison. -/
-theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
-  have : 0 < 2 ^ w₁ := by grind
-  lia
-
+  simp [maskOfWidth, BitVec.ofNat_add_ofNat, ← BitVec.ofNat_and,
+    Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
+    Nat.and_two_pow_sub_one_eq_mod]
 
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -22,7 +22,7 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
-/-- Inequality on the widths translates to inequality on the masks. -/
+/-- LT on the widths translates to the masks. -/
 theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
@@ -32,6 +32,29 @@ theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h�
   have := Nat.two_pow_pos w₁
   have := Nat.two_pow_pos w₂
   lia
+
+/-- LE on the widths translates to the masks. -/
+theorem Nat_le_eq_Mask_le (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [eq_iff_iff, BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      ← Nat.pow_le_pow_iff_right (a := 2) (by lia)]
+  have := Nat.two_pow_pos w₁
+  have := Nat.two_pow_pos w₂
+  lia
+
+/-- GE on the widths translates to the masks. -/
+theorem Nat_ge_eq_Mask_ge (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
+  grind [Nat_le_eq_Mask_le]
+
+/-- GT on the widths translates to the masks. -/
+theorem Nat_gt_eq_Mask_gt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ > w₂) = (m₁ > m₂) := by
+  grind [Nat_lt_eq_Mask_lt]
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -34,18 +34,11 @@ theorem Nat_lt_eq_Mask_lt {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w�
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
   subst m₁ m₂
-  rw [eq_iff_iff]
-  constructor
-  · grind only[maskOfWidth_lt_maskOfWidth]
-  · intro h
-    rw [BitVec.lt_def] at h
-    repeat rw [toNat_maskOfWidth] at h
-    have h_pow1 : (2 ^ w₁ > 0) := by grind
-    have h_pow2 : (2 ^ w₂ > 0) := by grind
-    have h_pows : (2 ^ w₁ < 2 ^ w₂) := by grind
-    exact (Nat.pow_lt_pow_iff_right (a:= 2) (by omega)).mp h_pows
-    · exact h₂
-    · exact h₁
+  rw [eq_iff_iff, BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      ← Nat.pow_lt_pow_iff_right (a := 2) (by lia)]
+  have := Nat.two_pow_pos w₁
+  have := Nat.two_pow_pos w₂
+  lia
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -14,13 +14,15 @@ namespace Veir.Data.PBV
 
 public section
 
-/-! ## Introducing `setWidth o` at the root -/
 
+/-- Introducing `setWidth o` at the root -/
 theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w), (a = b) = (a.setWidth o = b.setWidth o) := by
   intro a b
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
+
+/-! ## Translating conditions on `Nat` widths into conditions on masks -/
 
 /-- LT on the widths translates to the masks. -/
 theorem lt_eq_lt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
@@ -64,8 +66,6 @@ theorem setWidth_setWidth {w o : Nat} (h : w ≤ o) :
   intro u a
   refine setWidth_eq_and_maskOfWidth h ?_
   rw [BitVec.toNat_setWidth, BitVec.toNat_setWidth, Nat.mod_mod_pow_of_le h]
-
-/-! ## Width-sensitive arithmetic: mask the result -/
 
 theorem setWidth_add {w o : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w),

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -22,15 +22,8 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
-/-- Strict width order becomes strict mask order. -/
-theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ < w₂) : m₁ < m₂ := by
-  subst m₁ m₂
-  grind only[maskOfWidth_lt_maskOfWidth]
-
 /-- Inequality on the widths translates to inequality on the masks. -/
-theorem Nat_lt_eq_Mask_lt {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
   subst m₁ m₂
@@ -85,7 +78,7 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
 
 /-- `a.msb` can be implemented by masking the sign bit,
 which are definitions the bitblaster can see. -/
-theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
+theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a : BitVec w),
       a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
   intro a

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -23,38 +23,11 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
 /-- Strict width order becomes strict mask order. -/
-theorem nat_lt_nat_eq_mask_lt_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ < w₂) = (m₁ < m₂) := by
+theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ :  w₁ < w₂) : m₁ < m₂ := by
   subst m₁ m₂
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have : 0 < 2 ^ w₁ := by grind
-  simp only [eq_iff_iff]
-  constructor
-  · intros h
-    have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
-    have : 0 < 2 ^ w₁ := by grind
-    lia
-  · intros h
-    apply Nat.pow_lt_pow_iff_right (a := 2) (h := by decide) .. |>.mp
-    · grind
-
-/-- Strict width order becomes strict mask order. -/
-theorem nat_le_nat_eq_mask_le_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
-  subst m₁ m₂
-  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have : 0 < 2 ^ w₁ := by grind
-  simp only [eq_iff_iff]
-  constructor
-  · intros h
-    have hlt : 2 ^ w₁ ≤ 2 ^ w₂ := Nat.pow_le_pow_right (by lia) (by lia)
-    have : 0 < 2 ^ w₁ := by grind
-    lia
-  · intros h
-    apply Nat.pow_le_pow_iff_right (a := 2) (h := by decide) .. |>.mp
-    · grind
+  grind only[maskOfWidth_lt_maskOfWidth]
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -16,11 +16,45 @@ public section
 
 /-! ## Introducing `setWidth o` at the root -/
 
-theorem eq_iff {w o : Nat} (h : w ≤ o) :
+theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w), (a = b) = (a.setWidth o = b.setWidth o) := by
   intro a b
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
+
+/-- Strict width order becomes strict mask order. -/
+theorem nat_lt_nat_eq_mask_lt_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ < w₂) = (m₁ < m₂) := by
+  subst m₁ m₂
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
+  have : 0 < 2 ^ w₁ := by grind
+  simp only [eq_iff_iff]
+  constructor
+  · intros h
+    have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
+    have : 0 < 2 ^ w₁ := by grind
+    lia
+  · intros h
+    apply Nat.pow_lt_pow_iff_right (a := 2) (h := by decide) .. |>.mp
+    · grind
+
+/-- Strict width order becomes strict mask order. -/
+theorem nat_le_nat_eq_mask_le_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
+  have : 0 < 2 ^ w₁ := by grind
+  simp only [eq_iff_iff]
+  constructor
+  · intros h
+    have hlt : 2 ^ w₁ ≤ 2 ^ w₂ := Nat.pow_le_pow_right (by lia) (by lia)
+    have : 0 < 2 ^ w₁ := by grind
+    lia
+  · intros h
+    apply Nat.pow_le_pow_iff_right (a := 2) (h := by decide) .. |>.mp
+    · grind
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -23,7 +23,7 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
 /-- LT on the widths translates to the masks. -/
-theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem lt_eq_lt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
   subst m₁ m₂
@@ -34,7 +34,7 @@ theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h�
   lia
 
 /-- LE on the widths translates to the masks. -/
-theorem Nat_le_eq_Mask_le (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem le_eq_le_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
   subst m₁ m₂
@@ -45,16 +45,16 @@ theorem Nat_le_eq_Mask_le (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h�
   lia
 
 /-- GE on the widths translates to the masks. -/
-theorem Nat_ge_eq_Mask_ge (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem ge_eq_ge_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
-  grind [Nat_le_eq_Mask_le]
+  grind [le_eq_le_of_eq_maskOfWidth]
 
 /-- GT on the widths translates to the masks. -/
-theorem Nat_gt_eq_Mask_gt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem gt_eq_gt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ > w₂) = (m₁ > m₂) := by
-  grind [Nat_lt_eq_Mask_lt]
+  grind [lt_eq_lt_of_eq_maskOfWidth]
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -25,9 +25,27 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
 /-- Strict width order becomes strict mask order. -/
 theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ :  w₁ < w₂) : m₁ < m₂ := by
+    (hw₁w₂ : w₁ < w₂) : m₁ < m₂ := by
   subst m₁ m₂
   grind only[maskOfWidth_lt_maskOfWidth]
+
+/-- Inequality on the widths translates to inequality on the masks. -/
+theorem Nat_lt_eq_Mask_lt {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ < w₂) = (m₁ < m₂) := by
+  subst m₁ m₂
+  rw [eq_iff_iff]
+  constructor
+  · grind only[maskOfWidth_lt_maskOfWidth]
+  · intro h
+    rw [BitVec.lt_def] at h
+    repeat rw [toNat_maskOfWidth] at h
+    have h_pow1 : (2 ^ w₁ > 0) := by grind
+    have h_pow2 : (2 ^ w₂ > 0) := by grind
+    have h_pows : (2 ^ w₁ < 2 ^ w₂) := by grind
+    exact (Nat.pow_lt_pow_iff_right (a:= 2) (by omega)).mp h_pows
+    · exact h₂
+    · exact h₁
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -184,7 +184,7 @@ meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 
 /--
 Translate width precondition into BitVec hypothesis.
-TODO: consider more complicated width exprs.
+TODO: Deal with constants.
 -/
 meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl) :
     MetaM (MVarId) := g.withContext do
@@ -193,15 +193,9 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     if ty == mkConst ``Nat then
       if let some wa := winfos.infos[ea]? then
         if let some wb := winfos.infos[eb]? then
-          -- Apply mask_lt_mask using the known facts of the widths
-          let bvLTExpr := mkAppM ``mask_lt_mask
-            #[.fvar wa.hypWidthLeBoundNote,
-              .fvar wb.hypWidthLeBoundNote,
-              .fvar wa.widthMaskHypFvar,
-              .fvar wb.widthMaskHypFvar,
-              .fvar ldecl.fvarId]
-          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") (← bvLTExpr)
-          logInfo m!"Translated {ldecl.toExpr} : {ldecl.type} to bitvec"
+          let (natLTHyp, g) ← g.withContext do
+            g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") ldecl.toExpr
+          let (#[_], g) ← g.revert #[natLTHyp] | throwError "Reverting shuold produce a single FVar."
           return g
     return g
   | _ => return g
@@ -226,14 +220,18 @@ meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
 
 /--
-These rewrites introduce the toplevel equality that convers `a = b` into
-`a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
+These theorems require pre-filling the width bound in order to be used within
+the Simp set.
 -/
-meta def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
+meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let mut simp := simp
-  simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
-  return simp
+  let thms := #[
+        ``eq_iff,
+        ``Nat_lt_eq_Mask_lt]
+
+  thms.foldlM (init := simp) fun simps name =>
+    return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
+
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -292,7 +290,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let g ← translateWidthPreconds widthInfos g
 
   -- Run simp
-  let thms := ← addToplevelRewrites g ctx
+  let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -53,20 +53,19 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     -- Retrieve the ldecl from the context.
     let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
-
     if !(← Expr.isNat widthExpr) then
       throwError s!"`BitVec` width {← inferType widthExpr} is not a `Nat`"
-
+    -- Apply width_elim
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
-      | throwError "width_elim should generate a goal"
+      | throwError m!"{``width_elim} should generate a goal"
     -- Intros
     let maskName := Name.mkSimple s!"m{name}"
-    let (mask, g) ← g.withContext do g.intro maskName
-    let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+    let (#[mask, maskHyp], g) ← g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
+      | throwError m!"Failed to intro {``width_elim}"
     -- Define bounding conditions.
     let hypWidthLeBound ← g.withContext do
-      mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+      mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -160,7 +160,7 @@ from the simp-set. This makes them user-extensible with no metaprogramming neede
 -/
 meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let others := #[``BitVec.setWidth_eq, ``eq_iff, ``setWidth_add, ``setWidth_setWidth]
+  let others := #[``BitVec.setWidth_eq, ``setWidth_add, ``setWidth_setWidth]
   let mut simp := simp
   for n in others do
     simp ← simp.addTheorem (.other n) (mkConst n [])

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -39,17 +39,24 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
+meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
+  let some fvarId := e.fvarId? | return none
+  return (← getLCtx).find? fvarId
+
 meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Retrieve the ldecl from the context.
-    let ldecl ← getFVarLocalDecl widthExpr
+    let ldeclOpt ← localDecl? widthExpr
+    let name := if let some ldecl := ldeclOpt then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
-    assert! ldecl.type == (mkConst ``Nat)
+    if (← inferType widthExpr) != (mkConst ``Nat) then
+      throwError s!"`BitVec` width {widthExpr} is not a `Nat`"
+
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
       | throwError "width_elim should generate a goal"
     -- Intros
-    let maskName := Name.mkSimple s!"m{ldecl.userName}"
+    let maskName := Name.mkSimple s!"m{name}"
     let (mask, g) ← g.withContext do g.intro maskName
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
@@ -58,14 +65,14 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
       mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
-    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{ldecl.userName}_le_bound") hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
     let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_isMask") hypExpr
 
     let info : WidthInfo := {
-      widthName := ldecl.userName,
+      widthName := name,
       widthExpr := widthExpr,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
@@ -349,4 +356,16 @@ public meta def evalPbvDecide : Tactic := fun stx => do
 --   pbv_decide 4
 --   · simp only [eq_iff 4 hw]
 --     bv_decide
+--   · grind
+
+-- TODO: handle addition inside of the mask widths.
+-- example (p q r : Nat) (x : BitVec p)
+--   (hr : q ≤ 8)
+--   (hpq : p < q) :
+--   (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
+--   := by
+--   pbv_decide 8
+--   · bv_decide
+--   · grind
+--   · grind
 --   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -7,6 +7,9 @@ public import Veir.Data.PBV
 open Lean Elab Tactic Meta Simp Std
 namespace Veir.Data.PBV
 
+meta def Expr.isNat (e : Expr) : MetaM Bool := do
+  return (← inferType e).isConstOf ``Nat
+
 /--
 Information about the width variable and associated hypotheses.
 -/
@@ -21,7 +24,9 @@ structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
+  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it.
+      TODO: it's not clear why we need a `FVar` for `simp` to decide to rewrite with it.
+  -/
   hypWidthLeBoundNote : FVarId
 
 
@@ -48,8 +53,9 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     -- Retrieve the ldecl from the context.
     let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
-    if (← inferType widthExpr) != (mkConst ``Nat) then
-      throwError s!"`BitVec` width {widthExpr} is not a `Nat`"
+
+    if !(← Expr.isNat widthExpr) then
+      throwError s!"`BitVec` width {← inferType widthExpr} is not a `Nat`"
 
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
@@ -60,7 +66,6 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
     let hypWidthLeBound ← g.withContext do
-      -- Add a meaninful name using : (userName := Name.mkSimple "foo")
       mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
@@ -219,7 +224,7 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     let some wa ← winfos.get? ea | return g
     let some wb ← winfos.get? eb | return g
     let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
-    let (#[_], g) ← g.revert #[natHyp] | throwError "Reverting shuold produce a single FVar."
+    let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
     return g
   else
     return g
@@ -250,10 +255,10 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
-        ``Nat_lt_eq_Mask_lt,
-        ``Nat_le_eq_Mask_le,
-        ``Nat_ge_eq_Mask_ge,
-        ``Nat_gt_eq_Mask_gt,
+        ``lt_eq_lt_of_eq_maskOfWidth,
+        ``le_eq_le_of_eq_maskOfWidth,
+        ``ge_eq_ge_of_eq_maskOfWidth,
+        ``gt_eq_gt_of_eq_maskOfWidth,
         ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
   ]
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -98,8 +98,6 @@ meta structure BitVecInfos where
 meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
-
-
 /--
 Match on an expression, and if it is a `BitVec w`, return the `w`.
 Otherwise, return `none`.
@@ -310,37 +308,6 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
-
-
-/-- Manual trace of the future tactic, transforming an unbounded parametric width
-    statement into a bounded one and solving it up to the bound (4 in this case) -/
-theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
--- Step 1: Bound widths to the provided blast width (redundant in this case)
-  have w_le_bw :  w ≤ 4 := by grind
--- Step 2-3: Introduce mask to replace `w` Nat var
-  apply width_elim 4 w
-  intro mw h_mw
--- Step 4: Eliminate the parametric bv var of width `w`
---         enforcing width constraint with mask
-  revert x
-  apply var_elim 4 w w_le_bw
-  intro x h_xmw
-  revert y
-  apply var_elim 4 w w_le_bw
-  intro y h_ymw
--- Step 5: Convert width hypothesis to mask hypothesis
-  have mw_mask := isMask_of_eq_maskOfWidth h_mw
--- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [
-      eq_iff _ w_le_bw,             -- Introduce `setWidth` to goal
-      setWidth_add,       -- Push `setWidth` down add
-      setWidth_setWidth,  -- Push `setWidth` down setWidth
-      BitVec.setWidth_eq,         -- Remove redundant setWidths
-      w_le_bw]                     -- Replace mask with nat with bv constraint
-      at h_xmw h_ymw ⊢
--- Step 8: Bitblast!
-  bv_decide
 
 example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -69,8 +69,8 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) 
 /--
 Either get existing width info, or create one if it does not exist.
 -/
-meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
-    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := do
+def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
+    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
   if let some info := this.infos[wExpr]? then
     return (g, info, this)
   else
@@ -111,35 +111,42 @@ def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-meta def introBitvecVar (ctx : PbvTranslateContext) (widthInfos : WidthInfos) (g : MVarId)
-      (bvInfos : BitVecInfos) (ldecl : LocalDecl) :
-      MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
-  unless ldecl.isImplementationDetail do
-    -- Find the BitVec {width_expr} variables.
-    if let some wExpr := getBitvecType? ldecl.type then
-      let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
-      -- Revert to expose forall with the BitVec.
-      let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
-      -- Apply ``var_elim
-      let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-          #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
-        | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
-      -- Intros
-      let name ← oldVar.getUserName
-      let (bvVar, g) ← g.intro name
-      let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
-      return (g, widthInfos, bvInfos.push { bvVar, bvHyp })
-  return (g, widthInfos, bvInfos)
+def introBitvecFVarChecked (ctx : PbvTranslateContext) (g : MVarId)
+      (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
+      MetaM (MVarId × BitVecInfos) := g.withContext do
+  -- Find the BitVec {width_expr} variables.
+    -- Revert to expose forall with the BitVec.
+  let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError "reverting shuold produce a var"
+  -- Apply ``var_elim
+  let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
+      #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
+    | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
+  -- Intros
+  let name ← oldVar.getUserName
+  let (bvVar, g) ← g.intro name
+  let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
+  return (g, bvInfos.push { bvVar, bvHyp })
+
 
 /--
-Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
-hypotheses.
+boo lean is stupid, it can't see that this will terminate.
 -/
-meta def introBitvecVars (ctx : PbvTranslateContext) (g : MVarId) :
-    MetaM (MVarId × WidthInfos × BitVecInfos) := do
-  let decls : LocalContext ← g.withContext getLCtx
-  decls.foldlM (init := (g, {}, {})) fun (g, widthInfos, bvInfos) ldecl =>
-    introBitvecVar ctx widthInfos g bvInfos ldecl
+partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId) (widthInfos : WidthInfos) (bvInfos : BitVecInfos) (e : Expr) :
+    MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
+  let (f, args) := (e.getAppFn, e.getAppArgs)
+  let (g, widthInfos, bvInfos) ← g.withContext do
+    args.foldlM (init := (g, widthInfos, bvInfos)) fun (g, widthInfos, bvInfos) arg => visitExpr ctx g widthInfos bvInfos arg
+  let tf ← inferType f
+  if let some wExpr := getBitvecType? tf then
+    let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
+    if let some fvarId := f.fvarId? then
+      let (g, bvInfos) ← introBitvecFVarChecked ctx g bvInfos fvarId widthInfo
+      return (g, widthInfos, bvInfos)
+    else
+      return (g, widthInfos, bvInfos)
+  else
+    return (g, widthInfos, bvInfos)
+
 
 
 /--
@@ -200,7 +207,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, widthInfos, bvInfos) ← introBitvecVars ctx g
+  let (g, widthInfos, bvInfos) ← visitExpr ctx g {} {} (← g.getType)
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
@@ -269,4 +276,13 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
+  · grind
+
+set_option trace.Meta.Tactic.simp.all true
+set_option trace.Meta.Tactic.simp true
+example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
+  x + y = y + x := by
+  pbv_decide 4
+  · bv_decide
+  · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -46,8 +46,7 @@ meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
 meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Retrieve the ldecl from the context.
-    let ldeclOpt ← localDecl? widthExpr
-    let name := if let some ldecl := ldeclOpt then ldecl.userName else (Name.mkSimple "widthVar")
+    let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
     if (← inferType widthExpr) != (mkConst ``Nat) then
       throwError s!"`BitVec` width {widthExpr} is not a `Nat`"

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -1,17 +1,17 @@
 module
 
 public meta import Lean
+public meta import Std
 public import Veir.Data.PBV
 
-open Lean Elab Tactic Meta Simp
+open Lean Elab Tactic Meta Simp Std
 namespace Veir.Data.PBV
 
 /--
 Information about the width variable and associated hypotheses.
 -/
-meta structure WidthInfo where
-  /-- The LocalDecl corresponding to this width variable. -/
-  widthNatLocalDecl : LocalDecl
+structure WidthInfo where
+  widthExpr : Expr
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
@@ -19,20 +19,15 @@ meta structure WidthInfo where
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
   /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
-  hypWidthLeBoundNoteNote : FVarId
+  hypWidthLeBoundNote : FVarId
 
-meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
-  info.widthNatLocalDecl.fvarId
-
-meta def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
-  .fvar info.widthFvarId
 
 structure WidthInfos where
     /-- One WidthInfo per width -/
-    infos : Array WidthInfo := #[]
+    infos : HashMap Expr WidthInfo := {}
 
 def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-  { infos := this.infos.push info }
+  { infos := this.infos.insert info.widthExpr info }
 
 /--
 Read-only configuration for the tactic.
@@ -41,45 +36,45 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : LocalDecl) (infos : WidthInfos)
-  : MetaM (MVarId × WidthInfos) := g.withContext do
-    unless ldecl.isImplementationDetail do
-        if ← isDefEq ldecl.type (mkConst ``Nat) then
-        -- Apply ``width_elim
-        let [g] ← g.withContext do
-          g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
-          | throwError "width_elim should generate a goal"
-        -- Intros
-        let maskName := Name.mkSimple s!"m{ldecl.userName}"
-        let (mask, g) ← g.withContext do g.intro maskName
-        let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
-        -- Define bounding conditions.
-        let hypWidthLeBound <- g.withContext do
-          mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
-            #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
-        g.withContext <| check hypWidthLeBound
-        let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
-        g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
-        -- Assert the BitVec mask constraint.
-        let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-        let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
-        let info : WidthInfo := {
-          widthNatLocalDecl := ldecl,
-          widthMaskFvar := mask,
-          widthMaskHypFvar := maskHyp
-          hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
-          hypWidthLeBoundNoteNote
-        }
-        return (g, infos.push info)
-    return (g, infos)
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
+    -- TODO: check that the value has Nat.
+    let [g] ← g.withContext do
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl, ← g.getType]
+      | throwError "width_elim should generate a goal"
+    -- Intros
+    let maskName := Name.mkSimple s!"maskWidth_new_var" -- TODO: find the name if it's an Fvar, and otherwise abstract it into a new name.
+    let (mask, g) ← g.withContext do g.intro maskName
+    let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+    -- Define bounding conditions.
+    let hypWidthLeBound <- g.withContext do
+      mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+        #[mkConst ``Nat, mkConst ``instLENat, ldecl, mkNatLit ctx.bmcBound])
+    g.withContext <| check hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+    g.withContext <| check (mkFVar hypWidthLeBoundNote)
+    -- Assert the BitVec mask constraint.
+    let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
+    let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    let info : WidthInfo := {
+      widthExpr := ldecl,
+      widthMaskFvar := mask,
+      widthMaskHypFvar := maskHyp
+      hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
+      hypWidthLeBoundNote
+    }
+    return (g, info, infos.push info)
+    -- return (g, infos)
 
-
-/-- Find the local declaration of the (single) width variable,
-and eliminate it, producing the mask variable, and the masking constraint.
+/--
+Either get existing width info, or create one if it does not exist.
 -/
-meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
-  (← getLCtx).foldrM (init := (g, {})) fun ldecl (g, infos) =>
-    introMaskWidth ctx g ldecl infos
+meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
+    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := do
+  if let some info := this.infos[wExpr]? then
+    return (g, info, this)
+  else
+    introMaskWidth ctx g wExpr this
 
 
 /--
@@ -101,47 +96,61 @@ meta structure BitVecInfos where
 meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
+
+
+/--
+Match on an expression, and if it is a `BitVec w`, return the `w`.
+Otherwise, return `none`.
+-/
+def getBitvecType? (e : Expr) : Option Expr :=
+  match_expr e with
+  | BitVec w => some w
+  | _ => none
+
 /--
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
-      (infos : BitVecInfos) (ldecl : LocalDecl) :
-      MetaM (MVarId × BitVecInfos) := g.withContext do
+meta def introBitvecVar (ctx : PbvTranslateContext) (widthInfos : WidthInfos) (g : MVarId)
+      (bvInfos : BitVecInfos) (ldecl : LocalDecl) :
+      MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
   unless ldecl.isImplementationDetail do
     -- Find the BitVec {width_expr} variables.
-    if Expr.equal ldecl.type (mkApp (mkConst ``BitVec) widthInfo.widthFvar) then
+    if let some wExpr := getBitvecType? ldecl.type then
+      let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
       -- Revert to expose forall with the BitVec.
       let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
       -- Apply ``var_elim
       let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBoundMVarId]
+          #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
         | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
       -- Intros
       let name ← oldVar.getUserName
       let (bvVar, g) ← g.intro name
       let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
-      return (g, infos.push { bvVar, bvHyp})
-  return (g, infos)
+      return (g, widthInfos, bvInfos.push { bvVar, bvHyp })
+  return (g, widthInfos, bvInfos)
 
 /--
 Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
 hypotheses.
 -/
-meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) :
-    MetaM (MVarId × BitVecInfos) := do
+meta def introBitvecVars (ctx : PbvTranslateContext) (g : MVarId) :
+    MetaM (MVarId × WidthInfos × BitVecInfos) := do
   let decls : LocalContext ← g.withContext getLCtx
-  decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
-    introVar ctx widthInfo g infos ldecl
+  decls.foldlM (init := (g, {}, {})) fun (g, widthInfos, bvInfos) ldecl =>
+    introBitvecVar ctx widthInfos g bvInfos ldecl
 
 
 /--
 These rewrites introduce the toplevel equality that convers `a = b` into
 `a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-meta def addToplevelRewrites (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) :
+meta def addToplevelRewrites (g : MVarId) (widthInfos : WidthInfos) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBoundMVarId])
+  let mut simp := simp
+  for (_widthExpr, widthInfo) in widthInfos.infos do
+    simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkFVar widthInfo.hypWidthLeBoundNote])
   return simp
 
 /--
@@ -170,11 +179,12 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
 /--
 Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
 -/
-meta def addWidthInfo (g : MVarId) (info : WidthInfo)
+meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
-  simp ← simp.addTheorem (.other info.hypWidthLeBoundMVarId.name)
-       (mkFVar info.hypWidthLeBoundNoteNote)
+  for (_wexpr, widthInfo) in widthInfos.infos do
+    simp ← simp.addTheorem (.other widthInfo.hypWidthLeBoundNote.name)
+        (mkFVar widthInfo.hypWidthLeBoundNote)
   return simp
 
 /--
@@ -188,17 +198,17 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
-  let (g, widthInfos) ← introMaskWidths ctx g
+  -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, bvInfos) ← introVars ctx g widthInfos
+  let (g, widthInfos, bvInfos) ← introBitvecVars ctx g
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
-                      <| ← addWidthInfo g widthInfos #[]
+                      <| ← addWidthInfosSimpLemmas g widthInfos #[]
   let g ← applySimp g thms
 
-  return [g, widthInfo.hypWidthLeBoundMVarId]
+  return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
 
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -239,24 +239,24 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
         ``Nat_lt_eq_Mask_lt,
         ``Nat_le_eq_Mask_le,
         ``Nat_ge_eq_Mask_ge,
-        ``Nat_gt_eq_Mask_gt
+        ``Nat_gt_eq_Mask_gt,
+        ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
   ]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
 
-
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
-TODO: make this a simp-set, called `pbv_push`, and just gather these
-from the simp-set. This makes them user-extensible with no metaprogramming needed.
 -/
 meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let others := #[
       ``BitVec.setWidth_eq,
       ``setWidth_add,
-      ``setWidth_setWidth
+      ``setWidth_setWidth,
+      ``signBitOfMask_eq,
+      ``setWidth_signExtend_eq_and_maskOfWidth
   ]
 
   let mut simp := simp
@@ -297,24 +297,22 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
   return g
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
-  -- throwError s!"Deciding with bound {ctx.bmcBound}"
-  -- let (g, widthInfos) ← introMaskWidths ctx g
-  -- Introduce bitvector variables
+  -- Find `BitVec`s and intro their widths
   let (g, widthInfos, bvsToRevert) ← visitExprRec ctx g {} {} (← g.getType)
-  for (w, _winfo) in widthInfos.infos do
-    g.withContext do logInfo m!"width: '{w}'"
-
+  -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
-
-  -- Run simp
+  -- Create simp Set
+  -- TODO: make this a simp-set, called `pbv_push`, and just gather these
+  -- from the simp-set. This makes them user-extensible with no metaprogramming needed.
   let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
-
+  -- Run simp
   let g ← applySimp g thms
-
+  -- Return modified goal and subgoals
   return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
 /--

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -80,10 +80,18 @@ Either get existing width info, or create one if it does not exist.
 -/
 meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
     (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-  if let some info := this.infos[wExpr]? then
+  let reducedWExpr ← whnf wExpr
+  if let some info := this.infos[reducedWExpr]? then
     return (g, info, this)
   else
-    introMaskWidth ctx g wExpr this
+    introMaskWidth ctx g reducedWExpr this
+
+/--
+Get some width Expr from infos.
+-/
+meta def WidthInfos.get? (this: WidthInfos) (wExpr : Expr)
+    : MetaM (Option WidthInfo) := do
+  return this.infos[← whnf wExpr]?
 
 
 /--
@@ -202,8 +210,8 @@ goal. This allows for a single call to Simp later.
 meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId) := g.withContext do
   if let some (ea, eb) := matchWidthRel ldecl.type then
-    let some wa := winfos.infos[ea]? | return g
-    let some wb := winfos.infos[eb]? | return g
+    let some wa ← winfos.get? ea | return g
+    let some wb ← winfos.get? eb | return g
     let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
     let (#[_], g) ← g.revert #[natHyp] | throwError "Reverting shuold produce a single FVar."
     return g
@@ -335,46 +343,10 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
 
-example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
-  pbv_decide 4
-  · bv_decide
-  · grind
-
-theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-
-theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
-  (hr : t <= 8)
-  (hqr : q ≤ r)
-  (hpq : q > p)
-  (hrt : t ≥ r):
-  ((x.zeroExtend q).zeroExtend r).zeroExtend t = x.zeroExtend t
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-  · grind
-
-theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).signExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
+-- TODO: get the following working by also instantiating the provided width bound
+-- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
+--   x + y = y + x := by
+--   pbv_decide 4
+--   · simp only [eq_iff 4 hw]
+--     bv_decide
+--   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -17,9 +17,9 @@ meta structure WidthInfo where
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
-  hypWidthLeBound : MVarId
+  hypWidthLeBoundMVarId : MVarId
   /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
-  hypWidthLeBoundNoteHACK : FVarId
+  hypWidthLeBoundNoteNote : FVarId
 
 meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
   info.widthNatLocalDecl.fvarId
@@ -55,8 +55,8 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
             mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
               #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
           g.withContext <| check hypWidthLeBound
-          let (hypWidthLeBoundNoteHACK, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
-          g.withContext <| check (mkFVar hypWidthLeBoundNoteHACK)
+          let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+          g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
           -- Assert the BitVec mask constraint.
           let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
           let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
@@ -64,8 +64,8 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
             widthNatLocalDecl := ldecl,
             widthMaskFvar := mask,
             widthMaskHypFvar := maskHyp
-            hypWidthLeBound := hypWidthLeBound.mvarId!,
-            hypWidthLeBoundNoteHACK
+            hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
+            hypWidthLeBoundNoteNote
           }
           return (g, info)
     throwError "unable to find a valid width variable."
@@ -103,7 +103,7 @@ meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarI
       let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
       -- Apply ``var_elim
       let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBound]
+          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBoundMVarId]
         | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
       -- Intros
       let name ← oldVar.getUserName
@@ -129,7 +129,7 @@ These rewrites introduce the toplevel equality that convers `a = b` into
 -/
 meta def addToplevelRewrites (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBound])
+  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBoundMVarId])
   return simp
 
 /--
@@ -161,9 +161,8 @@ Add BitVecInfos theorems to the Simp theorem context that don't need special bin
 meta def addWidthInfo (g : MVarId) (info : WidthInfo)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
-  simp ← simp.addTheorem (.other info.hypWidthLeBound.name)
-      (mkMVar info.hypWidthLeBound)
-       --(mkFVar info.hypWidthLeBoundNoteHACK)
+  simp ← simp.addTheorem (.other info.hypWidthLeBoundMVarId.name)
+       (mkFVar info.hypWidthLeBoundNoteNote)
   return simp
 
 /--
@@ -187,7 +186,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
                       <| ← addWidthInfo g widthInfo #[]
   let g ← applySimp g thms
 
-  return [g, widthInfo.hypWidthLeBound]
+  return [g, widthInfo.hypWidthLeBoundMVarId]
 
 
 
@@ -232,9 +231,6 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 5: Convert width hypothesis to mask hypothesis
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [eq_iff w_le_bw]
-  simp only [setWidth_add, w_le_bw]
-
   simp only [
       eq_iff w_le_bw,             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -48,7 +48,8 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) 
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
     let hypWidthLeBound <- g.withContext do
-      mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+      -- Add a meaninful name using : (userName := Name.mkSimple "foo")
+      mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, ldecl, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
@@ -137,8 +138,6 @@ def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (width
   if this.bvs.contains fvar then  this
   else { bvs := this.bvs.insert fvar widthInfo }
 
-
-
 /--
 Visit the expression collecting widths, introducing masks,
 and then eliminating them all in the next step.
@@ -179,11 +178,10 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 Translate width precondition into BitVec hypothesis.
 TODO: consider more complicated exprs that might have additions...
 -/
-def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
+def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
     MetaM (MVarId) := g.withContext do
-  match_expr e with
-  | LT.lt u ty _inst ea eb =>
-    throwError "foo"
+  match_expr ldecl.type with
+  | LT.lt ty _inst ea eb =>
     -- ea ≤ eb
     -- translate ea
     -- translate eb
@@ -192,13 +190,14 @@ def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
       if let some wa := winfos.infos[ea]? then
         if let some wb := winfos.infos[eb]? then
           -- Apply mask_lt_mask using the known facts of the widths
-          let bvLTExpr := mkAppN (mkConst ``mask_lt_mask [])
+          let bvLTExpr := mkAppM ``mask_lt_mask
             #[.fvar wa.hypWidthLeBoundNote,
               .fvar wb.hypWidthLeBoundNote,
               .fvar wa.widthMaskHypFvar,
-              .fvar wb.widthMaskHypFvar]
-          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple "a_lt_b") bvLTExpr
-          -- discard hyp, not needed
+              .fvar wb.widthMaskHypFvar,
+              (.fvar ldecl.fvarId)]
+          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{ea}_lt_{eb}") (← bvLTExpr) -- discard hyp, not needed
+          logInfo m!"Translated {ldecl.toExpr} : {ldecl.type} to bitvec"
           return g
     return g
   | _ => return g
@@ -207,7 +206,7 @@ def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
   let mut g := g
   for ldecl in ← getLCtx do
-    g ← translateWidthPrecond winfos g ldecl.toExpr
+    g ← translateWidthPrecond winfos g ldecl
   return g
 /--
 eliminate the bitvector variables to introduce the masked versions
@@ -348,11 +347,11 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
-example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
-  x + y = y + x := by
-  pbv_decide 4
-  · bv_decide
-  · grind
+-- example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
+--   x + y = y + x := by
+--   pbv_decide 4
+--   · bv_decide
+--   · grind
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)
@@ -360,4 +359,5 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
-  pbv_decide 13
+  pbv_decide 8
+  · bv_decide

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -175,35 +175,40 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
   else
     return (g, widthInfos, bvs)
 
-  -- let tf ← g.withContext do inferType f
-  -- if let some wExpr := getBitvecType? tf then
-  --   let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
-  --   if let some fvarId := f.fvarId? then
-  --     return (g, widthInfos, bvs.push fvarId widthInfo)
-  --   else
-  --     return (g, widthInfos, bvs)
-  -- else
-  --   return (g, widthInfos, bvs)
-
-def translateWidthPrecond (ctx : PbvTranslateContext) (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
-    MetaM (MVarId × WidthInfos) := g.withContext do
+/--
+Translate width precondition into BitVec hypothesis.
+TODO: consider more complicated exprs that might have additions...
+-/
+def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
+    MetaM (MVarId) := g.withContext do
   match_expr e with
-  | LE.le ty inst ea eb =>
+  | LT.lt u ty _inst ea eb =>
+    throwError "foo"
+    -- ea ≤ eb
+    -- translate ea
+    -- translate eb
+    -- note the mask theorem for this particular.
     if ty == mkConst ``Nat then
-      -- ea ≤ eb
-      -- translate ea
-      -- translate eb
-      -- note the mask theorem for this particular.
-      sorry
-    else
-      return (g, winfos)
-  | _ => return (g, winfos)
+      if let some wa := winfos.infos[ea]? then
+        if let some wb := winfos.infos[eb]? then
+          -- Apply mask_lt_mask using the known facts of the widths
+          let bvLTExpr := mkAppN (mkConst ``mask_lt_mask [])
+            #[.fvar wa.hypWidthLeBoundNote,
+              .fvar wb.hypWidthLeBoundNote,
+              .fvar wa.widthMaskHypFvar,
+              .fvar wb.widthMaskHypFvar]
+          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple "a_lt_b") bvLTExpr
+          -- discard hyp, not needed
+          return g
+    return g
+  | _ => return g
 
-def translateWidthPreconds (ctx : PbvTranslateContext) (winfos: WidthInfos) (g : MVarId) : MetaM (MVarId × WidthInfos) := do
-  -- loop over ← getLCtx, call translateWidthPrecond
-  sorry
-
-
+def translateWidthPreconds (winfos: WidthInfos)
+    (g : MVarId) : MetaM MVarId := g.withContext do
+  let mut g := g
+  for ldecl in ← getLCtx do
+    g ← translateWidthPrecond winfos g ldecl.toExpr
+  return g
 /--
 eliminate the bitvector variables to introduce the masked versions
 -/
@@ -220,8 +225,6 @@ def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpThe
     MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
   simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
-  simp ← simp.addTheorem (.other ``nat_lt_nat_eq_mask_lt_mask) <| (← mkAppM ``nat_lt_nat_eq_mask_lt_mask #[mkNatLit ctx.bmcBound])
-  simp ← simp.addTheorem (.other ``nat_le_nat_eq_mask_le_mask) <| (← mkAppM ``nat_le_nat_eq_mask_le_mask #[mkNatLit ctx.bmcBound])
   return simp
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -275,6 +278,8 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
     g.withContext do logInfo m!"width: '{w}'"
 
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  let g ← translateWidthPreconds widthInfos g
+
   -- Run simp
   let thms := ← addToplevelRewrites g ctx
                       <| ← addPushTheorems g
@@ -349,8 +354,6 @@ example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) 
   · bv_decide
   · grind
 
-theorem imp_eq_not_or (P Q : Prop) : (P → Q) = (¬ P ∨ Q) := by grind
-
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)
   (hqr : q < r)
@@ -358,7 +361,3 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
   pbv_decide 13
-  · sorry
-  · sorry
-  · sorry
-  · sorry

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -125,7 +125,6 @@ def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
   let name ← oldVar.getUserName
   let (bvVar, g) ← g.withContext <| g.intro name
   let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_m{name}"
-  logInfo m!"{g}"
   return (g, bvInfos.push { bvVar, bvHyp })
 
 /--
@@ -138,27 +137,53 @@ def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (width
   if this.bvs.contains fvar then  this
   else { bvs := this.bvs.insert fvar widthInfo }
 
+
+
 /--
-Visit an expression, collecting all widths and introducing mask variables.
-For bitvectors, collect the bitvectors that need to be eliminated,
-and then eliminate them all in the next step.
+Visit the expression collecting widths, introducing masks,
+and then eliminating them all in the next step.
 -/
-partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId)
+def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
     MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
-  let (f, args) := (e.getAppFn, e.getAppArgs)
-  let (g, widthInfos, bvs) ← g.withContext do
-    args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExpr ctx g widthInfos bvs arg
-  let tf ← g.withContext do inferType f
-  if let some wExpr := getBitvecType? tf then
+  let te ← g.withContext do inferType e
+  if let some wExpr := getBitvecType? te then
     let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
-    if let some fvarId := f.fvarId? then
+    if let some fvarId := e.fvarId? then
       return (g, widthInfos, bvs.push fvarId widthInfo)
     else
       return (g, widthInfos, bvs)
   else
     return (g, widthInfos, bvs)
+
+/--
+Visit an expression, collecting all widths and introducing mask variables.
+For bitvectors, collect the bitvectors that need to be eliminated,
+and then eliminate them all in the next step.
+-/
+partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
+    (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
+    (e : Expr) :
+    MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
+  let (g, widthInfos, bvs) ← visitExprNonrec ctx g widthInfos bvs e
+  if e.isApp then
+    let (f, args) := (e.getAppFn, e.getAppArgs)
+    let (g, widthInfos, bvs) ← g.withContext do
+      args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExprRec ctx g widthInfos bvs arg
+    visitExprRec ctx g widthInfos bvs f
+  else
+    return (g, widthInfos, bvs)
+
+  -- let tf ← g.withContext do inferType f
+  -- if let some wExpr := getBitvecType? tf then
+  --   let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
+  --   if let some fvarId := f.fvarId? then
+  --     return (g, widthInfos, bvs.push fvarId widthInfo)
+  --   else
+  --     return (g, widthInfos, bvs)
+  -- else
+  --   return (g, widthInfos, bvs)
 
 
 /--
@@ -166,7 +191,6 @@ eliminate the bitvector variables to introduce the masked versions
 -/
 def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
-  logInfo m!"number of bvs to revert {bvs.bvs.size}"
   bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
     introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
 
@@ -228,7 +252,10 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, widthInfos, bvsToRevert) ← visitExpr ctx g {} {} (← g.getType)
+  let (g, widthInfos, bvsToRevert) ← visitExprRec ctx g {} {} (← g.getType)
+  for (w, _winfo) in widthInfos.infos do
+    g.withContext do logInfo m!"width: '{w}'"
+
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
@@ -292,18 +319,26 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 8: Bitblast!
   bv_decide
 
-set_option trace.Meta.Tactic.simp.all true
-set_option trace.Meta.Tactic.simp true
 example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
 
-set_option trace.Meta.Tactic.simp.all true
-set_option trace.Meta.Tactic.simp true
 example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
+
+theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
+  (hr : r <= 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · sorry
+  · sorry
+  · sorry
+  · sorry

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -21,7 +21,7 @@ structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
+  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
   hypWidthLeBoundNote : FVarId
 
 
@@ -41,7 +41,7 @@ meta structure PbvTranslateContext where
 
 meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-    -- Retrieve the ldecl from the context
+    -- Retrieve the ldecl from the context.
     let ldecl ← getFVarLocalDecl widthExpr
     -- Check that the Expr is of type Nat.
     assert! ldecl.type == (mkConst ``Nat)
@@ -190,7 +190,6 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     MetaM (MVarId) := g.withContext do
   match_expr ldecl.type with
   | LT.lt ty _inst ea eb =>
-    -- note the mask theorem for this particular.
     if ty == mkConst ``Nat then
       if let some wa := winfos.infos[ea]? then
         if let some wb := winfos.infos[eb]? then
@@ -207,14 +206,19 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     return g
   | _ => return g
 
+/--
+Traverse the local context and translate any hypotheses on `Nat` widths into
+`BitVec` hypotheses.
+-/
 meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
   let mut g := g
   for ldecl in ← getLCtx do
     g ← translateWidthPrecond winfos g ldecl
   return g
+
 /--
-eliminate the bitvector variables to introduce the masked versions
+Eliminate the bitvector variables to introduce the masked versions.
 -/
 meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
@@ -245,7 +249,9 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context that don't need special bindings.
+Add BitVecInfos theorems to the Simp theorem context. Simplify the final formula
+to remove redundant masking operations, not strictly necessary for `bv_decide`
+to decide the resulting formula.
 -/
 meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -255,7 +261,7 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
+Add theorems bounding each of width to the provided bound to the simp set.
 -/
 meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -287,9 +293,10 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 
   -- Run simp
   let thms := ← addToplevelRewrites g ctx
-                      <| ← addPushTheorems g
-                      <| ← addBvInfos g bvInfos
-                      <| ← addWidthInfosSimpLemmas g widthInfos #[]
+           <| ← addPushTheorems g
+           <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
+           <| ← addWidthInfosSimpLemmas g widthInfos #[]
+
   let g ← applySimp g thms
 
   return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
@@ -323,7 +330,7 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   · grind
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r <= 8)
+  (hr : r ≤ 8)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
@@ -344,6 +351,18 @@ theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
   pbv_decide 8
   · bv_decide
   · grind
+  · grind
+  · grind
+  · grind
+
+theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
   · grind
   · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -26,7 +26,7 @@ structure WidthInfos where
     /-- One WidthInfo per width -/
     infos : HashMap Expr WidthInfo := {}
 
-def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
+meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
   { infos := this.infos.insert info.widthExpr info }
 
 /--
@@ -36,7 +36,7 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- TODO: check that the value has Nat.
     let [g] ← g.withContext do
@@ -71,7 +71,7 @@ def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (info
 /--
 Either get existing width info, or create one if it does not exist.
 -/
-def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
+meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
     (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
   if let some info := this.infos[wExpr]? then
     return (g, info, this)
@@ -104,7 +104,7 @@ meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos 
 Match on an expression, and if it is a `BitVec w`, return the `w`.
 Otherwise, return `none`.
 -/
-def getBitvecType? (e : Expr) : Option Expr :=
+meta def getBitvecType? (e : Expr) : Option Expr :=
   match_expr e with
   | BitVec w => some w
   | _ => none
@@ -113,7 +113,7 @@ def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
+meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   -- Find the BitVec {width_expr} variables.
@@ -135,7 +135,7 @@ This creates a plan of bitvector fvars to be reverted, and their corresponding w
 structure BitVecFVarsToRevert where
   bvs : HashMap FVarId WidthInfo := {}
 
-def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
+meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
   if this.bvs.contains fvar then  this
   else { bvs := this.bvs.insert fvar widthInfo }
 
@@ -143,7 +143,7 @@ def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (width
 Visit the expression collecting widths, introducing masks,
 and then eliminating them all in the next step.
 -/
-def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
+meta def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
     MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
@@ -162,7 +162,7 @@ Visit an expression, collecting all widths and introducing mask variables.
 For bitvectors, collect the bitvectors that need to be eliminated,
 and then eliminate them all in the next step.
 -/
-partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
+meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
     MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
@@ -179,7 +179,7 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 Translate width precondition into BitVec hypothesis.
 TODO: consider more complicated exprs that might have additions...
 -/
-def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
     MetaM (MVarId) := g.withContext do
   match_expr ldecl.type with
   | LT.lt ty _inst ea eb =>
@@ -203,7 +203,7 @@ def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
     return g
   | _ => return g
 
-def translateWidthPreconds (winfos: WidthInfos)
+meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
   let mut g := g
   for ldecl in ← getLCtx do
@@ -212,7 +212,7 @@ def translateWidthPreconds (winfos: WidthInfos)
 /--
 eliminate the bitvector variables to introduce the masked versions
 -/
-def introMaskedBitvectors (ctx : PbvTranslateContext)
+meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
   bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
     introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
@@ -221,7 +221,7 @@ def introMaskedBitvectors (ctx : PbvTranslateContext)
 These rewrites introduce the toplevel equality that convers `a = b` into
 `a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
+meta def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
   simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
@@ -269,7 +269,7 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
     | throwError "goal solved by simp"
   return g
 
-def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
+meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -18,6 +18,8 @@ meta structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBound : MVarId
+  /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
+  hypWidthLeBoundNoteHACK : FVarId
 
 meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
   info.widthNatLocalDecl.fvarId
@@ -50,9 +52,11 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
           let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
           -- Define bounding conditions.
           let hypWidthLeBound <- g.withContext do
-            mkFreshExprMVar (mkAppN (Expr.const `Nat.le [])
-              #[Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
+            mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+              #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
           g.withContext <| check hypWidthLeBound
+          let (hypWidthLeBoundNoteHACK, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+          g.withContext <| check (mkFVar hypWidthLeBoundNoteHACK)
           -- Assert the BitVec mask constraint.
           let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
           let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
@@ -60,7 +64,8 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
             widthNatLocalDecl := ldecl,
             widthMaskFvar := mask,
             widthMaskHypFvar := maskHyp
-            hypWidthLeBound := hypWidthLeBound.mvarId!
+            hypWidthLeBound := hypWidthLeBound.mvarId!,
+            hypWidthLeBoundNoteHACK
           }
           return (g, info)
     throwError "unable to find a valid width variable."
@@ -111,29 +116,30 @@ meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarI
 Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
 hypotheses.
 -/
-meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) : MetaM (MVarId × BitVecInfos) := do
+meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) :
+    MetaM (MVarId × BitVecInfos) := do
   let decls : LocalContext ← g.withContext getLCtx
   decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
     introVar ctx widthInfo g infos ldecl
 
+
 /--
-Add the hardcoded push theorems to the Simp theorem context, bind each application to the
-concrete blast width (`o`) and parametric width (`w`).
+These rewrites introduce the toplevel equality that convers `a = b` into
+`a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-meta def addPushTheorems (g : MVarId)
-    (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
-  let thms := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
-  let mut simp := simp
-  for thm in thms do
-    let push_thm ← g.withContext do mkAppM thm #[.mvar widthInfo.hypWidthLeBound]
-    simp ← simp.addTheorem (.other thm) push_thm
+meta def addToplevelRewrites (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) :
+    MetaM SimpTheoremsArray := g.withContext do
+  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBound])
   return simp
 
 /--
-Add theorems to the Simp theorem context that don't need special bindings
+Add theorems to the Simp theorem context that push the `setWidth`s in.
+TODO: make this a simp-set, called `pbv_push`, and just gather these
+from the simp-set. This makes them user-extensible with no metaprogramming needed.
 -/
-meta def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
-  let others := #[``BitVec.setWidth_eq]
+meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
+    MetaM SimpTheoremsArray := g.withContext do
+  let others := #[``BitVec.setWidth_eq, ``eq_iff, ``setWidth_add, ``setWidth_setWidth]
   let mut simp := simp
   for n in others do
     simp ← simp.addTheorem (.other n) (mkConst n [])
@@ -150,16 +156,15 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   return simp
 
 /--
-Add width mask hypothesis
+Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
 -/
-meta def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
+meta def addWidthInfo (g : MVarId) (info : WidthInfo)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
-  -- TODO: make this cleaner by collecting them all into a single array.
-  let simpThms : SimpTheorems := {}
-  let simpThms ← do
-    simpThms.add (.other widthInfo.widthMaskHypFvar.name)
-      #[] (mkFVar widthInfo.widthMaskHypFvar) (inv := true)
-  return simp.push simpThms
+  let mut simp := simp
+  simp ← simp.addTheorem (.other info.hypWidthLeBound.name)
+      (mkMVar info.hypWidthLeBound)
+       --(mkFVar info.hypWidthLeBoundNoteHACK)
+  return simp
 
 /--
 Run simp on an MVarId given a set of simp theorems.
@@ -176,12 +181,15 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Introduce bitvector variables
   let (g, bvInfos) ← introVars ctx g widthInfo
   -- Run simp
-  let g ← applySimp g <| ← addPushTheorems g widthInfo
-                      <| ← addOtherTheorems g
+  let thms := ← addToplevelRewrites g widthInfo
+                      <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
-                      <| ← addWidthHyp g widthInfo #[]
+                      <| ← addWidthInfo g widthInfo #[]
+  let g ← applySimp g thms
 
   return [g, widthInfo.hypWidthLeBound]
+
+
 
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
@@ -202,3 +210,45 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
+
+
+/-- Manual trace of the future tactic, transforming an unbounded parametric width
+    statement into a bounded one and solving it up to the bound (4 in this case) -/
+theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+-- Step 1: Bound widths to the provided blast width (redundant in this case)
+  have w_le_bw :  w ≤ 4 := by grind
+-- Step 2-3: Introduce mask to replace `w` Nat var
+  apply width_elim 4 w
+  intro mw h_mw
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
+  revert x
+  apply var_elim 4 w w_le_bw
+  intro x h_xmw
+  revert y
+  apply var_elim 4 w w_le_bw
+  intro y h_ymw
+-- Step 5: Convert width hypothesis to mask hypothesis
+  have mw_mask := isMask_of_eq_maskOfWidth h_mw
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
+  simp only [eq_iff w_le_bw]
+  simp only [setWidth_add, w_le_bw]
+
+  simp only [
+      eq_iff w_le_bw,             -- Introduce `setWidth` to goal
+      setWidth_add,       -- Push `setWidth` down add
+      setWidth_setWidth,  -- Push `setWidth` down setWidth
+      BitVec.setWidth_eq,         -- Remove redundant setWidths
+      w_le_bw]                     -- Replace mask with nat with bv constraint
+      at h_xmw h_ymw ⊢
+-- Step 8: Bitblast!
+  bv_decide
+
+set_option trace.Meta.Tactic.simp.all true
+set_option trace.Meta.Tactic.simp true
+example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+  pbv_decide 4
+  · bv_decide
+  · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -27,6 +27,13 @@ meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
 meta def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
   .fvar info.widthFvarId
 
+structure WidthInfos where
+    /-- One WidthInfo per width -/
+    infos : Array WidthInfo := #[]
+
+def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
+  { infos := this.infos.push info }
+
 /--
 Read-only configuration for the tactic.
 -/
@@ -34,41 +41,46 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : LocalDecl) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfos) := g.withContext do
+    unless ldecl.isImplementationDetail do
+        if ← isDefEq ldecl.type (mkConst ``Nat) then
+        -- Apply ``width_elim
+        let [g] ← g.withContext do
+          g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
+          | throwError "width_elim should generate a goal"
+        -- Intros
+        let maskName := Name.mkSimple s!"m{ldecl.userName}"
+        let (mask, g) ← g.withContext do g.intro maskName
+        let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+        -- Define bounding conditions.
+        let hypWidthLeBound <- g.withContext do
+          mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+            #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
+        g.withContext <| check hypWidthLeBound
+        let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+        g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
+        -- Assert the BitVec mask constraint.
+        let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
+        let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+        let info : WidthInfo := {
+          widthNatLocalDecl := ldecl,
+          widthMaskFvar := mask,
+          widthMaskHypFvar := maskHyp
+          hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
+          hypWidthLeBoundNoteNote
+        }
+        return (g, infos.push info)
+    return (g, infos)
+
+
 /-- Find the local declaration of the (single) width variable,
 and eliminate it, producing the mask variable, and the masking constraint.
 -/
-meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
-  g.withContext do
-    for ldecl in ← getLCtx do
-      unless ldecl.isImplementationDetail do
-        if ← isDefEq ldecl.type (mkConst ``Nat) then
-          -- Apply ``width_elim
-          let [g] ← g.withContext do
-            g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
-            | throwError "width_elim should generate a goal"
-          -- Intros
-          let maskName := Name.mkSimple s!"m{ldecl.userName}"
-          let (mask, g) ← g.withContext do g.intro maskName
-          let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
-          -- Define bounding conditions.
-          let hypWidthLeBound <- g.withContext do
-            mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
-              #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
-          g.withContext <| check hypWidthLeBound
-          let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
-          g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
-          -- Assert the BitVec mask constraint.
-          let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-          let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
-          let info : WidthInfo := {
-            widthNatLocalDecl := ldecl,
-            widthMaskFvar := mask,
-            widthMaskHypFvar := maskHyp
-            hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
-            hypWidthLeBoundNoteNote
-          }
-          return (g, info)
-    throwError "unable to find a valid width variable."
+meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
+  (← getLCtx).foldrM (init := (g, {})) fun ldecl (g, infos) =>
+    introMaskWidth ctx g ldecl infos
+
 
 /--
 Pair of local facts about the converted `BitVec` variables.
@@ -176,14 +188,14 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
-  let (g, widthInfo) ← introMaskWidths ctx g
+  let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, bvInfos) ← introVars ctx g widthInfo
+  let (g, bvInfos) ← introVars ctx g widthInfos
   -- Run simp
-  let thms := ← addToplevelRewrites g widthInfo
+  let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
-                      <| ← addWidthInfo g widthInfo #[]
+                      <| ← addWidthInfo g widthInfos #[]
   let g ← applySimp g thms
 
   return [g, widthInfo.hypWidthLeBoundMVarId]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -111,7 +111,7 @@ def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-def introBitvecFVarChecked (ctx : PbvTranslateContext) (g : MVarId)
+def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   -- Find the BitVec {width_expr} variables.
@@ -123,31 +123,52 @@ def introBitvecFVarChecked (ctx : PbvTranslateContext) (g : MVarId)
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
   -- Intros
   let name ← oldVar.getUserName
-  let (bvVar, g) ← g.intro name
-  let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
+  let (bvVar, g) ← g.withContext <| g.intro name
+  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_m{name}"
+  logInfo m!"{g}"
   return (g, bvInfos.push { bvVar, bvHyp })
 
+/--
+This creates a plan of bitvector fvars to be reverted, and their corresponding widths.
+-/
+structure BitVecFVarsToRevert where
+  bvs : HashMap FVarId WidthInfo := {}
+
+def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
+  if this.bvs.contains fvar then  this
+  else { bvs := this.bvs.insert fvar widthInfo }
 
 /--
-boo lean is stupid, it can't see that this will terminate.
+Visit an expression, collecting all widths and introducing mask variables.
+For bitvectors, collect the bitvectors that need to be eliminated,
+and then eliminate them all in the next step.
 -/
-partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId) (widthInfos : WidthInfos) (bvInfos : BitVecInfos) (e : Expr) :
-    MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
+partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId)
+    (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
+    (e : Expr) :
+    MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
   let (f, args) := (e.getAppFn, e.getAppArgs)
-  let (g, widthInfos, bvInfos) ← g.withContext do
-    args.foldlM (init := (g, widthInfos, bvInfos)) fun (g, widthInfos, bvInfos) arg => visitExpr ctx g widthInfos bvInfos arg
-  let tf ← inferType f
+  let (g, widthInfos, bvs) ← g.withContext do
+    args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExpr ctx g widthInfos bvs arg
+  let tf ← g.withContext do inferType f
   if let some wExpr := getBitvecType? tf then
     let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
     if let some fvarId := f.fvarId? then
-      let (g, bvInfos) ← introBitvecFVarChecked ctx g bvInfos fvarId widthInfo
-      return (g, widthInfos, bvInfos)
+      return (g, widthInfos, bvs.push fvarId widthInfo)
     else
-      return (g, widthInfos, bvInfos)
+      return (g, widthInfos, bvs)
   else
-    return (g, widthInfos, bvInfos)
+    return (g, widthInfos, bvs)
 
 
+/--
+eliminate the bitvector variables to introduce the masked versions
+-/
+def introMaskedBitvectors (ctx : PbvTranslateContext)
+    (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
+  logInfo m!"number of bvs to revert {bvs.bvs.size}"
+  bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
+    introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
 
 /--
 These rewrites introduce the toplevel equality that convers `a = b` into
@@ -203,11 +224,12 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
     | throwError "goal solved by simp"
   return g
 
-meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
+def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, widthInfos, bvInfos) ← visitExpr ctx g {} {} (← g.getType)
+  let (g, widthInfos, bvsToRevert) ← visitExpr ctx g {} {} (← g.getType)
+  let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
@@ -284,5 +306,4 @@ example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) 
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
-  · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -11,6 +11,9 @@ namespace Veir.Data.PBV
 Information about the width variable and associated hypotheses.
 -/
 structure WidthInfo where
+  /-- The Name correspodning to this width. -/
+  widthName : Name
+  /-- The Expr corresponding to this width. -/
   widthExpr : Expr
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
@@ -36,30 +39,34 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-    -- TODO: check that the value has Nat.
+    -- Retrieve the ldecl from the context
+    let ldecl ← getFVarLocalDecl widthExpr
+    -- Check that the Expr is of type Nat.
+    assert! ldecl.type == (mkConst ``Nat)
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
       | throwError "width_elim should generate a goal"
     -- Intros
-    let maskName := Name.mkSimple s!"maskWidth_new_var" -- TODO: find the name if it's an Fvar, and otherwise abstract it into a new name.
+    let maskName := Name.mkSimple s!"m{ldecl.userName}"
     let (mask, g) ← g.withContext do g.intro maskName
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
-    let hypWidthLeBound <- g.withContext do
+    let hypWidthLeBound ← g.withContext do
       -- Add a meaninful name using : (userName := Name.mkSimple "foo")
       mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
-        #[mkConst ``Nat, mkConst ``instLENat, ldecl, mkNatLit ctx.bmcBound])
+        #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
-    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{ldecl.userName}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_isMask") hypExpr
 
     let info : WidthInfo := {
-      widthExpr := ldecl,
+      widthName := ldecl.userName,
+      widthExpr := widthExpr,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
       hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
@@ -124,7 +131,8 @@ meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
   -- Intros
   let name ← oldVar.getUserName
   let (bvVar, g) ← g.withContext <| g.intro name
-  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_m{name}"
+  let widthMaskName ← widthInfo.widthMaskFvar.getUserName
+  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_{name}_{widthMaskName}"
   return (g, bvInfos.push { bvVar, bvHyp })
 
 /--
@@ -138,8 +146,9 @@ meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (
   else { bvs := this.bvs.insert fvar widthInfo }
 
 /--
-Visit the expression collecting widths, introducing masks,
-and then eliminating them all in the next step.
+Given an expression, if it is of `BitVec w` type then create a mask for the
+width `w`. If it is also an FVar, then it means it's a variable hence it has to
+be added to the set of FVars to be reverted.
 -/
 meta def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
@@ -175,15 +184,12 @@ meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 
 /--
 Translate width precondition into BitVec hypothesis.
-TODO: consider more complicated exprs that might have additions...
+TODO: consider more complicated width exprs.
 -/
-meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl) :
     MetaM (MVarId) := g.withContext do
   match_expr ldecl.type with
   | LT.lt ty _inst ea eb =>
-    -- ea ≤ eb
-    -- translate ea
-    -- translate eb
     -- note the mask theorem for this particular.
     if ty == mkConst ``Nat then
       if let some wa := winfos.infos[ea]? then
@@ -194,8 +200,8 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
               .fvar wb.hypWidthLeBoundNote,
               .fvar wa.widthMaskHypFvar,
               .fvar wb.widthMaskHypFvar,
-              (.fvar ldecl.fvarId)]
-          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{ea}_lt_{eb}") (← bvLTExpr) -- discard hyp, not needed
+              .fvar ldecl.fvarId]
+          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") (← bvLTExpr)
           logInfo m!"Translated {ldecl.toExpr} : {ldecl.type} to bitvec"
           return g
     return g
@@ -224,6 +230,7 @@ meta def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : Si
   let mut simp := simp
   simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
   return simp
+
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
 TODO: make this a simp-set, called `pbv_push`, and just gather these
@@ -294,10 +301,10 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 parametric bitvector formula, containing a single-width parameter, into a
 concrete width formula.
 
-The tactic generates two goals:
+The tactic generates multiple goals:
 1. The desired concrete width formula that can be decided using `bv_decide`
-2. A side-goal to prove that the width parameter is bounded by the provided
-bound, this should be solvable by grind.
+2. Multiple side-goals to prove that the width parameters are bounded by the
+provided bound, these should be solvable by grind.
 -/
 syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num) : tactic
 
@@ -323,6 +330,20 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   := by
   pbv_decide 8
   · bv_decide
+  · grind
+  · grind
+  · grind
+
+theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
+  (hr : t <= 8)
+  (hqr : q < r)
+  (hpq : p < q)
+  (hrt : r < t):
+  ((x.zeroExtend q).zeroExtend r).zeroExtend t = x.zeroExtend t
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
   · grind
   · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -36,7 +36,16 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+/--
+Rewrite a local decl using a provided Expr
+-/
+def rewriteHypWith (g : MVarId) (h : FVarId) (eq : Expr) :
+    MetaM (MVarId × FVarId × List MVarId) := g.withContext do
+  let r ← g.rewrite (← h.getType) eq
+  let res ← g.replaceLocalDecl h r.eNew r.eqProof
+  return (res.mvarId, res.fvarId, r.mvarIds)
+
+def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- TODO: check that the value has Nat.
     let [g] ← g.withContext do
@@ -56,7 +65,10 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) 
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    let (hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    -- Express `IsMask` in terms on `BitVec`s
+    let (g, _hIsMaskOfEq, _) ← rewriteHypWith g hIsMaskOfEq (mkConst ``isMask_eq)
+
     let info : WidthInfo := {
       widthExpr := ldecl,
       widthMaskFvar := mask,
@@ -361,3 +373,6 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   := by
   pbv_decide 8
   · bv_decide
+  · grind
+  · grind
+  · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -185,6 +185,24 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
   -- else
   --   return (g, widthInfos, bvs)
 
+def translateWidthPrecond (ctx : PbvTranslateContext) (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
+    MetaM (MVarId × WidthInfos) := g.withContext do
+  match_expr e with
+  | LE.le ty inst ea eb =>
+    if ty == mkConst ``Nat then
+      -- ea ≤ eb
+      -- translate ea
+      -- translate eb
+      -- note the mask theorem for this particular.
+      sorry
+    else
+      return (g, winfos)
+  | _ => return (g, winfos)
+
+def translateWidthPreconds (ctx : PbvTranslateContext) (winfos: WidthInfos) (g : MVarId) : MetaM (MVarId × WidthInfos) := do
+  -- loop over ← getLCtx, call translateWidthPrecond
+  sorry
+
 
 /--
 eliminate the bitvector variables to introduce the masked versions
@@ -198,13 +216,13 @@ def introMaskedBitvectors (ctx : PbvTranslateContext)
 These rewrites introduce the toplevel equality that convers `a = b` into
 `a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-meta def addToplevelRewrites (g : MVarId) (widthInfos : WidthInfos) (simp : SimpTheoremsArray) :
+def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
-  for (_widthExpr, widthInfo) in widthInfos.infos do
-    simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkFVar widthInfo.hypWidthLeBoundNote])
+  simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
+  simp ← simp.addTheorem (.other ``nat_lt_nat_eq_mask_lt_mask) <| (← mkAppM ``nat_lt_nat_eq_mask_lt_mask #[mkNatLit ctx.bmcBound])
+  simp ← simp.addTheorem (.other ``nat_le_nat_eq_mask_le_mask) <| (← mkAppM ``nat_le_nat_eq_mask_le_mask #[mkNatLit ctx.bmcBound])
   return simp
-
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
 TODO: make this a simp-set, called `pbv_push`, and just gather these
@@ -258,7 +276,7 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
 
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Run simp
-  let thms := ← addToplevelRewrites g widthInfos
+  let thms := ← addToplevelRewrites g ctx
                       <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
                       <| ← addWidthInfosSimpLemmas g widthInfos #[]
@@ -310,7 +328,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
-      eq_iff w_le_bw,             -- Introduce `setWidth` to goal
+      eq_iff _ w_le_bw,             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add
       setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
@@ -331,13 +349,15 @@ example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) 
   · bv_decide
   · grind
 
+theorem imp_eq_not_or (P Q : Prop) : (P → Q) = (¬ P ∨ Q) := by grind
+
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
-  pbv_decide 8
+  pbv_decide 13
   · sorry
   · sorry
   · sorry

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -71,8 +71,8 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
-    let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_isMask") hypExpr
+    let hypExpr ← g.withContext do mkAppM ``maskOfWidth_and_add_one_eq_zero #[mkFVar maskHyp]
+    let (_, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_bv_mask") hypExpr
 
     let info : WidthInfo := {
       widthName := name,
@@ -83,7 +83,6 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
       hypWidthLeBoundNote
     }
     return (g, info, infos.push info)
-    -- return (g, infos)
 
 /--
 Either get existing width info, or create one if it does not exist.
@@ -321,9 +320,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
-  -- Create simp Set
-  -- TODO: make this a simp-set, called `pbv_push`, and just gather these
-  -- from the simp-set. This makes them user-extensible with no metaprogramming needed.
+  -- Create simp set
   let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
@@ -352,23 +349,3 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
-
--- TODO: get the following working by also instantiating the provided width bound
--- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
---   x + y = y + x := by
---   pbv_decide 4
---   · simp only [eq_iff 4 hw]
---     bv_decide
---   · grind
-
--- TODO: handle addition inside of the mask widths.
--- example (p q r : Nat) (x : BitVec p)
---   (hr : q ≤ 8)
---   (hpq : p < q) :
---   (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
---   := by
---   pbv_decide 8
---   · bv_decide
---   · grind
---   · grind
---   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -36,15 +36,6 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-/--
-Rewrite a local decl using a provided Expr
--/
-def rewriteHypWith (g : MVarId) (h : FVarId) (eq : Expr) :
-    MetaM (MVarId × FVarId × List MVarId) := g.withContext do
-  let r ← g.rewrite (← h.getType) eq
-  let res ← g.replaceLocalDecl h r.eNew r.eqProof
-  return (res.mvarId, res.fvarId, r.mvarIds)
-
 def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- TODO: check that the value has Nat.
@@ -65,9 +56,7 @@ def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (info
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
-    -- Express `IsMask` in terms on `BitVec`s
-    let (g, _hIsMaskOfEq, _) ← rewriteHypWith g hIsMaskOfEq (mkConst ``isMask_eq)
+    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
 
     let info : WidthInfo := {
       widthExpr := ldecl,
@@ -358,12 +347,6 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   pbv_decide 4
   · bv_decide
   · grind
-
--- example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
---   x + y = y + x := by
---   pbv_decide 4
---   · bv_decide
---   · grind
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -183,26 +183,35 @@ meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
     return (g, widthInfos, bvs)
 
 /--
-Translate width precondition into BitVec hypothesis.
-TODO: Deal with constants.
+Match width relation.
 -/
-meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl) :
-    MetaM (MVarId) := g.withContext do
-  match_expr ldecl.type with
-  | LT.lt ty _inst ea eb =>
-    if ty == mkConst ``Nat then
-      if let some wa := winfos.infos[ea]? then
-        if let some wb := winfos.infos[eb]? then
-          let (natLTHyp, g) ← g.withContext do
-            g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") ldecl.toExpr
-          let (#[_], g) ← g.revert #[natLTHyp] | throwError "Reverting shuold produce a single FVar."
-          return g
-    return g
-  | _ => return g
+meta def matchWidthRel (e : Expr) :
+    Option (Expr × Expr) :=
+  match_expr e with
+  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | _ => none
 
 /--
-Traverse the local context and translate any hypotheses on `Nat` widths into
-`BitVec` hypotheses.
+If a condition on the width hypothesis is found, and the widths are contained
+within the `WidthInfos` set, then duplicate the hypothesis and add it to the
+goal. This allows for a single call to Simp later.
+-/
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+    : MetaM (MVarId) := g.withContext do
+  if let some (ea, eb) := matchWidthRel ldecl.type then
+    let some wa := winfos.infos[ea]? | return g
+    let some wb := winfos.infos[eb]? | return g
+    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
+    let (#[_], g) ← g.revert #[natHyp] | throwError "Reverting shuold produce a single FVar."
+    return g
+  else
+    return g
+
+/--
+Traverse the local context and add any width pre-conditions to the goal.
 -/
 meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
@@ -227,7 +236,11 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
-        ``Nat_lt_eq_Mask_lt]
+        ``Nat_lt_eq_Mask_lt,
+        ``Nat_le_eq_Mask_le,
+        ``Nat_ge_eq_Mask_ge,
+        ``Nat_gt_eq_Mask_gt
+  ]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
@@ -240,7 +253,12 @@ from the simp-set. This makes them user-extensible with no metaprogramming neede
 -/
 meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let others := #[``BitVec.setWidth_eq, ``setWidth_add, ``setWidth_setWidth]
+  let others := #[
+      ``BitVec.setWidth_eq,
+      ``setWidth_add,
+      ``setWidth_setWidth
+  ]
+
   let mut simp := simp
   for n in others do
     simp ← simp.addTheorem (.other n) (mkConst n [])
@@ -299,8 +317,6 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 
   return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
-
-
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula, containing a single-width parameter, into a
@@ -341,9 +357,9 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
 
 theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
   (hr : t <= 8)
-  (hqr : q < r)
-  (hpq : p < q)
-  (hrt : r < t):
+  (hqr : q ≤ r)
+  (hpq : q > p)
+  (hrt : t ≥ r):
   ((x.zeroExtend q).zeroExtend r).zeroExtend t = x.zeroExtend t
   := by
   pbv_decide 8


### PR DESCRIPTION
`pbv_decide` now handles sign and zero extensions, on top of addition.

- Tactic
  - Update the tactic logic to traverse the AST of the goal to extract bitvector widths and variables. 
    - This is instead of simply looking for widths in the local context, potentially missing widths defined in intermediate expressions
  - Apply the `var_elim` theorem after having collected all `BitVec` expressions
- Width preconditions
  - Translate preconditions on the widths by introducing them into the goal and rewriting them during the same `simp` pass
  - Introduce new theorems in `push` to translate width conditions into mask conditions
- Other:
  - Remove `def IsMask`, was redundant and only added extra steps for the tactic. 
  - Redefine `eq_iff` and other theorems in `Push.lean` to make the width bound variable `o` explicit, as it has to be bound in order for the `simp` based rewriting to succeed.  