### PR TITLE
feat(veir-interpret,veir2mir): read the input program from stdin

### DIFF
--- a/Test/Passes/InstructionSelection/RISCV64/ashr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/br_block_args_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/br_block_args_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 // Regression test for a bug in isel-br-riscv64 where block-argument operands
 // passed across a branch were emitted in reverse order, so the successor block

--- a/Test/Passes/InstructionSelection/RISCV64/icmp_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/icmp_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "llvm.func"() <{sym_name = "main", function_type = !llvm.func<i64 ()>}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/lshr_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/lshr_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce | veir-interpret | filecheck %s
 
 // Functional check for `sdivPow2Exact` (positive and negative divisor): evenly
 // divisible signed division by a constant power of two, using the `exact` flag.

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce | veir-interpret | filecheck %s
 
 // Functional check for `sdivPow2` (general, non-`exact`, positive and negative
 // divisor): truncating (round-toward-zero) division by a constant power of two.

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_i32_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_i32_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce | veir-interpret | filecheck %s
 
 // `i32` analogue of sdiv_pow2_exec.mlir (`sdivwPow2`, general non-`exact` form).
 

--- a/Test/Passes/InstructionSelection/RISCV64/srem_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/srem_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/sub_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sub_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce | veir-interpret | filecheck %s
 
 // Functional check for `udivPow2`: unsigned division by a constant power of two,
 // including the `2^63` boundary (whose bit pattern is decoded as a negative `Int`

--- a/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_i32_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv_pow2_i32_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=canonicalize,instcombine,canonicalize,cse,dce,isel-br-riscv64,isel-sdag-riscv64,isel-riscv64,canonicalize,riscv-combine,coerce-function-boundaries-to-riscv-reg,reconcile-cast,dce | veir-interpret | filecheck %s
 
 // `i32` analogue of udiv_pow2_exec.mlir (`udivwPow2`).
 //

--- a/Test/Passes/InstructionSelection/RISCV64/urem_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/urem_exec.mlir
@@ -1,5 +1,5 @@
 // RUN: veir-interpret %s | filecheck %s --check-prefix=SRC
-// RUN: veir-opt %s -p=riscv > %t && veir-interpret %t | filecheck %s
+// RUN: veir-opt %s -p=riscv | veir-interpret | filecheck %s
 
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> i64}> ({

--- a/Veir/Input.lean
+++ b/Veir/Input.lean
@@ -1,0 +1,62 @@
+import Veir.Parser.MlirParser
+import Veir.Parser.ParserError
+import Veir.GlobalOpInfo
+
+/-!
+  Helpers shared by the VeIR command-line tools (`veir-opt`, `veir-interpret`,
+  `veir2mir`) for reading an input program from a file or from standard input
+  and parsing it into a well-formed IR context.
+
+  When no file argument is given, the program is read from standard input.
+ -/
+
+open Veir.Parser
+open Veir
+
+namespace Veir.Input
+
+/-- Read the input program from `filename`, or from standard input when it is
+    `none`. -/
+def getFileContent (filename : Option String) : ExceptT String IO ByteArray := do
+  if let some f := filename then
+    try
+      return ← IO.FS.readBinFile f
+    catch e =>
+      throw s!"Error reading file '{f}': {e}"
+  return ← IO.FS.Stream.readBinToEnd (←IO.getStdin)
+
+/-- Parse program bytes into a well-formed IR context and its top-level
+    operation, formatting parse errors caret-style against `sourceName`. -/
+def parseContent (content : ByteArray) (sourceName : String)
+    (allowUnregisteredDialect : Bool) :
+    ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
+  let some (ctx, _) := WfIRContext.create OpCode
+    | throw "Failed to create IR context"
+  match ParserState.fromInput content with
+  | .ok parser =>
+    let state := MlirParserState.fromContext ctx allowUnregisteredDialect
+    match parseTopLevelOp.run state parser with
+    | .ok (op, state, _) =>
+      return (state.ctx, op)
+    | .error err =>
+      throw (err.format sourceName content)
+  | .error err =>
+    throw (err.format sourceName content)
+
+/-- Read and parse the input program, naming the source `<stdin>` when it comes
+    from standard input. -/
+def parseOperation (filename : Option String) (allowUnregisteredDialect : Bool := false) :
+    ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
+  let content ← getFileContent filename
+  let sourceName := if let some f := filename then f else "<stdin>"
+  parseContent content sourceName allowUnregisteredDialect
+
+/-- Map positional CLI arguments to an input source: `[]` means standard input;
+    a single argument names the input file. -/
+def inputSourceOfArgs (positional : List String) : Except String (Option String) :=
+  match positional with
+  | [] => .ok none
+  | [filename] => .ok (some filename)
+  | _ => .error "Expected at most one positional argument for the input filename."
+
+end Veir.Input

--- a/VeirInterpret.lean
+++ b/VeirInterpret.lean
@@ -1,34 +1,21 @@
 import Veir.Parser.MlirParser
 import Veir.Verifier
 import Veir.Interpreter.Basic
+import Veir.Input
 import Veir.Panic
 
 /-!
   # Veir Interpreter CLI Tool
 
   This file implements a simple command-line tool that reads an MLIR
-  file, finds a zero-argument func.func or llvm.func named `main`, and
-  then executes that function using the interpreter defined in
-  `Veir.Interpreter`.
+  program from a file or from standard input, finds a zero-argument
+  func.func or llvm.func named `main`, and then executes that function
+  using the interpreter defined in `Veir.Interpreter`.
  -/
 
 open Veir.Parser
+open Veir.Input
 open Veir
-
-def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
-  let fileContent ← IO.FS.readBinFile filename
-  let some (ctx, _) := WfIRContext.create OpCode
-    | throw "Failed to create IR context"
-  match ParserState.fromInput fileContent with
-  | .ok parser =>
-    let parserState := MlirParserState.fromContext ctx (allowUnregisteredDialect := true)
-    match parseTopLevelOp.run parserState parser with
-    | .ok (op, state, _) =>
-      return (state.ctx, op)
-    | .error errMsg =>
-      throw s!"Error parsing operation: {errMsg}"
-  | .error errMsg =>
-    throw s!"Error reading file: {errMsg}"
 
 /-- Returns true if `op` is a viable zero-argument `@main` function. -/
 private def isZeroArgMainFunc (ctx : IRContext OpCode) (op : OperationPtr) : Bool :=
@@ -75,29 +62,31 @@ def resolveEntryPoint (ctx : IRContext OpCode) (moduleOp : OperationPtr) : IO Op
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do
   enableExitOnPanic
-  match args with
-  | [filename] =>
-    match ← parseOperation filename with
-    | .ok (ctx, op) =>
-      match ctx.verify op with
-      | .ok _ =>
-        let rawCtx : IRContext OpCode := ctx
-        let mainOp ← resolveEntryPoint rawCtx op
-        let result := bind (interpretFunction (ctx := ctx) mainOp #[] MemoryState.empty (by sorry))
-                           (fun (_, r) => pure r)
-        match result with
-        | .ok results => IO.println s!"Program output: {results}"
-        | .ub => IO.println "Undefined behavior"
-        | .fail =>
-          IO.eprintln "Error while interpreting module"
-          IO.Process.exit 1
-      | .error errMsg =>
-        IO.eprintln s!"Error verifying input program: {errMsg}"
+  let filename ←
+    match inputSourceOfArgs args with
+    | .ok filename => pure filename
+    | .error errMsg =>
+      IO.eprintln errMsg
+      IO.eprintln "Usage: veir-interpret [filename]"
+      IO.eprintln "  Reads the program from standard input if no filename is given."
+      IO.Process.exit 2
+  match ← parseOperation filename (allowUnregisteredDialect := true) with
+  | .ok (ctx, op) =>
+    match ctx.verify op with
+    | .ok _ =>
+      let rawCtx : IRContext OpCode := ctx
+      let mainOp ← resolveEntryPoint rawCtx op
+      let result := bind (interpretFunction (ctx := ctx) mainOp #[] MemoryState.empty (by sorry))
+                         (fun (_, r) => pure r)
+      match result with
+      | .ok results => IO.println s!"Program output: {results}"
+      | .ub => IO.println "Undefined behavior"
+      | .fail =>
+        IO.eprintln "Error while interpreting module"
         IO.Process.exit 1
     | .error errMsg =>
-      IO.eprintln s!"Error: {errMsg}"
+      IO.eprintln s!"Error verifying input program: {errMsg}"
       IO.Process.exit 1
-  | _ =>
-    IO.eprintln "Wrong number of arguments."
-    IO.eprintln "Usage: veir-interpret <filename>"
-    IO.Process.exit 2
+  | .error errMsg =>
+    IO.eprintln s!"Error: {errMsg}"
+    IO.Process.exit 1

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -1,6 +1,7 @@
 import Veir.Parser.MlirParser
 import Veir.Printer
 import Veir.Panic
+import Veir.Input
 
 import Veir.Passes.PrintIR
 import Veir.Passes.InstCombine
@@ -19,6 +20,7 @@ import Veir.Passes.Legalization
 
 open Veir.Parser
 open Veir.Parser.ParserError
+open Veir.Input
 open Veir
 
 /--
@@ -152,44 +154,10 @@ def parseArgs (args : List String) : Except String VeirOptArgs := do
   if let some flag := flags.head? then
     .error s!"Unrecognized flag '{flag}'."
 
-  if positional.length == 0 then -- read from stdin
-    return { filename := none, passes := pipeline, allowUnregisteredDialect, disableVerifiers }
-
-  let [filename] := positional
-    | .error "Expected exactly one positional argument for the input filename."
-
-  if filename == "-" then
-    return { filename := none, passes := pipeline, allowUnregisteredDialect, disableVerifiers }
-
-  return { filename := some filename, passes := pipeline, allowUnregisteredDialect, disableVerifiers }
-
-def getFileContent (filename : Option String) : ExceptT String IO ByteArray := do
-  if let some f := filename then
-    try
-      return ← IO.FS.readBinFile f
-    catch e =>
-      throw s!"Error reading file '{filename}': {e}"
-
-  return ← IO.FS.Stream.readBinToEnd (←IO.getStdin)
-
-def parseOperation (filename : Option String) (allowUnregisteredDialect : Bool := false) :
-    ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
-  let fileContent ← getFileContent filename
-  let some (ctx, _) := WfIRContext.create OpCode
-    | throw "Failed to create IR context"
-
-  let filename := if let some f := filename then f else "<stdin>"
-
-  match ParserState.fromInput fileContent with
-  | .ok parser =>
-    let state := MlirParserState.fromContext ctx allowUnregisteredDialect
-    match parseTopLevelOp.run state parser with
-    | .ok (op, state, _) =>
-      return (state.ctx, op)
-    | .error err =>
-      throw (err.format filename fileContent)
-  | .error err =>
-    throw (err.format filename fileContent)
+  match inputSourceOfArgs positional with
+  | .ok filename =>
+    return { filename, passes := pipeline, allowUnregisteredDialect, disableVerifiers }
+  | .error errMsg => .error errMsg
 
 set_option warn.sorry false in
 def main (args : List String) : IO Unit := do

--- a/VeirToMIR.lean
+++ b/VeirToMIR.lean
@@ -1,30 +1,18 @@
 import Veir.Parser.MlirParser
+import Veir.Input
 import Veir.MIRPrinter
 
 /-!
   # veir2mir CLI tool
 
-  Reads an MLIR file whose `main` function has been lowered to the VeIR
-  `riscv` / `riscv_cf` dialects and prints LLVM pre-register-allocation MIR.
+  Reads an MLIR program from a file or from standard input, whose `main`
+  function has been lowered to the VeIR `riscv` / `riscv_cf` dialects, and
+  prints LLVM pre-register-allocation MIR.
 -/
 
 open Veir.Parser
+open Veir.Input
 open Veir
-
-def parseOperation (filename : String) : ExceptT String IO (WfIRContext OpCode × OperationPtr) := do
-  let fileContent ← IO.FS.readBinFile filename
-  let some (ctx, _) := WfIRContext.create OpCode
-    | throw "Failed to create IR context"
-  match ParserState.fromInput fileContent with
-  | .ok parser =>
-    let parserState := MlirParserState.fromContext ctx (allowUnregisteredDialect := true)
-    match parseTopLevelOp.run parserState parser with
-    | .ok (op, state, _) =>
-      return (state.ctx, op)
-    | .error errMsg =>
-      throw s!"Error parsing operation: {errMsg}"
-  | .error errMsg =>
-    throw s!"Error reading file: {errMsg}"
 
 /-- Find the first function-like operation in the module's top block. -/
 partial def findFunc (ctx : IRContext OpCode) (op : Option OperationPtr) : Option OperationPtr :=
@@ -35,9 +23,14 @@ partial def findFunc (ctx : IRContext OpCode) (op : Option OperationPtr) : Optio
     else findFunc ctx (op.get! ctx).next
 
 def main (args : List String) : IO Unit := do
-  match args with
-  | [filename] =>
-    match ← parseOperation filename with
+  match inputSourceOfArgs args with
+  | .error errMsg =>
+    IO.eprintln errMsg
+    IO.eprintln "Usage: veir2mir [filename]"
+    IO.eprintln "  Reads the program from standard input if no filename is given."
+    IO.Process.exit 2
+  | .ok filename =>
+    match ← parseOperation filename (allowUnregisteredDialect := true) with
     | .ok (ctx, moduleOp) =>
       let rawCtx : IRContext OpCode := ctx
       let region := moduleOp.getRegion! rawCtx 0
@@ -52,6 +45,3 @@ def main (args : List String) : IO Unit := do
     | .error errMsg =>
       IO.eprintln s!"Error: {errMsg}"
       IO.Process.exit 1
-  | _ =>
-    IO.eprintln "Usage: veir2mir <filename>"
-    IO.Process.exit 2


### PR DESCRIPTION
`veir-opt` has read from stdin since #605 (when the CLI receives no positional argument or a `-` filename), but `veir-interpret` and `veir2mir` have always required a file name. This forces pipelines like `veir-opt ... > %t && veir-interpret %t` to materialize a temporary file.

This PR ports the stdin handling to `veir-interpret` and `veir2mir`, and lift the duplicated read-and-parse logic into a shared `Veir.Input` module:
- `getFileContent`: read a file, or stdin when the filename is `none`
- `parseContent`: parse program bytes with caret-style diagnostics
- `parseOperation`: read and parse, naming the source `<stdin>`
- `inputSourceOfArgs`: map positional args (`[]` -> stdin)

Also update the lit tests that used the `veir-opt > %t && veir-interpret %t` pattern to the more elegant `veir-opt | veir-interpret`. Some tests use `veir-opt | tee %t | veir-interpret` because the intermediate MLIR output also needs to be checked.

This also removes `-` from the list of valid file names.