### PR TITLE
feat: Add proofs of size equality in `MatchDecl.operation`

### DIFF
--- a/Veir/PatternRewriter/Puddle/Builders.lean
+++ b/Veir/PatternRewriter/Puddle/Builders.lean
@@ -123,9 +123,11 @@ def MatchProg.operation (opCode : OpCode) (operands : Array (Handle OpCode .valu
     let res := (Array.range returnTypes.size).map fun index =>
       Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
     let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
+    have hresults : res.size = returnTypes.size := by grind
     (⟨op, res, properties⟩, { state with
       nextId := state.nextId + returnTypes.size + 2
-      decls := .operation opCode operands returnTypes property properties op res :: state.decls
+      decls := .operation opCode operands returnTypes property properties op res hresults ::
+        state.decls
     })⟩
 
 /--
@@ -145,11 +147,12 @@ def MatchProg.root (opCode : OpCode) (operands : Array (Handle OpCode .value))
     let results := (Array.range returnTypes.size).map fun index =>
       Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
     let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
+    have hresults : results.size = returnTypes.size := by grind
     (⟨op, properties⟩, { state with
       nextId := state.nextId + returnTypes.size + 2
       root? := some op
       rootConstraints :=
-        .operation opCode operands returnTypes property properties op results ::
+        .operation opCode operands returnTypes property properties op results hresults ::
           state.rootConstraints
       numRoots := state.numRoots + 1
     })⟩

--- a/Veir/PatternRewriter/Puddle/Definitions.lean
+++ b/Veir/PatternRewriter/Puddle/Definitions.lean
@@ -104,11 +104,12 @@ handle against that operation, require the given opcode, operands, result types,
 and bind the discovered entities to their corresponding handles. -/
 | operation (opCode : OpInfo)
     (operands : Array (Handle OpInfo .value))
-    (returnTypes : Array (Handle OpInfo .type))
+    (resultTypes : Array (Handle OpInfo .type))
     (property : PropertyMatcher opCode)
     (propertyResult : Handle OpInfo (.prop opCode))
     (result : Handle OpInfo .op)
     (results : Array (Handle OpInfo .value))
+    (resultsSize : results.size = resultTypes.size)
 
 /--
 A match program together with the value exported by its builder. Exports typically contain handles

--- a/Veir/PatternRewriter/Puddle/Execution.lean
+++ b/Veir/PatternRewriter/Puddle/Execution.lean
@@ -220,7 +220,7 @@ assignment if it succeeds.
 def MatchDecl.run (decl : MatchDecl OpInfo) (ctx : IRContext OpInfo)
     (assignment : Assignment OpInfo) : Option (Assignment OpInfo) := do
   match decl with
-  | .operation opCode operands resultTypes property propertyHandle opHandle results =>
+  | .operation opCode operands resultTypes property propertyHandle opHandle results _ =>
     /- First, find the matched operation through its handle or one of its result handles. -/
     let matchedOp ← Assignment.findOp assignment opHandle results
     /- Then, bind the operation and result handles. -/


### PR DESCRIPTION
`MatchDecl.operation` has one argument for result types, and one for result handles. This change adds as an argument a proof that both have the same size. Also, change the name `returnTypes` to `resultTypes`, which makes more sense.