### PR TITLE
feat(puddle): Improve runtime of puddle patterns

### DIFF
--- a/UnitTest/Puddle.lean
+++ b/UnitTest/Puddle.lean
@@ -75,8 +75,8 @@ private def mulTwoProgram := r#""builtin.module"() ({
 /-- Parse a program, apply a compiled Puddle pattern, and print the resulting module. -/
 private def rewriteAndPrint (source : String) (rule : Pattern OpCode) : IO Unit := do
   let some program := parseBinaryProgram source | IO.println "parse failed"
-  let pattern := RewritePattern.fromLocalRewrite (Pattern.compile rule)
-  let some ctx := RewritePattern.applyInContext pattern program.ctx | IO.println "rewrite failed"
+  let pattern := Pattern.compile rule
+  let some ctx := RewritePattern.applyInContext pattern.run program.ctx | IO.println "rewrite failed"
   Printer.printModule ctx.raw program.moduleOp
 
 /--

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -271,35 +271,20 @@ def lowerRotateLocal
 /--
   `llvm.intr.ctlz` -> `riscv.clz`.
 -/
-def ctlz32 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite ctlz32_pattern.compile rewriter op opInBounds
-
-def ctlz64 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite ctlz64_pattern.compile rewriter op opInBounds
+def ctlz32 : Puddle.CompiledPattern OpCode := ctlz32_pattern.compile
+def ctlz64 : Puddle.CompiledPattern OpCode := ctlz64_pattern.compile
 
 /--
   `llvm.intr.cttz` -> `riscv.ctz`.
 -/
-def cttz32 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite cttz32_pattern.compile rewriter op opInBounds
-
-def cttz64 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite cttz64_pattern.compile rewriter op opInBounds
+def cttz32 : Puddle.CompiledPattern OpCode := cttz32_pattern.compile
+def cttz64 : Puddle.CompiledPattern OpCode := cttz64_pattern.compile
 
 /--
   `llvm.intr.ctpop` -> `riscv.cpop`.
 -/
-def ctpop32 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite ctpop32_pattern.compile rewriter op opInBounds
-
-def ctpop64 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
-    (opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) :=
-  RewritePattern.fromLocalRewrite ctpop64_pattern.compile rewriter op opInBounds
+def ctpop32 : Puddle.CompiledPattern OpCode := ctpop32_pattern.compile
+def ctpop64 : Puddle.CompiledPattern OpCode := ctpop64_pattern.compile
 
 /--
   `llvm.intr.bswap` -> `riscv.rev8`.
@@ -1687,7 +1672,8 @@ def ISelPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBound
   | some ctx => pure ctx
   /- Main loop: the existing per-op lowerings. -/
   let pattern := RewritePattern.GreedyRewritePattern #[selectCzeroeqz, selectCzeronez, selectGeneral,
-    ctlz32, ctlz64, cttz32, cttz64, ctpop32, ctpop64, bswap, bitreverse, constant, add, and, ashr, icmp, or, xor, mul,
+    ctlz32.run, ctlz64.run, cttz32.run, cttz64.run, ctpop32.run, ctpop64.run, bswap, bitreverse,
+    constant, add, and, ashr, icmp, or, xor, mul,
     sdiv, udiv, srem, urem, sext, zext, trunc, shl, lshr, sub, bitcast, load, getelementptr, store,
     smax, smin, umax, umin, saddSat, ssubSat, uaddSat, usubSat, sshlSat, ushlSat, abs,
     fshlConst, fshrConst, fshl, fshr, fshlGeneral, fshrGeneral, poisonConst, freeze]

--- a/Veir/PatternRewriter/Puddle/Execution.lean
+++ b/Veir/PatternRewriter/Puddle/Execution.lean
@@ -341,12 +341,12 @@ def CreateProg.run (prog : CreateProg OpInfo α) (assignment : Assignment OpInfo
     Option (WfIRContext OpInfo × Array OperationPtr × Assignment OpInfo) :=
   CreateProg.runDecls prog.decls ctx assignment
 
-/-- Compile a Puddle pattern to the local rewrite-pattern interface.
+/-- Interpret a Puddle pattern.
 
 Matcher rejection returns a nonfatal no-match result. After matching succeeds, any failure
 is a fatal rewrite error. -/
 @[expose, specialize rule]
-def Pattern.compile (rule : Pattern OpInfo) : LocalRewritePattern OpInfo :=
+def Pattern.interpret (rule : Pattern OpInfo) : LocalRewritePattern OpInfo :=
   fun ctx root =>
     /- First, run the matcher. -/
     match rule.matcher.run ctx.raw root with
@@ -360,6 +360,24 @@ def Pattern.compile (rule : Pattern OpInfo) : LocalRewritePattern OpInfo :=
         match assignment.getValues rule.replacement.values with
         | none => none
         | some newValues => some (newCtx, some (newOps, newValues))
+
+/--
+A compiled Puddle pattern stored as data rather than exposed directly as a function-valued
+definition. Closed values of this type can be initialized once and their rewrite closure reused
+for every operation visited by a rewrite driver.
+-/
+structure CompiledPattern (OpInfo : Type) [HasOpInfo OpInfo] where
+  /-- The reusable pattern-rewriter entry point. -/
+  run : RewritePattern OpInfo
+
+/--
+Compile a Puddle rule into a reusable rewrite-pattern value.
+This function is more efficient than `Pattern.interpret` because it allows the Lean compiler to
+initialize things only once, rather than reinitializing them for each application of the pattern.
+-/
+@[expose, specialize rule]
+def Pattern.compile (rule : Pattern OpInfo) : CompiledPattern OpInfo :=
+  ⟨RewritePattern.fromLocalRewrite (Pattern.interpret rule)⟩
 
 end
 


### PR DESCRIPTION
`Pattern.compile` was not compiled as efficiently as it could by Lean, and was reinitializing the closure at each invocation. This PR changes `compile` to create a structure that contains this closure, which makes it more efficient. In the worse case I measured, this makes us go from a `2.62x` slowdown to a `1.85x` slowdown.