### PR TITLE
refactor(puddle): track matcher root structurally

### DIFF
--- a/UnitTest/Puddle.lean
+++ b/UnitTest/Puddle.lean
@@ -44,6 +44,23 @@ private def mulTwo : Pattern OpCode :=
       return add)
     (fun result => result)
 
+/- ## Test matcher builder validation -/
+
+/-- A matcher that is missing a root declaration. -/
+private def missingRootBuilder : MatchProg.Builder Unit := pure ()
+
+#guard_panic in
+#eval (MatchProg.build missingRootBuilder).rootHandle.id
+
+/-- A matcher that has a duplicate root declaration. -/
+private def duplicateRootBuilder : MatchProg.Builder Unit := do
+  let _ ← MatchProg.root (.arith .addi) #[] #[]
+  let _ ← MatchProg.root (.arith .addi) #[] #[]
+  return ()
+
+#guard_panic in
+#eval (MatchProg.build duplicateRootBuilder).rootHandle.id
+
 /- ## Test pattern execution -/
 
 private structure BinaryProgram where

--- a/Veir/PatternRewriter/Puddle/Builders.lean
+++ b/Veir/PatternRewriter/Puddle/Builders.lean
@@ -31,8 +31,14 @@ are prepended so the finished program can be interpreted from root to leaves.
 structure MatchProg.BuilderState where
   /-- The next free identifier for a handle. -/
   nextId : Nat := 0
-  /-- Declarations in interpreter order; after a well-formed build, the root is first. -/
+  /-- Non-root declarations in interpreter order. -/
   decls : List (MatchDecl OpCode) := []
+  /-- The most recently designated root. -/
+  root? : Option (Handle OpCode .op) := none
+  /-- Operation constraints created by root designations. -/
+  rootConstraints : List (MatchDecl OpCode) := []
+  /-- Number of root designations, used to reject missing or duplicate roots structurally. -/
+  numRoots : Nat := 0
 
 /--
 A stateful builder for a match program that exports a value of type `α`.
@@ -59,6 +65,8 @@ structure OpHandle (opCode : OpCode) where
 
 /-- Handles exported by a matched root without exposing the root's SSA results. -/
 structure RootHandle (opCode : OpCode) where
+  /-- The root operation handle. -/
+  op : Handle OpCode .op
   /-- The matched root's concrete properties. -/
   properties : Handle OpCode (.prop opCode)
 
@@ -81,7 +89,7 @@ def MatchProg.type (Attr : Type) [IsTypeAttr Attr] (matcher : Attr → Bool := f
   ⟨fun state =>
     let result := Handle.mk (OpInfo := OpCode) state.nextId
     let matcher := fun (attr : TypeAttr) => ((attr.cast? Attr).map matcher).getD false
-    (result, {
+    (result, { state with
       nextId := state.nextId + 1
       decls := .type matcher result :: state.decls
     })⟩
@@ -94,7 +102,7 @@ Match a value with a given type. This should be used to match values where their
 def MatchProg.value (type : Handle OpCode .type) : MatchProg.Builder (Handle OpCode .value) :=
   ⟨fun state =>
     let result := Handle.mk (OpInfo := OpCode) state.nextId
-    (result, {
+    (result, { state with
       nextId := state.nextId + 1
       decls := .value type result :: state.decls
     })⟩
@@ -115,17 +123,17 @@ def MatchProg.operation (opCode : OpCode) (operands : Array (Handle OpCode .valu
     let res := (Array.range returnTypes.size).map fun index =>
       Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
     let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
-    (⟨op, res, properties⟩, {
+    (⟨op, res, properties⟩, { state with
       nextId := state.nextId + returnTypes.size + 2
       decls := .operation opCode operands returnTypes property properties op res :: state.decls
     })⟩
 
 /--
 Match a root operation given its opcode, operands, result types, and properties. This should be the
-last declaration in a Puddle match. At runtime, this is the entry point of the matcher. It returns
-a handle for accessing its concrete properties, but in particular does not return handles for its
-results or the operation itself, since those are accessible from the root through already-bound
-handles.
+last declaration in a Puddle match, and should be called exactly once. At runtime, this is the entry
+point of the matcher. It returns a handle for accessing its concrete properties, but in particular
+does not return handles for its results or the operation itself, since those are accessible from the
+root through already-bound handles.
 -/
 @[expose, inline]
 def MatchProg.root (opCode : OpCode) (operands : Array (Handle OpCode .value))
@@ -137,17 +145,29 @@ def MatchProg.root (opCode : OpCode) (operands : Array (Handle OpCode .value))
     let results := (Array.range returnTypes.size).map fun index =>
       Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
     let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
-    (⟨properties⟩, {
+    (⟨op, properties⟩, { state with
       nextId := state.nextId + returnTypes.size + 2
-      decls := .root op ::
-        .operation opCode operands returnTypes property properties op results :: state.decls
+      root? := some op
+      rootConstraints :=
+        .operation opCode operands returnTypes property properties op results ::
+          state.rootConstraints
+      numRoots := state.numRoots + 1
     })⟩
 
-/-- Build a match program using `MatchProg.Builder`. -/
+/-- Build a match program, panicking unless exactly one call to `MatchProg.root` was made. -/
 @[expose, inline]
 def MatchProg.build (builder : MatchProg.Builder α) : MatchProg OpCode α :=
   let (exports, state) := builder.run {}
-  ⟨state.decls, state.nextId, exports⟩
+  let rootHandle :=
+    match state.numRoots, state.root? with
+    | 1, some root => root
+    | _, _ => panic! "MatchProg.build requires exactly one call to MatchProg.root"
+  {
+    rootHandle
+    decls := state.rootConstraints ++ state.decls
+    numHandles := state.nextId
+    exports
+  }
 
 /-!
 ## Creation builder

--- a/Veir/PatternRewriter/Puddle/Definitions.lean
+++ b/Veir/PatternRewriter/Puddle/Definitions.lean
@@ -74,16 +74,12 @@ deriving Repr, DecidableEq, Inhabited
 the `MatchProg.Builder` API, which allocates fresh handles, rather than construct declarations
 directly.
 
-Stored matcher declarations are ordered top-down, in execution order. The first declaration marks
-the root operation; the remaining declarations constrain operations and operands recursively
-reachable from the root.
-
 Matching always proceeds from an entity already bound in the current assignment. The root
-declaration seeds the assignment with the candidate root operation; every subsequent declaration
-is anchored by an already-bound operation, SSA value, type, or metadata handle. A declaration may
-reject that binding by checking additional constraints, and it may extend the assignment with newly
-discovered operands, result types, properties, or results. Matching therefore expands outward from
-the root through already-bound handles.
+handle seeds the assignment with the candidate root operation before declarations execute; every
+declaration is anchored by an already-bound operation, SSA value, type, or metadata handle. A
+declaration may reject that binding by checking additional constraints, and it may extend the
+assignment with newly discovered operands, result types, properties, or results. Matching therefore
+expands outward from the root through already-bound handles.
 -/
 
 /--
@@ -113,19 +109,15 @@ and bind the discovered entities to their corresponding handles. -/
     (propertyResult : Handle OpInfo (.prop opCode))
     (result : Handle OpInfo .op)
     (results : Array (Handle OpInfo .value))
-/-- Bind `result` to the candidate root operation. `MatchProg.Builder` emits a companion `operation`
-declaration that constrains the root after this declaration seeds the assignment. -/
-| root (result : Handle OpInfo .op)
 
 /--
 A match program together with the value exported by its builder. Exports typically contain handles
 used by the creation or replacement phase of a `Pattern`.
-
-Declarations are stored in execution order, starting with the root marker and continuing through
-the operation and operand constraints recursively reachable from it.
 -/
 structure MatchProg (OpInfo : Type) [HasOpInfo OpInfo] (Exports : Type) where
-  /-- Match declarations in interpreter order, beginning with a root declaration. -/
+  /-- The root handle. -/
+  rootHandle : Handle OpInfo .op
+  /-- Match declarations in interpreter order, beginning with the root operation constraint. -/
   decls : List (MatchDecl OpInfo)
   /-- The number of rule-wide handle identifiers reserved by the matching phase. -/
   numHandles : Nat

--- a/Veir/PatternRewriter/Puddle/Execution.lean
+++ b/Veir/PatternRewriter/Puddle/Execution.lean
@@ -218,11 +218,8 @@ assignment if it succeeds.
 -/
 @[expose, inline_if_reduce]
 def MatchDecl.run (decl : MatchDecl OpInfo) (ctx : IRContext OpInfo)
-    (root : OperationPtr) (assignment : Assignment OpInfo) : Option (Assignment OpInfo) := do
+    (assignment : Assignment OpInfo) : Option (Assignment OpInfo) := do
   match decl with
-  | .root opHandle =>
-    /- A root instruction only binds the root operation to the given handle. -/
-    Assignment.bindOp assignment opHandle root
   | .operation opCode operands resultTypes property propertyHandle opHandle results =>
     /- First, find the matched operation through its handle or one of its result handles. -/
     let matchedOp ← Assignment.findOp assignment opHandle results
@@ -264,12 +261,12 @@ updated assignment if all matches succeed.
 -/
 @[expose, inline_if_reduce]
 def MatchProg.runDecls (decls : List (MatchDecl OpInfo)) (ctx : IRContext OpInfo)
-    (root : OperationPtr) (assignment : Assignment OpInfo) : Option (Assignment OpInfo) :=
+    (assignment : Assignment OpInfo) : Option (Assignment OpInfo) :=
   match decls with
   | [] => some assignment
   | decl :: decls => do
-    let assignment ← decl.run ctx root assignment
-    runDecls decls ctx root assignment
+    let assignment ← decl.run ctx assignment
+    runDecls decls ctx assignment
 
 /--
 Interpret a match program, returning `none` if any match fails, or an updated assignment if the
@@ -278,7 +275,10 @@ match succeeds.
 @[expose, inline]
 def MatchProg.run (prog : MatchProg OpInfo α) (ctx : IRContext OpInfo)
     (root : OperationPtr) : Option (Assignment OpInfo) :=
-  MatchProg.runDecls prog.decls ctx root (Assignment.empty OpInfo prog.numHandles)
+  do
+    let assignment ← Assignment.bindOp
+      (Assignment.empty OpInfo prog.numHandles) prog.rootHandle root
+    MatchProg.runDecls prog.decls ctx assignment
 
 /-- Successful matching of `root` by `prog`. -/
 @[expose]


### PR DESCRIPTION
This PR removes `MatchDecl.root` and tracks the root operation in a `MatchProg` field instead. This makes it easier to express the soundness of puddle patterns, and removes one thing we have to think about in our proofs.