### PR TITLE
fix(LLVM): extend properly on mixed integer width (#1297)

### DIFF
--- a/Test/Interpreter/LLVM/constant_attr_i1_zext_to_wider_result.mlir
+++ b/Test/Interpreter/LLVM/constant_attr_i1_zext_to_wider_result.mlir
@@ -1,6 +1,4 @@
 // RUN: veir-interpret %s | filecheck %s
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
 
 // MLIR special-cases width-1 (and unsigned) integer attributes: they are
 // *zero*-extended to the result width, not sign-extended.  See

--- a/Test/Interpreter/LLVM/constant_attr_i1_zext_to_wider_result.mlir
+++ b/Test/Interpreter/LLVM/constant_attr_i1_zext_to_wider_result.mlir
@@ -1,7 +1,6 @@
 // RUN: veir-interpret %s | filecheck %s
 // Expected to fail until `llvm.mlir.constant` handles the value attribute's
 // integer width the way MLIR does; drop the XFAIL with the fix.
-// XFAIL: *
 
 // MLIR special-cases width-1 (and unsigned) integer attributes: they are
 // *zero*-extended to the result width, not sign-extended.  See

--- a/Test/Interpreter/LLVM/constant_attr_sext_to_wider_result.mlir
+++ b/Test/Interpreter/LLVM/constant_attr_sext_to_wider_result.mlir
@@ -1,7 +1,6 @@
 // RUN: veir-interpret %s | filecheck %s
 // Expected to fail until `llvm.mlir.constant` handles the value attribute's
 // integer width the way MLIR does; drop the XFAIL with the fix.
-// XFAIL: *
 
 // `llvm.mlir.constant` permits the value attribute's integer type to differ
 // from the result type. MLIR reads the literal as an APInt of the *attribute's*

--- a/Test/Interpreter/LLVM/constant_attr_sext_to_wider_result.mlir
+++ b/Test/Interpreter/LLVM/constant_attr_sext_to_wider_result.mlir
@@ -1,6 +1,4 @@
 // RUN: veir-interpret %s | filecheck %s
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
 
 // `llvm.mlir.constant` permits the value attribute's integer type to differ
 // from the result type. MLIR reads the literal as an APInt of the *attribute's*

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -783,7 +783,12 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
     | .integer intAttr =>
       let .integerType bw := resType.val
         | none
-      return (#[.int bw.bitwidth (LLVM.Int.constant bw.bitwidth intAttr.value)], mem, none)
+      let origbw := intAttr.type.bitwidth
+      let rawbits := BitVec.ofInt origbw intAttr.value
+      let extended := match origbw with
+        | 1 => rawbits.zeroExtend bw.bitwidth
+        | _ => rawbits.signExtend bw.bitwidth
+      return (#[.int bw.bitwidth (LLVM.Int.val extended)], mem, none)
     | .float floatAttr =>
       let .floatType bw := resType.val
         | none


### PR DESCRIPTION
We need to zero-extend when the width of attribute integer type is 1, and sign-extend otherwise.