### PR TITLE
test(func): rename `visibility` property to `sym_visibility`

### DIFF
--- a/Test/Func/func_properties.mlir
+++ b/Test/Func/func_properties.mlir
@@ -1,7 +1,7 @@
 // RUN: VEIR_ROUNDTRIP
 
 "builtin.module"() ({
-  "func.func"() <{sym_name = "f", visibility = "private", function_type = (i32) -> i32}> ({
+  "func.func"() <{sym_name = "f", sym_visibility = "private", function_type = (i32) -> i32}> ({
   ^bb0(%arg0: i32):
     "func.return"(%arg0) : (i32) -> ()
   }) : () -> ()
@@ -9,5 +9,5 @@
 
 // CHECK:      "func.func"() <{
 // CHECK-SAME:   "sym_name" = "f"
-// CHECK-SAME:   "visibility" = "private"
+// CHECK-SAME:   "sym_visibility" = "private"
 // CHECK-SAME: }> ({


### PR DESCRIPTION
The `Test/Func/func_properties.mlir` test uses the `visibility` attribute on a `func.func`:
```mlir
"func.func"() <{sym_name = "f", visibility = "private", function_type = (i32) -> i32}> ({
  // ...
}) : () -> ()
```
which is syntactically correct, but I'd assume that the original intention is `sym_visibility = "private`? This property name is consistent with upstream MLIR's `SymbolTable::getVisibilityAttrName()` and with VeIR's own HW dialect; both use `sym_visibility` to control a symbol's visibility.

This test is not wrong but needs to be fixed for #1236 because when `func.func`'s custom syntax has an optional `private` keyword depending on the value of `sym_visibility`.