### PR TITLE
feat(RISCV): use Puddle for isel patterns

### DIFF
--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -83,7 +83,6 @@ def ctpop64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .c
   LLVM op whose operand has integer type `i64` or `i32`, cast the operand to a register, apply
   `op64` (or its `W` variant `op32` for `i32`), and cast the result back to the source type.
 -/
-
 def lowerUnaryWLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × P))
     (op64 op32 : Riscv)

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -57,23 +57,23 @@ def lowerUnaryWPuddle (llvmOp : Llvm) (bw : Nat) (riscvOp : Riscv)
       return castBackOp)
     (fun castBackOp => castBackOp)
 
-/-- `llvm.intr.ctlz` (`i32`) -> `riscv.clzw`, as a Puddle pattern. -/
-def ctlzPuddle32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 32 .clzw ()
+/-- `llvm.intr.ctlz` (`i32`) -> `riscv.clzw`. -/
+def ctlz32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 32 .clzw ()
 
-/-- `llvm.intr.ctlz` (`i64`) -> `riscv.clz`, as a Puddle pattern. -/
-def ctlzPuddle64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 64 .clz ()
+/-- `llvm.intr.ctlz` (`i64`) -> `riscv.clz`. -/
+def ctlz64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 64 .clz ()
 
-/-- `llvm.intr.cttz` (`i32`) -> `riscv.ctzw`, as a Puddle pattern. -/
-def cttzPuddle32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 32 .ctzw ()
+/-- `llvm.intr.cttz` (`i32`) -> `riscv.ctzw` -/
+def cttz32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 32 .ctzw ()
 
-/-- `llvm.intr.cttz` (`i64`) -> `riscv.ctz`, as a Puddle pattern. -/
-def cttzPuddle64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 64 .ctz ()
+/-- `llvm.intr.cttz` (`i64`) -> `riscv.ctz` -/
+def cttz64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 64 .ctz ()
 
-/-- `llvm.intr.ctpop` (`i32`) -> `riscv.cpopw`, as a Puddle pattern. -/
-def ctpopPuddle32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 32 .cpopw ()
+/-- `llvm.intr.ctpop` (`i32`) -> `riscv.cpopw` -/
+def ctpop32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 32 .cpopw ()
 
-/-- `llvm.intr.ctpop` (`i64`) -> `riscv.cpop`, as a Puddle pattern. -/
-def ctpopPuddle64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .cpop ()
+/-- `llvm.intr.ctpop` (`i64`) -> `riscv.cpop` -/
+def ctpop64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .cpop ()
 
 /--
   Shared shape of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`): match a single-operand

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -6,6 +6,7 @@ import Veir.DataLayout.RISCV64
 import Veir.Passes.Matching.LLVM.Basic
 import Veir.Passes.InstructionSelection.Common
 import Veir.PatternRewriter.Puddle.Builders
+import Veir.PatternRewriter.Puddle.Execution
 
 namespace Veir
 
@@ -58,25 +59,22 @@ def lowerUnaryWPuddle (llvmOp : Llvm) (bw : Nat) (riscvOp : Riscv)
     (fun castBackOp => castBackOp)
 
 /-- `llvm.intr.ctlz` (`i32`) -> `riscv.clzw`. -/
-def ctlz32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 32 .clzw ()
+def ctlz32_pattern : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 32 .clzw ()
 
 /-- `llvm.intr.ctlz` (`i64`) -> `riscv.clz`. -/
-def ctlz64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 64 .clz ()
+def ctlz64_pattern : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 64 .clz ()
 
 /-- `llvm.intr.cttz` (`i32`) -> `riscv.ctzw`. -/
-def cttz32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 32 .ctzw ()
+def cttz32_pattern : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 32 .ctzw ()
 
 /-- `llvm.intr.cttz` (`i64`) -> `riscv.ctz`. -/
-def cttz64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 64 .ctz ()
+def cttz64_pattern : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 64 .ctz ()
 
 /-- `llvm.intr.ctpop` (`i32`) -> `riscv.cpopw`. -/
-def ctpop32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 32 .cpopw ()
+def ctpop32_pattern : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 32 .cpopw ()
 
 /-- `llvm.intr.ctpop` (`i64`) -> `riscv.cpop`. -/
-def ctpop64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .cpop ()
-
-
-
+def ctpop64_pattern : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .cpop ()
 
 /--
   Shared shape of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`): match a single-operand
@@ -298,44 +296,35 @@ def lowerRotateLocal
 /--
   `llvm.intr.ctlz` -> `riscv.clz`.
 -/
-def ctlz_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
-  lowerUnaryWLocal matchCtlz .clz .clzw () () ctx op
-
-/--
-  `llvm.intr.ctlz` -> `riscv.clz`.
--/
-def ctlz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def ctlz32 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite ctlz_local rewriter op opInBounds
+  RewritePattern.fromLocalRewrite ctlz32_pattern.compile rewriter op opInBounds
+
+def ctlz64 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite ctlz64_pattern.compile rewriter op opInBounds
 
 /--
   `llvm.intr.cttz` -> `riscv.ctz`.
 -/
-def cttz_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
-  lowerUnaryWLocal matchCttz .ctz .ctzw () () ctx op
-
-/--
-  `llvm.intr.cttz` -> `riscv.ctz`.
--/
-def cttz (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def cttz32 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite cttz_local rewriter op opInBounds
+  RewritePattern.fromLocalRewrite cttz32_pattern.compile rewriter op opInBounds
+
+def cttz64 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite cttz64_pattern.compile rewriter op opInBounds
 
 /--
   `llvm.intr.ctpop` -> `riscv.cpop`.
 -/
-def ctpop_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) :=
-  lowerUnaryWLocal matchCtpop .cpop .cpopw () () ctx op
-
-/--
-  `llvm.intr.ctpop` -> `riscv.cpop`.
--/
-def ctpop (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+def ctpop32 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite ctpop_local rewriter op opInBounds
+  RewritePattern.fromLocalRewrite ctpop32_pattern.compile rewriter op opInBounds
+
+def ctpop64 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
+  RewritePattern.fromLocalRewrite ctpop64_pattern.compile rewriter op opInBounds
 
 /--
   `llvm.intr.bswap` -> `riscv.rev8`.
@@ -1723,7 +1712,7 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   | some ctx => pure ctx
   /- Main loop: the existing per-op lowerings. -/
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral,
-    ctlz, cttz, ctpop, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
+    ctlz32, ctlz64, cttz32, cttz64, ctpop32, ctpop64, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, bitcast, load, getelementptr, store,
     smax, smin, umax, umin, saddSat, ssubSat, uaddSat, usubSat, sshlSat, ushlSat, abs,
     fshlConst, fshrConst, fshl, fshr, fshlGeneral, fshrGeneral, poisonConst, freeze]

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -33,16 +33,7 @@ def getIntByteTypeBitwidth (t : TypeAttr) : Option Nat :=
   | _ => none
 
 /--
-  Puddle rendition of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`), specialized to one
-  width `bw` (`32` or `64`): match a single-operand LLVM op `llvmOp` whose operand (and, since the
-  root's result type handle is reused for the operand, its result too) has integer type `i{bw}`,
-  cast the operand to a register, apply `riscvOp`, and cast the result back to the source type.
-
-  Puddle patterns are purely declarative and cannot branch on a runtime bitwidth the way
-  `lowerUnaryWLocal` does (picking `op64` vs. its `W` variant `op32` once the operand's width is
-  known): `riscvOp` is fixed when the pattern is built, so lowering an intrinsic for both `i32` and
-  `i64` needs two instantiations of this builder, one per width (see e.g. `ctlzPuddle32`/
-  `ctlzPuddle64` below).
+  RISC-V lowerings with Puddle for unary operations.
 -/
 def lowerUnaryWPuddle (llvmOp : Llvm) (bw : Nat) (riscvOp : Riscv)
     (riscvProps : propertiesOf (OpCode.riscv riscvOp)) : Veir.Puddle.Pattern OpCode :=

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -63,26 +63,25 @@ def ctlz32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 32 .clz
 /-- `llvm.intr.ctlz` (`i64`) -> `riscv.clz`. -/
 def ctlz64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 64 .clz ()
 
-/-- `llvm.intr.cttz` (`i32`) -> `riscv.ctzw` -/
+/-- `llvm.intr.cttz` (`i32`) -> `riscv.ctzw`. -/
 def cttz32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 32 .ctzw ()
 
-/-- `llvm.intr.cttz` (`i64`) -> `riscv.ctz` -/
+/-- `llvm.intr.cttz` (`i64`) -> `riscv.ctz`. -/
 def cttz64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 64 .ctz ()
 
-/-- `llvm.intr.ctpop` (`i32`) -> `riscv.cpopw` -/
+/-- `llvm.intr.ctpop` (`i32`) -> `riscv.cpopw`. -/
 def ctpop32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 32 .cpopw ()
 
-/-- `llvm.intr.ctpop` (`i64`) -> `riscv.cpop` -/
+/-- `llvm.intr.ctpop` (`i64`) -> `riscv.cpop`. -/
 def ctpop64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .cpop ()
+
+
+
 
 /--
   Shared shape of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`): match a single-operand
   LLVM op whose operand has integer type `i64` or `i32`, cast the operand to a register, apply
   `op64` (or its `W` variant `op32` for `i32`), and cast the result back to the source type.
-
-  This is the imperative `LocalRewritePattern` still wired into the pass (see `ctlz_local`,
-  `cttz_local`, `ctpop_local` below); `lowerUnaryWPuddle` above is its declarative Puddle
-  counterpart. There is no Puddle interpreter yet, so the two coexist for now.
 -/
 
 def lowerUnaryWLocal {P : Type}

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -5,6 +5,7 @@ public import Veir.PatternRewriter.Basic
 import Veir.DataLayout.RISCV64
 import Veir.Passes.Matching.LLVM.Basic
 import Veir.Passes.InstructionSelection.Common
+import Veir.PatternRewriter.Puddle.Builders
 
 namespace Veir
 
@@ -32,10 +33,67 @@ def getIntByteTypeBitwidth (t : TypeAttr) : Option Nat :=
   | _ => none
 
 /--
+  Puddle rendition of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`), specialized to one
+  width `bw` (`32` or `64`): match a single-operand LLVM op `llvmOp` whose operand (and, since the
+  root's result type handle is reused for the operand, its result too) has integer type `i{bw}`,
+  cast the operand to a register, apply `riscvOp`, and cast the result back to the source type.
+
+  Puddle patterns are purely declarative and cannot branch on a runtime bitwidth the way
+  `lowerUnaryWLocal` does (picking `op64` vs. its `W` variant `op32` once the operand's width is
+  known): `riscvOp` is fixed when the pattern is built, so lowering an intrinsic for both `i32` and
+  `i64` needs two instantiations of this builder, one per width (see e.g. `ctlzPuddle32`/
+  `ctlzPuddle64` below).
+-/
+def lowerUnaryWPuddle (llvmOp : Llvm) (bw : Nat) (riscvOp : Riscv)
+    (riscvProps : propertiesOf (OpCode.riscv riscvOp)) : Veir.Puddle.Pattern OpCode :=
+  Veir.Puddle.Pattern.Builder
+    (do
+      let returnType ← Veir.Puddle.MatchProg.type (Attr := IntegerType) (fun t => t.bitwidth == bw)
+      let x ← Veir.Puddle.MatchProg.value returnType
+      let _ ← Veir.Puddle.MatchProg.root (.llvm llvmOp) #[x] #[returnType]
+      return (returnType, x))
+    (fun (returnType, x) => do
+      let regType ← Veir.Puddle.CreateProg.type (RegisterType.mk none)
+      let castProps ← Veir.Puddle.CreateProg.property (.builtin .unrealized_conversion_cast) ()
+      let castOp ← Veir.Puddle.CreateProg.operation (.builtin .unrealized_conversion_cast)
+          #[x] #[regType] castProps
+      let riscvOpProps ← Veir.Puddle.CreateProg.property (.riscv riscvOp) riscvProps
+      let riscvResOp ← Veir.Puddle.CreateProg.operation (.riscv riscvOp)
+          #[castOp.res[0]!] #[regType] riscvOpProps
+      let castBackProps ← Veir.Puddle.CreateProg.property (.builtin .unrealized_conversion_cast) ()
+      let castBackOp ← Veir.Puddle.CreateProg.operation (.builtin .unrealized_conversion_cast)
+          #[riscvResOp.res[0]!] #[returnType] castBackProps
+      return castBackOp)
+    (fun castBackOp => castBackOp)
+
+/-- `llvm.intr.ctlz` (`i32`) -> `riscv.clzw`, as a Puddle pattern. -/
+def ctlzPuddle32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 32 .clzw ()
+
+/-- `llvm.intr.ctlz` (`i64`) -> `riscv.clz`, as a Puddle pattern. -/
+def ctlzPuddle64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctlz 64 .clz ()
+
+/-- `llvm.intr.cttz` (`i32`) -> `riscv.ctzw`, as a Puddle pattern. -/
+def cttzPuddle32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 32 .ctzw ()
+
+/-- `llvm.intr.cttz` (`i64`) -> `riscv.ctz`, as a Puddle pattern. -/
+def cttzPuddle64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__cttz 64 .ctz ()
+
+/-- `llvm.intr.ctpop` (`i32`) -> `riscv.cpopw`, as a Puddle pattern. -/
+def ctpopPuddle32 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 32 .cpopw ()
+
+/-- `llvm.intr.ctpop` (`i64`) -> `riscv.cpop`, as a Puddle pattern. -/
+def ctpopPuddle64 : Veir.Puddle.Pattern OpCode := lowerUnaryWPuddle .intr__ctpop 64 .cpop ()
+
+/--
   Shared shape of the unary RISC-V lowerings (`ctlz`/`cttz`/`ctpop`): match a single-operand
   LLVM op whose operand has integer type `i64` or `i32`, cast the operand to a register, apply
   `op64` (or its `W` variant `op32` for `i32`), and cast the result back to the source type.
+
+  This is the imperative `LocalRewritePattern` still wired into the pass (see `ctlz_local`,
+  `cttz_local`, `ctpop_local` below); `lowerUnaryWPuddle` above is its declarative Puddle
+  counterpart. There is no Puddle interpreter yet, so the two coexist for now.
 -/
+
 def lowerUnaryWLocal {P : Type}
     (match? : OperationPtr → IRContext OpCode → Option (ValuePtr × P))
     (op64 op32 : Riscv)

--- a/Veir/PatternRewriter/Puddle/Builders.lean
+++ b/Veir/PatternRewriter/Puddle/Builders.lean
@@ -187,6 +187,19 @@ instance CreateProg.instMonadBuilder : Monad CreateProg.Builder where
     (next value).run state⟩
 
 /--
+Append a concrete type to the creation program and return the handle bound to it.
+-/
+@[expose, inline]
+def CreateProg.type {Attr : Type} [IsTypeAttr Attr] (value : Attr) :
+    CreateProg.Builder (Handle OpCode .type) :=
+  ⟨fun state =>
+    let result := Handle.mk (OpInfo := OpCode) state.nextId
+    (result, {
+      nextId := state.nextId + 1
+      decls := .type (value : TypeAttr) result :: state.decls
+    })⟩
+
+/--
 Append a concrete property record to the creation program and return the handle bound to it.
 -/
 @[expose, inline]

--- a/Veir/PatternRewriter/Puddle/Definitions.lean
+++ b/Veir/PatternRewriter/Puddle/Definitions.lean
@@ -151,6 +151,8 @@ earlier property declaration.
 
 /-- An internal declarative instruction in a creation program. -/
 inductive CreateDecl (OpInfo : Type) [HasOpInfo OpInfo] where
+/-- Bind a concrete type to `result` for use by a later operation declaration. -/
+| type (value : TypeAttr) (result : Handle OpInfo .type)
 /-- Bind a concrete property record to `result` for use by a later operation declaration. -/
 | property (opCode : OpInfo) (value : propertiesOf opCode) (result : Handle OpInfo (.prop opCode))
 /--

--- a/Veir/PatternRewriter/Puddle/Execution.lean
+++ b/Veir/PatternRewriter/Puddle/Execution.lean
@@ -313,6 +313,7 @@ def CreateDecl.run (decl : CreateDecl OpInfo) (assignment : Assignment OpInfo)
       return (ctx, #[newOp], assignment)
     else
       none
+  | .type _ _ => sorry
 
 /--
 Execute creation declarations in program order, returning newly created operations as well as the

--- a/Veir/PatternRewriter/Puddle/Execution.lean
+++ b/Veir/PatternRewriter/Puddle/Execution.lean
@@ -313,7 +313,9 @@ def CreateDecl.run (decl : CreateDecl OpInfo) (assignment : Assignment OpInfo)
       return (ctx, #[newOp], assignment)
     else
       none
-  | .type _ _ => sorry
+  | .type value result =>
+    let assignment ← Assignment.bindType assignment result value
+    return (ctx, #[], assignment)
 
 /--
 Execute creation declarations in program order, returning newly created operations as well as the


### PR DESCRIPTION
Port lowering pattern for unary riscv operations to puddle. If we are happy with this, I will port the remaining rewrites in the next PR.

Co-authored by Claude. 