### PR TITLE
feat(puddle): add `Puddle.Valid` to assert structural correctness

### DIFF
--- a/UnitTest/Puddle.lean
+++ b/UnitTest/Puddle.lean
@@ -1,5 +1,6 @@
 import Veir.PatternRewriter.Puddle.Builders
 import Veir.PatternRewriter.Puddle.Execution
+import Veir.PatternRewriter.Puddle.Validity
 import Veir.Parser.MlirParser
 import Veir.Printer
 
@@ -28,6 +29,10 @@ private def addZero : Pattern OpCode :=
     pure
     (fun x => x)
 
+theorem addZero_valid : Pattern.Valid addZero := by
+  simp only [addZero, matchConstant]
+  provePuddleValid
+
 /-- Rewrite `x * 2` to `x + x`. -/
 private def mulTwo : Pattern OpCode :=
   Pattern.Builder
@@ -43,6 +48,10 @@ private def mulTwo : Pattern OpCode :=
       let add ← CreateProg.operation (.arith .addi) #[x, x] #[returnType] properties
       return add)
     (fun result => result)
+
+theorem mulTwo_valid : Pattern.Valid mulTwo := by
+  simp only [mulTwo, matchConstant]
+  provePuddleValid
 
 /- ## Test matcher builder validation -/
 

--- a/Veir/PatternRewriter/Puddle/Validity.lean
+++ b/Veir/PatternRewriter/Puddle/Validity.lean
@@ -1,0 +1,131 @@
+module
+
+public import Veir.PatternRewriter.Puddle.Builders
+
+/-!
+# Puddle Patterns Validity
+
+This file defines the obligations for a Puddle pattern to be considered valid (`Pattern.Valid`),
+both structurally and semantically. If `Pattern.Valid` holds, then compiling the Puddle pattern
+with `Pattern.compile` should produce a rewrite pattern that satisfies `LocalRewritePattern.Valid`.
+-/
+
+namespace Veir.Puddle
+
+public section
+
+variable {OpInfo : Type} [HasOpInfo OpInfo]
+
+/-!
+## Supported Opcodes
+
+Puddle currently only supports operations that cannot terminate a block and have no memory effects.
+-/
+
+/--
+An opcode is supported when it is not a terminator and has no memory effects for any possible
+property value.
+
+We could in the future support opcodes when we know that the properties matched or created by the
+pattern are such that the operation has no memory effects, but this is only happening in rare cases.
+-/
+@[expose]
+def SupportedOpCode (opCode : OpInfo) : Prop :=
+  HasOpInfo.isTerminator opCode = false ∧
+    ∀ property, HasOpInfo.getEffects opCode property = .none
+
+/-- A match declaration is supported when the opcode of an operation declaration is supported. -/
+@[expose]
+def MatchDecl.Supported (decl : MatchDecl OpInfo) : Prop :=
+  match decl with
+  | .operation opCode _ _ _ _ _ _ _ => SupportedOpCode opCode
+  | _ => True
+
+/-- Every declaration in a match program uses supported opcodes. -/
+@[expose]
+def MatchProg.Supported (prog : MatchProg OpInfo α) : Prop :=
+  ∀ decl ∈ prog.decls, decl.Supported
+
+/-- A creation declaration is supported when the opcode of an operation declaration is supported. -/
+@[expose]
+def CreateDecl.Supported : CreateDecl OpInfo → Prop
+  | .operation opCode _ _ _ _ _ => SupportedOpCode opCode
+  | _ => True
+
+/-- Every declaration in a creation program uses supported opcodes. -/
+@[expose]
+def CreateProg.Supported (prog : CreateProg OpInfo α) : Prop :=
+  ∀ decl ∈ prog.decls, decl.Supported
+
+/-- The pattern only references supported opcodes. -/
+@[expose]
+def Pattern.Supported (rule : Pattern OpInfo) : Prop :=
+  rule.matcher.Supported ∧ rule.creation.Supported
+
+/-! ## Root Constraint -/
+
+/--
+The first declaration in the match program is an operation declaration whose operation handle is
+the program's distinguished root handle.
+-/
+@[expose]
+def MatchProg.ConstrainsRoot (prog : MatchProg OpInfo α) : Prop :=
+  match prog.decls with
+  | .operation _ _ _ _ _ opHandle _ _ :: _ => opHandle = prog.rootHandle
+  | _ => False
+
+/-!
+## Pattern Validity
+
+`Pattern.Valid` is the predicate that a Puddle pattern is both sound structurally and
+semantically.  If `Pattern.Valid` holds, then compiling the Puddle pattern
+with `Pattern.compile` should produce a rewrite pattern that satisfies `LocalRewritePattern.Valid`.
+-/
+
+/-- The static validity conditions required by a Puddle pattern. -/
+structure Pattern.Valid (rule : Pattern OpInfo) : Prop where
+  /-- Every operation declaration in the pattern uses a supported opcode. -/
+  Supported : rule.Supported
+  /-- The match program starts with an operation declaration constraining its root handle. -/
+  ConstrainsRoot : rule.matcher.ConstrainsRoot
+
+/-!
+## Validity Tactics
+
+This section defines tactics for proving the different obligations of `Pattern.Valid`. These tactics
+are intended to be used in the proof of `Pattern.Valid` for a specific Puddle pattern.
+-/
+
+/-- Unfold and simplify the builders used to construct a concrete Puddle pattern. -/
+macro "unfoldPuddleBuilder" : tactic =>
+  `(tactic| (
+    /- Unfold the builder functions -/
+    simp only [Pattern.Builder, MatchProg.build, CreateProg.build, bind, pure,
+      MatchProg.value, MatchProg.type, MatchProg.root, MatchProg.operation, CreateProg.operation,
+      CreateProg.property];
+    /- Simplify the resulting expressions with standard simplifications -/
+    simp only [Nat.zero_add, Nat.reduceAdd, List.size_toArray, List.length_cons, List.length_nil,
+      Array.size_map, Array.size_range, Nat.lt_add_one, getElem!_pos, Array.getElem_map,
+      Array.getElem_range, Nat.add_zero, List.cons_append, List.nil_append, List.reverse_nil,
+      List.reverse_cons, List.reverse_nil, List.nil_append, List.cons_append]))
+
+/-- Prove a `Puddle.Supported` goal. -/
+macro "provePuddleSupported" : tactic =>
+  `(tactic| (
+    simp [Pattern.Supported, CreateProg.Supported, MatchProg.Supported, MatchDecl.Supported,
+      CreateDecl.Supported, SupportedOpCode, get_effects, is_terminator];
+    done
+  ))
+
+/-- Prove a `Puddle.Valid` goal. -/
+macro "provePuddleValid" : tactic =>
+  `(tactic| (
+    unfoldPuddleBuilder
+    constructor
+    · provePuddleSupported
+    · rfl
+  ))
+
+end
+
+end Veir.Puddle


### PR DESCRIPTION
`Puddle.Valid` is meant to be a necessary condition for which the compiled pattern is `LocalRewritePattern.Valid`. This initial implementation only contains one field for supported opcodes, and one for ensuring the root is constrained. More fields will be added in following PRs, as well as a proof that `Pattern.Valid` implies `LocalRewritePattern.Valid`.