### PR TITLE
feat(tactic): add simp sets for isTerminator and getEffects

### DIFF
--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -114,6 +114,7 @@ def Arith.toAttrDict
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Arith.getEffects
     (_op : Arith) (_props : Arith.propertiesOf _op) : MemoryEffects :=
   .none

--- a/Veir/Dialects/Builtin/OpInfo.lean
+++ b/Veir/Dialects/Builtin/OpInfo.lean
@@ -37,6 +37,7 @@ def Builtin.toAttrDict
   | .unregistered => Std.HashMap.ofList props.properties.entries.toList
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Builtin.getEffects
     (op : Builtin) (_props : Builtin.propertiesOf op) : MemoryEffects :=
   match op with

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -40,6 +40,7 @@ def Cf.toAttrDict
       (Attribute.denseArrayAttr props.operandSegmentSizes)
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Cf.getEffects
     (_op : Cf) (_props : Cf.propertiesOf _op) : MemoryEffects :=
   .none
@@ -51,6 +52,7 @@ def Cf.hasSSADominance (_op : Cf) (_index : Nat) : Bool :=
   true
 
 /-- Every `cf` operation is a branch, and so terminates its block. -/
+@[is_terminator]
 def Cf.isTerminator (_op : Cf) : Bool :=
   true
 

--- a/Veir/Dialects/Comb/OpInfo.lean
+++ b/Veir/Dialects/Comb/OpInfo.lean
@@ -63,6 +63,7 @@ def Comb.toAttrDict
       "predicate".toUTF8 (Attribute.integerAttr props.predicate)
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Comb.getEffects
     (_op : Comb) (_props : Comb.propertiesOf _op) : MemoryEffects :=
   .none

--- a/Veir/Dialects/Datapath/OpInfo.lean
+++ b/Veir/Dialects/Datapath/OpInfo.lean
@@ -30,6 +30,7 @@ def Datapath.toAttrDict
     Std.HashMap ByteArray Attribute :=
   Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Datapath.getEffects
     (_op : Datapath) (_props : Datapath.propertiesOf _op) : MemoryEffects :=
   .none

--- a/Veir/Dialects/Func/OpInfo.lean
+++ b/Veir/Dialects/Func/OpInfo.lean
@@ -47,6 +47,7 @@ def Func.toAttrDict
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Func.getEffects
     (op : Func) (_props : Func.propertiesOf op) : MemoryEffects :=
   match op with
@@ -64,6 +65,7 @@ def Func.isIsolatedFromAbove (op : Func) : Bool :=
 def Func.hasSSADominance (_op : Func) (_index : Nat) : Bool :=
   true
 
+@[is_terminator]
 def Func.isTerminator (op : Func) : Bool :=
   match op with
   | .return => true

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -49,6 +49,7 @@ def HW.toAttrDict
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def HW.getEffects
     (_op : HW) (_props : HW.propertiesOf _op) : MemoryEffects :=
   .none
@@ -66,6 +67,7 @@ def HW.isIsolatedFromAbove (op : HW) : Bool :=
 def HW.hasSSADominance (_op : HW) (_index : Nat) : Bool :=
   true
 
+@[is_terminator]
 def HW.isTerminator (op : HW) : Bool :=
   match op with
   | .output => true

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -283,6 +283,7 @@ def Llvm.toAttrDict
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :=
   match op, props with
   | .alloca, _ => .allocate
@@ -323,6 +324,7 @@ def Llvm.isIsolatedFromAbove (op : Llvm) : Bool :=
 def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
   true
 
+@[is_terminator]
 def Llvm.isTerminator (op : Llvm) : Bool :=
   match op with
   | .br | .cond_br | .return | .unreachable => true

--- a/Veir/Dialects/ModArith/OpInfo.lean
+++ b/Veir/Dialects/ModArith/OpInfo.lean
@@ -41,6 +41,7 @@ def Mod_Arith.toAttrDict
       "value".toUTF8 (Attribute.integerAttr props.value)
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Mod_Arith.getEffects
     (_op : Mod_Arith) (_props : Mod_Arith.propertiesOf _op) : MemoryEffects :=
   .none

--- a/Veir/Dialects/PDL/OpInfo.lean
+++ b/Veir/Dialects/PDL/OpInfo.lean
@@ -124,6 +124,7 @@ def PDL.toAttrDict
 /-- MLIR marks only `pdl.range`, `pdl.result` and `pdl.results` `Pure` (see
     `PDLOps.td`). The rest describe or perform rewrite actions and carry no
     memory-effect interface, so we report the conservative answer for them. -/
+@[get_effects]
 def PDL.getEffects (op : PDL) (_props : PDL.propertiesOf op) : MemoryEffects :=
   match op with
   | .range | .result | .results => .none
@@ -149,6 +150,7 @@ def PDL.hasNoTerminator (op : PDL) (_index : Nat) : Bool :=
 
 /-- MLIR marks `pdl.rewrite` itself a `Terminator`: it is the last operation of
     the `pdl.pattern` body it lives in. -/
+@[is_terminator]
 def PDL.isTerminator (op : PDL) : Bool :=
   match op with
   | .rewrite => true

--- a/Veir/Dialects/RISCV/OpInfo.lean
+++ b/Veir/Dialects/RISCV/OpInfo.lean
@@ -201,6 +201,7 @@ def Riscv.toAttrDict
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Riscv.getEffects (op : Riscv) (props : Riscv.propertiesOf op) : MemoryEffects :=
   match op, props with
   | .ld, props | .lw, props | .lwu, props

--- a/Veir/Dialects/RISCV_Cf/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Cf/OpInfo.lean
@@ -54,6 +54,7 @@ def Riscv_Cf.toAttrDict
       (Attribute.denseArrayAttr props.operandSegmentSizes)
   | _ => Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Riscv_Cf.getEffects
     (_op : Riscv_Cf) (_props : Riscv_Cf.propertiesOf _op) : MemoryEffects :=
   .none
@@ -65,6 +66,7 @@ def Riscv_Cf.hasSSADominance (_op : Riscv_Cf) (_index : Nat) : Bool :=
   true
 
 /-- Every `riscv_cf` operation is a branch, and so terminates its block. -/
+@[is_terminator]
 def Riscv_Cf.isTerminator (_op : Riscv_Cf) : Bool :=
   true
 

--- a/Veir/Dialects/RISCV_Stack/OpInfo.lean
+++ b/Veir/Dialects/RISCV_Stack/OpInfo.lean
@@ -36,6 +36,7 @@ def Riscv_Stack.toAttrDict
     dict := dict.insert "size".toUTF8 (Attribute.integerAttr props.size)
     dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
 
+@[get_effects]
 def Riscv_Stack.getEffects
     (_op : Riscv_Stack) (_props : Riscv_Stack.propertiesOf _op) : MemoryEffects :=
   .allocate

--- a/Veir/Dialects/RV64/OpInfo.lean
+++ b/Veir/Dialects/RV64/OpInfo.lean
@@ -30,6 +30,7 @@ def Rv64.toAttrDict
     Std.HashMap ByteArray Attribute :=
   Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Rv64.getEffects
     (_op : Rv64) (_props : Rv64.propertiesOf _op) : MemoryEffects :=
   .none

--- a/Veir/Dialects/Test/OpInfo.lean
+++ b/Veir/Dialects/Test/OpInfo.lean
@@ -27,6 +27,7 @@ def Test.toAttrDict
     Std.HashMap ByteArray Attribute :=
   Std.HashMap.emptyWithCapacity 0
 
+@[get_effects]
 def Test.getEffects
     (_op : Test) (_props : Test.propertiesOf _op) : MemoryEffects :=
   .unknown

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -36,6 +36,7 @@ match opCode with
   What are the memory effects of an operation with this opcode and these
   properties?
 -/
+@[get_effects]
 def OpCode.getEffects (opCode : OpCode) (props : _propertiesOf opCode) : MemoryEffects :=
   match opCode, props with
   | .arith op, props => Arith.getEffects op props
@@ -143,6 +144,7 @@ def OpCode.isIsolatedFromAbove (opCode : OpCode) : Bool :=
   Does this OpCode count as an MLIR basic block terminator? Dialects that do
   not say otherwise inherit the `HasOpInfo` default of `false`.
 -/
+@[is_terminator]
 def OpCode.isTerminator (opCode : OpCode) : Bool :=
   match opCode with
   | .arith op => HasOpInfo.isTerminator op

--- a/Veir/IR/OpInfo.lean
+++ b/Veir/IR/OpInfo.lean
@@ -125,6 +125,9 @@ class HasOpInfo (opCode: Type)
   -/
   isIsolatedFromAbove : opCode → Bool := fun _ => false
 
+attribute [get_effects] HasOpInfo.getEffects
+attribute [is_terminator] HasOpInfo.isTerminator
+
 variable {OpInfo : Type} [HasOpInfo OpInfo]
 
 /-- Verify the local invariants of an operation using its opcode interface. -/

--- a/Veir/IR/Simp.lean
+++ b/Veir/IR/Simp.lean
@@ -12,3 +12,7 @@ register_simp_attr eq_bang
 
 /- Simp set for folding away `Dialect`.propertiesOf calls -/
 register_simp_attr properties_of
+
+/- Simp sets for reducing operation memory effects and terminator information. -/
+register_simp_attr get_effects
+register_simp_attr is_terminator


### PR DESCRIPTION
`isTerminator` and `getEffects` are going to be used inside `Puddle` rewrite proofs. So, in order to make generic tactic to discharge these proofs, we need a simp set for these functions, which are defined for each dialect.