### PR TITLE
feat(PBV): Refactor tactic 

### DIFF
--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -51,7 +51,7 @@ example (p q r : Nat) (x : BitVec p)
 /-- Double zero extending with composite width. -/
 example (p q : Nat) (x : BitVec p)
   (hr : q ≤ 8)
-  (hpq : p < q) :
+  (hpq : q > p) :
   (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
   := by
   pbv_decide 8

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -1,19 +1,47 @@
 import Veir.Meta.PBVDecide
 
+/-- Commutativity of addition -/
 example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
 
+/-- Commutativity of addition for three variables -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
   pbv_decide 4
   · bv_decide
   · grind
 
-example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
-  pbv_decide 4
+-- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
+--   x + y = y + x := by
+--   pbv_decide 4
+--   · bv_decide
+--   · grind
+
+/-- Zero extending a zero extension-/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
   · bv_decide
+  · grind
+  · grind
+  · grind
+
+/-- Sign extending a zero extensions -/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
+  · grind
   · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -6,17 +6,12 @@ example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   pbv_decide 4
   · bv_decide
   · grind
-  · grind
-  · grind
 
 /-- Commutativity of addition for three variables -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
   pbv_decide 4
   · bv_decide
-  · grind
-  · grind
-  · grind
   · grind
 
 /-- Zero extending a zero extension-/
@@ -28,9 +23,6 @@ example (p q r : Nat) (x : BitVec p)
   := by
   pbv_decide 8
   · bv_decide
-  · grind
-  · grind
-  · grind
   · grind
 
 /-- Sign extending a zero extensions -/

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -46,3 +46,14 @@ example (p q r : Nat) (x : BitVec p)
   · grind
   · grind
   · grind
+
+/-- Appending and adding. -/
+example (w : Nat) (a b : BitVec w) (hw: w ≤ 8)
+  : (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
+  · grind
+  · grind
+  · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -24,6 +24,8 @@ example (p q r : Nat) (x : BitVec p)
   pbv_decide 8
   · bv_decide
   · grind
+  · grind
+  · grind
 
 /-- Sign extending a zero extensions -/
 example (p q r : Nat) (x : BitVec p)
@@ -37,7 +39,6 @@ example (p q r : Nat) (x : BitVec p)
   · grind
   · grind
   · grind
-  · grind
 
 /-- Appending and adding. -/
 example (w : Nat) (a b : BitVec w) (hw: w ≤ 8)
@@ -45,7 +46,5 @@ example (w : Nat) (a b : BitVec w) (hw: w ≤ 8)
   := by
   pbv_decide 8
   · bv_decide
-  · grind
-  · grind
   · grind
   · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -6,12 +6,17 @@ example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   pbv_decide 4
   · bv_decide
   · grind
+  · grind
+  · grind
 
 /-- Commutativity of addition for three variables -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
   pbv_decide 4
   · bv_decide
+  · grind
+  · grind
+  · grind
   · grind
 
 /-- Zero extending a zero extension-/
@@ -26,6 +31,7 @@ example (p q r : Nat) (x : BitVec p)
   · grind
   · grind
   · grind
+  · grind
 
 /-- Sign extending a zero extensions -/
 example (p q r : Nat) (x : BitVec p)
@@ -36,6 +42,7 @@ example (p q r : Nat) (x : BitVec p)
   := by
   pbv_decide 8
   · bv_decide
+  · grind
   · grind
   · grind
   · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -21,12 +21,3 @@ example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   pbv_decide 4
   · bv_decide
   · grind
-
-/-- Appending and adding. -/
-example (w : Nat) (a b : BitVec w) (hw: w ≤ 8)
-  : (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -7,6 +7,14 @@ example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
+/-- Commutativity of addition with definitionally-not-syntactically equal widths-/
+example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+  pbv_decide 4
+  · bv_decide
+  · grind
+  · grind
+
 /-- Commutativity of addition for three variables -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
@@ -33,6 +41,18 @@ example (p q r : Nat) (x : BitVec p)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
+  · grind
+  · grind
+
+/-- Double zero extending with composite width. -/
+example (p q : Nat) (x : BitVec p)
+  (hr : q ≤ 8)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
   := by
   pbv_decide 8
   · bv_decide

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -14,12 +14,6 @@ example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
--- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
---   x + y = y + x := by
---   pbv_decide 4
---   · bv_decide
---   · grind
-
 /-- Zero extending a zero extension-/
 example (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -7,7 +7,7 @@ example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
-/-- Commutativity of addition with definitionally-not-syntactically equal widths-/
+/-- Commutativity of addition with definitionally-not-syntactically equal widths -/
 example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -22,44 +22,6 @@ example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
-/-- Zero extending a zero extension-/
-example (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-
-/-- Sign extending a zero extensions -/
-example (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).signExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-
-/-- Double zero extending with composite width. -/
-example (p q : Nat) (x : BitVec p)
-  (hr : q ≤ 8)
-  (hpq : q > p) :
-  (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-
 /-- Appending and adding. -/
 example (w : Nat) (a b : BitVec w) (hw: w ≤ 8)
   : (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)

--- a/Veir/Data/PBV.lean
+++ b/Veir/Data/PBV.lean
@@ -49,7 +49,7 @@ which we wish to prove it, the tactic performs the following steps:
 
 * `Veir.Data.PBV.Lemmas` — `Nat` and `BitVec` lemmas used by the translation.
 * `Veir.Data.PBV.Elim` — steps 3 and 4: `width_elim` and `var_elim`.
-* `Veir.Data.PBV.Mask` — step 5: `maskOfWidth`, `IsMask`, the mask constraint.
+* `Veir.Data.PBV.Mask` — step 5: `maskOfWidth`, the mask constraint.
 * `Veir.Data.PBV.Push` — step 6: pushing `setWidth` from the root to its leaves.
 * `Veir.Data.PBV.Examples` — a manual trace of the whole pipeline.
 

--- a/Veir/Data/PBV/Elim.lean
+++ b/Veir/Data/PBV/Elim.lean
@@ -28,7 +28,7 @@ theorem width_elim (o w : Nat) (Q : Prop)
 /-- This theorem states that if some Prop `Q` holds for a bitvector variable `x`
 of width `o` that is masked to "behave" as if it had width `w` (where `w ≤ o`)
 then it also holds for a bitvector `x` of width `w`. -/
-theorem var_elim (o w : Nat) (hwo : w ≤ o) (Q : BitVec w → Prop)
+theorem var_elim {o w : Nat} (hwo : w ≤ o) (Q : BitVec w → Prop)
     (h : ∀ (x : BitVec o), x &&& maskOfWidth o w = x → Q (x.setWidth w)) :
     ∀ (x : BitVec w), Q x := by
   intro x

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -34,7 +34,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
-      eq_iff 4,             -- Introduce `setWidth` to goal
+      eq_iff (o := 4),             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add
       setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
@@ -75,22 +75,21 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  have bv_p_lt_q := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
     eq_iff (o := 8),
+    setWidth_setWidth (o := 8),
+    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
-    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
-    setWidth_setWidth r_le_bw,
-    setWidth_setWidth q_le_bw,
-    setWidth_setWidth p_le_bw,
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
+    p_le_bw,
     r_le_bw,
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
-  ]  at h_xmp ⊢
+  ] at h_xmp ⊢
 -- Step 7: Drop the Nat 'p', 'q', 'r'
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -168,7 +168,7 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   intro b b_mw
 
   have mask := isMask_of_eq_maskOfWidth h_mw
-  have mask_add := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_o w_le_o w_add_w_le_o h_mw h_mw
+  -- have mask_add := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_o w_le_o w_add_w_le_o h_mw h_mw
 
   simp only [
     eq_iff (o := 16),
@@ -176,7 +176,18 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
     setWidth_append_eq_mul_maskOfWidth (o := 16),
     setWidth_setWidth,
     w_add_w_le_o,
-    w_le_o
+    w_le_o,
+    ← h_mw,
+    BitVec.setWidth_eq
   ]
+
+  simp only [← h_mw] at a_mw b_mw
+
+  clear hw
+  clear h_mw
+  clear w_le_o w_add_w_le_o
+  clear a_mw b_mw
+
+  -- clear mask_add
 
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -137,7 +137,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,
     setWidth_setWidth,
-    signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
+    signBitOfMask_eq,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
     p_le_bw,
     r_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -34,7 +34,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
-      eq_iff w_le_bw,             -- Introduce `setWidth` to goal
+      eq_iff 4,             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add
       setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
@@ -43,56 +43,6 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 8: Bitblast!
   bv_decide
 
-/-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
-    which is a single zero extension to `r`, for all widths `p < q < r ≤ 8` -/
-theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
--- Step 1: Bound widths to the provided blast width
-  have r_le_bw : r ≤ 8 := by grind
-  have q_le_bw : q ≤ 8 := by grind
-  have p_le_bw : p ≤ 8 := by grind
--- Step 2-3: Introduce mask to replace `w` Nat var
-  apply width_elim 8 r
-  intro mr h_mr
-  apply width_elim 8 q
-  intro mq h_mq
-  apply width_elim 8 p
-  intro mp h_mp
--- Step 4: Eliminate the parametric bv var of width `w`
---         enforcing width constraint with mask
-  revert x
-  apply var_elim 8 p p_le_bw
-  intro x h_xmp
--- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := isMask_of_eq_maskOfWidth h_mr
-  have mq_mask := isMask_of_eq_maskOfWidth h_mq
-  have mp_mask := isMask_of_eq_maskOfWidth h_mp
--- Step 5B: Translate the condition on the natural number width
---   into a fact about the bitvector masks
-  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
-  simp only [isMask_eq] at mr_mask mq_mask mp_mask
--- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [
-    eq_iff r_le_bw,
-    setWidth_setWidth r_le_bw,
-    setWidth_setWidth p_le_bw,
-    setWidth_setWidth q_le_bw,
-    BitVec.zeroExtend_eq_setWidth,
-    BitVec.setWidth_eq,
-    ← h_mr,
-    ← h_mq,
-    ← h_mp,
-  ] at h_xmp ⊢
--- Step 7: Drop the Nat 'p', 'q', 'r'
-  clear h_mp h_mq h_mr
-  clear hr hqr hpq r_le_bw q_le_bw p_le_bw
-  clear p q r
--- Step 8: Bitblast!
-  bv_decide
 
 /-- Manual trace of a zero extension to `q` followed by a sign extension to `r`,
     which is a single zero extension to `r`, since `p < q` leaves the sign bit
@@ -125,28 +75,27 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --   into a fact about the bitvector masks
-  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  -- have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
+  revert hpq hqr
+
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [
-    eq_iff r_le_bw,
-    setWidth_signExtend_eq_and_maskOfWidth,                -- Push `setWidth` down signExtend
-    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,  -- Sign bit test becomes a mask test
+  simp  only [
+    eq_iff (o := 8),
+    nat_lt_nat_eq_mask_lt_mask (o := 8),
+    setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
+    msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
+    h_mq, h_mr, h_mp,
+    p_le_bw,
+    r_le_bw,
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
-    ← h_mr,
-    ← h_mq,
-    ← h_mp,
-  ] at h_xmp ⊢
+  ]  at h_xmp ⊢
 -- Step 7: Drop the Nat 'p', 'q', 'r'
-  clear h_mp h_mq h_mr
-  clear hr hqr hpq r_le_bw q_le_bw p_le_bw
-  clear p q r
--- Step 8: Bitblast!
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -35,15 +35,11 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
       eq_iff w_le_bw,             -- Introduce `setWidth` to goal
-      setWidth_add w_le_bw,       -- Push `setWidth` down add
-      setWidth_setWidth w_le_bw,  -- Push `setWidth` down setWidth
+      setWidth_add,       -- Push `setWidth` down add
+      setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
-      ← h_mw]                     -- Replace mask with nat with bv constraint
+      w_le_bw]                     -- Replace mask with nat with bv constraint
       at h_xmw h_ymw ⊢
--- Step 7: Drop the Nat `w`
-  clear hw
-  clear w_le_bw h_mw
-  clear w
 -- Step 8: Bitblast!
   bv_decide
 

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -20,10 +20,8 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 1: Bound widths to the provided blast width (redundant in this case)
   have w_le_bw : w ≤ 4 := by grind
 -- Step 2-3: Introduce mask to replace `w` Nat var
-  -- apply width_elim 4 w
-  -- intro mw h_mw
-  let mw := maskOfWidth 4 w
-  -- obtain ⟨mw, h_mw⟩ : ∃ mw : BitVec 8, mw = maskOfWidth 8 w := ⟨_, rfl⟩
+  apply width_elim 4 w
+  intro mw h_mw
 -- Step 4: Eliminate the parametric bv var of width `w`
 --         enforcing width constraint with mask
   revert x
@@ -167,7 +165,7 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   apply var_elim w_le_o
   intro b b_mw
 
-  have mask := isMask_of_eq_maskOfWidth h_mw
+  have mask := maskOfWidth_and_add_one_eq_zero h_mw
   -- have mask_add := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_o w_le_o w_add_w_le_o h_mw h_mw
 
   simp only [

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -74,15 +74,13 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mq_mask := isMask_of_eq_maskOfWidth h_mq
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
---   into a fact about the bitvector masks
-  -- have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+--          into a fact about the bitvector masks
+  have le_pq := mask_lt_mask 8 p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
-  revert hpq hqr
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
     eq_iff (o := 8),
-    nat_lt_nat_eq_mask_lt_mask (o := 8),
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -76,7 +76,6 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
-  simp only [isMask_eq] at mr_mask mq_mask mp_mask
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
@@ -89,8 +88,6 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     BitVec.zeroExtend_eq_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
-    h_mq, h_mr, h_mp,
-    p_le_bw,
     r_le_bw,
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -75,15 +75,13 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_p_lt_q := h_pq
-  revert bv_p_lt_q
-  have bv_q_lt_r := h_qr
-  revert bv_q_lt_r
+  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq h_pq
+  have bv_q_lt_r := lt_eq_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr h_qr
+
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
-    lt_eq_lt_of_eq_maskOfWidth (o := 8),
     setWidth_setWidth,
     BitVec.zeroExtend_eq_setWidth,
     BitVec.setWidth_eq,
@@ -126,13 +124,12 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_p_lt_q := hpq
-  revert bv_p_lt_q
+  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq hpq
+  -- revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
-    lt_eq_lt_of_eq_maskOfWidth (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -81,7 +81,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   simp  only [
     eq_iff (o := 8),
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
-    msb_eq_and_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
+    msb_eq_and_signBitOfMask_maskOfWidth_ne_zero q_le_bw,          -- Replace the sign bit test with a mask test
     setWidth_setWidth r_le_bw,
     setWidth_setWidth q_le_bw,
     setWidth_setWidth p_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -77,6 +77,8 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 --          into a fact about the bitvector masks
   have bv_p_lt_q := h_pq
   revert bv_p_lt_q
+  have bv_q_lt_r := h_qr
+  revert bv_q_lt_r
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
@@ -128,7 +130,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp  only [
+  simp only [
     eq_iff (o := 8),
     Nat_lt_eq_Mask_lt (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -50,7 +50,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (h_qr : q < r)
-  (h_pq : (p + 1) - 1 < q) :
+  (h_pq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
 -- Step 1: Bound widths to the provided blast width
@@ -76,12 +76,13 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have bv_p_lt_q := h_pq
-  simp [Nat_lt_eq_Mask_lt (o := 8), p_le_bw, q_le_bw] at bv_p_lt_q
+  revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp  only [
+  simp only [
     eq_iff (o := 8),
-    setWidth_setWidth (o := 8),
+    Nat_lt_eq_Mask_lt (o := 8),
+    setWidth_setWidth,
     BitVec.zeroExtend_eq_setWidth,
     BitVec.setWidth_eq,
     p_le_bw,
@@ -123,15 +124,17 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_p_lt_q := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+  have bv_p_lt_q := hpq
+  revert bv_p_lt_q
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp  only [
     eq_iff (o := 8),
-    setWidth_setWidth (o := 8),
+    Nat_lt_eq_Mask_lt (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,
+    setWidth_setWidth,
     signBitOfMask,                 -- Unfold, else `bv_decide` abstracts it away
     BitVec.setWidth_eq,
     p_le_bw,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -178,11 +178,11 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   intro mw h_mw
 
   revert a
-  apply var_elim 8 w (by grind)
+  apply var_elim 16 w (by grind)
   intro a a_mw
 
   revert b
-  apply var_elim 8 w (by grind)
+  apply var_elim 16 w (by grind)
   intro b b_mw
 
   have mask := isMask_of_eq_maskOfWidth h_mw

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -27,10 +27,10 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 4: Eliminate the parametric bv var of width `w`
 --         enforcing width constraint with mask
   revert x
-  apply var_elim 4 w w_le_bw
+  apply var_elim w_le_bw
   intro x h_xmw
   revert y
-  apply var_elim 4 w w_le_bw
+  apply var_elim w_le_bw
   intro y h_ymw
 -- Step 5: Convert width hypothesis to mask hypothesis
   have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
@@ -69,7 +69,7 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 -- Step 4: Eliminate the parametric bv var of width `w`
 --         enforcing width constraint with mask
   revert x
-  apply var_elim 8 p p_le_bw
+  apply var_elim p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
   have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
@@ -120,7 +120,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 4: Eliminate the parametric bv var of width `w`
 --         enforcing width constraint with mask
   revert x
-  apply var_elim 8 p p_le_bw
+  apply var_elim p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
   have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
@@ -160,11 +160,11 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   intro mw h_mw
 
   revert a
-  apply var_elim 16 w (by grind)
+  apply var_elim w_le_o
   intro a a_mw
 
   revert b
-  apply var_elim 16 w (by grind)
+  apply var_elim w_le_o
   intro b b_mw
 
   have mask := isMask_of_eq_maskOfWidth h_mw

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -149,30 +149,12 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 8: BitBlast!
   bv_decide
 
-theorem pbv_setWidth_append {w o : Nat} (h : w ≤ o) :
-    ∀ {v : Nat} (a : BitVec v) (b : BitVec w), v + w ≤ o →
-      (a ++ b).setWidth o
-        = ((a.setWidth o) * (maskOfWidth o w + 1#o)) ||| b.setWidth o := by
-  intro v a b hvw
-  have hv : v ≤ o := by omega
-  -- The shifted high part fits below `2^(v+w) ≤ 2^o`, so nothing wraps.
-  have hshift : a.toNat <<< w < 2 ^ o := by
-    rw [Nat.shiftLeft_eq]
-    calc a.toNat * 2 ^ w
-        < 2 ^ v * 2 ^ w := by
-          exact Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
-      _ = 2 ^ (v + w) := (Nat.pow_add 2 v w).symm
-      _ ≤ 2 ^ o := Nat.pow_le_pow_right (by omega) hvw
-  have hb : b.toNat < 2 ^ o :=
-    Nat.lt_of_lt_of_le b.isLt (Nat.pow_le_pow_right (by omega) h)
-  apply BitVec.eq_of_toNat_eq
-  sorry
-
 theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
   := by
-  -- have w_le_bw : w <= 8 := by grind
+  -- o = 16, because the append width is w + w which is bounded by 16
   have w_le_o : w <= 16 := by grind
+  have w_add_w_le_o : w + w ≤ 16 := by grind
 
   apply width_elim 16 w
   intro mw h_mw
@@ -186,20 +168,15 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   intro b b_mw
 
   have mask := isMask_of_eq_maskOfWidth h_mw
-  have : maskOfWidth 16 (w + w) = ((maskOfWidth 16 w + 1) * (maskOfWidth 16 w + 1)) - 1 := sorry
-
-  have w_w_le_bw : w + w ≤ 16 := by grind
+  have mask_add := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_o w_le_o w_add_w_le_o h_mw h_mw
 
   simp only [
-    w_w_le_bw,
     eq_iff (o := 16),
     setWidth_add,
-    pbv_setWidth_append (o := 16),
+    setWidth_append_eq_mul_maskOfWidth (o := 16),
+    setWidth_setWidth,
+    w_add_w_le_o,
     w_le_o
   ]
 
-  simp [
-    setWidth_setWidth,
-    w_le_o,
-  ]
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -44,6 +44,54 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   bv_decide
 
 
+/-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
+    which is a single zero extension to `r`, since `p < q`.
+-/
+theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (h_qr : q < r)
+  (h_pq : (p + 1) - 1 < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+-- Step 1: Bound widths to the provided blast width
+  have r_le_bw : r ≤ 8 := by grind
+  have q_le_bw : q ≤ 8 := by grind
+  have p_le_bw : p ≤ 8 := by grind
+-- Step 2-3: Introduce mask to replace `w` Nat var
+  apply width_elim 8 r
+  intro mr h_mr
+  apply width_elim 8 q
+  intro mq h_mq
+  apply width_elim 8 p
+  intro mp h_mp
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
+  revert x
+  apply var_elim 8 p p_le_bw
+  intro x h_xmp
+-- Step 5: Convert width hypothesis to mask hypothesis
+  have mr_mask := isMask_of_eq_maskOfWidth h_mr
+  have mq_mask := isMask_of_eq_maskOfWidth h_mq
+  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+-- Step 5B: Translate the condition on the natural number width
+--          into a fact about the bitvector masks
+  have bv_p_lt_q := h_pq
+  simp [Nat_lt_eq_Mask_lt (o := 8), p_le_bw, q_le_bw] at bv_p_lt_q
+
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
+  simp  only [
+    eq_iff (o := 8),
+    setWidth_setWidth (o := 8),
+    BitVec.zeroExtend_eq_setWidth,
+    BitVec.setWidth_eq,
+    p_le_bw,
+    r_le_bw,
+    q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
+                                   -- `setWidth_signExtend_eq_and_maskOfWidth`
+  ] at h_xmp ⊢
+-- Step 8: BitBlast!
+  bv_decide
+
 /-- Manual trace of a zero extension to `q` followed by a sign extension to `r`,
     which is a single zero extension to `r`, since `p < q` leaves the sign bit
     of the intermediate value clear -/
@@ -91,5 +139,5 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
   ] at h_xmp ⊢
--- Step 7: Drop the Nat 'p', 'q', 'r'
+-- Step 8: BitBlast!
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -31,7 +31,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   apply var_elim 4 w w_le_bw
   intro y h_ymw
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mw_mask := isMask_of_eq_maskOfWidth h_mw
+  have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
       eq_iff (o := 4),             -- Introduce `setWidth` to goal
@@ -70,9 +70,9 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   apply var_elim 8 p p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := isMask_of_eq_maskOfWidth h_mr
-  have mq_mask := isMask_of_eq_maskOfWidth h_mq
-  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+  have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
+  have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
+  have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have bv_p_lt_q := h_pq
@@ -121,9 +121,9 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   apply var_elim 8 p p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := isMask_of_eq_maskOfWidth h_mr
-  have mq_mask := isMask_of_eq_maskOfWidth h_mq
-  have mp_mask := isMask_of_eq_maskOfWidth h_mp
+  have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
+  have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
+  have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
   have bv_p_lt_q := hpq

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -168,9 +168,6 @@ theorem pbv_setWidth_append {w o : Nat} (h : w ≤ o) :
   apply BitVec.eq_of_toNat_eq
   sorry
 
-
-
-
 theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
   := by
@@ -189,6 +186,7 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
   intro b b_mw
 
   have mask := isMask_of_eq_maskOfWidth h_mw
+  have : maskOfWidth 16 (w + w) = ((maskOfWidth 16 w + 1) * (maskOfWidth 16 w + 1)) - 1 := sorry
 
   have w_w_le_bw : w + w ≤ 16 := by grind
 
@@ -196,12 +194,9 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
     w_w_le_bw,
     eq_iff (o := 16),
     setWidth_add,
+    pbv_setWidth_append (o := 16),
+    w_le_o
   ]
-  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
-  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
-  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
-  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
-  have : maskOfWidth 16 (w + w) = ((maskOfWidth 16 w + 1) * (maskOfWidth 16 w + 1)) - 1 := sorry
 
   simp [
     setWidth_setWidth,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -83,7 +83,7 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
-    Nat_lt_eq_Mask_lt (o := 8),
+    lt_eq_lt_of_eq_maskOfWidth (o := 8),
     setWidth_setWidth,
     BitVec.zeroExtend_eq_setWidth,
     BitVec.setWidth_eq,
@@ -132,7 +132,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
-    Nat_lt_eq_Mask_lt (o := 8),
+    lt_eq_lt_of_eq_maskOfWidth (o := 8),
     msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o := 8),          -- Replace the sign bit test with a mask test
     setWidth_signExtend_eq_and_maskOfWidth,          -- Push `setWidth` down signExtend
     BitVec.zeroExtend_eq_setWidth,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -75,7 +75,7 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mp_mask := isMask_of_eq_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have le_pq := mask_lt_mask 8 p_le_bw q_le_bw h_mp h_mq hpq
+  have le_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
   simp only [isMask_eq] at mr_mask mq_mask mp_mask
 
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -74,11 +74,8 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
   have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
---          into a fact about the bitvector masks
-  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq h_pq
-  have bv_q_lt_r := lt_eq_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr h_qr
-
-
+--   into a fact about the bitvector masks
+  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq h_pq
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
@@ -123,10 +120,8 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
   have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
---          into a fact about the bitvector masks
-  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq hpq
-  -- revert bv_p_lt_q
-
+--   into a fact about the bitvector masks
+  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
@@ -142,47 +137,4 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
   ] at h_xmp ⊢
 -- Step 8: BitBlast!
-  bv_decide
-
-theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
-  (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
-  := by
-  -- o = 16, because the append width is w + w which is bounded by 16
-  have w_le_o : w <= 16 := by grind
-  have w_add_w_le_o : w + w ≤ 16 := by grind
-
-  apply width_elim 16 w
-  intro mw h_mw
-
-  revert a
-  apply var_elim w_le_o
-  intro a a_mw
-
-  revert b
-  apply var_elim w_le_o
-  intro b b_mw
-
-  have mask := maskOfWidth_and_add_one_eq_zero h_mw
-  -- have mask_add := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_o w_le_o w_add_w_le_o h_mw h_mw
-
-  simp only [
-    eq_iff (o := 16),
-    setWidth_add,
-    setWidth_append_eq_mul_maskOfWidth (o := 16),
-    setWidth_setWidth,
-    w_add_w_le_o,
-    w_le_o,
-    ← h_mw,
-    BitVec.setWidth_eq
-  ]
-
-  simp only [← h_mw] at a_mw b_mw
-
-  clear hw
-  clear h_mw
-  clear w_le_o w_add_w_le_o
-  clear a_mw b_mw
-
-  -- clear mask_add
-
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -20,8 +20,10 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 1: Bound widths to the provided blast width (redundant in this case)
   have w_le_bw : w ≤ 4 := by grind
 -- Step 2-3: Introduce mask to replace `w` Nat var
-  apply width_elim 4 w
-  intro mw h_mw
+  -- apply width_elim 4 w
+  -- intro mw h_mw
+  let mw := maskOfWidth 4 w
+  -- obtain ⟨mw, h_mw⟩ : ∃ mw : BitVec 8, mw = maskOfWidth 8 w := ⟨_, rfl⟩
 -- Step 4: Eliminate the parametric bv var of width `w`
 --         enforcing width constraint with mask
   revert x
@@ -145,4 +147,64 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
   ] at h_xmp ⊢
 -- Step 8: BitBlast!
+  bv_decide
+
+theorem pbv_setWidth_append {w o : Nat} (h : w ≤ o) :
+    ∀ {v : Nat} (a : BitVec v) (b : BitVec w), v + w ≤ o →
+      (a ++ b).setWidth o
+        = ((a.setWidth o) * (maskOfWidth o w + 1#o)) ||| b.setWidth o := by
+  intro v a b hvw
+  have hv : v ≤ o := by omega
+  -- The shifted high part fits below `2^(v+w) ≤ 2^o`, so nothing wraps.
+  have hshift : a.toNat <<< w < 2 ^ o := by
+    rw [Nat.shiftLeft_eq]
+    calc a.toNat * 2 ^ w
+        < 2 ^ v * 2 ^ w := by
+          exact Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
+      _ = 2 ^ (v + w) := (Nat.pow_add 2 v w).symm
+      _ ≤ 2 ^ o := Nat.pow_le_pow_right (by omega) hvw
+  have hb : b.toNat < 2 ^ o :=
+    Nat.lt_of_lt_of_le b.isLt (Nat.pow_le_pow_right (by omega) h)
+  apply BitVec.eq_of_toNat_eq
+  sorry
+
+
+
+
+theorem trace_append (w : Nat) (a b : BitVec w) (hw : w <= 8):
+  (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
+  := by
+  -- have w_le_bw : w <= 8 := by grind
+  have w_le_o : w <= 16 := by grind
+
+  apply width_elim 16 w
+  intro mw h_mw
+
+  revert a
+  apply var_elim 8 w (by grind)
+  intro a a_mw
+
+  revert b
+  apply var_elim 8 w (by grind)
+  intro b b_mw
+
+  have mask := isMask_of_eq_maskOfWidth h_mw
+
+  have w_w_le_bw : w + w ≤ 16 := by grind
+
+  simp only [
+    w_w_le_bw,
+    eq_iff (o := 16),
+    setWidth_add,
+  ]
+  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
+  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
+  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
+  rw [pbv_setWidth_append (by grind) _ _ (by grind)]
+  have : maskOfWidth 16 (w + w) = ((maskOfWidth 16 w + 1) * (maskOfWidth 16 w + 1)) - 1 := sorry
+
+  simp [
+    setWidth_setWidth,
+    w_le_o,
+  ]
   bv_decide

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -46,6 +46,28 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
 
+/-- Adding one to a mask makes it a twoPow BitVec. -/
+theorem add_one_maskOfWidth_eq_twoPow {o w : Nat} (h : w ≤ o) : maskOfWidth o w + 1#o = BitVec.twoPow o w := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, toNat_maskOfWidth h, BitVec.toNat_twoPow]
+  cases o
+  · have w_zero : w = 0 := by grind
+    simp [w_zero]
+  · congr
+    simp [BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
+    grind
+
+/-- Mask is BitVec.twoPow minus one. -/
+theorem maskOfWidth_eq_twoPow_sub_one {o w : Nat} (h : w ≤ o) : maskOfWidth o w = BitVec.twoPow o w - 1#o := by
+  apply BitVec.eq_of_toNat_eq
+  grind [add_one_maskOfWidth_eq_twoPow]
+
+/-- Mask of zero is zero. -/
+theorem maskOfWidth_zero_eq_zero {w : Nat} (h : w ≤ 0) : maskOfWidth 0 w = 0 := by
+  apply BitVec.eq_of_toNat_eq
+  have : w = 0 := by grind
+  simp [maskOfWidth, this]
+
 /-- The `i`th bit of `maskOfWidth o w` is enabled iff
 the index `i` is inbounds of `o` and `w`. -/
 @[simp] theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -84,7 +84,12 @@ the index `i` is inbounds of `w`. -/
 
 /-- `signBitOfMask m` keeps only the top bit of the mask `m`.
 This is used to extract the sign bit of a width `o` bitvector. -/
-@[expose] def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
+def signBitOfMask {o : Nat} (m : BitVec o) := m - (m >>> 1)
+
+theorem signBitOfMask_eq {o : Nat} (m : BitVec o) :
+    signBitOfMask m = m - (m >>> 1) := by
+  unfold signBitOfMask
+  rfl
 
 /-- The zero bitvector, which is the mask of width `0`, has no sign bit. -/
 @[simp] theorem signBitOfMask_zero {o : Nat} : signBitOfMask (0#o) = 0#o := by

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -34,6 +34,20 @@ theorem maskOfWidth_and_add_one_eq_zero {o w : Nat} {m : BitVec o}
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
+/-- `maskOfWidth` is monotone with respect to unsigned bitvec comparison. -/
+theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
+  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
+  have : 0 < 2 ^ w₁ := by grind
+  lia
+
+/-- Strict width order becomes strict mask order. -/
+theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw : w₁ < w₂) : m₁ < m₂ := by
+  grind only [maskOfWidth_lt_maskOfWidth]
+
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :
     (x &&& maskOfWidth o w).toNat = x.toNat % 2 ^ w := by
@@ -45,28 +59,6 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
     a.setWidth o = b &&& maskOfWidth o w := by
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
-
-/-- Adding one to a mask makes it a twoPow BitVec. -/
-theorem add_one_maskOfWidth_eq_twoPow {o w : Nat} (h : w ≤ o) : maskOfWidth o w + 1#o = BitVec.twoPow o w := by
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_add, toNat_maskOfWidth h, BitVec.toNat_twoPow]
-  cases o
-  · have w_zero : w = 0 := by grind
-    simp [w_zero]
-  · congr
-    simp [BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
-    grind
-
-/-- Mask is BitVec.twoPow minus one. -/
-theorem maskOfWidth_eq_twoPow_sub_one {o w : Nat} (h : w ≤ o) : maskOfWidth o w = BitVec.twoPow o w - 1#o := by
-  apply BitVec.eq_of_toNat_eq
-  grind [add_one_maskOfWidth_eq_twoPow]
-
-/-- Mask of zero is zero. -/
-theorem maskOfWidth_zero_eq_zero {w : Nat} (h : w ≤ 0) : maskOfWidth 0 w = 0 := by
-  apply BitVec.eq_of_toNat_eq
-  have : w = 0 := by grind
-  simp [maskOfWidth, this]
 
 /-- The `i`th bit of `maskOfWidth o w` is enabled iff
 the index `i` is inbounds of `o` and `w`. -/

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -41,10 +41,9 @@ theorem isMask_maskOfWidth {o w : Nat} :
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- The mask constraint: the only fact about `m` surviving abstraction.
-Unfold the IsMask def here to simplify use in the proof. -/
+/-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
+    (hm : m = maskOfWidth o w) : IsMask m := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -19,7 +19,7 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
 /-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
-@[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
+def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
 /-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
 theorem isMask_eq {o : Nat} (m : BitVec o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -55,11 +55,6 @@ theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂
   have : 0 < 2 ^ w₁ := by grind
   lia
 
-/-- Strict width order becomes strict mask order. -/
-theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw : w₁ < w₂) : m₁ < m₂ := by
-  grind only [maskOfWidth_lt_maskOfWidth]
 
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -21,12 +21,6 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
 def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
-/-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
-theorem isMask_eq {o : Nat} (m : BitVec o) :
-    IsMask m = (m &&& (m + 1#o) = 0#o) := by
-  unfold IsMask
-  rfl
-
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by
   rw [maskOfWidth, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
@@ -43,7 +37,7 @@ theorem isMask_maskOfWidth {o w : Nat} :
 
 /-- The mask constraint: the only fact about `m` surviving abstraction. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : IsMask m := by
+    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -41,9 +41,10 @@ theorem isMask_maskOfWidth {o w : Nat} :
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- The mask constraint: the only fact about `m` surviving abstraction. -/
+/-- The mask constraint: the only fact about `m` surviving abstraction.
+Unfold the IsMask def here to simplify use in the proof. -/
 theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
-    (hm : m = maskOfWidth o w) : IsMask m := by
+    (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   exact isMask_maskOfWidth
 

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -19,7 +19,7 @@ def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
 /-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
 operations removing the dependency on `k` and allowing it to be bitblasted. -/
-def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
+@[expose] def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
 
 /-- Unfold `IsMask` into the constraint handed to the bitblaster. -/
 theorem isMask_eq {o : Nat} (m : BitVec o) :

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -17,10 +17,6 @@ public section
 /-- `maskOfWidth o w : BitVec o` has its low `w` bits set. -/
 def maskOfWidth (o w : Nat) : BitVec o := BitVec.ofNat o (2 ^ w - 1)
 
-/-- `IsMask` encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector
-operations removing the dependency on `k` and allowing it to be bitblasted. -/
-def IsMask {o : Nat} (m : BitVec o) : Prop := m &&& (m + 1#o) = 0#o
-
 theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
     (maskOfWidth o w).toNat = 2 ^ w - 1 := by
   rw [maskOfWidth, BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
@@ -28,27 +24,15 @@ theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
   have h2 : 0 < 2 ^ w := Nat.two_pow_pos w
   lia
 
-/-- Soundness: every real mask satisfies the constraint. -/
-theorem isMask_maskOfWidth {o w : Nat} :
-    IsMask (maskOfWidth o w) := by
-  simp [IsMask, maskOfWidth, BitVec.ofNat_add_ofNat, ← BitVec.ofNat_and,
-    Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
-    Nat.and_two_pow_sub_one_eq_mod]
-
-/-- The mask constraint: the only fact about `m` surviving abstraction. -/
-theorem isMask_of_eq_maskOfWidth {o w : Nat} {m : BitVec o}
+/-- The mask constraint: the only fact about `m` surviving abstraction. This
+encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector operations
+removing the dependency on `k` and allowing it to be bitblasted. -/
+theorem maskOfWidth_and_add_one_eq_zero {o w : Nat} {m : BitVec o}
     (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
-  exact isMask_maskOfWidth
-
-/-- `maskOfWidth` is monotone with respect to unsigned bitvec comparison. -/
-theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
-  have : 0 < 2 ^ w₁ := by grind
-  lia
-
+  simp [maskOfWidth, BitVec.ofNat_add_ofNat, ← BitVec.ofNat_and,
+    Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
+    Nat.and_two_pow_sub_one_eq_mod]
 
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -22,7 +22,7 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
-/-- Inequality on the widths translates to inequality on the masks. -/
+/-- LT on the widths translates to the masks. -/
 theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
@@ -32,6 +32,29 @@ theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h�
   have := Nat.two_pow_pos w₁
   have := Nat.two_pow_pos w₂
   lia
+
+/-- LE on the widths translates to the masks. -/
+theorem Nat_le_eq_Mask_le (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [eq_iff_iff, BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      ← Nat.pow_le_pow_iff_right (a := 2) (by lia)]
+  have := Nat.two_pow_pos w₁
+  have := Nat.two_pow_pos w₂
+  lia
+
+/-- GE on the widths translates to the masks. -/
+theorem Nat_ge_eq_Mask_ge (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
+  grind [Nat_le_eq_Mask_le]
+
+/-- GT on the widths translates to the masks. -/
+theorem Nat_gt_eq_Mask_gt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ > w₂) = (m₁ > m₂) := by
+  grind [Nat_lt_eq_Mask_lt]
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -34,18 +34,11 @@ theorem Nat_lt_eq_Mask_lt {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w�
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
   subst m₁ m₂
-  rw [eq_iff_iff]
-  constructor
-  · grind only[maskOfWidth_lt_maskOfWidth]
-  · intro h
-    rw [BitVec.lt_def] at h
-    repeat rw [toNat_maskOfWidth] at h
-    have h_pow1 : (2 ^ w₁ > 0) := by grind
-    have h_pow2 : (2 ^ w₂ > 0) := by grind
-    have h_pows : (2 ^ w₁ < 2 ^ w₂) := by grind
-    exact (Nat.pow_lt_pow_iff_right (a:= 2) (by omega)).mp h_pows
-    · exact h₂
-    · exact h₁
+  rw [eq_iff_iff, BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      ← Nat.pow_lt_pow_iff_right (a := 2) (by lia)]
+  have := Nat.two_pow_pos w₁
+  have := Nat.two_pow_pos w₂
+  lia
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -14,13 +14,15 @@ namespace Veir.Data.PBV
 
 public section
 
-/-! ## Introducing `setWidth o` at the root -/
 
+/-- Introducing `setWidth o` at the root -/
 theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w), (a = b) = (a.setWidth o = b.setWidth o) := by
   intro a b
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
+
+/-! ## Translating conditions on `Nat` widths into conditions on masks -/
 
 /-- LT on the widths translates to the masks. -/
 theorem lt_eq_lt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
@@ -64,8 +66,6 @@ theorem setWidth_setWidth {w o : Nat} (h : w ≤ o) :
   intro u a
   refine setWidth_eq_and_maskOfWidth h ?_
   rw [BitVec.toNat_setWidth, BitVec.toNat_setWidth, Nat.mod_mod_pow_of_le h]
-
-/-! ## Width-sensitive arithmetic: mask the result -/
 
 theorem setWidth_add {w o : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w),

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -22,15 +22,8 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
-/-- Strict width order becomes strict mask order. -/
-theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ < w₂) : m₁ < m₂ := by
-  subst m₁ m₂
-  grind only[maskOfWidth_lt_maskOfWidth]
-
 /-- Inequality on the widths translates to inequality on the masks. -/
-theorem Nat_lt_eq_Mask_lt {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
   subst m₁ m₂
@@ -85,7 +78,7 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
 
 /-- `a.msb` can be implemented by masking the sign bit,
 which are definitions the bitblaster can see. -/
-theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero {w o : Nat} (h : w ≤ o) :
+theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a : BitVec w),
       a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
   intro a

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -16,7 +16,7 @@ public section
 
 
 /-- Introducing `setWidth o` at the root -/
-theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
+theorem eq_iff {w : Nat} (o : Nat) (h : w ≤ o) :
     ∀ (a b : BitVec w), (a = b) = (a.setWidth o = b.setWidth o) := by
   intro a b
   apply propext
@@ -67,7 +67,7 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
 
 /-- `a.msb` can be implemented by masking the sign bit,
 which are definitions the bitblaster can see. -/
-theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o : Nat) {w : Nat} (h : w ≤ o) :
+theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero {w : Nat} (o : Nat) (h : w ≤ o) :
     ∀ (a : BitVec w),
       a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
   intro a

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -23,38 +23,11 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
 /-- Strict width order becomes strict mask order. -/
-theorem nat_lt_nat_eq_mask_lt_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ < w₂) = (m₁ < m₂) := by
+theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ :  w₁ < w₂) : m₁ < m₂ := by
   subst m₁ m₂
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have : 0 < 2 ^ w₁ := by grind
-  simp only [eq_iff_iff]
-  constructor
-  · intros h
-    have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
-    have : 0 < 2 ^ w₁ := by grind
-    lia
-  · intros h
-    apply Nat.pow_lt_pow_iff_right (a := 2) (h := by decide) .. |>.mp
-    · grind
-
-/-- Strict width order becomes strict mask order. -/
-theorem nat_le_nat_eq_mask_le_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
-  subst m₁ m₂
-  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have : 0 < 2 ^ w₁ := by grind
-  simp only [eq_iff_iff]
-  constructor
-  · intros h
-    have hlt : 2 ^ w₁ ≤ 2 ^ w₂ := Nat.pow_le_pow_right (by lia) (by lia)
-    have : 0 < 2 ^ w₁ := by grind
-    lia
-  · intros h
-    apply Nat.pow_le_pow_iff_right (a := 2) (h := by decide) .. |>.mp
-    · grind
+  grind only[maskOfWidth_lt_maskOfWidth]
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -16,11 +16,45 @@ public section
 
 /-! ## Introducing `setWidth o` at the root -/
 
-theorem eq_iff {w o : Nat} (h : w ≤ o) :
+theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w), (a = b) = (a.setWidth o = b.setWidth o) := by
   intro a b
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
+
+/-- Strict width order becomes strict mask order. -/
+theorem nat_lt_nat_eq_mask_lt_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ < w₂) = (m₁ < m₂) := by
+  subst m₁ m₂
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
+  have : 0 < 2 ^ w₁ := by grind
+  simp only [eq_iff_iff]
+  constructor
+  · intros h
+    have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
+    have : 0 < 2 ^ w₁ := by grind
+    lia
+  · intros h
+    apply Nat.pow_lt_pow_iff_right (a := 2) (h := by decide) .. |>.mp
+    · grind
+
+/-- Strict width order becomes strict mask order. -/
+theorem nat_le_nat_eq_mask_le_mask (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
+  have : 0 < 2 ^ w₁ := by grind
+  simp only [eq_iff_iff]
+  constructor
+  · intros h
+    have hlt : 2 ^ w₁ ≤ 2 ^ w₂ := Nat.pow_le_pow_right (by lia) (by lia)
+    have : 0 < 2 ^ w₁ := by grind
+    lia
+  · intros h
+    apply Nat.pow_le_pow_iff_right (a := 2) (h := by decide) .. |>.mp
+    · grind
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -23,7 +23,7 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
 /-- LT on the widths translates to the masks. -/
-theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem lt_eq_lt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ < w₂) = (m₁ < m₂) := by
   subst m₁ m₂
@@ -34,7 +34,7 @@ theorem Nat_lt_eq_Mask_lt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h�
   lia
 
 /-- LE on the widths translates to the masks. -/
-theorem Nat_le_eq_Mask_le (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem le_eq_le_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
   subst m₁ m₂
@@ -45,16 +45,16 @@ theorem Nat_le_eq_Mask_le (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h�
   lia
 
 /-- GE on the widths translates to the masks. -/
-theorem Nat_ge_eq_Mask_ge (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem ge_eq_ge_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
-  grind [Nat_le_eq_Mask_le]
+  grind [le_eq_le_of_eq_maskOfWidth]
 
 /-- GT on the widths translates to the masks. -/
-theorem Nat_gt_eq_Mask_gt (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem gt_eq_gt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
     (w₁ > w₂) = (m₁ > m₂) := by
-  grind [Nat_lt_eq_Mask_lt]
+  grind [lt_eq_lt_of_eq_maskOfWidth]
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -27,35 +27,35 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
 /-- LT on the widths translates to the masks. -/
 theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw1w2 : w₁ < w₂) : (m₁ < m₂) := by
+    (hw₁w₂ : w₁ < w₂) : (m₁ < m₂) := by
   subst m₁ m₂
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂, Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
-  exact hw1w2
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
+  exact hw₁w₂
 
 /-- LE on the widths translates to the masks. -/
--- theorem le_eq_le_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
---     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
---     (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
---   subst m₁ m₂
---   rw [eq_iff_iff, BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
---       ← Nat.pow_le_pow_iff_right (a := 2) (by lia)]
---   have := Nat.two_pow_pos w₁
---   have := Nat.two_pow_pos w₂
---   lia
+theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      Nat.sub_le_sub_iff_right (by grind), Nat.pow_le_pow_iff_right (by grind)]
+  exact hw₁w₂
 
--- /-- GE on the widths translates to the masks. -/
--- theorem ge_eq_ge_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
---     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
---     (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
---   grind [le_eq_le_of_eq_maskOfWidth]
+/-- LE on the widths translates to the masks. -/
+theorem ge_eq_ge_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ ≥ w₂) : (m₁ ≥ m₂) := by
+  grind [le_eq_le_of_eq_maskOfWidth]
 
--- /-- GT on the widths translates to the masks. -/
--- theorem gt_eq_gt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
---     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
---     (w₁ > w₂) = (m₁ > m₂) := by
---   grind [lt_eq_lt_of_eq_maskOfWidth]
+/-- LE on the widths translates to the masks. -/
+theorem gt_eq_gt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ > w₂) : (m₁ > m₂) := by
+  grind [lt_eq_lt_of_eq_maskOfWidth]
 
-theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
+theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o}
+    (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
   : maskOfWidth o (w₁ + w₂) = (m₁ + 1#o) * (m₂ + 1#o) - 1#o
   := by

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -63,29 +63,6 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
     cases hmsb : a.msb <;>
       simp [hiv, getLsbD_maskOfWidth, Bool.and_comm]
 
-theorem setWidth_append_eq_mul_maskOfWidth {w o : Nat} (h : w ≤ o) :
-    ∀ {v : Nat} (a : BitVec v) (b : BitVec w), v + w ≤ o →
-      (a ++ b).setWidth o
-        = ((a.setWidth o) * (maskOfWidth o w + 1#o)) ||| b.setWidth o := by
-  intro v a b hvw
-  have hv : v ≤ o := by lia
-  have ha : a.toNat * 2 ^ w < 2 ^ o := by
-    calc a.toNat * 2 ^ w < 2 ^ v * 2 ^ w :=
-          Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
-      _ = 2 ^ (v + w) := (Nat.pow_add 2 v w).symm
-      _ ≤ 2 ^ o := Nat.pow_le_pow_right (by lia) hvw
-  apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_setWidth_of_le hvw, BitVec.toNat_or, BitVec.toNat_append,
-      BitVec.toNat_setWidth_of_le h, BitVec.toNat_mul, BitVec.toNat_add,
-      BitVec.toNat_setWidth_of_le hv, toNat_maskOfWidth h, BitVec.toNat_ofNat]
-  congr 1
-  have h2 : (2 ^ w - 1 + 1 % 2 ^ o) % 2 ^ o = 2 ^ w % 2 ^ o := by
-    rw [Nat.add_mod_mod]
-    congr 1
-    have := Nat.two_pow_pos w
-    lia
-  rw [h2, Nat.mul_mod_mod, Nat.shiftLeft_eq, Nat.mod_eq_of_lt ha]
-
 /-! ### The sign bit: a test against the mask's top bit -/
 
 /-- `a.msb` can be implemented by masking the sign bit,

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -25,38 +25,35 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
 /-! ## Translating conditions on `Nat` widths into conditions on masks -/
 
 /-- LT on the widths translates to the masks. -/
-theorem lt_eq_lt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ < w₂) = (m₁ < m₂) := by
+theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw1w2 : w₁ < w₂) : (m₁ < m₂) := by
   subst m₁ m₂
-  rw [eq_iff_iff, BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
-      ← Nat.pow_lt_pow_iff_right (a := 2) (by lia)]
-  have := Nat.two_pow_pos w₁
-  have := Nat.two_pow_pos w₂
-  lia
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂, Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
+  exact hw1w2
 
 /-- LE on the widths translates to the masks. -/
-theorem le_eq_le_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
-  subst m₁ m₂
-  rw [eq_iff_iff, BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
-      ← Nat.pow_le_pow_iff_right (a := 2) (by lia)]
-  have := Nat.two_pow_pos w₁
-  have := Nat.two_pow_pos w₂
-  lia
+-- theorem le_eq_le_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+--     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+--     (w₁ ≤ w₂) = (m₁ ≤ m₂) := by
+--   subst m₁ m₂
+--   rw [eq_iff_iff, BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+--       ← Nat.pow_le_pow_iff_right (a := 2) (by lia)]
+--   have := Nat.two_pow_pos w₁
+--   have := Nat.two_pow_pos w₂
+--   lia
 
-/-- GE on the widths translates to the masks. -/
-theorem ge_eq_ge_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
-  grind [le_eq_le_of_eq_maskOfWidth]
+-- /-- GE on the widths translates to the masks. -/
+-- theorem ge_eq_ge_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+--     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+--     (w₁ ≥ w₂) = (m₁ ≥ m₂) := by
+--   grind [le_eq_le_of_eq_maskOfWidth]
 
-/-- GT on the widths translates to the masks. -/
-theorem gt_eq_gt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    (w₁ > w₂) = (m₁ > m₂) := by
-  grind [lt_eq_lt_of_eq_maskOfWidth]
+-- /-- GT on the widths translates to the masks. -/
+-- theorem gt_eq_gt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+--     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+--     (w₁ > w₂) = (m₁ > m₂) := by
+--   grind [lt_eq_lt_of_eq_maskOfWidth]
 
 theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -25,9 +25,27 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
 /-- Strict width order becomes strict mask order. -/
 theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ :  w₁ < w₂) : m₁ < m₂ := by
+    (hw₁w₂ : w₁ < w₂) : m₁ < m₂ := by
   subst m₁ m₂
   grind only[maskOfWidth_lt_maskOfWidth]
+
+/-- Inequality on the widths translates to inequality on the masks. -/
+theorem Nat_lt_eq_Mask_lt {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    (w₁ < w₂) = (m₁ < m₂) := by
+  subst m₁ m₂
+  rw [eq_iff_iff]
+  constructor
+  · grind only[maskOfWidth_lt_maskOfWidth]
+  · intro h
+    rw [BitVec.lt_def] at h
+    repeat rw [toNat_maskOfWidth] at h
+    have h_pow1 : (2 ^ w₁ > 0) := by grind
+    have h_pow2 : (2 ^ w₂ > 0) := by grind
+    have h_pows : (2 ^ w₁ < 2 ^ w₂) := by grind
+    exact (Nat.pow_lt_pow_iff_right (a:= 2) (by omega)).mp h_pows
+    · exact h₂
+    · exact h₁
 
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -22,49 +22,7 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
-/-! ## Translating conditions on `Nat` widths into conditions on masks -/
-
-/-- LT on the widths translates to the masks. -/
-theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ < w₂) : (m₁ < m₂) := by
-  subst m₁ m₂
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
-      Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
-  exact hw₁w₂
-
-/-- LE on the widths translates to the masks. -/
-theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by
-  subst m₁ m₂
-  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
-      Nat.sub_le_sub_iff_right (by grind), Nat.pow_le_pow_iff_right (by grind)]
-  exact hw₁w₂
-
-/-- LE on the widths translates to the masks. -/
-theorem ge_eq_ge_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ ≥ w₂) : (m₁ ≥ m₂) := by
-  grind [le_eq_le_of_eq_maskOfWidth]
-
-/-- LE on the widths translates to the masks. -/
-theorem gt_eq_gt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ > w₂) : (m₁ > m₂) := by
-  grind [lt_eq_lt_of_eq_maskOfWidth]
-
-theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o}
-    (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-  : maskOfWidth o (w₁ + w₂) = (m₁ + 1#o) * (m₂ + 1#o) - 1#o
-  := by
-  cases o
-  · simp [hm₁, hm₂, maskOfWidth_zero_eq_zero, h₁, h₂, h₁₂]
-  · rw [hm₁, add_one_maskOfWidth_eq_twoPow h₁, hm₂, add_one_maskOfWidth_eq_twoPow h₂, BitVec.twoPow_mul_twoPow_eq]
-    apply maskOfWidth_eq_twoPow_sub_one h₁₂
-
-/-! # Pushing `setWidth o` towards the leaves — leaves and width changes -/
+/-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 
 theorem setWidth_setWidth {w o : Nat} (h : w ≤ o) :
     ∀ {u : Nat} (a : BitVec u),
@@ -72,6 +30,8 @@ theorem setWidth_setWidth {w o : Nat} (h : w ≤ o) :
   intro u a
   refine setWidth_eq_and_maskOfWidth h ?_
   rw [BitVec.toNat_setWidth, BitVec.toNat_setWidth, Nat.mod_mod_pow_of_le h]
+
+/-! ## Width-sensitive arithmetic: mask the result -/
 
 theorem setWidth_add {w o : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w),

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -58,7 +58,16 @@ theorem gt_eq_gt_of_eq_maskOfWidth (o : Nat) {w₁ w₂ : Nat} {m₁ m₂ : BitV
     (w₁ > w₂) = (m₁ > m₂) := by
   grind [lt_eq_lt_of_eq_maskOfWidth]
 
-/-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
+theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+  : maskOfWidth o (w₁ + w₂) = (m₁ + 1#o) * (m₂ + 1#o) - 1#o
+  := by
+  cases o
+  · simp [hm₁, hm₂, maskOfWidth_zero_eq_zero, h₁, h₂, h₁₂]
+  · rw [hm₁, add_one_maskOfWidth_eq_twoPow h₁, hm₂, add_one_maskOfWidth_eq_twoPow h₂, BitVec.twoPow_mul_twoPow_eq]
+    apply maskOfWidth_eq_twoPow_sub_one h₁₂
+
+/-! # Pushing `setWidth o` towards the leaves — leaves and width changes -/
 
 theorem setWidth_setWidth {w o : Nat} (h : w ≤ o) :
     ∀ {u : Nat} (a : BitVec u),
@@ -96,6 +105,29 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
     rw [BitVec.getLsbD_of_ge a i (by lia)]
     cases hmsb : a.msb <;>
       simp [hiv, getLsbD_maskOfWidth, Bool.and_comm]
+
+theorem setWidth_append_eq_mul_maskOfWidth {w o : Nat} (h : w ≤ o) :
+    ∀ {v : Nat} (a : BitVec v) (b : BitVec w), v + w ≤ o →
+      (a ++ b).setWidth o
+        = ((a.setWidth o) * (maskOfWidth o w + 1#o)) ||| b.setWidth o := by
+  intro v a b hvw
+  have hv : v ≤ o := by lia
+  have ha : a.toNat * 2 ^ w < 2 ^ o := by
+    calc a.toNat * 2 ^ w < 2 ^ v * 2 ^ w :=
+          Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
+      _ = 2 ^ (v + w) := (Nat.pow_add 2 v w).symm
+      _ ≤ 2 ^ o := Nat.pow_le_pow_right (by lia) hvw
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_setWidth_of_le hvw, BitVec.toNat_or, BitVec.toNat_append,
+      BitVec.toNat_setWidth_of_le h, BitVec.toNat_mul, BitVec.toNat_add,
+      BitVec.toNat_setWidth_of_le hv, toNat_maskOfWidth h, BitVec.toNat_ofNat]
+  congr 1
+  have h2 : (2 ^ w - 1 + 1 % 2 ^ o) % 2 ^ o = 2 ^ w % 2 ^ o := by
+    rw [Nat.add_mod_mod]
+    congr 1
+    have := Nat.two_pow_pos w
+    lia
+  rw [h2, Nat.mul_mod_mod, Nat.shiftLeft_eq, Nat.mod_eq_of_lt ha]
 
 /-! ### The sign bit: a test against the mask's top bit -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -15,8 +15,11 @@ namespace Veir.Data.PBV
 public section
 
 
-/-- Introducing `setWidth o` at the root -/
-theorem eq_iff {w : Nat} (o : Nat) (h : w ≤ o) :
+/-- Introducing `setWidth o` at the root.
+`o` must be the first binder, since it should be bound to the concrete width
+being used in the proof..
+ -/
+theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a b : BitVec w), (a = b) = (a.setWidth o = b.setWidth o) := by
   intro a b
   apply propext
@@ -67,7 +70,7 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
 
 /-- `a.msb` can be implemented by masking the sign bit,
 which are definitions the bitblaster can see. -/
-theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero {w : Nat} (o : Nat) (h : w ≤ o) :
+theorem msb_eq_and_signBitOfMask_maskOfWidth_ne_zero (o : Nat) {w : Nat} (h : w ≤ o) :
     ∀ (a : BitVec w),
       a.msb = (((a.setWidth o) &&& signBitOfMask (maskOfWidth o w)) != 0#o) := by
   intro a

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -184,7 +184,7 @@ meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 
 /--
 Translate width precondition into BitVec hypothesis.
-TODO: consider more complicated width exprs.
+TODO: Deal with constants.
 -/
 meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl) :
     MetaM (MVarId) := g.withContext do
@@ -193,15 +193,9 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     if ty == mkConst ``Nat then
       if let some wa := winfos.infos[ea]? then
         if let some wb := winfos.infos[eb]? then
-          -- Apply mask_lt_mask using the known facts of the widths
-          let bvLTExpr := mkAppM ``mask_lt_mask
-            #[.fvar wa.hypWidthLeBoundNote,
-              .fvar wb.hypWidthLeBoundNote,
-              .fvar wa.widthMaskHypFvar,
-              .fvar wb.widthMaskHypFvar,
-              .fvar ldecl.fvarId]
-          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") (← bvLTExpr)
-          logInfo m!"Translated {ldecl.toExpr} : {ldecl.type} to bitvec"
+          let (natLTHyp, g) ← g.withContext do
+            g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") ldecl.toExpr
+          let (#[_], g) ← g.revert #[natLTHyp] | throwError "Reverting shuold produce a single FVar."
           return g
     return g
   | _ => return g
@@ -226,14 +220,18 @@ meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
 
 /--
-These rewrites introduce the toplevel equality that convers `a = b` into
-`a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
+These theorems require pre-filling the width bound in order to be used within
+the Simp set.
 -/
-meta def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
+meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let mut simp := simp
-  simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
-  return simp
+  let thms := #[
+        ``eq_iff,
+        ``Nat_lt_eq_Mask_lt]
+
+  thms.foldlM (init := simp) fun simps name =>
+    return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
+
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -292,7 +290,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let g ← translateWidthPreconds widthInfos g
 
   -- Run simp
-  let thms := ← addToplevelRewrites g ctx
+  let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -53,20 +53,19 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     -- Retrieve the ldecl from the context.
     let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
-
     if !(← Expr.isNat widthExpr) then
       throwError s!"`BitVec` width {← inferType widthExpr} is not a `Nat`"
-
+    -- Apply width_elim
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
-      | throwError "width_elim should generate a goal"
+      | throwError m!"{``width_elim} should generate a goal"
     -- Intros
     let maskName := Name.mkSimple s!"m{name}"
-    let (mask, g) ← g.withContext do g.intro maskName
-    let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+    let (#[mask, maskHyp], g) ← g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
+      | throwError m!"Failed to intro {``width_elim}"
     -- Define bounding conditions.
     let hypWidthLeBound ← g.withContext do
-      mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+      mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -25,7 +25,7 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
   | BitVec w => some w
   | _ => none
 
-/-- An environment that maps width atoms in 'Tm' into its 'Expr' -/
+/-- An environment that maps width atoms in `Tm` into its `Expr` -/
 meta structure TmWidthEnv where
   width2expr : Array Expr := #[]
 
@@ -34,11 +34,14 @@ meta def TmWidthEnv.push (this : TmWidthEnv) (width : Expr) : TmWidthEnv :=
 
 meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
   (← getLCtx).foldrM (init := {}) (fun ldecl (widthEnv : TmWidthEnv ) => do
-      let some width := getBitvecType? ldecl.type | pure widthEnv
-      if let some _ := widthEnv.width2expr.idxOf? width then
+      if let some width := getBitvecType? ldecl.type then
+        let some _ := widthEnv.width2expr.idxOf? width | pure <| widthEnv.push width
         pure widthEnv
       else
-        pure <| widthEnv.push width
+        if Expr.isNat ldecl.type then
+          pure <| widthEnv.push ldecl.toExpr
+        else
+          pure widthEnv
     )
 
 
@@ -412,6 +415,8 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- Construct the width environment
   let widthEnv ← createWidthEnv g
+  for w in widthEnv.width2expr do
+    logInfo m!"wenv : {w}"
   -- Find `BitVec`s and intro their widths
   let (g, widthTms, bvsToRevert) ← visitExprRec g { env := widthEnv } {} (← g.getType)
   -- Introduce the width masks, bounded by the max width

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -160,7 +160,7 @@ from the simp-set. This makes them user-extensible with no metaprogramming neede
 -/
 meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let others := #[``BitVec.setWidth_eq, ``eq_iff, ``setWidth_add, ``setWidth_setWidth]
+  let others := #[``BitVec.setWidth_eq, ``setWidth_add, ``setWidth_setWidth]
   let mut simp := simp
   for n in others do
     simp ← simp.addTheorem (.other n) (mkConst n [])

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -39,17 +39,24 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
+meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
+  let some fvarId := e.fvarId? | return none
+  return (← getLCtx).find? fvarId
+
 meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Retrieve the ldecl from the context.
-    let ldecl ← getFVarLocalDecl widthExpr
+    let ldeclOpt ← localDecl? widthExpr
+    let name := if let some ldecl := ldeclOpt then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
-    assert! ldecl.type == (mkConst ``Nat)
+    if (← inferType widthExpr) != (mkConst ``Nat) then
+      throwError s!"`BitVec` width {widthExpr} is not a `Nat`"
+
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
       | throwError "width_elim should generate a goal"
     -- Intros
-    let maskName := Name.mkSimple s!"m{ldecl.userName}"
+    let maskName := Name.mkSimple s!"m{name}"
     let (mask, g) ← g.withContext do g.intro maskName
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
@@ -58,14 +65,14 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
       mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
-    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{ldecl.userName}_le_bound") hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
     let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_isMask") hypExpr
 
     let info : WidthInfo := {
-      widthName := ldecl.userName,
+      widthName := name,
       widthExpr := widthExpr,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
@@ -349,4 +356,16 @@ public meta def evalPbvDecide : Tactic := fun stx => do
 --   pbv_decide 4
 --   · simp only [eq_iff 4 hw]
 --     bv_decide
+--   · grind
+
+-- TODO: handle addition inside of the mask widths.
+-- example (p q r : Nat) (x : BitVec p)
+--   (hr : q ≤ 8)
+--   (hpq : p < q) :
+--   (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
+--   := by
+--   pbv_decide 8
+--   · bv_decide
+--   · grind
+--   · grind
 --   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -7,6 +7,9 @@ public import Veir.Data.PBV
 open Lean Elab Tactic Meta Simp Std
 namespace Veir.Data.PBV
 
+meta def Expr.isNat (e : Expr) : MetaM Bool := do
+  return (← inferType e).isConstOf ``Nat
+
 /--
 Information about the width variable and associated hypotheses.
 -/
@@ -21,7 +24,9 @@ structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
+  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it.
+      TODO: it's not clear why we need a `FVar` for `simp` to decide to rewrite with it.
+  -/
   hypWidthLeBoundNote : FVarId
 
 
@@ -48,8 +53,9 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     -- Retrieve the ldecl from the context.
     let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
-    if (← inferType widthExpr) != (mkConst ``Nat) then
-      throwError s!"`BitVec` width {widthExpr} is not a `Nat`"
+
+    if !(← Expr.isNat widthExpr) then
+      throwError s!"`BitVec` width {← inferType widthExpr} is not a `Nat`"
 
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
@@ -60,7 +66,6 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
     let hypWidthLeBound ← g.withContext do
-      -- Add a meaninful name using : (userName := Name.mkSimple "foo")
       mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
@@ -219,7 +224,7 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     let some wa ← winfos.get? ea | return g
     let some wb ← winfos.get? eb | return g
     let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
-    let (#[_], g) ← g.revert #[natHyp] | throwError "Reverting shuold produce a single FVar."
+    let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
     return g
   else
     return g
@@ -250,10 +255,10 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
-        ``Nat_lt_eq_Mask_lt,
-        ``Nat_le_eq_Mask_le,
-        ``Nat_ge_eq_Mask_ge,
-        ``Nat_gt_eq_Mask_gt,
+        ``lt_eq_lt_of_eq_maskOfWidth,
+        ``le_eq_le_of_eq_maskOfWidth,
+        ``ge_eq_ge_of_eq_maskOfWidth,
+        ``gt_eq_gt_of_eq_maskOfWidth,
         ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
   ]
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -25,7 +25,9 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
   | BitVec w => some w
   | _ => none
 
-/-- An environment that maps width atoms in `Tm` into its `Expr` -/
+/--
+An environment that maps width atoms in `Tm` into its `Expr`
+-/
 meta structure TmWidthEnv where
   width2expr : Array Expr := #[]
 
@@ -38,7 +40,7 @@ expressions. These are either width `Expr`s coming from `BitVec w` or
 `Nat` variables in the local context.
 -/
 meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
-  (← getLCtx).foldrM (init := {}) (fun ldecl (widthEnv : TmWidthEnv ) => do
+  (← getLCtx).foldrM (init := {}) fun ldecl (widthEnv : TmWidthEnv ) => do
       if let some width := getBitvecType? ldecl.type then
         let some _ := widthEnv.width2expr.idxOf? width | pure <| widthEnv.push width
         pure widthEnv
@@ -47,7 +49,6 @@ meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
           pure <| widthEnv.push ldecl.toExpr
         else
           pure widthEnv
-    )
 
 /--
 Type to capture the expressions this tactic will handle.
@@ -152,6 +153,8 @@ structure WidthInfo where
   /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
   hypWidthLeBoundNote : FVarId
 
+meta def WidthInfo.name (this : WidthInfo) : Name :=
+  this.widthTm.toName
 
 structure WidthInfos where
   /-- One WidthInfo per width -/
@@ -324,7 +327,7 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
   if let some (ea, eb) := matchWidthRel ldecl.type then
     let some wa ← winfos.getFromExpr? ea | return g
     let some wb ← winfos.getFromExpr? eb | return g
-    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
+    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.name}_{wb.name}") ldecl.toExpr
     let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
     return g
   else

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -349,7 +349,6 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
       ``BitVec.setWidth_eq,
       ``setWidth_add,
       ``setWidth_setWidth,
-      ``setWidth_append_eq_mul_maskOfWidth
   ]
 
   let mut simp := simp

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -98,8 +98,6 @@ meta structure BitVecInfos where
 meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
-
-
 /--
 Match on an expression, and if it is a `BitVec w`, return the `w`.
 Otherwise, return `none`.
@@ -310,37 +308,6 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
-
-
-/-- Manual trace of the future tactic, transforming an unbounded parametric width
-    statement into a bounded one and solving it up to the bound (4 in this case) -/
-theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
--- Step 1: Bound widths to the provided blast width (redundant in this case)
-  have w_le_bw :  w ≤ 4 := by grind
--- Step 2-3: Introduce mask to replace `w` Nat var
-  apply width_elim 4 w
-  intro mw h_mw
--- Step 4: Eliminate the parametric bv var of width `w`
---         enforcing width constraint with mask
-  revert x
-  apply var_elim 4 w w_le_bw
-  intro x h_xmw
-  revert y
-  apply var_elim 4 w w_le_bw
-  intro y h_ymw
--- Step 5: Convert width hypothesis to mask hypothesis
-  have mw_mask := isMask_of_eq_maskOfWidth h_mw
--- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [
-      eq_iff _ w_le_bw,             -- Introduce `setWidth` to goal
-      setWidth_add,       -- Push `setWidth` down add
-      setWidth_setWidth,  -- Push `setWidth` down setWidth
-      BitVec.setWidth_eq,         -- Remove redundant setWidths
-      w_le_bw]                     -- Replace mask with nat with bv constraint
-      at h_xmw h_ymw ⊢
--- Step 8: Bitblast!
-  bv_decide
 
 example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -56,7 +56,6 @@ Only capture `width` at the moment.
 -/
 inductive TmKind
 | width
-| prop
 
 /--
 Inductive data structure to express the Terms that this tactic reasons about.
@@ -64,10 +63,6 @@ Inductive data structure to express the Terms that this tactic reasons about.
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
 | widthAdd (v w : Tm .width) : Tm .width
-| widthLT (v m : Tm .width) : Tm .prop
-| widthLE (v m : Tm .width) : Tm .prop
-| widthGT (v m : Tm .width) : Tm .prop
-| widthGE (v m : Tm .width) : Tm .prop
 
 /--
 Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
@@ -86,26 +81,6 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
         let some b ← Tm.reifyWidth env be | pure none
         pure (some (.widthAdd a b))
     | _ => pure none
-
-/--
-Match width relation.
--/
-meta def matchWidthRel (e : Expr) :
-    Option ((Tm TmKind.width → Tm TmKind.width → Tm TmKind.prop) × Expr × Expr) :=
-  match_expr e with
-  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLT, ea, eb) else none
-  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLE, ea, eb) else none
-  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGT, ea, eb) else none
-  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGE, ea, eb) else none
-  | _ => none
-
-meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
-  if let some (rel, ea, eb) := matchWidthRel e then
-    let some wa ← Tm.reifyWidth env ea | pure none
-    let some wb ← Tm.reifyWidth env eb | pure none
-    pure <| some (rel wa wb)
-  else
-    pure none
 
 /--
 Convert a `Tm` into an `Expr` provided and environment.
@@ -335,49 +310,6 @@ meta partial def visitExprRec (g : MVarId)
   else
     return (g, widthTms, bvs)
 
-/--
-Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
--/
-meta def getThmFromTm (term : Tm .prop) : Option (Name × Tm .width × Tm .width) :=
-  match term with
-  | .widthLT v w => (``lt_eq_lt_of_eq_maskOfWidth, v, w)
-  | .widthLE v w => (``le_eq_le_of_eq_maskOfWidth, v, w)
-  | .widthGT v w => (``gt_eq_gt_of_eq_maskOfWidth, v, w)
-  | .widthGE v w => (``ge_eq_ge_of_eq_maskOfWidth, v, w)
-  | _ => none
-
-/--
-If a condition on the width hypothesis is found, and the widths are contained
-within the `WidthInfos` set, then convert into a statement about the width masks.
--/
-meta def translateWidthPrecond (widthInfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
-    : MetaM (MVarId) := g.withContext do
-  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return g
-  let some (thm, v, w) := getThmFromTm prop | return g
-  let some vInfo := widthInfos.getFromTm? v |
-    logInfo m!"Skipping width condition transformation, term {v.toExpr widthInfos.env} is not a mask."
-    return g
-  let some wInfo := widthInfos.getFromTm? w |
-    logInfo m!"Skipping width condition transformation, term {w.toExpr widthInfos.env} is not a mask."
-    return g
-  let (_, g) ← g.withContext
-    <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
-    <| ← mkAppM thm <| #[
-        vInfo.hypWidthLeBoundNote,
-        wInfo.hypWidthLeBoundNote,
-        vInfo.widthMaskHypFvar,
-        wInfo.widthMaskHypFvar,
-        ldecl.fvarId,
-        ].map mkFVar
-  return g
-
-/--
-Traverse the local context and add any width pre-conditions to the goal.
--/
-meta def translateWidthPreconds (winfos: WidthInfos)
-    (g : MVarId) : MetaM MVarId := g.withContext do
-  (← getLCtx).foldlM (translateWidthPrecond winfos) g
-
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
@@ -402,10 +334,7 @@ the Simp set.
 meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
   (widthTms : WidthTms) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let thms := #[
-        ``eq_iff,
-        ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
-  ]
+  let thms := #[``eq_iff]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name)
@@ -420,8 +349,6 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
       ``BitVec.setWidth_eq,
       ``setWidth_add,
       ``setWidth_setWidth,
-      ``signBitOfMask_eq,
-      ``setWidth_signExtend_eq_and_maskOfWidth,
       ``setWidth_append_eq_mul_maskOfWidth
   ]
 
@@ -472,8 +399,6 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
-  -- Find preconditions on the width `FVar`s
-  let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -27,22 +27,29 @@ inductive Tm : TmKind → Type
 -- Might have a problem reifying "atom" widths which are composite eg: BitVec (w + 1 - 1)
 -- TODO fixable by first traversing the BitVec definitions to obtain the atoms, and then look
 -- them up while reifying
-meta partial def Tm.reifyWidth (e : Expr) : Option (Tm .width) :=
+meta partial def Tm.reifyWidth (e : Expr) : MetaM (Option (Tm .width)) := do
   match_expr e with
-  | HAdd.hAdd Nat _Nat _Nat _instHAdd ae be =>
-    if let some a := Tm.reifyWidth ae then
-      if let some b := Tm.reifyWidth be then
-        some (.widthAdd a b)
-      else none
-    else none
+  | HAdd.hAdd ty _ _ _ ae be =>
+    if (← Expr.isNat ty) then
+      if let some a ← Tm.reifyWidth ae then
+        if let some b ← Tm.reifyWidth be then
+          pure (some (.widthAdd a b))
+        else pure none
+      else pure none
+    else pure none
   | _ =>
     match e with
-    | .fvar _ => some (.widthAtom (e))
-    | _ => none
+    | .fvar _ => pure (some (.widthAtom (e)))
+    | _ => pure none
 
 meta def Tm.toExpr : Tm .width → Expr
   | .widthAtom e => e
   | .widthAdd v w => mkNatAdd v.toExpr w.toExpr
+
+meta def Tm.toName (tm: Tm .width) (g : MVarId) : MetaM Name := g.withContext do
+  match tm with
+  | .widthAtom e => pure <| Name.mkSimple s!"{← e.fvarId!.getUserName}"
+  | .widthAdd v w => pure <| Name.mkSimple s!"{← v.toName g}_add_{← w.toName g}"
 
 /-- Computes the upper bound of widths needed to calculate this width without overflowing.
 That maximum such, across all widths, will be used to get the universal upper bound. -/
@@ -68,7 +75,7 @@ Either get existing width term, or try and reify one if it does not exist.
 -/
 meta def WidthTms.getOrCreateTm
     (g : MVarId) (this : WidthTms) (wExpr : Expr) : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
-  let some reified := Tm.reifyWidth wExpr | throwError m!"Failed to reify width expr: {wExpr}"
+  let some reified ← Tm.reifyWidth wExpr | throwError m!"Failed to reify width expr: {wExpr}"
   if let some info := this.terms[reified.toExpr]? then -- use reified.toExpr as a kind of "normal"/"canonical" form
     return (g, info, this)
   else
@@ -116,10 +123,7 @@ meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
 
 meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfos) := g.withContext do
-    -- Retrieve the ldecl from the context.
-    -- let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
-    -- let name := widthTm.term.getName
-    let name := Name.mkSimple "test"
+    let name ← widthTm.term.toName g
     -- Apply width_elim
     let [g] ← g.withContext do
       g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.term.toExpr, ← g.getType]
@@ -252,7 +256,8 @@ meta partial def visitExprRec (g : MVarId)
   if e.isApp then
     let (f, args) := (e.getAppFn, e.getAppArgs)
     let (g, widthTms, bvs) ← g.withContext do
-      args.foldlM (init := (g, widthTms, bvs)) fun (g, widthTms, bvs) arg => g.withContext do visitExprRec g widthTms bvs arg
+      args.foldlM (init := (g, widthTms, bvs)) fun (g, widthTms, bvs) arg =>
+      g.withContext do visitExprRec g widthTms bvs arg
     visitExprRec g widthTms bvs f
   else
     return (g, widthTms, bvs)
@@ -311,10 +316,7 @@ meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (List MVarId × BitVecInfos) := do
   bvs.bvs.foldM (init := ([g], {})) fun (gs, bvInfos) bvFvarId widthTm => do
     let g :: other := gs | throwError m!"{gs} should always have at least one element"
-    logInfo g
     let (g', bvInfos) ← introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthTm
-    for o in g' do
-      logInfo o
     return (g' ++ other, bvInfos)
 /--
 These theorems require pre-filling the width bound in order to be used within
@@ -387,26 +389,22 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- Find `BitVec`s and intro their widths
   let (g, widthTms, bvsToRevert) ← visitExprRec g {} {} (← g.getType)
-  for (w, term) in widthTms.terms do
-    logInfo m!"{w}, {term.term.toExpr}"
-
   -- Introduce the width masks, bounded by the max width
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
 
   -- Intro the `BitVec`s
-  let (gs, _bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  let (gs, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   let g :: secondaryGoals := gs | throwError "should have more than one"
   -- Find preconditions on the width `FVar`s
-  -- let g ← translateWidthPreconds widthInfos g
+  let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
-          --  <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
+           <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
   -- Run simp
   let g ← applySimp g thms
   -- -- Return modified goal and subgoals
-  -- return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
   return g :: secondaryGoals ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -69,8 +69,8 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) 
 /--
 Either get existing width info, or create one if it does not exist.
 -/
-meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
-    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := do
+def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
+    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
   if let some info := this.infos[wExpr]? then
     return (g, info, this)
   else
@@ -111,35 +111,42 @@ def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-meta def introBitvecVar (ctx : PbvTranslateContext) (widthInfos : WidthInfos) (g : MVarId)
-      (bvInfos : BitVecInfos) (ldecl : LocalDecl) :
-      MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
-  unless ldecl.isImplementationDetail do
-    -- Find the BitVec {width_expr} variables.
-    if let some wExpr := getBitvecType? ldecl.type then
-      let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
-      -- Revert to expose forall with the BitVec.
-      let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
-      -- Apply ``var_elim
-      let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-          #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
-        | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
-      -- Intros
-      let name ← oldVar.getUserName
-      let (bvVar, g) ← g.intro name
-      let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
-      return (g, widthInfos, bvInfos.push { bvVar, bvHyp })
-  return (g, widthInfos, bvInfos)
+def introBitvecFVarChecked (ctx : PbvTranslateContext) (g : MVarId)
+      (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
+      MetaM (MVarId × BitVecInfos) := g.withContext do
+  -- Find the BitVec {width_expr} variables.
+    -- Revert to expose forall with the BitVec.
+  let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError "reverting shuold produce a var"
+  -- Apply ``var_elim
+  let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
+      #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
+    | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
+  -- Intros
+  let name ← oldVar.getUserName
+  let (bvVar, g) ← g.intro name
+  let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
+  return (g, bvInfos.push { bvVar, bvHyp })
+
 
 /--
-Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
-hypotheses.
+boo lean is stupid, it can't see that this will terminate.
 -/
-meta def introBitvecVars (ctx : PbvTranslateContext) (g : MVarId) :
-    MetaM (MVarId × WidthInfos × BitVecInfos) := do
-  let decls : LocalContext ← g.withContext getLCtx
-  decls.foldlM (init := (g, {}, {})) fun (g, widthInfos, bvInfos) ldecl =>
-    introBitvecVar ctx widthInfos g bvInfos ldecl
+partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId) (widthInfos : WidthInfos) (bvInfos : BitVecInfos) (e : Expr) :
+    MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
+  let (f, args) := (e.getAppFn, e.getAppArgs)
+  let (g, widthInfos, bvInfos) ← g.withContext do
+    args.foldlM (init := (g, widthInfos, bvInfos)) fun (g, widthInfos, bvInfos) arg => visitExpr ctx g widthInfos bvInfos arg
+  let tf ← inferType f
+  if let some wExpr := getBitvecType? tf then
+    let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
+    if let some fvarId := f.fvarId? then
+      let (g, bvInfos) ← introBitvecFVarChecked ctx g bvInfos fvarId widthInfo
+      return (g, widthInfos, bvInfos)
+    else
+      return (g, widthInfos, bvInfos)
+  else
+    return (g, widthInfos, bvInfos)
+
 
 
 /--
@@ -200,7 +207,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, widthInfos, bvInfos) ← introBitvecVars ctx g
+  let (g, widthInfos, bvInfos) ← visitExpr ctx g {} {} (← g.getType)
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
@@ -269,4 +276,13 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
+  · grind
+
+set_option trace.Meta.Tactic.simp.all true
+set_option trace.Meta.Tactic.simp true
+example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
+  x + y = y + x := by
+  pbv_decide 4
+  · bv_decide
+  · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -62,7 +62,6 @@ Inductive data structure to express the Terms that this tactic reasons about.
 -/
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
-| widthAdd (v w : Tm .width) : Tm .width
 
 /--
 Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
@@ -74,13 +73,7 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
     -- An atom is an expression is present in the Env
     pure <| some (.widthAtom id)
   else
-    match_expr e with
-    | HAdd.hAdd ty _ _ _ ae be =>
-        let .true := Expr.isNat ty | pure none
-        let some a ← Tm.reifyWidth env ae | pure none
-        let some b ← Tm.reifyWidth env be | pure none
-        pure (some (.widthAdd a b))
-    | _ => pure none
+    pure none
 
 /--
 Convert a `Tm` into an `Expr` provided and environment.
@@ -88,7 +81,6 @@ Convert a `Tm` into an `Expr` provided and environment.
 meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
   match this with
   | .widthAtom id => env.width2expr[id]!
-  | .widthAdd v w => mkNatAdd (v.toExpr env) (w.toExpr env)
 
 /--
 Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
@@ -96,16 +88,6 @@ Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable
 meta def Tm.toName (tm: Tm .width) : Name :=
   match tm with
   | .widthAtom e => Name.mkSimple s!"w{e}"
-  | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
-
-/--
-Compute the upper bound of widths needed to calculate this width without overflowing.
-The maximum, across all widths, will be used to get the universal upper bound.
--/
-meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
-  match tm with
-  | .widthAtom _ => ctx.bmcBound
-  | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
 
 structure WidthTm where
   term : Tm .width
@@ -129,13 +111,6 @@ meta def WidthTms.getOrCreateTm (g : MVarId) (this : WidthTms) (wExpr : Expr)
   else
     let widthTm := { term := reified }
     return (g, widthTm, this.push widthTm)
-
-
-/-- Get the maximum width needed for blasting across all widths. -/
-meta def WidthTms.getUniverseWidthUpperBound (ctx : PbvTranslateContext)
-    (winfos : WidthTms) : Nat :=
-  winfos.terms.fold (fun val _e wTm =>
-    val.max (wTm.term.getUniverseWidthUpperBound ctx)) 1
 
 /--
 Information about the width variable and associated hypotheses.
@@ -313,11 +288,9 @@ meta partial def visitExprRec (g : MVarId)
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
-  -- Compute max width
-  let maxWidth := widthTms.getUniverseWidthUpperBound ctx
   -- Intro all the masks
   widthTms.terms.foldM (init := (g, { env := widthTms.env })) (fun (g, widthInfos) _ widthTm =>
-    introMaskWidth maxWidth g widthTm widthInfos
+    introMaskWidth ctx.bmcBound g widthTm widthInfos
   )
 
 /--
@@ -332,13 +305,12 @@ These theorems require pre-filling the width bound in order to be used within
 the Simp set.
 -/
 meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
-  (widthTms : WidthTms) (simp : SimpTheoremsArray) :
-    MetaM SimpTheoremsArray := g.withContext do
+  (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let thms := #[``eq_iff]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name)
-      <| ← mkAppM name #[mkNatLit <| widthTms.getUniverseWidthUpperBound ctx]
+      <| ← mkAppM name #[mkNatLit <| ctx.bmcBound]
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -399,7 +371,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Create simp set
-  let thms := ← addBoundRewrites g ctx widthTms
+  let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -10,6 +10,33 @@ namespace Veir.Data.PBV
 meta def Expr.isNat (e : Expr) : MetaM Bool := do
   return (← inferType e).isConstOf ``Nat
 
+inductive TmKind
+| width
+
+inductive Tm : TmKind → Type
+| widthAtom (e : Expr) : Tm .width
+| widthAdd (v w : Tm .width) : Tm .width
+
+-- Might have a problem reifying "atom" widths which are composite eg: BitVec (w + 1 - 1)
+-- TODO fixable by first traversing the BitVec definitions to obtain the atoms, and then look
+-- them up while reifying
+meta partial def Tm.reifyWidth (e : Expr) : Option (Tm .width) :=
+  match_expr e with
+  | Nat.add ae be =>
+    if let some a := Tm.reifyWidth ae then
+      if let some b := Tm.reifyWidth be then
+        some (.widthAdd a b)
+      else none
+    else none
+  | _ =>
+    match e with
+    | .fvar _ => some (.widthAtom (e))
+    | _ => none
+
+meta def Tm.toExpr : Tm .width → Expr
+  | .widthAtom e => e
+  | .widthAdd v w => mkNatAdd v.toExpr w.toExpr
+
 /--
 Information about the width variable and associated hypotheses.
 -/
@@ -17,7 +44,7 @@ structure WidthInfo where
   /-- The Name correspodning to this width. -/
   widthName : Name
   /-- The Expr corresponding to this width. -/
-  widthExpr : Expr
+  widthExpr : Tm .width
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
@@ -35,7 +62,7 @@ structure WidthInfos where
     infos : HashMap Expr WidthInfo := {}
 
 meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-  { infos := this.infos.insert info.widthExpr info }
+{ infos := this.infos.insert (info.widthExpr.toExpr) info }
 
 /--
 Read-only configuration for the tactic.
@@ -43,6 +70,20 @@ Read-only configuration for the tactic.
 meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
+
+/-- Computes the upper bound of widths needed to calculate this width without overflowing.
+That maximum such, across all widths, will be used to get the universal upper bound. -/
+meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
+  match tm with
+  | .widthAtom _ => ctx.bmcBound
+  | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
+
+/-- Get the maximum width needed for blasting across all widths. -/
+meta def WidthInfos.getUniverseWidthUpperBound (ctx : PbvTranslateContext)
+    (winfos : WidthInfos) : Nat :=
+  winfos.infos.fold (fun val _e winfo =>
+        val.max (winfo.widthExpr.getUniverseWidthUpperBound ctx)) 1
+
 
 meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
   let some fvarId := e.fvarId? | return none
@@ -63,7 +104,7 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let maskName := Name.mkSimple s!"m{name}"
     let (#[mask, maskHyp], g) ← g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
       | throwError m!"Failed to intro {``width_elim}"
-    -- Define bounding conditions.
+  -- Define bounding conditions.
     let hypWidthLeBound ← g.withContext do
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
@@ -74,9 +115,11 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let hypExpr ← g.withContext do mkAppM ``maskOfWidth_and_add_one_eq_zero #[mkFVar maskHyp]
     let (_, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_bv_mask") hypExpr
 
+    let some term := Tm.reifyWidth widthExpr | throwError m!"Failed to reify width expression: {widthExpr}"
+
     let info : WidthInfo := {
       widthName := name,
-      widthExpr := widthExpr,
+      widthExpr := term,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
       hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
@@ -143,7 +186,7 @@ meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
   let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError "reverting shuold produce a var"
   -- Apply ``var_elim
   let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-      #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
+      #[mkNatLit ctx.bmcBound, widthInfo.widthExpr.toExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
   -- Intros
   let name ← oldVar.getUserName

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -211,8 +211,6 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
     }
     return (g, infos.push info)
 
-
-
 /--
 Pair of local facts about the converted `BitVec` variables.
 -/
@@ -231,8 +229,6 @@ meta structure BitVecInfos where
 
 meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
-
-
 
 /--
 Analyze a single bitvector FVarId, and try to introduce it as a `BitVec`

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -46,8 +46,7 @@ meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
 meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Retrieve the ldecl from the context.
-    let ldeclOpt ← localDecl? widthExpr
-    let name := if let some ldecl := ldeclOpt then ldecl.userName else (Name.mkSimple "widthVar")
+    let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
     -- Check that the Expr is of type Nat.
     if (← inferType widthExpr) != (mkConst ``Nat) then
       throwError s!"`BitVec` width {widthExpr} is not a `Nat`"

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -1,17 +1,17 @@
 module
 
 public meta import Lean
+public meta import Std
 public import Veir.Data.PBV
 
-open Lean Elab Tactic Meta Simp
+open Lean Elab Tactic Meta Simp Std
 namespace Veir.Data.PBV
 
 /--
 Information about the width variable and associated hypotheses.
 -/
-meta structure WidthInfo where
-  /-- The LocalDecl corresponding to this width variable. -/
-  widthNatLocalDecl : LocalDecl
+structure WidthInfo where
+  widthExpr : Expr
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
@@ -19,20 +19,15 @@ meta structure WidthInfo where
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
   /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
-  hypWidthLeBoundNoteNote : FVarId
+  hypWidthLeBoundNote : FVarId
 
-meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
-  info.widthNatLocalDecl.fvarId
-
-meta def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
-  .fvar info.widthFvarId
 
 structure WidthInfos where
     /-- One WidthInfo per width -/
-    infos : Array WidthInfo := #[]
+    infos : HashMap Expr WidthInfo := {}
 
 def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-  { infos := this.infos.push info }
+  { infos := this.infos.insert info.widthExpr info }
 
 /--
 Read-only configuration for the tactic.
@@ -41,45 +36,45 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : LocalDecl) (infos : WidthInfos)
-  : MetaM (MVarId × WidthInfos) := g.withContext do
-    unless ldecl.isImplementationDetail do
-        if ← isDefEq ldecl.type (mkConst ``Nat) then
-        -- Apply ``width_elim
-        let [g] ← g.withContext do
-          g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
-          | throwError "width_elim should generate a goal"
-        -- Intros
-        let maskName := Name.mkSimple s!"m{ldecl.userName}"
-        let (mask, g) ← g.withContext do g.intro maskName
-        let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
-        -- Define bounding conditions.
-        let hypWidthLeBound <- g.withContext do
-          mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
-            #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
-        g.withContext <| check hypWidthLeBound
-        let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
-        g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
-        -- Assert the BitVec mask constraint.
-        let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-        let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
-        let info : WidthInfo := {
-          widthNatLocalDecl := ldecl,
-          widthMaskFvar := mask,
-          widthMaskHypFvar := maskHyp
-          hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
-          hypWidthLeBoundNoteNote
-        }
-        return (g, infos.push info)
-    return (g, infos)
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
+    -- TODO: check that the value has Nat.
+    let [g] ← g.withContext do
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl, ← g.getType]
+      | throwError "width_elim should generate a goal"
+    -- Intros
+    let maskName := Name.mkSimple s!"maskWidth_new_var" -- TODO: find the name if it's an Fvar, and otherwise abstract it into a new name.
+    let (mask, g) ← g.withContext do g.intro maskName
+    let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+    -- Define bounding conditions.
+    let hypWidthLeBound <- g.withContext do
+      mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+        #[mkConst ``Nat, mkConst ``instLENat, ldecl, mkNatLit ctx.bmcBound])
+    g.withContext <| check hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+    g.withContext <| check (mkFVar hypWidthLeBoundNote)
+    -- Assert the BitVec mask constraint.
+    let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
+    let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    let info : WidthInfo := {
+      widthExpr := ldecl,
+      widthMaskFvar := mask,
+      widthMaskHypFvar := maskHyp
+      hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
+      hypWidthLeBoundNote
+    }
+    return (g, info, infos.push info)
+    -- return (g, infos)
 
-
-/-- Find the local declaration of the (single) width variable,
-and eliminate it, producing the mask variable, and the masking constraint.
+/--
+Either get existing width info, or create one if it does not exist.
 -/
-meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
-  (← getLCtx).foldrM (init := (g, {})) fun ldecl (g, infos) =>
-    introMaskWidth ctx g ldecl infos
+meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
+    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := do
+  if let some info := this.infos[wExpr]? then
+    return (g, info, this)
+  else
+    introMaskWidth ctx g wExpr this
 
 
 /--
@@ -101,47 +96,61 @@ meta structure BitVecInfos where
 meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
+
+
+/--
+Match on an expression, and if it is a `BitVec w`, return the `w`.
+Otherwise, return `none`.
+-/
+def getBitvecType? (e : Expr) : Option Expr :=
+  match_expr e with
+  | BitVec w => some w
+  | _ => none
+
 /--
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarId)
-      (infos : BitVecInfos) (ldecl : LocalDecl) :
-      MetaM (MVarId × BitVecInfos) := g.withContext do
+meta def introBitvecVar (ctx : PbvTranslateContext) (widthInfos : WidthInfos) (g : MVarId)
+      (bvInfos : BitVecInfos) (ldecl : LocalDecl) :
+      MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
   unless ldecl.isImplementationDetail do
     -- Find the BitVec {width_expr} variables.
-    if Expr.equal ldecl.type (mkApp (mkConst ``BitVec) widthInfo.widthFvar) then
+    if let some wExpr := getBitvecType? ldecl.type then
+      let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
       -- Revert to expose forall with the BitVec.
       let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
       -- Apply ``var_elim
       let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBoundMVarId]
+          #[mkNatLit ctx.bmcBound, widthInfo.widthExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
         | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
       -- Intros
       let name ← oldVar.getUserName
       let (bvVar, g) ← g.intro name
       let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
-      return (g, infos.push { bvVar, bvHyp})
-  return (g, infos)
+      return (g, widthInfos, bvInfos.push { bvVar, bvHyp })
+  return (g, widthInfos, bvInfos)
 
 /--
 Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
 hypotheses.
 -/
-meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) :
-    MetaM (MVarId × BitVecInfos) := do
+meta def introBitvecVars (ctx : PbvTranslateContext) (g : MVarId) :
+    MetaM (MVarId × WidthInfos × BitVecInfos) := do
   let decls : LocalContext ← g.withContext getLCtx
-  decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
-    introVar ctx widthInfo g infos ldecl
+  decls.foldlM (init := (g, {}, {})) fun (g, widthInfos, bvInfos) ldecl =>
+    introBitvecVar ctx widthInfos g bvInfos ldecl
 
 
 /--
 These rewrites introduce the toplevel equality that convers `a = b` into
 `a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-meta def addToplevelRewrites (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) :
+meta def addToplevelRewrites (g : MVarId) (widthInfos : WidthInfos) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBoundMVarId])
+  let mut simp := simp
+  for (_widthExpr, widthInfo) in widthInfos.infos do
+    simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkFVar widthInfo.hypWidthLeBoundNote])
   return simp
 
 /--
@@ -170,11 +179,12 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
 /--
 Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
 -/
-meta def addWidthInfo (g : MVarId) (info : WidthInfo)
+meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
-  simp ← simp.addTheorem (.other info.hypWidthLeBoundMVarId.name)
-       (mkFVar info.hypWidthLeBoundNoteNote)
+  for (_wexpr, widthInfo) in widthInfos.infos do
+    simp ← simp.addTheorem (.other widthInfo.hypWidthLeBoundNote.name)
+        (mkFVar widthInfo.hypWidthLeBoundNote)
   return simp
 
 /--
@@ -188,17 +198,17 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
-  let (g, widthInfos) ← introMaskWidths ctx g
+  -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, bvInfos) ← introVars ctx g widthInfos
+  let (g, widthInfos, bvInfos) ← introBitvecVars ctx g
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
-                      <| ← addWidthInfo g widthInfos #[]
+                      <| ← addWidthInfosSimpLemmas g widthInfos #[]
   let g ← applySimp g thms
 
-  return [g, widthInfo.hypWidthLeBoundMVarId]
+  return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
 
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -239,24 +239,24 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
         ``Nat_lt_eq_Mask_lt,
         ``Nat_le_eq_Mask_le,
         ``Nat_ge_eq_Mask_ge,
-        ``Nat_gt_eq_Mask_gt
+        ``Nat_gt_eq_Mask_gt,
+        ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
   ]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
 
-
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
-TODO: make this a simp-set, called `pbv_push`, and just gather these
-from the simp-set. This makes them user-extensible with no metaprogramming needed.
 -/
 meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let others := #[
       ``BitVec.setWidth_eq,
       ``setWidth_add,
-      ``setWidth_setWidth
+      ``setWidth_setWidth,
+      ``signBitOfMask_eq,
+      ``setWidth_signExtend_eq_and_maskOfWidth
   ]
 
   let mut simp := simp
@@ -297,24 +297,22 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
   return g
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
-  -- throwError s!"Deciding with bound {ctx.bmcBound}"
-  -- let (g, widthInfos) ← introMaskWidths ctx g
-  -- Introduce bitvector variables
+  -- Find `BitVec`s and intro their widths
   let (g, widthInfos, bvsToRevert) ← visitExprRec ctx g {} {} (← g.getType)
-  for (w, _winfo) in widthInfos.infos do
-    g.withContext do logInfo m!"width: '{w}'"
-
+  -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
-
-  -- Run simp
+  -- Create simp Set
+  -- TODO: make this a simp-set, called `pbv_push`, and just gather these
+  -- from the simp-set. This makes them user-extensible with no metaprogramming needed.
   let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
-
+  -- Run simp
   let g ← applySimp g thms
-
+  -- Return modified goal and subgoals
   return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
 /--

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -80,10 +80,18 @@ Either get existing width info, or create one if it does not exist.
 -/
 meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
     (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-  if let some info := this.infos[wExpr]? then
+  let reducedWExpr ← whnf wExpr
+  if let some info := this.infos[reducedWExpr]? then
     return (g, info, this)
   else
-    introMaskWidth ctx g wExpr this
+    introMaskWidth ctx g reducedWExpr this
+
+/--
+Get some width Expr from infos.
+-/
+meta def WidthInfos.get? (this: WidthInfos) (wExpr : Expr)
+    : MetaM (Option WidthInfo) := do
+  return this.infos[← whnf wExpr]?
 
 
 /--
@@ -202,8 +210,8 @@ goal. This allows for a single call to Simp later.
 meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId) := g.withContext do
   if let some (ea, eb) := matchWidthRel ldecl.type then
-    let some wa := winfos.infos[ea]? | return g
-    let some wb := winfos.infos[eb]? | return g
+    let some wa ← winfos.get? ea | return g
+    let some wb ← winfos.get? eb | return g
     let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
     let (#[_], g) ← g.revert #[natHyp] | throwError "Reverting shuold produce a single FVar."
     return g
@@ -335,46 +343,10 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
 
-example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
-  x + y = y + x := by
-  pbv_decide 4
-  · bv_decide
-  · grind
-
-theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-
-theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
-  (hr : t <= 8)
-  (hqr : q ≤ r)
-  (hpq : q > p)
-  (hrt : t ≥ r):
-  ((x.zeroExtend q).zeroExtend r).zeroExtend t = x.zeroExtend t
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
-  · grind
-
-theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).signExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind
+-- TODO: get the following working by also instantiating the provided width bound
+-- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
+--   x + y = y + x := by
+--   pbv_decide 4
+--   · simp only [eq_iff 4 hw]
+--     bv_decide
+--   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -17,9 +17,9 @@ meta structure WidthInfo where
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
-  hypWidthLeBound : MVarId
+  hypWidthLeBoundMVarId : MVarId
   /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
-  hypWidthLeBoundNoteHACK : FVarId
+  hypWidthLeBoundNoteNote : FVarId
 
 meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
   info.widthNatLocalDecl.fvarId
@@ -55,8 +55,8 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
             mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
               #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
           g.withContext <| check hypWidthLeBound
-          let (hypWidthLeBoundNoteHACK, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
-          g.withContext <| check (mkFVar hypWidthLeBoundNoteHACK)
+          let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+          g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
           -- Assert the BitVec mask constraint.
           let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
           let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
@@ -64,8 +64,8 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
             widthNatLocalDecl := ldecl,
             widthMaskFvar := mask,
             widthMaskHypFvar := maskHyp
-            hypWidthLeBound := hypWidthLeBound.mvarId!,
-            hypWidthLeBoundNoteHACK
+            hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
+            hypWidthLeBoundNoteNote
           }
           return (g, info)
     throwError "unable to find a valid width variable."
@@ -103,7 +103,7 @@ meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarI
       let (#[oldVar], g) ← g.revert #[ldecl.fvarId] | throwError "reverting shuold produce a var"
       -- Apply ``var_elim
       let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBound]
+          #[mkNatLit ctx.bmcBound, widthInfo.widthFvar, .mvar widthInfo.hypWidthLeBoundMVarId]
         | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
       -- Intros
       let name ← oldVar.getUserName
@@ -129,7 +129,7 @@ These rewrites introduce the toplevel equality that convers `a = b` into
 -/
 meta def addToplevelRewrites (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBound])
+  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBoundMVarId])
   return simp
 
 /--
@@ -161,9 +161,8 @@ Add BitVecInfos theorems to the Simp theorem context that don't need special bin
 meta def addWidthInfo (g : MVarId) (info : WidthInfo)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
-  simp ← simp.addTheorem (.other info.hypWidthLeBound.name)
-      (mkMVar info.hypWidthLeBound)
-       --(mkFVar info.hypWidthLeBoundNoteHACK)
+  simp ← simp.addTheorem (.other info.hypWidthLeBoundMVarId.name)
+       (mkFVar info.hypWidthLeBoundNoteNote)
   return simp
 
 /--
@@ -187,7 +186,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
                       <| ← addWidthInfo g widthInfo #[]
   let g ← applySimp g thms
 
-  return [g, widthInfo.hypWidthLeBound]
+  return [g, widthInfo.hypWidthLeBoundMVarId]
 
 
 
@@ -232,9 +231,6 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 5: Convert width hypothesis to mask hypothesis
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
-  simp only [eq_iff w_le_bw]
-  simp only [setWidth_add, w_le_bw]
-
   simp only [
       eq_iff w_le_bw,             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -48,7 +48,8 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) 
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
     let hypWidthLeBound <- g.withContext do
-      mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+      -- Add a meaninful name using : (userName := Name.mkSimple "foo")
+      mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, ldecl, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
@@ -137,8 +138,6 @@ def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (width
   if this.bvs.contains fvar then  this
   else { bvs := this.bvs.insert fvar widthInfo }
 
-
-
 /--
 Visit the expression collecting widths, introducing masks,
 and then eliminating them all in the next step.
@@ -179,11 +178,10 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 Translate width precondition into BitVec hypothesis.
 TODO: consider more complicated exprs that might have additions...
 -/
-def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
+def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
     MetaM (MVarId) := g.withContext do
-  match_expr e with
-  | LT.lt u ty _inst ea eb =>
-    throwError "foo"
+  match_expr ldecl.type with
+  | LT.lt ty _inst ea eb =>
     -- ea ≤ eb
     -- translate ea
     -- translate eb
@@ -192,13 +190,14 @@ def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
       if let some wa := winfos.infos[ea]? then
         if let some wb := winfos.infos[eb]? then
           -- Apply mask_lt_mask using the known facts of the widths
-          let bvLTExpr := mkAppN (mkConst ``mask_lt_mask [])
+          let bvLTExpr := mkAppM ``mask_lt_mask
             #[.fvar wa.hypWidthLeBoundNote,
               .fvar wb.hypWidthLeBoundNote,
               .fvar wa.widthMaskHypFvar,
-              .fvar wb.widthMaskHypFvar]
-          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple "a_lt_b") bvLTExpr
-          -- discard hyp, not needed
+              .fvar wb.widthMaskHypFvar,
+              (.fvar ldecl.fvarId)]
+          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{ea}_lt_{eb}") (← bvLTExpr) -- discard hyp, not needed
+          logInfo m!"Translated {ldecl.toExpr} : {ldecl.type} to bitvec"
           return g
     return g
   | _ => return g
@@ -207,7 +206,7 @@ def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
   let mut g := g
   for ldecl in ← getLCtx do
-    g ← translateWidthPrecond winfos g ldecl.toExpr
+    g ← translateWidthPrecond winfos g ldecl
   return g
 /--
 eliminate the bitvector variables to introduce the masked versions
@@ -348,11 +347,11 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   · bv_decide
   · grind
 
-example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
-  x + y = y + x := by
-  pbv_decide 4
-  · bv_decide
-  · grind
+-- example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
+--   x + y = y + x := by
+--   pbv_decide 4
+--   · bv_decide
+--   · grind
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)
@@ -360,4 +359,5 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
-  pbv_decide 13
+  pbv_decide 8
+  · bv_decide

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -175,35 +175,40 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
   else
     return (g, widthInfos, bvs)
 
-  -- let tf ← g.withContext do inferType f
-  -- if let some wExpr := getBitvecType? tf then
-  --   let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
-  --   if let some fvarId := f.fvarId? then
-  --     return (g, widthInfos, bvs.push fvarId widthInfo)
-  --   else
-  --     return (g, widthInfos, bvs)
-  -- else
-  --   return (g, widthInfos, bvs)
-
-def translateWidthPrecond (ctx : PbvTranslateContext) (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
-    MetaM (MVarId × WidthInfos) := g.withContext do
+/--
+Translate width precondition into BitVec hypothesis.
+TODO: consider more complicated exprs that might have additions...
+-/
+def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
+    MetaM (MVarId) := g.withContext do
   match_expr e with
-  | LE.le ty inst ea eb =>
+  | LT.lt u ty _inst ea eb =>
+    throwError "foo"
+    -- ea ≤ eb
+    -- translate ea
+    -- translate eb
+    -- note the mask theorem for this particular.
     if ty == mkConst ``Nat then
-      -- ea ≤ eb
-      -- translate ea
-      -- translate eb
-      -- note the mask theorem for this particular.
-      sorry
-    else
-      return (g, winfos)
-  | _ => return (g, winfos)
+      if let some wa := winfos.infos[ea]? then
+        if let some wb := winfos.infos[eb]? then
+          -- Apply mask_lt_mask using the known facts of the widths
+          let bvLTExpr := mkAppN (mkConst ``mask_lt_mask [])
+            #[.fvar wa.hypWidthLeBoundNote,
+              .fvar wb.hypWidthLeBoundNote,
+              .fvar wa.widthMaskHypFvar,
+              .fvar wb.widthMaskHypFvar]
+          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple "a_lt_b") bvLTExpr
+          -- discard hyp, not needed
+          return g
+    return g
+  | _ => return g
 
-def translateWidthPreconds (ctx : PbvTranslateContext) (winfos: WidthInfos) (g : MVarId) : MetaM (MVarId × WidthInfos) := do
-  -- loop over ← getLCtx, call translateWidthPrecond
-  sorry
-
-
+def translateWidthPreconds (winfos: WidthInfos)
+    (g : MVarId) : MetaM MVarId := g.withContext do
+  let mut g := g
+  for ldecl in ← getLCtx do
+    g ← translateWidthPrecond winfos g ldecl.toExpr
+  return g
 /--
 eliminate the bitvector variables to introduce the masked versions
 -/
@@ -220,8 +225,6 @@ def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpThe
     MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
   simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
-  simp ← simp.addTheorem (.other ``nat_lt_nat_eq_mask_lt_mask) <| (← mkAppM ``nat_lt_nat_eq_mask_lt_mask #[mkNatLit ctx.bmcBound])
-  simp ← simp.addTheorem (.other ``nat_le_nat_eq_mask_le_mask) <| (← mkAppM ``nat_le_nat_eq_mask_le_mask #[mkNatLit ctx.bmcBound])
   return simp
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -275,6 +278,8 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
     g.withContext do logInfo m!"width: '{w}'"
 
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  let g ← translateWidthPreconds widthInfos g
+
   -- Run simp
   let thms := ← addToplevelRewrites g ctx
                       <| ← addPushTheorems g
@@ -349,8 +354,6 @@ example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) 
   · bv_decide
   · grind
 
-theorem imp_eq_not_or (P Q : Prop) : (P → Q) = (¬ P ∨ Q) := by grind
-
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)
   (hqr : q < r)
@@ -358,7 +361,3 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
   pbv_decide 13
-  · sorry
-  · sorry
-  · sorry
-  · sorry

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -125,7 +125,6 @@ def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
   let name ← oldVar.getUserName
   let (bvVar, g) ← g.withContext <| g.intro name
   let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_m{name}"
-  logInfo m!"{g}"
   return (g, bvInfos.push { bvVar, bvHyp })
 
 /--
@@ -138,27 +137,53 @@ def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (width
   if this.bvs.contains fvar then  this
   else { bvs := this.bvs.insert fvar widthInfo }
 
+
+
 /--
-Visit an expression, collecting all widths and introducing mask variables.
-For bitvectors, collect the bitvectors that need to be eliminated,
-and then eliminate them all in the next step.
+Visit the expression collecting widths, introducing masks,
+and then eliminating them all in the next step.
 -/
-partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId)
+def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
     MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
-  let (f, args) := (e.getAppFn, e.getAppArgs)
-  let (g, widthInfos, bvs) ← g.withContext do
-    args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExpr ctx g widthInfos bvs arg
-  let tf ← g.withContext do inferType f
-  if let some wExpr := getBitvecType? tf then
+  let te ← g.withContext do inferType e
+  if let some wExpr := getBitvecType? te then
     let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
-    if let some fvarId := f.fvarId? then
+    if let some fvarId := e.fvarId? then
       return (g, widthInfos, bvs.push fvarId widthInfo)
     else
       return (g, widthInfos, bvs)
   else
     return (g, widthInfos, bvs)
+
+/--
+Visit an expression, collecting all widths and introducing mask variables.
+For bitvectors, collect the bitvectors that need to be eliminated,
+and then eliminate them all in the next step.
+-/
+partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
+    (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
+    (e : Expr) :
+    MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
+  let (g, widthInfos, bvs) ← visitExprNonrec ctx g widthInfos bvs e
+  if e.isApp then
+    let (f, args) := (e.getAppFn, e.getAppArgs)
+    let (g, widthInfos, bvs) ← g.withContext do
+      args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExprRec ctx g widthInfos bvs arg
+    visitExprRec ctx g widthInfos bvs f
+  else
+    return (g, widthInfos, bvs)
+
+  -- let tf ← g.withContext do inferType f
+  -- if let some wExpr := getBitvecType? tf then
+  --   let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
+  --   if let some fvarId := f.fvarId? then
+  --     return (g, widthInfos, bvs.push fvarId widthInfo)
+  --   else
+  --     return (g, widthInfos, bvs)
+  -- else
+  --   return (g, widthInfos, bvs)
 
 
 /--
@@ -166,7 +191,6 @@ eliminate the bitvector variables to introduce the masked versions
 -/
 def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
-  logInfo m!"number of bvs to revert {bvs.bvs.size}"
   bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
     introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
 
@@ -228,7 +252,10 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, widthInfos, bvsToRevert) ← visitExpr ctx g {} {} (← g.getType)
+  let (g, widthInfos, bvsToRevert) ← visitExprRec ctx g {} {} (← g.getType)
+  for (w, _winfo) in widthInfos.infos do
+    g.withContext do logInfo m!"width: '{w}'"
+
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
@@ -292,18 +319,26 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 -- Step 8: Bitblast!
   bv_decide
 
-set_option trace.Meta.Tactic.simp.all true
-set_option trace.Meta.Tactic.simp true
 example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
 
-set_option trace.Meta.Tactic.simp.all true
-set_option trace.Meta.Tactic.simp true
 example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
+
+theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
+  (hr : r <= 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · sorry
+  · sorry
+  · sorry
+  · sorry

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -21,7 +21,7 @@ structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
+  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
   hypWidthLeBoundNote : FVarId
 
 
@@ -41,7 +41,7 @@ meta structure PbvTranslateContext where
 
 meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-    -- Retrieve the ldecl from the context
+    -- Retrieve the ldecl from the context.
     let ldecl ← getFVarLocalDecl widthExpr
     -- Check that the Expr is of type Nat.
     assert! ldecl.type == (mkConst ``Nat)
@@ -190,7 +190,6 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     MetaM (MVarId) := g.withContext do
   match_expr ldecl.type with
   | LT.lt ty _inst ea eb =>
-    -- note the mask theorem for this particular.
     if ty == mkConst ``Nat then
       if let some wa := winfos.infos[ea]? then
         if let some wb := winfos.infos[eb]? then
@@ -207,14 +206,19 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
     return g
   | _ => return g
 
+/--
+Traverse the local context and translate any hypotheses on `Nat` widths into
+`BitVec` hypotheses.
+-/
 meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
   let mut g := g
   for ldecl in ← getLCtx do
     g ← translateWidthPrecond winfos g ldecl
   return g
+
 /--
-eliminate the bitvector variables to introduce the masked versions
+Eliminate the bitvector variables to introduce the masked versions.
 -/
 meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
@@ -245,7 +249,9 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context that don't need special bindings.
+Add BitVecInfos theorems to the Simp theorem context. Simplify the final formula
+to remove redundant masking operations, not strictly necessary for `bv_decide`
+to decide the resulting formula.
 -/
 meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -255,7 +261,7 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
+Add theorems bounding each of width to the provided bound to the simp set.
 -/
 meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -287,9 +293,10 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 
   -- Run simp
   let thms := ← addToplevelRewrites g ctx
-                      <| ← addPushTheorems g
-                      <| ← addBvInfos g bvInfos
-                      <| ← addWidthInfosSimpLemmas g widthInfos #[]
+           <| ← addPushTheorems g
+           <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
+           <| ← addWidthInfosSimpLemmas g widthInfos #[]
+
   let g ← applySimp g thms
 
   return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
@@ -323,7 +330,7 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   · grind
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
-  (hr : r <= 8)
+  (hr : r ≤ 8)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
@@ -344,6 +351,18 @@ theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
   pbv_decide 8
   · bv_decide
   · grind
+  · grind
+  · grind
+  · grind
+
+theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
   · grind
   · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -26,7 +26,7 @@ structure WidthInfos where
     /-- One WidthInfo per width -/
     infos : HashMap Expr WidthInfo := {}
 
-def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
+meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
   { infos := this.infos.insert info.widthExpr info }
 
 /--
@@ -36,7 +36,7 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- TODO: check that the value has Nat.
     let [g] ← g.withContext do
@@ -71,7 +71,7 @@ def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (info
 /--
 Either get existing width info, or create one if it does not exist.
 -/
-def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
+meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
     (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
   if let some info := this.infos[wExpr]? then
     return (g, info, this)
@@ -104,7 +104,7 @@ meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos 
 Match on an expression, and if it is a `BitVec w`, return the `w`.
 Otherwise, return `none`.
 -/
-def getBitvecType? (e : Expr) : Option Expr :=
+meta def getBitvecType? (e : Expr) : Option Expr :=
   match_expr e with
   | BitVec w => some w
   | _ => none
@@ -113,7 +113,7 @@ def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
+meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   -- Find the BitVec {width_expr} variables.
@@ -135,7 +135,7 @@ This creates a plan of bitvector fvars to be reverted, and their corresponding w
 structure BitVecFVarsToRevert where
   bvs : HashMap FVarId WidthInfo := {}
 
-def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
+meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
   if this.bvs.contains fvar then  this
   else { bvs := this.bvs.insert fvar widthInfo }
 
@@ -143,7 +143,7 @@ def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (width
 Visit the expression collecting widths, introducing masks,
 and then eliminating them all in the next step.
 -/
-def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
+meta def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
     MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
@@ -162,7 +162,7 @@ Visit an expression, collecting all widths and introducing mask variables.
 For bitvectors, collect the bitvectors that need to be eliminated,
 and then eliminate them all in the next step.
 -/
-partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
+meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
     MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
@@ -179,7 +179,7 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 Translate width precondition into BitVec hypothesis.
 TODO: consider more complicated exprs that might have additions...
 -/
-def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
     MetaM (MVarId) := g.withContext do
   match_expr ldecl.type with
   | LT.lt ty _inst ea eb =>
@@ -203,7 +203,7 @@ def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
     return g
   | _ => return g
 
-def translateWidthPreconds (winfos: WidthInfos)
+meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
   let mut g := g
   for ldecl in ← getLCtx do
@@ -212,7 +212,7 @@ def translateWidthPreconds (winfos: WidthInfos)
 /--
 eliminate the bitvector variables to introduce the masked versions
 -/
-def introMaskedBitvectors (ctx : PbvTranslateContext)
+meta def introMaskedBitvectors (ctx : PbvTranslateContext)
     (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
   bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
     introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
@@ -221,7 +221,7 @@ def introMaskedBitvectors (ctx : PbvTranslateContext)
 These rewrites introduce the toplevel equality that convers `a = b` into
 `a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
+meta def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
   simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
@@ -269,7 +269,7 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
     | throwError "goal solved by simp"
   return g
 
-def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
+meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -18,6 +18,8 @@ meta structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBound : MVarId
+  /-- Hack: intro the bound as an fvar so 'simp' rewrites with it? this is ludicrous if true. -/
+  hypWidthLeBoundNoteHACK : FVarId
 
 meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
   info.widthNatLocalDecl.fvarId
@@ -50,9 +52,11 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
           let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
           -- Define bounding conditions.
           let hypWidthLeBound <- g.withContext do
-            mkFreshExprMVar (mkAppN (Expr.const `Nat.le [])
-              #[Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
+            mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+              #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
           g.withContext <| check hypWidthLeBound
+          let (hypWidthLeBoundNoteHACK, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+          g.withContext <| check (mkFVar hypWidthLeBoundNoteHACK)
           -- Assert the BitVec mask constraint.
           let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
           let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
@@ -60,7 +64,8 @@ meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarI
             widthNatLocalDecl := ldecl,
             widthMaskFvar := mask,
             widthMaskHypFvar := maskHyp
-            hypWidthLeBound := hypWidthLeBound.mvarId!
+            hypWidthLeBound := hypWidthLeBound.mvarId!,
+            hypWidthLeBoundNoteHACK
           }
           return (g, info)
     throwError "unable to find a valid width variable."
@@ -111,29 +116,30 @@ meta def introVar (ctx : PbvTranslateContext) (widthInfo : WidthInfo) (g : MVarI
 Apply the introVar to all localDecls to obtain concrete width bitvectors from parametric ones and the corresponding
 hypotheses.
 -/
-meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) : MetaM (MVarId × BitVecInfos) := do
+meta def introVars (ctx : PbvTranslateContext) (g : MVarId) (widthInfo : WidthInfo) :
+    MetaM (MVarId × BitVecInfos) := do
   let decls : LocalContext ← g.withContext getLCtx
   decls.foldlM (init := (g, {})) fun (g, infos) ldecl =>
     introVar ctx widthInfo g infos ldecl
 
+
 /--
-Add the hardcoded push theorems to the Simp theorem context, bind each application to the
-concrete blast width (`o`) and parametric width (`w`).
+These rewrites introduce the toplevel equality that convers `a = b` into
+`a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-meta def addPushTheorems (g : MVarId)
-    (widthInfo : WidthInfo) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
-  let thms := #[``eq_iff, ``setWidth_add, ``setWidth_setWidth] -- hardcoded theorems
-  let mut simp := simp
-  for thm in thms do
-    let push_thm ← g.withContext do mkAppM thm #[.mvar widthInfo.hypWidthLeBound]
-    simp ← simp.addTheorem (.other thm) push_thm
+meta def addToplevelRewrites (g : MVarId) (widthInfo : WidthInfo) (simp : SimpTheoremsArray) :
+    MetaM SimpTheoremsArray := g.withContext do
+  let simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkMVar widthInfo.hypWidthLeBound])
   return simp
 
 /--
-Add theorems to the Simp theorem context that don't need special bindings
+Add theorems to the Simp theorem context that push the `setWidth`s in.
+TODO: make this a simp-set, called `pbv_push`, and just gather these
+from the simp-set. This makes them user-extensible with no metaprogramming needed.
 -/
-meta def addOtherTheorems (g : MVarId) (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
-  let others := #[``BitVec.setWidth_eq]
+meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
+    MetaM SimpTheoremsArray := g.withContext do
+  let others := #[``BitVec.setWidth_eq, ``eq_iff, ``setWidth_add, ``setWidth_setWidth]
   let mut simp := simp
   for n in others do
     simp ← simp.addTheorem (.other n) (mkConst n [])
@@ -150,16 +156,15 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   return simp
 
 /--
-Add width mask hypothesis
+Add BitVecInfos theorems to the Simp theorem context that don't need special bindings
 -/
-meta def addWidthHyp (g : MVarId) (widthInfo : WidthInfo)
+meta def addWidthInfo (g : MVarId) (info : WidthInfo)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
-  -- TODO: make this cleaner by collecting them all into a single array.
-  let simpThms : SimpTheorems := {}
-  let simpThms ← do
-    simpThms.add (.other widthInfo.widthMaskHypFvar.name)
-      #[] (mkFVar widthInfo.widthMaskHypFvar) (inv := true)
-  return simp.push simpThms
+  let mut simp := simp
+  simp ← simp.addTheorem (.other info.hypWidthLeBound.name)
+      (mkMVar info.hypWidthLeBound)
+       --(mkFVar info.hypWidthLeBoundNoteHACK)
+  return simp
 
 /--
 Run simp on an MVarId given a set of simp theorems.
@@ -176,12 +181,15 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Introduce bitvector variables
   let (g, bvInfos) ← introVars ctx g widthInfo
   -- Run simp
-  let g ← applySimp g <| ← addPushTheorems g widthInfo
-                      <| ← addOtherTheorems g
+  let thms := ← addToplevelRewrites g widthInfo
+                      <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
-                      <| ← addWidthHyp g widthInfo #[]
+                      <| ← addWidthInfo g widthInfo #[]
+  let g ← applySimp g thms
 
   return [g, widthInfo.hypWidthLeBound]
+
+
 
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
@@ -202,3 +210,45 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
+
+
+/-- Manual trace of the future tactic, transforming an unbounded parametric width
+    statement into a bounded one and solving it up to the bound (4 in this case) -/
+theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+-- Step 1: Bound widths to the provided blast width (redundant in this case)
+  have w_le_bw :  w ≤ 4 := by grind
+-- Step 2-3: Introduce mask to replace `w` Nat var
+  apply width_elim 4 w
+  intro mw h_mw
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
+  revert x
+  apply var_elim 4 w w_le_bw
+  intro x h_xmw
+  revert y
+  apply var_elim 4 w w_le_bw
+  intro y h_ymw
+-- Step 5: Convert width hypothesis to mask hypothesis
+  have mw_mask := isMask_of_eq_maskOfWidth h_mw
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
+  simp only [eq_iff w_le_bw]
+  simp only [setWidth_add, w_le_bw]
+
+  simp only [
+      eq_iff w_le_bw,             -- Introduce `setWidth` to goal
+      setWidth_add,       -- Push `setWidth` down add
+      setWidth_setWidth,  -- Push `setWidth` down setWidth
+      BitVec.setWidth_eq,         -- Remove redundant setWidths
+      w_le_bw]                     -- Replace mask with nat with bv constraint
+      at h_xmw h_ymw ⊢
+-- Step 8: Bitblast!
+  bv_decide
+
+set_option trace.Meta.Tactic.simp.all true
+set_option trace.Meta.Tactic.simp true
+example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
+  x + y = y + x := by
+  pbv_decide 4
+  · bv_decide
+  · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -27,6 +27,13 @@ meta def WidthInfo.widthFvarId (info : WidthInfo) : FVarId :=
 meta def WidthInfo.widthFvar (info : WidthInfo) : Expr :=
   .fvar info.widthFvarId
 
+structure WidthInfos where
+    /-- One WidthInfo per width -/
+    infos : Array WidthInfo := #[]
+
+def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
+  { infos := this.infos.push info }
+
 /--
 Read-only configuration for the tactic.
 -/
@@ -34,41 +41,46 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : LocalDecl) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfos) := g.withContext do
+    unless ldecl.isImplementationDetail do
+        if ← isDefEq ldecl.type (mkConst ``Nat) then
+        -- Apply ``width_elim
+        let [g] ← g.withContext do
+          g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
+          | throwError "width_elim should generate a goal"
+        -- Intros
+        let maskName := Name.mkSimple s!"m{ldecl.userName}"
+        let (mask, g) ← g.withContext do g.intro maskName
+        let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
+        -- Define bounding conditions.
+        let hypWidthLeBound <- g.withContext do
+          mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
+            #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
+        g.withContext <| check hypWidthLeBound
+        let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+        g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
+        -- Assert the BitVec mask constraint.
+        let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
+        let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+        let info : WidthInfo := {
+          widthNatLocalDecl := ldecl,
+          widthMaskFvar := mask,
+          widthMaskHypFvar := maskHyp
+          hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
+          hypWidthLeBoundNoteNote
+        }
+        return (g, infos.push info)
+    return (g, infos)
+
+
 /-- Find the local declaration of the (single) width variable,
 and eliminate it, producing the mask variable, and the masking constraint.
 -/
-meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfo) := do
-  g.withContext do
-    for ldecl in ← getLCtx do
-      unless ldecl.isImplementationDetail do
-        if ← isDefEq ldecl.type (mkConst ``Nat) then
-          -- Apply ``width_elim
-          let [g] ← g.withContext do
-            g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl.toExpr, ← g.getType]
-            | throwError "width_elim should generate a goal"
-          -- Intros
-          let maskName := Name.mkSimple s!"m{ldecl.userName}"
-          let (mask, g) ← g.withContext do g.intro maskName
-          let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
-          -- Define bounding conditions.
-          let hypWidthLeBound <- g.withContext do
-            mkFreshExprMVar (userName := Name.mkSimple "foo") (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
-              #[mkConst ``Nat, mkConst ``instLENat, Expr.fvar ldecl.fvarId, mkNatLit ctx.bmcBound])
-          g.withContext <| check hypWidthLeBound
-          let (hypWidthLeBoundNoteNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
-          g.withContext <| check (mkFVar hypWidthLeBoundNoteNote)
-          -- Assert the BitVec mask constraint.
-          let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-          let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
-          let info : WidthInfo := {
-            widthNatLocalDecl := ldecl,
-            widthMaskFvar := mask,
-            widthMaskHypFvar := maskHyp
-            hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
-            hypWidthLeBoundNoteNote
-          }
-          return (g, info)
-    throwError "unable to find a valid width variable."
+meta def introMaskWidths (ctx : PbvTranslateContext) (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
+  (← getLCtx).foldrM (init := (g, {})) fun ldecl (g, infos) =>
+    introMaskWidth ctx g ldecl infos
+
 
 /--
 Pair of local facts about the converted `BitVec` variables.
@@ -176,14 +188,14 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
-  let (g, widthInfo) ← introMaskWidths ctx g
+  let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, bvInfos) ← introVars ctx g widthInfo
+  let (g, bvInfos) ← introVars ctx g widthInfos
   -- Run simp
-  let thms := ← addToplevelRewrites g widthInfo
+  let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
-                      <| ← addWidthInfo g widthInfo #[]
+                      <| ← addWidthInfo g widthInfos #[]
   let g ← applySimp g thms
 
   return [g, widthInfo.hypWidthLeBoundMVarId]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -58,7 +58,7 @@ inductive TmKind
 | width
 
 /--
-Inductive data structure to express the Terms that this tactic reasons about.
+Inductive data structure to express the terms that this tactic reasons about.
 -/
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
@@ -70,13 +70,13 @@ blocks of the terms.
 -/
 meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .width)) := do
   if let some id := env.width2expr.idxOf? e then
-    -- An atom is an expression is present in the Env
+    -- An atom is an expression that is present in the Env.
     pure <| some (.widthAtom id)
   else
     pure none
 
 /--
-Convert a `Tm` into an `Expr` provided and environment.
+Convert a `Tm` into an `Expr` given an environment.
 -/
 meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
   match this with
@@ -116,7 +116,7 @@ meta def WidthTms.getOrCreateTm (g : MVarId) (this : WidthTms) (wExpr : Expr)
 Information about the width variable and associated hypotheses.
 -/
 structure WidthInfo where
-  /-- The Name correspodning to this width. -/
+  /-- The Name corresponding to this width. -/
   widthName : Name
   /-- The Expr corresponding to this width. -/
   widthTm : Tm .width
@@ -152,9 +152,9 @@ Get WidthInfo from an Expr.
 -/
 meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
     : MetaM (Option WidthInfo) := do
-  -- Reduce the expression (allows for cases such as (w + 0) to be reduced to w)
+  -- Reduce the expression (allows for cases such as (w + 0) to be reduced to w).
   let reducedExpr ← whnf wExpr
-  -- Reify the expr using the env and then look for it in the Hashmap
+  -- Reify the expr using the env and then look for it in the Hashmap.
   let some reified ← Tm.reifyWidth this.env reducedExpr | pure none
   return this.infos[reified.toName]?
 
@@ -341,7 +341,7 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   return simp
 
 /--
-Add theorems bounding each of width to the provided bound to the simp set.
+Add theorems bounding each width to the provided bound to the simp set.
 -/
 meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -377,7 +377,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
   -- Run simp
   let g ← applySimp g thms
-  -- Return modified goal and subgoals
+  -- Return modified goal and subgoals.
   return g :: (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
 /--

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -16,41 +16,66 @@ meta structure PbvTranslateContext where
 
 meta def Expr.isNat (e : Expr) : Bool := e.isConstOf ``Nat
 
+/--
+Match on an expression, and if it is a `BitVec w`, return the `w`.
+Otherwise, return `none`.
+-/
+meta def getBitvecType? (e : Expr) : Option Expr :=
+  match_expr e with
+  | BitVec w => some w
+  | _ => none
+
+/-- An environment that maps width atoms in 'Tm' into its 'Expr' -/
+meta structure TmWidthEnv where
+  width2expr : Array Expr := #[]
+
+meta def TmWidthEnv.push (this : TmWidthEnv) (width : Expr) : TmWidthEnv :=
+  { width2expr := this.width2expr.push width }
+
+meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
+  (← getLCtx).foldrM (init := {}) (fun ldecl (widthEnv : TmWidthEnv ) => do
+      let some width := getBitvecType? ldecl.type | pure widthEnv
+      if let some _ := widthEnv.width2expr.idxOf? width then
+        pure widthEnv
+      else
+        pure <| widthEnv.push width
+    )
+
+
 inductive TmKind
 | width
 
-/-- An environment that maps width atoms in 'Tm' into its 'Expr' -/
-structure TmWidthEnv where
-    width2expr : Nat → Expr
 
 inductive Tm : TmKind → Type
-| widthAtom (e : Expr) : Tm .width -- TODO: this should be Nat.
+| widthAtom (id : Nat) : Tm .width -- TODO: this should be Nat.
 | widthAdd (v w : Tm .width) : Tm .width
 -- | withPropLe (a b : Tm .width) : Tm .prop
 
 -- Might have a problem reifying "atom" widths which are composite eg: BitVec (w + 1 - 1)
 -- TODO fixable by first traversing the BitVec definitions to obtain the atoms, and then look
 -- them up while reifying
-meta partial def Tm.reifyWidth (e : Expr) : MetaM (Option (Tm .width)) := do
-  match_expr e with
-  | HAdd.hAdd ty _ _ _ ae be =>
-      let .true := Expr.isNat ty | pure none
-      let some a ← Tm.reifyWidth ae | pure none
-      let some b ← Tm.reifyWidth be | pure none
-      pure (some (.widthAdd a b))
-  | _ =>
-    match e with
-    | .fvar _ => pure (some (.widthAtom (e)))
+meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .width)) := do
+  if let some id := env.width2expr.idxOf? e then
+    -- The atom is whatever expression is present in the Env
+    pure <| some (.widthAtom id)
+  else
+    match_expr e with
+    | HAdd.hAdd ty _ _ _ ae be =>
+        let .true := Expr.isNat ty | pure none
+        let some a ← Tm.reifyWidth env ae | pure none
+        let some b ← Tm.reifyWidth env be | pure none
+        pure (some (.widthAdd a b))
     | _ => pure none
 
-meta def Tm.toExpr : Tm .width → Expr
-  | .widthAtom e => e
-  | .widthAdd v w => mkNatAdd v.toExpr w.toExpr
+meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
+  match this with
+  | .widthAtom id => env.width2expr[id]!
+  | .widthAdd v w => mkNatAdd (v.toExpr env) (w.toExpr env)
 
-meta def Tm.toName (tm: Tm .width) (g : MVarId) : MetaM Name := g.withContext do
+meta def Tm.toName (tm: Tm .width) : Name :=
   match tm with
-  | .widthAtom e => pure <| Name.mkSimple s!"{← e.fvarId!.getUserName}" -- assume atom is Fvar for docs purposes
-  | .widthAdd v w => pure <| Name.mkSimple s!"{← v.toName g}_add_{← w.toName g}"
+  | .widthAtom e => Name.mkSimple s!"w{e}"
+  | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
 
 /-- Computes the upper bound of widths needed to calculate this width without overflowing.
 That maximum such, across all widths, will be used to get the universal upper bound. -/
@@ -67,18 +92,19 @@ structure WidthTm where
   term : Tm .width
 
 structure WidthTms where
-  terms: HashMap Expr WidthTm := {}
+  env : TmWidthEnv
+  terms: HashMap Name WidthTm := {}
 
 meta def WidthTms.push (this : WidthTms) (width : WidthTm) : WidthTms :=
-{ terms := this.terms.insert (width.term.toExpr) width }
+{ terms := this.terms.insert (width.term.toName) width, env := this.env }
 
 /--
 Either get existing width term, or try and reify one if it does not exist.
 -/
 meta def WidthTms.getOrCreateTm
     (g : MVarId) (this : WidthTms) (wExpr : Expr) : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
-  let some reified ← Tm.reifyWidth wExpr | throwError m!"Failed to reify width expr: {wExpr}"
-  if let some info := this.terms[reified.toExpr]? then -- use reified.toExpr as a kind of "normal"/"canonical" form
+  let some reified ← Tm.reifyWidth this.env wExpr | throwError m!"Failed to reify width expr: {wExpr}"
+  if let some info := this.terms[reified.toName]? then -- use reified.toExpr as a kind of "normal"/"canonical" form
     return (g, info, this)
   else
     let widthTm := { term := reified }
@@ -112,32 +138,42 @@ structure WidthInfo where
 
 
 structure WidthInfos where
-    /-- One WidthInfo per width -/
-    infos : HashMap Expr WidthInfo := {}
+  /-- One WidthInfo per width -/
+  infos : HashMap Name WidthInfo := {}
+  /-- Width Environemnt -/
+  env: TmWidthEnv
 
 meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-{ infos := this.infos.insert (info.widthTm.toExpr) info }
+  { infos := this.infos.insert (info.widthTm.toName) info, env := this.env }
 
+/--
+Get WidthInfo from a Term.
+-/
+meta def WidthInfos.getFromTm? (this : WidthInfos) (wTm : WidthTm) : Option WidthInfo :=
+  this.infos[wTm.term.toName]?
 
-meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
-  let some fvarId := e.fvarId? | return none
-  return (← getLCtx).find? fvarId
+-- /--
+-- Get WidthInfo from an Expr.
+-- -/
+-- meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
+--     : MetaM (Option WidthInfo) := do
+--   return this.infos[← whnf wExpr]?
 
 meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfos) := g.withContext do
-    let name ← widthTm.term.toName g
     -- Apply width_elim
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.term.toExpr, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.term.toExpr infos.env, ← g.getType]
       | throwError m!"{``width_elim} should generate a goal"
     -- Intros
-    let maskName := Name.mkSimple s!"m{name}"
+    let name := widthTm.term.toName
+    let maskName := Name.mkSimple s!"m_{name}"
     let (#[mask, maskHyp], g) ← g.withContext <| g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
       | throwError m!"Failed to intro {``width_elim}"
     -- Introduce width bound on the variable.
     let hypWidthLeBound ← g.withContext do
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
-        #[mkConst ``Nat, mkConst ``instLENat, widthTm.term.toExpr, mkNatLit maxBound])
+        #[mkConst ``Nat, mkConst ``instLENat, widthTm.term.toExpr infos.env, mkNatLit maxBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_blast") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
@@ -155,12 +191,6 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
     }
     return (g, infos.push info)
 
-/--
-Get some width Expr from infos.
--/
-meta def WidthInfos.get? (this: WidthInfos) (wExpr : Expr)
-    : MetaM (Option WidthInfo) := do
-  return this.infos[← whnf wExpr]?
 
 
 /--
@@ -182,14 +212,7 @@ meta structure BitVecInfos where
 meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos :=
   { this with infos := this.infos.push val }
 
-/--
-Match on an expression, and if it is a `BitVec w`, return the `w`.
-Otherwise, return `none`.
--/
-meta def getBitvecType? (e : Expr) : Option Expr :=
-  match_expr e with
-  | BitVec w => some w
-  | _ => none
+
 
 /--
 Analyze a single bitvector FVarId, and try to introduce it as a `BitVec`
@@ -201,16 +224,16 @@ meta def introBitvecFVarUnchecked (widthInfos : WidthInfos) (g : MVarId)
   -- Revert to expose forall with the BitVec.
   let (#[oldVar], g) ← g.revert #[bvFVarId]
     | throwError m!"Reverting {g} shuold produce a var."
-  let wExpr := widthTm.term.toExpr
+  let wExpr := widthTm.term.toExpr widthInfos.env
   -- Apply ``var_elim.
-  let some infos := widthInfos.infos[wExpr]?
-    | throwError m!"{widthTm.term.toExpr} Shuold have be defined in widthInfos."
+  let some infos := widthInfos.getFromTm? widthTm
+    | throwError m!"{wExpr} Shuold have be defined in widthInfos."
   let [g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim #[.fvar infos.hypWidthLeBoundNote]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
 
   let name ← oldVar.getUserName
   let (#[bvVar, bvHyp], g) ← g.withContext <| g.introN 2
-    [name, Name.mkSimple s!"h_{name}_maskOfWidth_{← widthTm.term.toName g}"]
+    [name, Name.mkSimple s!"h_{name}_maskOfWidth_{widthTm.term.toName}"]
     | throwError m!"Expecting two intros from {g}"
 
   return (g, bvInfos.push { bvVar, bvHyp })
@@ -275,38 +298,38 @@ meta def matchWidthRel (e : Expr) :
   | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
   | _ => none
 
-/--
-If a condition on the width hypothesis is found, and the widths are contained
-within the `WidthInfos` set, then duplicate the hypothesis and add it to the
-goal. This allows for a single call to Simp later.
--/
-meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
-    : MetaM (MVarId) := g.withContext do
-  if let some (ea, eb) := matchWidthRel ldecl.type then
-    let some wa ← winfos.get? ea | return g
-    let some wb ← winfos.get? eb | return g
-    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
-    let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
-    return g
-  else
-    return g
+-- /--
+-- If a condition on the width hypothesis is found, and the widths are contained
+-- within the `WidthInfos` set, then duplicate the hypothesis and add it to the
+-- goal. This allows for a single call to Simp later.
+-- -/
+-- meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+--     : MetaM (MVarId) := g.withContext do
+--   if let some (ea, eb) := matchWidthRel ldecl.type then
+--     let some wa ← winfos.get? ea | return g
+--     let some wb ← winfos.get? eb | return g
+--     let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
+--     let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
+--     return g
+--   else
+--     return g
 
-/--
-Traverse the local context and add any width pre-conditions to the goal.
--/
-meta def translateWidthPreconds (winfos: WidthInfos)
-    (g : MVarId) : MetaM MVarId := g.withContext do
-  let mut g := g
-  for ldecl in ← getLCtx do
-    g ← translateWidthPrecond winfos g ldecl
-  return g
+-- /--
+-- Traverse the local context and add any width pre-conditions to the goal.
+-- -/
+-- meta def translateWidthPreconds (winfos: WidthInfos)
+--     (g : MVarId) : MetaM MVarId := g.withContext do
+--   let mut g := g
+--   for ldecl in ← getLCtx do
+--     g ← translateWidthPrecond winfos g ldecl
+--   return g
 
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
   let maxWidth := widthTms.getUniverseWidthUpperBound ctx
 
-  widthTms.terms.foldM (init := (g, {})) (fun (g, widthInfos) _ widthTm =>
+  widthTms.terms.foldM (init := (g, { env := widthTms.env })) (fun (g, widthInfos) _ widthTm =>
     introMaskWidth maxWidth g widthTm widthInfos
   )
 
@@ -387,15 +410,17 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
   return g
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
+  -- Construct the width environment
+  let widthEnv ← createWidthEnv g
   -- Find `BitVec`s and intro their widths
-  let (g, widthTms, bvsToRevert) ← visitExprRec g {} {} (← g.getType)
+  let (g, widthTms, bvsToRevert) ← visitExprRec g { env := widthEnv } {} (← g.getType)
   -- Introduce the width masks, bounded by the max width
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
 
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Find preconditions on the width `FVar`s
-  let g ← translateWidthPreconds widthInfos g
+--   let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -7,6 +7,13 @@ public import Veir.Data.PBV
 open Lean Elab Tactic Meta Simp Std
 namespace Veir.Data.PBV
 
+/--
+Read-only configuration for the tactic.
+-/
+meta structure PbvTranslateContext where
+  /-- The bound upto which we want to bitblast our widths. -/
+   bmcBound : Nat
+
 meta def Expr.isNat (e : Expr) : MetaM Bool := do
   return (← inferType e).isConstOf ``Nat
 
@@ -22,7 +29,7 @@ inductive Tm : TmKind → Type
 -- them up while reifying
 meta partial def Tm.reifyWidth (e : Expr) : Option (Tm .width) :=
   match_expr e with
-  | Nat.add ae be =>
+  | HAdd.hAdd Nat _Nat _Nat _instHAdd ae be =>
     if let some a := Tm.reifyWidth ae then
       if let some b := Tm.reifyWidth be then
         some (.widthAdd a b)
@@ -37,6 +44,44 @@ meta def Tm.toExpr : Tm .width → Expr
   | .widthAtom e => e
   | .widthAdd v w => mkNatAdd v.toExpr w.toExpr
 
+/-- Computes the upper bound of widths needed to calculate this width without overflowing.
+That maximum such, across all widths, will be used to get the universal upper bound. -/
+meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
+  match tm with
+  | .widthAtom _ => ctx.bmcBound
+  | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
+
+-- structure WidthAtoms where
+  --
+
+structure WidthTm where
+  term : Tm .width
+
+structure WidthTms where
+  terms: HashMap Expr WidthTm := {}
+
+meta def WidthTms.push (this : WidthTms) (width : WidthTm) : WidthTms :=
+{ terms := this.terms.insert (width.term.toExpr) width }
+
+/--
+Either get existing width term, or try and reify one if it does not exist.
+-/
+meta def WidthTms.getOrCreateTm
+    (g : MVarId) (this : WidthTms) (wExpr : Expr) : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
+  let some reified := Tm.reifyWidth wExpr | throwError m!"Failed to reify width expr: {wExpr}"
+  if let some info := this.terms[reified.toExpr]? then -- use reified.toExpr as a kind of "normal"/"canonical" form
+    return (g, info, this)
+  else
+    let widthTm := { term := reified }
+    return (g, widthTm, this.push widthTm)
+
+
+/-- Get the maximum width needed for blasting across all widths. -/
+meta def WidthTms.getUniverseWidthUpperBound (ctx : PbvTranslateContext)
+    (winfos : WidthTms) : Nat :=
+  winfos.terms.fold (fun val _e wTm =>
+    val.max (wTm.term.getUniverseWidthUpperBound ctx)) 1
+
 /--
 Information about the width variable and associated hypotheses.
 -/
@@ -44,7 +89,7 @@ structure WidthInfo where
   /-- The Name correspodning to this width. -/
   widthName : Name
   /-- The Expr corresponding to this width. -/
-  widthExpr : Tm .width
+  widthTm : Tm .width
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
@@ -62,52 +107,31 @@ structure WidthInfos where
     infos : HashMap Expr WidthInfo := {}
 
 meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-{ infos := this.infos.insert (info.widthExpr.toExpr) info }
-
-/--
-Read-only configuration for the tactic.
--/
-meta structure PbvTranslateContext where
-  /-- The bound upto which we want to bitblast our widths. -/
-   bmcBound : Nat
-
-/-- Computes the upper bound of widths needed to calculate this width without overflowing.
-That maximum such, across all widths, will be used to get the universal upper bound. -/
-meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
-  match tm with
-  | .widthAtom _ => ctx.bmcBound
-  | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
-
-/-- Get the maximum width needed for blasting across all widths. -/
-meta def WidthInfos.getUniverseWidthUpperBound (ctx : PbvTranslateContext)
-    (winfos : WidthInfos) : Nat :=
-  winfos.infos.fold (fun val _e winfo =>
-        val.max (winfo.widthExpr.getUniverseWidthUpperBound ctx)) 1
+{ infos := this.infos.insert (info.widthTm.toExpr) info }
 
 
 meta def localDecl? (e : Expr) : MetaM (Option LocalDecl) := do
   let some fvarId := e.fvarId? | return none
   return (← getLCtx).find? fvarId
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
-  : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
+meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfos) := g.withContext do
     -- Retrieve the ldecl from the context.
-    let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
-    -- Check that the Expr is of type Nat.
-    if !(← Expr.isNat widthExpr) then
-      throwError s!"`BitVec` width {← inferType widthExpr} is not a `Nat`"
+    -- let name := if let some ldecl := (← localDecl? widthExpr) then ldecl.userName else (Name.mkSimple "widthVar")
+    -- let name := widthTm.term.getName
+    let name := Name.mkSimple "test"
     -- Apply width_elim
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.term.toExpr, ← g.getType]
       | throwError m!"{``width_elim} should generate a goal"
     -- Intros
     let maskName := Name.mkSimple s!"m{name}"
-    let (#[mask, maskHyp], g) ← g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
+    let (#[mask, maskHyp], g) ← g.withContext <| g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
       | throwError m!"Failed to intro {``width_elim}"
   -- Define bounding conditions.
     let hypWidthLeBound ← g.withContext do
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
-        #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
+        #[mkConst ``Nat, mkConst ``instLENat, widthTm.term.toExpr, mkNatLit maxBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
@@ -115,28 +139,16 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let hypExpr ← g.withContext do mkAppM ``maskOfWidth_and_add_one_eq_zero #[mkFVar maskHyp]
     let (_, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_bv_mask") hypExpr
 
-    let some term := Tm.reifyWidth widthExpr | throwError m!"Failed to reify width expression: {widthExpr}"
-
     let info : WidthInfo := {
       widthName := name,
-      widthExpr := term,
+      widthTm := widthTm.term,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
       hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
       hypWidthLeBoundNote
     }
-    return (g, info, infos.push info)
-
-/--
-Either get existing width info, or create one if it does not exist.
--/
-meta def WidthInfos.getOrCreateInfo (ctx : PbvTranslateContext)
-    (g : MVarId) (this : WidthInfos) (wExpr : Expr) : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-  let reducedWExpr ← whnf wExpr
-  if let some info := this.infos[reducedWExpr]? then
-    return (g, info, this)
-  else
-    introMaskWidth ctx g reducedWExpr this
+    return (g, infos.push info)
+    -- return (g, infos)
 
 /--
 Get some width Expr from infos.
@@ -175,72 +187,75 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
   | _ => none
 
 /--
-Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
-if it is in fact a `BitVec` variable.
+Analyze a single bitvector FVarId, and try to introduce it as a `BitVec`
+variable in our larger universe.
 -/
 meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
-      (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
-      MetaM (MVarId × BitVecInfos) := g.withContext do
+      (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthTm : WidthTm) :
+      MetaM (List MVarId × BitVecInfos) := g.withContext do
   -- Find the BitVec {width_expr} variables.
     -- Revert to expose forall with the BitVec.
   let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError "reverting shuold produce a var"
-  -- Apply ``var_elim
-  let (List.cons g _) ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-      #[mkNatLit ctx.bmcBound, widthInfo.widthExpr.toExpr, .mvar widthInfo.hypWidthLeBoundMVarId]
+  -- Apply ``var_elim leaving a hole to be filled relating to the proof that the width expr is less than the bound width
+  let [newGoal, g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim
+      #[mkNatLit ctx.bmcBound, widthTm.term.toExpr]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
+  -- logInfo m!"old goal: {g}"
+  -- logInfo m!"new goal: {newGoal}"
   -- Intros
   let name ← oldVar.getUserName
-  let (bvVar, g) ← g.withContext <| g.intro name
-  let widthMaskName ← widthInfo.widthMaskFvar.getUserName
-  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_{name}_{widthMaskName}"
-  return (g, bvInfos.push { bvVar, bvHyp })
+  let widthMaskName := "ahhh"
+  let (#[bvVar, bvHyp], g) ← g.withContext <| g.introN 2 [name, Name.mkSimple s!"h_{name}_{widthMaskName}"]
+    | throwError m!"Expecting two intros from {g}"
+
+  return ([g, newGoal], bvInfos.push { bvVar, bvHyp })
 
 /--
 This creates a plan of bitvector fvars to be reverted, and their corresponding widths.
 -/
 structure BitVecFVarsToRevert where
-  bvs : HashMap FVarId WidthInfo := {}
+  bvs : HashMap FVarId WidthTm := {}
 
-meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
+meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthTm : WidthTm) : BitVecFVarsToRevert :=
   if this.bvs.contains fvar then  this
-  else { bvs := this.bvs.insert fvar widthInfo }
+  else { bvs := this.bvs.insert fvar widthTm }
 
 /--
 Given an expression, if it is of `BitVec w` type then create a mask for the
 width `w`. If it is also an FVar, then it means it's a variable hence it has to
 be added to the set of FVars to be reverted.
 -/
-meta def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
-    (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
+meta def visitExprNonrec (g : MVarId)
+    (widthTms : WidthTms) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
-    MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
+    MetaM (MVarId × WidthTms × BitVecFVarsToRevert) := g.withContext do
   let te ← g.withContext do inferType e
   if let some wExpr := getBitvecType? te then
-    let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
+    let (g, widthTm, widthTms) ← widthTms.getOrCreateTm g wExpr
     if let some fvarId := e.fvarId? then
-      return (g, widthInfos, bvs.push fvarId widthInfo)
+      return (g, widthTms, bvs.push fvarId widthTm)
     else
-      return (g, widthInfos, bvs)
+      return (g, widthTms, bvs)
   else
-    return (g, widthInfos, bvs)
+    return (g, widthTms, bvs)
 
 /--
 Visit an expression, collecting all widths and introducing mask variables.
 For bitvectors, collect the bitvectors that need to be eliminated,
 and then eliminate them all in the next step.
 -/
-meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
-    (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
+meta partial def visitExprRec (g : MVarId)
+    (widthTms : WidthTms) (bvs : BitVecFVarsToRevert)
     (e : Expr) :
-    MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
-  let (g, widthInfos, bvs) ← visitExprNonrec ctx g widthInfos bvs e
+    MetaM (MVarId × WidthTms × BitVecFVarsToRevert) := g.withContext do
+  let (g, widthTms, bvs) ← visitExprNonrec g widthTms bvs e
   if e.isApp then
     let (f, args) := (e.getAppFn, e.getAppArgs)
-    let (g, widthInfos, bvs) ← g.withContext do
-      args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExprRec ctx g widthInfos bvs arg
-    visitExprRec ctx g widthInfos bvs f
+    let (g, widthTms, bvs) ← g.withContext do
+      args.foldlM (init := (g, widthTms, bvs)) fun (g, widthTms, bvs) arg => g.withContext do visitExprRec g widthTms bvs arg
+    visitExprRec g widthTms bvs f
   else
-    return (g, widthInfos, bvs)
+    return (g, widthTms, bvs)
 
 /--
 Match width relation.
@@ -280,14 +295,27 @@ meta def translateWidthPreconds (winfos: WidthInfos)
     g ← translateWidthPrecond winfos g ldecl
   return g
 
+meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
+  : MetaM (MVarId × WidthInfos)
+  := g.withContext do
+  let maxWidth := widthTms.getUniverseWidthUpperBound ctx
+
+  widthTms.terms.foldM (init := (g, {})) (fun (g, widthInfos) _ widthTm =>
+    introMaskWidth maxWidth g widthTm widthInfos
+  )
+
 /--
 Eliminate the bitvector variables to introduce the masked versions.
 -/
 meta def introMaskedBitvectors (ctx : PbvTranslateContext)
-    (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
-  bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
-    introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
-
+    (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (List MVarId × BitVecInfos) := do
+  bvs.bvs.foldM (init := ([g], {})) fun (gs, bvInfos) bvFvarId widthTm => do
+    let g :: other := gs | throwError m!"{gs} should always have at least one element"
+    logInfo g
+    let (g', bvInfos) ← introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthTm
+    for o in g' do
+      logInfo o
+    return (g' ++ other, bvInfos)
 /--
 These theorems require pre-filling the width bound in order to be used within
 the Simp set.
@@ -358,21 +386,28 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- Find `BitVec`s and intro their widths
-  let (g, widthInfos, bvsToRevert) ← visitExprRec ctx g {} {} (← g.getType)
+  let (g, widthTms, bvsToRevert) ← visitExprRec g {} {} (← g.getType)
+  for (w, term) in widthTms.terms do
+    logInfo m!"{w}, {term.term.toExpr}"
+
+  -- Introduce the width masks, bounded by the max width
+  let (g, widthInfos) ← introMaskWidths widthTms g ctx
+
   -- Intro the `BitVec`s
-  let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  let (gs, _bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
+  let g :: secondaryGoals := gs | throwError "should have more than one"
   -- Find preconditions on the width `FVar`s
-  let g ← translateWidthPreconds widthInfos g
+  -- let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
-           <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
+          --  <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
   -- Run simp
   let g ← applySimp g thms
-  -- Return modified goal and subgoals
-  return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
-
+  -- -- Return modified goal and subgoals
+  -- return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
+  return g :: secondaryGoals ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula, containing a single-width parameter, into a

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -111,7 +111,7 @@ def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single local decl, and try to introduce it as a `BitVec` variable in our larger universe
 if it is in fact a `BitVec` variable.
 -/
-def introBitvecFVarChecked (ctx : PbvTranslateContext) (g : MVarId)
+def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthInfo : WidthInfo) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   -- Find the BitVec {width_expr} variables.
@@ -123,31 +123,52 @@ def introBitvecFVarChecked (ctx : PbvTranslateContext) (g : MVarId)
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
   -- Intros
   let name ← oldVar.getUserName
-  let (bvVar, g) ← g.intro name
-  let (bvHyp, g) ← g.intro <| Name.mkSimple s!"h_m{name}"
+  let (bvVar, g) ← g.withContext <| g.intro name
+  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_m{name}"
+  logInfo m!"{g}"
   return (g, bvInfos.push { bvVar, bvHyp })
 
+/--
+This creates a plan of bitvector fvars to be reverted, and their corresponding widths.
+-/
+structure BitVecFVarsToRevert where
+  bvs : HashMap FVarId WidthInfo := {}
+
+def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthInfo : WidthInfo) : BitVecFVarsToRevert :=
+  if this.bvs.contains fvar then  this
+  else { bvs := this.bvs.insert fvar widthInfo }
 
 /--
-boo lean is stupid, it can't see that this will terminate.
+Visit an expression, collecting all widths and introducing mask variables.
+For bitvectors, collect the bitvectors that need to be eliminated,
+and then eliminate them all in the next step.
 -/
-partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId) (widthInfos : WidthInfos) (bvInfos : BitVecInfos) (e : Expr) :
-    MetaM (MVarId × WidthInfos × BitVecInfos) := g.withContext do
+partial def visitExpr (ctx : PbvTranslateContext) (g : MVarId)
+    (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
+    (e : Expr) :
+    MetaM (MVarId × WidthInfos × BitVecFVarsToRevert) := g.withContext do
   let (f, args) := (e.getAppFn, e.getAppArgs)
-  let (g, widthInfos, bvInfos) ← g.withContext do
-    args.foldlM (init := (g, widthInfos, bvInfos)) fun (g, widthInfos, bvInfos) arg => visitExpr ctx g widthInfos bvInfos arg
-  let tf ← inferType f
+  let (g, widthInfos, bvs) ← g.withContext do
+    args.foldlM (init := (g, widthInfos, bvs)) fun (g, widthInfos, bvs) arg => g.withContext do visitExpr ctx g widthInfos bvs arg
+  let tf ← g.withContext do inferType f
   if let some wExpr := getBitvecType? tf then
     let (g, widthInfo, widthInfos) ← widthInfos.getOrCreateInfo ctx g wExpr
     if let some fvarId := f.fvarId? then
-      let (g, bvInfos) ← introBitvecFVarChecked ctx g bvInfos fvarId widthInfo
-      return (g, widthInfos, bvInfos)
+      return (g, widthInfos, bvs.push fvarId widthInfo)
     else
-      return (g, widthInfos, bvInfos)
+      return (g, widthInfos, bvs)
   else
-    return (g, widthInfos, bvInfos)
+    return (g, widthInfos, bvs)
 
 
+/--
+eliminate the bitvector variables to introduce the masked versions
+-/
+def introMaskedBitvectors (ctx : PbvTranslateContext)
+    (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (MVarId × BitVecInfos) := do
+  logInfo m!"number of bvs to revert {bvs.bvs.size}"
+  bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthInfo =>
+    introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthInfo
 
 /--
 These rewrites introduce the toplevel equality that convers `a = b` into
@@ -203,11 +224,12 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
     | throwError "goal solved by simp"
   return g
 
-meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := do
+def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- throwError s!"Deciding with bound {ctx.bmcBound}"
   -- let (g, widthInfos) ← introMaskWidths ctx g
   -- Introduce bitvector variables
-  let (g, widthInfos, bvInfos) ← visitExpr ctx g {} {} (← g.getType)
+  let (g, widthInfos, bvsToRevert) ← visitExpr ctx g {} {} (← g.getType)
+  let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Run simp
   let thms := ← addToplevelRewrites g widthInfos
                       <| ← addPushTheorems g
@@ -284,5 +306,4 @@ example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) 
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
-  · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -322,7 +322,7 @@ meta def introMaskedBitvectors (ctx : PbvTranslateContext)
 These theorems require pre-filling the width bound in order to be used within
 the Simp set.
 -/
-meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
+meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (widthTms : WidthTms) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
@@ -334,7 +334,7 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
   ]
 
   thms.foldlM (init := simp) fun simps name =>
-    return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
+    return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit <| widthTms.getUniverseWidthUpperBound ctx]
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -346,7 +346,8 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
       ``setWidth_add,
       ``setWidth_setWidth,
       ``signBitOfMask_eq,
-      ``setWidth_signExtend_eq_and_maskOfWidth
+      ``setWidth_signExtend_eq_and_maskOfWidth,
+      ``setWidth_append_eq_mul_maskOfWidth
   ]
 
   let mut simp := simp
@@ -398,7 +399,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
   -- Create simp set
-  let thms := ← addBoundRewrites g ctx
+  let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -19,9 +19,14 @@ meta def Expr.isNat (e : Expr) : Bool := e.isConstOf ``Nat
 inductive TmKind
 | width
 
+/-- An environment that maps width atoms in 'Tm' into its 'Expr' -/
+structure TmWidthEnv where
+    width2expr : Nat → Expr
+
 inductive Tm : TmKind → Type
-| widthAtom (e : Expr) : Tm .width
+| widthAtom (e : Expr) : Tm .width -- TODO: this should be Nat.
 | widthAdd (v w : Tm .width) : Tm .width
+-- | withPropLe (a b : Tm .width) : Tm .prop
 
 -- Might have a problem reifying "atom" widths which are composite eg: BitVec (w + 1 - 1)
 -- TODO fixable by first traversing the BitVec definitions to obtain the atoms, and then look
@@ -29,13 +34,10 @@ inductive Tm : TmKind → Type
 meta partial def Tm.reifyWidth (e : Expr) : MetaM (Option (Tm .width)) := do
   match_expr e with
   | HAdd.hAdd ty _ _ _ ae be =>
-    if Expr.isNat ty then
-      if let some a ← Tm.reifyWidth ae then
-        if let some b ← Tm.reifyWidth be then
-          pure (some (.widthAdd a b))
-        else pure none
-      else pure none
-    else pure none
+      let .true := Expr.isNat ty | pure none
+      let some a ← Tm.reifyWidth ae | pure none
+      let some b ← Tm.reifyWidth be | pure none
+      pure (some (.widthAdd a b))
   | _ =>
     match e with
     | .fvar _ => pure (some (.widthAtom (e)))
@@ -132,7 +134,7 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
     let maskName := Name.mkSimple s!"m{name}"
     let (#[mask, maskHyp], g) ← g.withContext <| g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
       | throwError m!"Failed to intro {``width_elim}"
-  -- Define bounding conditions.
+    -- Introduce width bound on the variable.
     let hypWidthLeBound ← g.withContext do
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthTm.term.toExpr, mkNatLit maxBound])
@@ -152,7 +154,6 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
       hypWidthLeBoundNote
     }
     return (g, infos.push info)
-    -- return (g, infos)
 
 /--
 Get some width Expr from infos.
@@ -194,25 +195,25 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single bitvector FVarId, and try to introduce it as a `BitVec`
 variable in our larger universe.
 -/
-meta def introBitvecFVarUnchecked (blastBound : Nat) (g : MVarId)
+meta def introBitvecFVarUnchecked (widthInfos : WidthInfos) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthTm : WidthTm) :
-      MetaM (List MVarId × BitVecInfos) := g.withContext do
-  -- Find the BitVec {width_expr} variables.
-    -- Revert to expose forall with the BitVec.
-  let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError m!"Reverting {g} shuold produce a var."
-  -- Apply ``var_elim leaving a hole to be filled relating to the proof that the width expr is less than the bound width
-  let [newGoal, g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-      #[mkNatLit blastBound, widthTm.term.toExpr]
+      MetaM (MVarId × BitVecInfos) := g.withContext do
+  -- Revert to expose forall with the BitVec.
+  let (#[oldVar], g) ← g.revert #[bvFVarId]
+    | throwError m!"Reverting {g} shuold produce a var."
+  let wExpr := widthTm.term.toExpr
+  -- Apply ``var_elim.
+  let some infos := widthInfos.infos[wExpr]?
+    | throwError m!"{widthTm.term.toExpr} Shuold have be defined in widthInfos."
+  let [g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim #[.fvar infos.hypWidthLeBoundNote]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
-  -- logInfo m!"old goal: {g}"
-  -- logInfo m!"new goal: {newGoal}"
-  -- Intros
+
   let name ← oldVar.getUserName
-  let widthMaskName := s!"maskOfWidth_{← widthTm.term.toName g}"
-  let (#[bvVar, bvHyp], g) ← g.withContext <| g.introN 2 [name, Name.mkSimple s!"h_{name}_{widthMaskName}"]
+  let (#[bvVar, bvHyp], g) ← g.withContext <| g.introN 2
+    [name, Name.mkSimple s!"h_{name}_maskOfWidth_{← widthTm.term.toName g}"]
     | throwError m!"Expecting two intros from {g}"
 
-  return ([g, newGoal], bvInfos.push { bvVar, bvHyp })
+  return (g, bvInfos.push { bvVar, bvHyp })
 
 /--
 This creates a plan of bitvector fvars to be reverted, and their corresponding widths.
@@ -312,12 +313,10 @@ meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateC
 /--
 Eliminate the bitvector variables to introduce the masked versions.
 -/
-meta def introMaskedBitvectors (ctx : PbvTranslateContext)
-    (bvs : BitVecFVarsToRevert) (g : MVarId) (widthTms : WidthTms) : MetaM (List MVarId × BitVecInfos) := do
-  bvs.bvs.foldM (init := ([g], {})) fun (gs, bvInfos) bvFvarId widthTm => do
-    let g :: other := gs | throwError m!"{gs} should always have at least one element"
-    let (g', bvInfos) ← introBitvecFVarUnchecked (widthTms.getUniverseWidthUpperBound ctx) g bvInfos bvFvarId widthTm
-    return (g' ++ other, bvInfos)
+meta def introMaskedBitvectors (bvs : BitVecFVarsToRevert) (g : MVarId)
+    (widthInfos : WidthInfos) : MetaM (MVarId × BitVecInfos) := do
+  bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthTm => do
+    introBitvecFVarUnchecked widthInfos g bvInfos bvFvarId widthTm
 /--
 These theorems require pre-filling the width bound in order to be used within
 the Simp set.
@@ -394,8 +393,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
 
   -- Intro the `BitVec`s
-  let (g :: secondaryGoals, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g widthTms
-    | throwError "Shuold always have more than one goal."
+  let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
   -- Create simp set
@@ -406,7 +404,8 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Run simp
   let g ← applySimp g thms
   -- -- Return modified goal and subgoals
-  return g :: secondaryGoals ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
+  return g :: (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
+
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula, containing a single-width parameter, into a

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -11,6 +11,9 @@ namespace Veir.Data.PBV
 Information about the width variable and associated hypotheses.
 -/
 structure WidthInfo where
+  /-- The Name correspodning to this width. -/
+  widthName : Name
+  /-- The Expr corresponding to this width. -/
   widthExpr : Expr
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
@@ -36,30 +39,34 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-    -- TODO: check that the value has Nat.
+    -- Retrieve the ldecl from the context
+    let ldecl ← getFVarLocalDecl widthExpr
+    -- Check that the Expr is of type Nat.
+    assert! ldecl.type == (mkConst ``Nat)
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, ldecl, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit ctx.bmcBound, widthExpr, ← g.getType]
       | throwError "width_elim should generate a goal"
     -- Intros
-    let maskName := Name.mkSimple s!"maskWidth_new_var" -- TODO: find the name if it's an Fvar, and otherwise abstract it into a new name.
+    let maskName := Name.mkSimple s!"m{ldecl.userName}"
     let (mask, g) ← g.withContext do g.intro maskName
     let (maskHyp, g) ← g.withContext do g.intro (Name.mkSimple s!"h_{maskName}")
     -- Define bounding conditions.
-    let hypWidthLeBound <- g.withContext do
+    let hypWidthLeBound ← g.withContext do
       -- Add a meaninful name using : (userName := Name.mkSimple "foo")
       mkFreshExprMVar (kind := .syntheticOpaque) (mkAppN (Expr.const ``LE.le [.zero])
-        #[mkConst ``Nat, mkConst ``instLENat, ldecl, mkNatLit ctx.bmcBound])
+        #[mkConst ``Nat, mkConst ``instLENat, widthExpr, mkNatLit ctx.bmcBound])
     g.withContext <| check hypWidthLeBound
-    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"hack_hyp_width_le_bound_{maskName}") hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{ldecl.userName}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_isMask") hypExpr
 
     let info : WidthInfo := {
-      widthExpr := ldecl,
+      widthName := ldecl.userName,
+      widthExpr := widthExpr,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
       hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
@@ -124,7 +131,8 @@ meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
   -- Intros
   let name ← oldVar.getUserName
   let (bvVar, g) ← g.withContext <| g.intro name
-  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_m{name}"
+  let widthMaskName ← widthInfo.widthMaskFvar.getUserName
+  let (bvHyp, g) ← g.withContext <| g.intro <| Name.mkSimple s!"h_{name}_{widthMaskName}"
   return (g, bvInfos.push { bvVar, bvHyp })
 
 /--
@@ -138,8 +146,9 @@ meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (
   else { bvs := this.bvs.insert fvar widthInfo }
 
 /--
-Visit the expression collecting widths, introducing masks,
-and then eliminating them all in the next step.
+Given an expression, if it is of `BitVec w` type then create a mask for the
+width `w`. If it is also an FVar, then it means it's a variable hence it has to
+be added to the set of FVars to be reverted.
 -/
 meta def visitExprNonrec (ctx : PbvTranslateContext) (g : MVarId)
     (widthInfos : WidthInfos) (bvs : BitVecFVarsToRevert)
@@ -175,15 +184,12 @@ meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
 
 /--
 Translate width precondition into BitVec hypothesis.
-TODO: consider more complicated exprs that might have additions...
+TODO: consider more complicated width exprs.
 -/
-meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)  :
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl) :
     MetaM (MVarId) := g.withContext do
   match_expr ldecl.type with
   | LT.lt ty _inst ea eb =>
-    -- ea ≤ eb
-    -- translate ea
-    -- translate eb
     -- note the mask theorem for this particular.
     if ty == mkConst ``Nat then
       if let some wa := winfos.infos[ea]? then
@@ -194,8 +200,8 @@ meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : Local
               .fvar wb.hypWidthLeBoundNote,
               .fvar wa.widthMaskHypFvar,
               .fvar wb.widthMaskHypFvar,
-              (.fvar ldecl.fvarId)]
-          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{ea}_lt_{eb}") (← bvLTExpr) -- discard hyp, not needed
+              .fvar ldecl.fvarId]
+          let (_mask_hyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") (← bvLTExpr)
           logInfo m!"Translated {ldecl.toExpr} : {ldecl.type} to bitvec"
           return g
     return g
@@ -224,6 +230,7 @@ meta def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : Si
   let mut simp := simp
   simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
   return simp
+
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
 TODO: make this a simp-set, called `pbv_push`, and just gather these
@@ -294,10 +301,10 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 parametric bitvector formula, containing a single-width parameter, into a
 concrete width formula.
 
-The tactic generates two goals:
+The tactic generates multiple goals:
 1. The desired concrete width formula that can be decided using `bv_decide`
-2. A side-goal to prove that the width parameter is bounded by the provided
-bound, this should be solvable by grind.
+2. Multiple side-goals to prove that the width parameters are bounded by the
+provided bound, these should be solvable by grind.
 -/
 syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num) : tactic
 
@@ -323,6 +330,20 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   := by
   pbv_decide 8
   · bv_decide
+  · grind
+  · grind
+  · grind
+
+theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
+  (hr : t <= 8)
+  (hqr : q < r)
+  (hpq : p < q)
+  (hrt : r < t):
+  ((x.zeroExtend q).zeroExtend r).zeroExtend t = x.zeroExtend t
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
   · grind
   · grind
   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -14,8 +14,7 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def Expr.isNat (e : Expr) : MetaM Bool := do
-  return (← inferType e).isConstOf ``Nat
+meta def Expr.isNat (e : Expr) : Bool := e.isConstOf ``Nat
 
 inductive TmKind
 | width
@@ -30,7 +29,7 @@ inductive Tm : TmKind → Type
 meta partial def Tm.reifyWidth (e : Expr) : MetaM (Option (Tm .width)) := do
   match_expr e with
   | HAdd.hAdd ty _ _ _ ae be =>
-    if (← Expr.isNat ty) then
+    if Expr.isNat ty then
       if let some a ← Tm.reifyWidth ae then
         if let some b ← Tm.reifyWidth be then
           pure (some (.widthAdd a b))
@@ -48,7 +47,7 @@ meta def Tm.toExpr : Tm .width → Expr
 
 meta def Tm.toName (tm: Tm .width) (g : MVarId) : MetaM Name := g.withContext do
   match tm with
-  | .widthAtom e => pure <| Name.mkSimple s!"{← e.fvarId!.getUserName}"
+  | .widthAtom e => pure <| Name.mkSimple s!"{← e.fvarId!.getUserName}" -- assume atom is Fvar for docs purposes
   | .widthAdd v w => pure <| Name.mkSimple s!"{← v.toName g}_add_{← w.toName g}"
 
 /-- Computes the upper bound of widths needed to calculate this width without overflowing.
@@ -58,6 +57,7 @@ meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateConte
   | .widthAtom _ => ctx.bmcBound
   | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
 
+-- TODO (see above)
 -- structure WidthAtoms where
   --
 
@@ -137,7 +137,7 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat, mkConst ``instLENat, widthTm.term.toExpr, mkNatLit maxBound])
     g.withContext <| check hypWidthLeBound
-    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound
+    let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_blast") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``maskOfWidth_and_add_one_eq_zero #[mkFVar maskHyp]
@@ -194,21 +194,21 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
 Analyze a single bitvector FVarId, and try to introduce it as a `BitVec`
 variable in our larger universe.
 -/
-meta def introBitvecFVarUnchecked (ctx : PbvTranslateContext) (g : MVarId)
+meta def introBitvecFVarUnchecked (blastBound : Nat) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthTm : WidthTm) :
       MetaM (List MVarId × BitVecInfos) := g.withContext do
   -- Find the BitVec {width_expr} variables.
     -- Revert to expose forall with the BitVec.
-  let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError "reverting shuold produce a var"
+  let (#[oldVar], g) ← g.revert #[bvFVarId] | throwError m!"Reverting {g} shuold produce a var."
   -- Apply ``var_elim leaving a hole to be filled relating to the proof that the width expr is less than the bound width
   let [newGoal, g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim
-      #[mkNatLit ctx.bmcBound, widthTm.term.toExpr]
+      #[mkNatLit blastBound, widthTm.term.toExpr]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
   -- logInfo m!"old goal: {g}"
   -- logInfo m!"new goal: {newGoal}"
   -- Intros
   let name ← oldVar.getUserName
-  let widthMaskName := "ahhh"
+  let widthMaskName := s!"maskOfWidth_{← widthTm.term.toName g}"
   let (#[bvVar, bvHyp], g) ← g.withContext <| g.introN 2 [name, Name.mkSimple s!"h_{name}_{widthMaskName}"]
     | throwError m!"Expecting two intros from {g}"
 
@@ -313,10 +313,10 @@ meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateC
 Eliminate the bitvector variables to introduce the masked versions.
 -/
 meta def introMaskedBitvectors (ctx : PbvTranslateContext)
-    (bvs : BitVecFVarsToRevert) (g : MVarId) : MetaM (List MVarId × BitVecInfos) := do
+    (bvs : BitVecFVarsToRevert) (g : MVarId) (widthTms : WidthTms) : MetaM (List MVarId × BitVecInfos) := do
   bvs.bvs.foldM (init := ([g], {})) fun (gs, bvInfos) bvFvarId widthTm => do
     let g :: other := gs | throwError m!"{gs} should always have at least one element"
-    let (g', bvInfos) ← introBitvecFVarUnchecked ctx g bvInfos bvFvarId widthTm
+    let (g', bvInfos) ← introBitvecFVarUnchecked (widthTms.getUniverseWidthUpperBound ctx) g bvInfos bvFvarId widthTm
     return (g' ++ other, bvInfos)
 /--
 These theorems require pre-filling the width bound in order to be used within
@@ -393,8 +393,8 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
 
   -- Intro the `BitVec`s
-  let (gs, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
-  let g :: secondaryGoals := gs | throwError "should have more than one"
+  let (g :: secondaryGoals, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g widthTms
+    | throwError "Shuold always have more than one goal."
   -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
   -- Create simp set

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -36,7 +36,16 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
+/--
+Rewrite a local decl using a provided Expr
+-/
+def rewriteHypWith (g : MVarId) (h : FVarId) (eq : Expr) :
+    MetaM (MVarId × FVarId × List MVarId) := g.withContext do
+  let r ← g.rewrite (← h.getType) eq
+  let res ← g.replaceLocalDecl h r.eNew r.eqProof
+  return (res.mvarId, res.fvarId, r.mvarIds)
+
+def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- TODO: check that the value has Nat.
     let [g] ← g.withContext do
@@ -56,7 +65,10 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) 
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (_hIsMaskOfEq, g) ← g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    let (hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
+    -- Express `IsMask` in terms on `BitVec`s
+    let (g, _hIsMaskOfEq, _) ← rewriteHypWith g hIsMaskOfEq (mkConst ``isMask_eq)
+
     let info : WidthInfo := {
       widthExpr := ldecl,
       widthMaskFvar := mask,
@@ -361,3 +373,6 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   := by
   pbv_decide 8
   · bv_decide
+  · grind
+  · grind
+  · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -185,6 +185,24 @@ partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
   -- else
   --   return (g, widthInfos, bvs)
 
+def translateWidthPrecond (ctx : PbvTranslateContext) (winfos : WidthInfos) (g : MVarId) (e : Expr)  :
+    MetaM (MVarId × WidthInfos) := g.withContext do
+  match_expr e with
+  | LE.le ty inst ea eb =>
+    if ty == mkConst ``Nat then
+      -- ea ≤ eb
+      -- translate ea
+      -- translate eb
+      -- note the mask theorem for this particular.
+      sorry
+    else
+      return (g, winfos)
+  | _ => return (g, winfos)
+
+def translateWidthPreconds (ctx : PbvTranslateContext) (winfos: WidthInfos) (g : MVarId) : MetaM (MVarId × WidthInfos) := do
+  -- loop over ← getLCtx, call translateWidthPrecond
+  sorry
+
 
 /--
 eliminate the bitvector variables to introduce the masked versions
@@ -198,13 +216,13 @@ def introMaskedBitvectors (ctx : PbvTranslateContext)
 These rewrites introduce the toplevel equality that convers `a = b` into
 `a.setWidth o &&& mask = b.setWidth o &&& mask`, which kickstarts the pushing process.
 -/
-meta def addToplevelRewrites (g : MVarId) (widthInfos : WidthInfos) (simp : SimpTheoremsArray) :
+def addToplevelRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let mut simp := simp
-  for (_widthExpr, widthInfo) in widthInfos.infos do
-    simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkFVar widthInfo.hypWidthLeBoundNote])
+  simp ← simp.addTheorem (.other ``eq_iff) <| (← mkAppM ``eq_iff #[mkNatLit ctx.bmcBound])
+  simp ← simp.addTheorem (.other ``nat_lt_nat_eq_mask_lt_mask) <| (← mkAppM ``nat_lt_nat_eq_mask_lt_mask #[mkNatLit ctx.bmcBound])
+  simp ← simp.addTheorem (.other ``nat_le_nat_eq_mask_le_mask) <| (← mkAppM ``nat_le_nat_eq_mask_le_mask #[mkNatLit ctx.bmcBound])
   return simp
-
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
 TODO: make this a simp-set, called `pbv_push`, and just gather these
@@ -258,7 +276,7 @@ def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) 
 
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Run simp
-  let thms := ← addToplevelRewrites g widthInfos
+  let thms := ← addToplevelRewrites g ctx
                       <| ← addPushTheorems g
                       <| ← addBvInfos g bvInfos
                       <| ← addWidthInfosSimpLemmas g widthInfos #[]
@@ -310,7 +328,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   have mw_mask := isMask_of_eq_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
-      eq_iff w_le_bw,             -- Introduce `setWidth` to goal
+      eq_iff _ w_le_bw,             -- Introduce `setWidth` to goal
       setWidth_add,       -- Push `setWidth` down add
       setWidth_setWidth,  -- Push `setWidth` down setWidth
       BitVec.setWidth_eq,         -- Remove redundant setWidths
@@ -331,13 +349,15 @@ example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) 
   · bv_decide
   · grind
 
+theorem imp_eq_not_or (P Q : Prop) : (P → Q) = (¬ P ∨ Q) := by grind
+
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)
   (hqr : q < r)
   (hpq : p < q) :
   (x.zeroExtend q).zeroExtend r = x.zeroExtend r
   := by
-  pbv_decide 8
+  pbv_decide 13
   · sorry
   · sorry
   · sorry

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -432,13 +432,10 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
 meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
   -- Construct the width environment
   let widthEnv ← createWidthEnv g
-  for w in widthEnv.width2expr do
-    logInfo m!"wenv : {w}"
   -- Find `BitVec`s and intro their widths
   let (g, widthTms, bvsToRevert) ← visitExprRec g { env := widthEnv } {} (← g.getType)
   -- Introduce the width masks, bounded by the max width
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
-
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Find preconditions on the width `FVar`s

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -71,8 +71,8 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_bound") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
-    let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_isMask") hypExpr
+    let hypExpr ← g.withContext do mkAppM ``maskOfWidth_and_add_one_eq_zero #[mkFVar maskHyp]
+    let (_, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_bv_mask") hypExpr
 
     let info : WidthInfo := {
       widthName := name,
@@ -83,7 +83,6 @@ meta def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (widthExpr : Ex
       hypWidthLeBoundNote
     }
     return (g, info, infos.push info)
-    -- return (g, infos)
 
 /--
 Either get existing width info, or create one if it does not exist.
@@ -321,9 +320,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, bvInfos) ← introMaskedBitvectors ctx bvsToRevert g
   -- Find preconditions on the width `FVar`s
   let g ← translateWidthPreconds widthInfos g
-  -- Create simp Set
-  -- TODO: make this a simp-set, called `pbv_push`, and just gather these
-  -- from the simp-set. This makes them user-extensible with no metaprogramming needed.
+  -- Create simp set
   let thms := ← addBoundRewrites g ctx
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
@@ -352,23 +349,3 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
-
--- TODO: get the following working by also instantiating the provided width bound
--- example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
---   x + y = y + x := by
---   pbv_decide 4
---   · simp only [eq_iff 4 hw]
---     bv_decide
---   · grind
-
--- TODO: handle addition inside of the mask widths.
--- example (p q r : Nat) (x : BitVec p)
---   (hr : q ≤ 8)
---   (hpq : p < q) :
---   (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
---   := by
---   pbv_decide 8
---   · bv_decide
---   · grind
---   · grind
---   · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -36,15 +36,6 @@ meta structure PbvTranslateContext where
   /-- The bound upto which we want to bitblast our widths. -/
    bmcBound : Nat
 
-/--
-Rewrite a local decl using a provided Expr
--/
-def rewriteHypWith (g : MVarId) (h : FVarId) (eq : Expr) :
-    MetaM (MVarId × FVarId × List MVarId) := g.withContext do
-  let r ← g.rewrite (← h.getType) eq
-  let res ← g.replaceLocalDecl h r.eNew r.eqProof
-  return (res.mvarId, res.fvarId, r.mvarIds)
-
 def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- TODO: check that the value has Nat.
@@ -65,9 +56,7 @@ def introMaskWidth (ctx : PbvTranslateContext) (g : MVarId) (ldecl : Expr) (info
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
     let hypExpr ← g.withContext do mkAppM ``isMask_of_eq_maskOfWidth #[mkFVar maskHyp]
-    let (hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
-    -- Express `IsMask` in terms on `BitVec`s
-    let (g, _hIsMaskOfEq, _) ← rewriteHypWith g hIsMaskOfEq (mkConst ``isMask_eq)
+    let (_hIsMaskOfEq, g) ← g.withContext do g.note (Name.mkSimple s!"h_isMask_of_eq_{maskName}") hypExpr
 
     let info : WidthInfo := {
       widthExpr := ldecl,
@@ -358,12 +347,6 @@ example (w : Nat) (x y: BitVec w) (hw : w ≤ 4) :
   pbv_decide 4
   · bv_decide
   · grind
-
--- example (v w : Nat) (x y: BitVec w) (z : BitVec v) (hw : w ≤ 4) (hv : v <= 4) :
---   x + y = y + x := by
---   pbv_decide 4
---   · bv_decide
---   · grind
 
 theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r <= 8)

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -155,12 +155,16 @@ Get WidthInfo from a Term.
 meta def WidthInfos.getFromTm? (this : WidthInfos) (wTm : WidthTm) : Option WidthInfo :=
   this.infos[wTm.term.toName]?
 
--- /--
--- Get WidthInfo from an Expr.
--- -/
--- meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
---     : MetaM (Option WidthInfo) := do
---   return this.infos[← whnf wExpr]?
+/--
+Get WidthInfo from an Expr.
+-/
+meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
+    : MetaM (Option WidthInfo) := do
+  -- Reduce the expression (allows for cases such as (w + 0) to be reduced to w)
+  let reducedExpr ← whnf wExpr
+  -- Reify the expr using the env and then look for it in the Hashmap
+  let some reified ← Tm.reifyWidth this.env reducedExpr | pure none
+  return this.infos[reified.toName]?
 
 meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfos) := g.withContext do
@@ -301,31 +305,31 @@ meta def matchWidthRel (e : Expr) :
   | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
   | _ => none
 
--- /--
--- If a condition on the width hypothesis is found, and the widths are contained
--- within the `WidthInfos` set, then duplicate the hypothesis and add it to the
--- goal. This allows for a single call to Simp later.
--- -/
--- meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
---     : MetaM (MVarId) := g.withContext do
---   if let some (ea, eb) := matchWidthRel ldecl.type then
---     let some wa ← winfos.get? ea | return g
---     let some wb ← winfos.get? eb | return g
---     let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
---     let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
---     return g
---   else
---     return g
+/--
+If a condition on the width hypothesis is found, and the widths are contained
+within the `WidthInfos` set, then restate (note) the hypothesis and add it to the
+goal. This allows for a single call to Simp later.
+-/
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+    : MetaM (MVarId) := g.withContext do
+  if let some (ea, eb) := matchWidthRel ldecl.type then
+    let some wa ← winfos.getFromExpr? ea | return g
+    let some wb ← winfos.getFromExpr? eb | return g
+    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
+    let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
+    return g
+  else
+    return g
 
--- /--
--- Traverse the local context and add any width pre-conditions to the goal.
--- -/
--- meta def translateWidthPreconds (winfos: WidthInfos)
---     (g : MVarId) : MetaM MVarId := g.withContext do
---   let mut g := g
---   for ldecl in ← getLCtx do
---     g ← translateWidthPrecond winfos g ldecl
---   return g
+/--
+Traverse the local context and add any width pre-conditions to the goal.
+-/
+meta def translateWidthPreconds (winfos: WidthInfos)
+    (g : MVarId) : MetaM MVarId := g.withContext do
+  let mut g := g
+  for ldecl in ← getLCtx do
+    g ← translateWidthPrecond winfos g ldecl
+  return g
 
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
@@ -425,7 +429,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Find preconditions on the width `FVar`s
---   let g ← translateWidthPreconds widthInfos g
+  let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g
@@ -433,7 +437,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
   -- Run simp
   let g ← applySimp g thms
-  -- -- Return modified goal and subgoals
+  -- Return modified goal and subgoals
   return g :: (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
 /--

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -32,6 +32,11 @@ meta structure TmWidthEnv where
 meta def TmWidthEnv.push (this : TmWidthEnv) (width : Expr) : TmWidthEnv :=
   { width2expr := this.width2expr.push width }
 
+/--
+Traverse the local context to extract the width 'atoms' that make up width
+expressions. These are either width `Expr`s coming from `BitVec w` or
+`Nat` variables in the local context.
+-/
 meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
   (← getLCtx).foldrM (init := {}) (fun ldecl (widthEnv : TmWidthEnv ) => do
       if let some width := getBitvecType? ldecl.type then
@@ -44,22 +49,28 @@ meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
           pure widthEnv
     )
 
-
+/--
+Type to capture the expressions this tactic will handle.
+Only capture `width` at the moment.
+-/
 inductive TmKind
 | width
 
-
+/--
+Inductive data structure to express the Terms that this tactic reasons about.
+-/
 inductive Tm : TmKind → Type
-| widthAtom (id : Nat) : Tm .width -- TODO: this should be Nat.
+| widthAtom (id : Nat) : Tm .width
 | widthAdd (v w : Tm .width) : Tm .width
--- | withPropLe (a b : Tm .width) : Tm .prop
 
--- Might have a problem reifying "atom" widths which are composite eg: BitVec (w + 1 - 1)
--- TODO fixable by first traversing the BitVec definitions to obtain the atoms, and then look
--- them up while reifying
+/--
+Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
+the width term. The environment holds the 'atom' `Expr`s which are the building
+blocks of the terms.
+-/
 meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .width)) := do
   if let some id := env.width2expr.idxOf? e then
-    -- The atom is whatever expression is present in the Env
+    -- An atom is an expression is present in the Env
     pure <| some (.widthAtom id)
   else
     match_expr e with
@@ -70,26 +81,30 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
         pure (some (.widthAdd a b))
     | _ => pure none
 
+/--
+Convert a `Tm` into an `Expr` provided and environment.
+-/
 meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
   match this with
   | .widthAtom id => env.width2expr[id]!
   | .widthAdd v w => mkNatAdd (v.toExpr env) (w.toExpr env)
 
+/--
+Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
+-/
 meta def Tm.toName (tm: Tm .width) : Name :=
   match tm with
   | .widthAtom e => Name.mkSimple s!"w{e}"
   | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
 
-/-- Computes the upper bound of widths needed to calculate this width without overflowing.
-That maximum such, across all widths, will be used to get the universal upper bound. -/
+/--
+Compute the upper bound of widths needed to calculate this width without overflowing.
+The maximum, across all widths, will be used to get the universal upper bound.
+-/
 meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
   match tm with
   | .widthAtom _ => ctx.bmcBound
   | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
-
--- TODO (see above)
--- structure WidthAtoms where
-  --
 
 structure WidthTm where
   term : Tm .width
@@ -134,9 +149,7 @@ structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it.
-      TODO: it's not clear why we need a `FVar` for `simp` to decide to rewrite with it.
-  -/
+  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
   hypWidthLeBoundNote : FVarId
 
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -330,40 +330,36 @@ meta partial def visitExprRec (g : MVarId)
   else
     return (g, widthTms, bvs)
 
-meta def tmToNote (term : Tm .prop) (widthInfos : WidthInfos) (g : MVarId) (fvar : FVarId) : MetaM MVarId := g.withContext do
-  -- WIP assume the two sides of the prop are width "atoms" that are inside of widthInfos
+meta def getThmFromTm (term : Tm .prop) : Option (Name × Tm .width × Tm .width) :=
   match term with
-  | .widthLT v w =>
-    let some vInfo := widthInfos.getFromTm? v |
-      logInfo m!"Skipping width condition transformation, term {v.toExpr widthInfos.env} is not a mask."
-      return g
-    let some wInfo := widthInfos.getFromTm? w |
-      logInfo m!"Skipping width condition transformation, term {w.toExpr widthInfos.env} is not a mask."
-      return g
-    let (_newFvar, g) ← g.withContext <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
-      <| ← mkAppM ``lt_eq_lt_of_eq_maskOfWidth #[
-          .fvar vInfo.hypWidthLeBoundNote,
-          .fvar wInfo.hypWidthLeBoundNote,
-          .fvar vInfo.widthMaskHypFvar,
-          .fvar wInfo.widthMaskHypFvar,
-          .fvar fvar,
-          ]
-    return g
-  | _ => return g
-
+  | .widthLT v w => (``lt_eq_lt_of_eq_maskOfWidth, v, w)
+  | _ => none
 
 /--
 If a condition on the width hypothesis is found, and the widths are contained
-within the `WidthInfos` set, then restate (note) the hypothesis and add it to the
-goal. This allows for a single call to Simp later.
+within the `WidthInfos` set, then convert into a statement about the width masks.
 -/
-meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+meta def translateWidthPrecond (widthInfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId) := g.withContext do
-  let reified ← Tm.reifyProp winfos.env (ldecl.type)
-  if let some prop := reified then
-    logInfo m!"Managed to reify `{ldecl.toExpr}: {ldecl.type}`"
-    return ← tmToNote prop winfos g ldecl.fvarId
+  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return g
+  let some (thm, v, w) := getThmFromTm prop | return g
+  let some vInfo := widthInfos.getFromTm? v |
+    logInfo m!"Skipping width condition transformation, term {v.toExpr widthInfos.env} is not a mask."
+    return g
+  let some wInfo := widthInfos.getFromTm? w |
+    logInfo m!"Skipping width condition transformation, term {w.toExpr widthInfos.env} is not a mask."
+    return g
+  let (_, g) ← g.withContext
+    <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
+    <| ← mkAppM thm <| #[
+        wInfo.hypWidthLeBoundNote,
+        vInfo.hypWidthLeBoundNote,
+        vInfo.widthMaskHypFvar,
+        wInfo.widthMaskHypFvar,
+        ldecl.fvarId,
+        ].map mkFVar
   return g
+
 /--
 Traverse the local context and add any width pre-conditions to the goal.
 -/
@@ -495,16 +491,3 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
-
-/-- Zero extending a zero extension-/
-example (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-  · grind
-  · grind
-  · grind

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -183,26 +183,35 @@ meta partial def visitExprRec (ctx : PbvTranslateContext) (g : MVarId)
     return (g, widthInfos, bvs)
 
 /--
-Translate width precondition into BitVec hypothesis.
-TODO: Deal with constants.
+Match width relation.
 -/
-meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl) :
-    MetaM (MVarId) := g.withContext do
-  match_expr ldecl.type with
-  | LT.lt ty _inst ea eb =>
-    if ty == mkConst ``Nat then
-      if let some wa := winfos.infos[ea]? then
-        if let some wb := winfos.infos[eb]? then
-          let (natLTHyp, g) ← g.withContext do
-            g.note (Name.mkSimple s!"bv_{wa.widthName}_lt_{wb.widthName}") ldecl.toExpr
-          let (#[_], g) ← g.revert #[natLTHyp] | throwError "Reverting shuold produce a single FVar."
-          return g
-    return g
-  | _ => return g
+meta def matchWidthRel (e : Expr) :
+    Option (Expr × Expr) :=
+  match_expr e with
+  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
+  | _ => none
 
 /--
-Traverse the local context and translate any hypotheses on `Nat` widths into
-`BitVec` hypotheses.
+If a condition on the width hypothesis is found, and the widths are contained
+within the `WidthInfos` set, then duplicate the hypothesis and add it to the
+goal. This allows for a single call to Simp later.
+-/
+meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+    : MetaM (MVarId) := g.withContext do
+  if let some (ea, eb) := matchWidthRel ldecl.type then
+    let some wa := winfos.infos[ea]? | return g
+    let some wb := winfos.infos[eb]? | return g
+    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.widthName}_{wb.widthName}") ldecl.toExpr
+    let (#[_], g) ← g.revert #[natHyp] | throwError "Reverting shuold produce a single FVar."
+    return g
+  else
+    return g
+
+/--
+Traverse the local context and add any width pre-conditions to the goal.
 -/
 meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
@@ -227,7 +236,11 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (simp : SimpT
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
-        ``Nat_lt_eq_Mask_lt]
+        ``Nat_lt_eq_Mask_lt,
+        ``Nat_le_eq_Mask_le,
+        ``Nat_ge_eq_Mask_ge,
+        ``Nat_gt_eq_Mask_gt
+  ]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit ctx.bmcBound]
@@ -240,7 +253,12 @@ from the simp-set. This makes them user-extensible with no metaprogramming neede
 -/
 meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let others := #[``BitVec.setWidth_eq, ``setWidth_add, ``setWidth_setWidth]
+  let others := #[
+      ``BitVec.setWidth_eq,
+      ``setWidth_add,
+      ``setWidth_setWidth
+  ]
+
   let mut simp := simp
   for n in others do
     simp ← simp.addTheorem (.other n) (mkConst n [])
@@ -299,8 +317,6 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 
   return [g] ++ (widthInfos.infos.values.map (·.hypWidthLeBoundMVarId))
 
-
-
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula, containing a single-width parameter, into a
@@ -341,9 +357,9 @@ theorem trace_double_zero_extend (p q r : Nat) (x : BitVec p)
 
 theorem trace_triple_zero_extend (p q r t : Nat) (x : BitVec p)
   (hr : t <= 8)
-  (hqr : q < r)
-  (hpq : p < q)
-  (hrt : r < t):
+  (hqr : q ≤ r)
+  (hpq : q > p)
+  (hrt : t ≥ r):
   ((x.zeroExtend q).zeroExtend r).zeroExtend t = x.zeroExtend t
   := by
   pbv_decide 8

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -145,9 +145,10 @@ meta def WidthTms.push (this : WidthTms) (width : WidthTm) : WidthTms :=
 /--
 Either get existing width term, or try and reify one if it does not exist.
 -/
-meta def WidthTms.getOrCreateTm
-    (g : MVarId) (this : WidthTms) (wExpr : Expr) : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
-  let some reified ← Tm.reifyWidth this.env wExpr | throwError m!"Failed to reify width expr: {wExpr}"
+meta def WidthTms.getOrCreateTm (g : MVarId) (this : WidthTms) (wExpr : Expr)
+  : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
+  let some reified ← Tm.reifyWidth this.env wExpr
+    | throwError m!"Failed to reify width expr: {wExpr}"
   if let some info := this.terms[reified.toName]? then -- use reified.toExpr as a kind of "normal"/"canonical" form
     return (g, info, this)
   else
@@ -216,12 +217,16 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
     -- Intros
     let name := widthTm.term.toName
     let maskName := Name.mkSimple s!"m_{name}"
-    let (#[mask, maskHyp], g) ← g.withContext <| g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
+    let (#[mask, maskHyp], g) ← g.withContext
+      <| g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
       | throwError m!"Failed to intro {``width_elim}"
     -- Introduce width bound on the variable.
     let hypWidthLeBound ← g.withContext do
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
-        #[mkConst ``Nat, mkConst ``instLENat, widthTm.term.toExpr infos.env, mkNatLit maxBound])
+        #[mkConst ``Nat,
+          mkConst ``instLENat,
+          widthTm.term.toExpr infos.env,
+          mkNatLit maxBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_blast") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
@@ -330,9 +335,15 @@ meta partial def visitExprRec (g : MVarId)
   else
     return (g, widthTms, bvs)
 
+/--
+Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
+-/
 meta def getThmFromTm (term : Tm .prop) : Option (Name × Tm .width × Tm .width) :=
   match term with
   | .widthLT v w => (``lt_eq_lt_of_eq_maskOfWidth, v, w)
+  | .widthLE v w => (``le_eq_le_of_eq_maskOfWidth, v, w)
+  | .widthGT v w => (``gt_eq_gt_of_eq_maskOfWidth, v, w)
+  | .widthGE v w => (``ge_eq_ge_of_eq_maskOfWidth, v, w)
   | _ => none
 
 /--
@@ -352,8 +363,8 @@ meta def translateWidthPrecond (widthInfos : WidthInfos) (g : MVarId) (ldecl : L
   let (_, g) ← g.withContext
     <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
     <| ← mkAppM thm <| #[
-        wInfo.hypWidthLeBoundNote,
         vInfo.hypWidthLeBoundNote,
+        wInfo.hypWidthLeBoundNote,
         vInfo.widthMaskHypFvar,
         wInfo.widthMaskHypFvar,
         ldecl.fvarId,
@@ -365,16 +376,14 @@ Traverse the local context and add any width pre-conditions to the goal.
 -/
 meta def translateWidthPreconds (winfos: WidthInfos)
     (g : MVarId) : MetaM MVarId := g.withContext do
-  let mut g := g
-  for ldecl in ← getLCtx do
-    g ← translateWidthPrecond winfos g ldecl
-  return g
+  (← getLCtx).foldlM (translateWidthPrecond winfos) g
 
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
+  -- Compute max width
   let maxWidth := widthTms.getUniverseWidthUpperBound ctx
-
+  -- Intro all the masks
   widthTms.terms.foldM (init := (g, { env := widthTms.env })) (fun (g, widthInfos) _ widthTm =>
     introMaskWidth maxWidth g widthTm widthInfos
   )
@@ -390,7 +399,8 @@ meta def introMaskedBitvectors (bvs : BitVecFVarsToRevert) (g : MVarId)
 These theorems require pre-filling the width bound in order to be used within
 the Simp set.
 -/
-meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (widthTms : WidthTms) (simp : SimpTheoremsArray) :
+meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
+  (widthTms : WidthTms) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
@@ -398,7 +408,8 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (widthTms : W
   ]
 
   thms.foldlM (init := simp) fun simps name =>
-    return ← simps.addTheorem (.other name) <| ← mkAppM name #[mkNatLit <| widthTms.getUniverseWidthUpperBound ctx]
+    return ← simps.addTheorem (.other name)
+      <| ← mkAppM name #[mkNatLit <| widthTms.getUniverseWidthUpperBound ctx]
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -451,7 +462,8 @@ meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.w
     | throwError "goal solved by simp"
   return g
 
-meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId) := g.withContext do
+meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVarId)
+  := g.withContext do
   -- Construct the width environment
   let widthEnv ← createWidthEnv g
   -- Find `BitVec`s and intro their widths

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -56,6 +56,7 @@ Only capture `width` at the moment.
 -/
 inductive TmKind
 | width
+| prop
 
 /--
 Inductive data structure to express the Terms that this tactic reasons about.
@@ -63,6 +64,10 @@ Inductive data structure to express the Terms that this tactic reasons about.
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
 | widthAdd (v w : Tm .width) : Tm .width
+| widthLT (v m : Tm .width) : Tm .prop
+| widthLE (v m : Tm .width) : Tm .prop
+| widthGT (v m : Tm .width) : Tm .prop
+| widthGE (v m : Tm .width) : Tm .prop
 
 /--
 Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
@@ -81,6 +86,26 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
         let some b ← Tm.reifyWidth env be | pure none
         pure (some (.widthAdd a b))
     | _ => pure none
+
+/--
+Match width relation.
+-/
+meta def matchWidthRel (e : Expr) :
+    Option ((Tm TmKind.width → Tm TmKind.width → Tm TmKind.prop) × Expr × Expr) :=
+  match_expr e with
+  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLT, ea, eb) else none
+  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLE, ea, eb) else none
+  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGT, ea, eb) else none
+  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGE, ea, eb) else none
+  | _ => none
+
+meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
+  if let some (rel, ea, eb) := matchWidthRel e then
+    let some wa ← Tm.reifyWidth env ea | pure none
+    let some wb ← Tm.reifyWidth env eb | pure none
+    pure <| some (rel wa wb)
+  else
+    pure none
 
 /--
 Convert a `Tm` into an `Expr` provided and environment.
@@ -168,8 +193,8 @@ meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
 /--
 Get WidthInfo from a Term.
 -/
-meta def WidthInfos.getFromTm? (this : WidthInfos) (wTm : WidthTm) : Option WidthInfo :=
-  this.infos[wTm.term.toName]?
+meta def WidthInfos.getFromTm? (this : WidthInfos) (wTm : Tm .width) : Option WidthInfo :=
+  this.infos[wTm.toName]?
 
 /--
 Get WidthInfo from an Expr.
@@ -245,7 +270,7 @@ meta def introBitvecFVarUnchecked (widthInfos : WidthInfos) (g : MVarId)
     | throwError m!"Reverting {g} shuold produce a var."
   let wExpr := widthTm.term.toExpr widthInfos.env
   -- Apply ``var_elim.
-  let some infos := widthInfos.getFromTm? widthTm
+  let some infos := widthInfos.getFromTm? widthTm.term
     | throwError m!"{wExpr} Shuold have be defined in widthInfos."
   let [g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim #[.fvar infos.hypWidthLeBoundNote]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
@@ -305,17 +330,27 @@ meta partial def visitExprRec (g : MVarId)
   else
     return (g, widthTms, bvs)
 
-/--
-Match width relation.
--/
-meta def matchWidthRel (e : Expr) :
-    Option (Expr × Expr) :=
-  match_expr e with
-  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
-  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
-  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
-  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (ea, eb) else none
-  | _ => none
+meta def tmToNote (term : Tm .prop) (widthInfos : WidthInfos) (g : MVarId) (fvar : FVarId) : MetaM MVarId := g.withContext do
+  -- WIP assume the two sides of the prop are width "atoms" that are inside of widthInfos
+  match term with
+  | .widthLT v w =>
+    let some vInfo := widthInfos.getFromTm? v |
+      logInfo m!"Skipping width condition transformation, term {v.toExpr widthInfos.env} is not a mask."
+      return g
+    let some wInfo := widthInfos.getFromTm? w |
+      logInfo m!"Skipping width condition transformation, term {w.toExpr widthInfos.env} is not a mask."
+      return g
+    let (_newFvar, g) ← g.withContext <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
+      <| ← mkAppM ``lt_eq_lt_of_eq_maskOfWidth #[
+          .fvar vInfo.hypWidthLeBoundNote,
+          .fvar wInfo.hypWidthLeBoundNote,
+          .fvar vInfo.widthMaskHypFvar,
+          .fvar wInfo.widthMaskHypFvar,
+          .fvar fvar,
+          ]
+    return g
+  | _ => return g
+
 
 /--
 If a condition on the width hypothesis is found, and the widths are contained
@@ -324,15 +359,11 @@ goal. This allows for a single call to Simp later.
 -/
 meta def translateWidthPrecond (winfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId) := g.withContext do
-  if let some (ea, eb) := matchWidthRel ldecl.type then
-    let some wa ← winfos.getFromExpr? ea | return g
-    let some wb ← winfos.getFromExpr? eb | return g
-    let (natHyp, g) ← g.withContext do g.note (Name.mkSimple s!"bv_{wa.name}_{wb.name}") ldecl.toExpr
-    let (#[_], g) ← g.revert #[natHyp] | throwError m!"Reverting {← natHyp.getType} shuold produce a single FVar."
-    return g
-  else
-    return g
-
+  let reified ← Tm.reifyProp winfos.env (ldecl.type)
+  if let some prop := reified then
+    logInfo m!"Managed to reify `{ldecl.toExpr}: {ldecl.type}`"
+    return ← tmToNote prop winfos g ldecl.fvarId
+  return g
 /--
 Traverse the local context and add any width pre-conditions to the goal.
 -/
@@ -367,10 +398,6 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext) (widthTms : W
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
-        ``lt_eq_lt_of_eq_maskOfWidth,
-        ``le_eq_le_of_eq_maskOfWidth,
-        ``ge_eq_ge_of_eq_maskOfWidth,
-        ``gt_eq_gt_of_eq_maskOfWidth,
         ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
   ]
 
@@ -468,3 +495,16 @@ public meta def evalPbvDecide : Tactic := fun stx => do
       let ctx : PbvTranslateContext := { bmcBound := n.getNat }
       replaceMainGoal (← pbvTranslate (← getMainGoal) ctx)
   | _ => throwUnsupportedSyntax
+
+/-- Zero extending a zero extension-/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+  · grind
+  · grind
+  · grind


### PR DESCRIPTION
This PR changes the way the goal is transformed from a parametric width one into a bounded concrete width goal.
- Before we were traversing the local context to discover the widths and transform them into masks, then traversing the context again to find the bitvectors and transform those into concrete width ones. 
- Now, we instead recursively traverse the goal AST (in `visitExpRec`) and keeping track of the widths that are found and the leaf `BitVec` variables that need to be redefined in terms on a concrete width. Then, the collected widths are transformed into masks and the `BitVec`s redefined in terms of the bound width.

Further, the width expressions are now 'reified' into a term (`Tm`) AST in order to be able to reason about them structurally. At the moment, the only component is a width 'atom' which refers to an expression that is either a `Nat` in a local context or the `w` in a `BitVec w` definition. The atoms are collected from the context and used to construct the terms while recursing over the goal.

Minor changes:
- The `IsMask` definition is removed since it only added extra steps in the tactic metaprogramming.
- Redefine `eq_iff` and other theorems in `Push.lean` to make the width bound variable `o` explicit, as it has to be bound in order for the simp based rewriting to succeed.



 