### PR TITLE
parser: accept trailing type on unregistered attributes

### DIFF
--- a/Test/Parsing/unregistered_typed_attr.mlir
+++ b/Test/Parsing/unregistered_typed_attr.mlir
@@ -1,0 +1,23 @@
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+
+// Attributes from unregistered dialects may omit the `<body>` and may carry a
+// trailing `: type`, as MLIR's generic parser allows for any dialect attribute.
+// The type may be builtin or itself unregistered, and the attribute may appear
+// in properties, discardable attributes, and nested containers.
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    "unregistered.op_one"() {foo = #foo.bar} : () -> ()
+    "unregistered.op_two"() {foo = #foo.bar<baz> : i32} : () -> ()
+    "unregistered.op_three"() {foo = #foo.zero : !foo.ty} : () -> ()
+    %0 = "unregistered.op_four"() <{value = #foo.int<1> : !foo.int<s, 32>}> : () -> !foo.int<s, 32>
+    "unregistered.op_five"() {foo = [#foo.bar<1> : i32, #foo.bar<2> : !foo.ptr<!foo.int<s, 32>>]} : () -> ()
+    "unregistered.op_six"() {foo = {a = #foo.bar : i64, b = #foo.bar<2> : (i32) -> i32}} : () -> ()
+    // CHECK:      "unregistered.op_one"() {"foo" = #foo.bar} : () -> ()
+    // CHECK-NEXT: "unregistered.op_two"() {"foo" = #foo.bar<baz> : i32} : () -> ()
+    // CHECK-NEXT: "unregistered.op_three"() {"foo" = #foo.zero : !foo.ty} : () -> ()
+    // CHECK-NEXT: %{{.*}} = "unregistered.op_four"() <{"value" = #foo.int<1> : !foo.int<s, 32>}> : () -> !foo.int<s, 32>
+    // CHECK-NEXT: "unregistered.op_five"() {"foo" = [#foo.bar<1> : i32, #foo.bar<2> : !foo.ptr<!foo.int<s, 32>>]} : () -> ()
+    // CHECK-NEXT: "unregistered.op_six"() {"foo" = {"a" = #foo.bar : i64, "b" = #foo.bar<2> : (i32) -> i32}} : () -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Parsing/unregistered_typed_attr_error.mlir
+++ b/Test/Parsing/unregistered_typed_attr_error.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s --allow-unregistered-dialect 2>&1 | filecheck %s --strict-whitespace
+// RUN: MLIR_UNREGISTERED_INVALID
+
+"builtin.module"() ({
+    "func.return"() {foo = #bar.baz : } : () -> ()
+}) : () -> ()
+
+// CHECK:unregistered_typed_attr_error.mlir:5:39: error: type expected
+// CHECK-NEXT:    "func.return"() {foo = #bar.baz : } : () -> ()
+// CHECK-NEXT:                                      ^

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -222,8 +222,8 @@ macro "#assert " e:term : command =>
 #assert expectErrorAttr "#foo.bar<baz> :" "type expected" (some 15) true
 #assert expectErrorAttr "#foo.bar : 5" "type expected" (some 11) true
 -- The flag is still required when the attribute has no body or carries a type.
-#assert expectErrorAttr "#foo.bar" "attribute is not registered. Consider using --allow-unregistered-dialect." (some 0) false
-#assert expectErrorAttr "#foo.bar<baz> : i32" "attribute is not registered. Consider using --allow-unregistered-dialect." (some 0) false
+#assert expectErrorAttr "#foo.bar" "attribute '#foo.bar' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
+#assert expectErrorAttr "#foo.bar<baz> : i32" "attribute '#foo.bar' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
 -- Printing reproduces the source text, with the trailing type after the body.
 #assert expectRoundTripAttr "#foo.bar" true
 #assert expectRoundTripAttr "#foo.bar<baz>" true

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -97,6 +97,12 @@ def expectErrorAttr (s : String) (expected : String) (pos : Option Nat)
     && (testAttr s allowUnregisteredDialect).mapError errorInfo = .error (expected, pos)
 
 /--
+  Test that parsing an attribute and printing it back reproduces the input text exactly.
+-/
+def expectRoundTripAttr (s : String) (allowUnregisteredDialect : Bool := false) : Bool :=
+  (testAttr s allowUnregisteredDialect).map Attribute.toString = .ok s
+
+/--
   Macro to simplify test assertions. Wraps the test in #guard_msgs and #eval,
   expecting the result to be `true`.
 -/
@@ -182,9 +188,9 @@ macro "#assert " e:term : command =>
 
 /-! ## Unregistered dialect type -/
 
-#assert expectSuccessType "!foo.bar" ⟨UnregisteredAttr.mk "!foo.bar" true, by grind⟩ true
-#assert expectSuccessType "!foo<bar>" ⟨UnregisteredAttr.mk "!foo<bar>" true, by grind⟩ true
-#assert expectSuccessType "!test.test<bar>" ⟨UnregisteredAttr.mk "!test.test<bar>" true, by grind⟩ true
+#assert expectSuccessType "!foo.bar" ⟨UnregisteredAttr.mk "!foo.bar" true none, by grind⟩ true
+#assert expectSuccessType "!foo<bar>" ⟨UnregisteredAttr.mk "!foo<bar>" true none, by grind⟩ true
+#assert expectSuccessType "!test.test<bar>" ⟨UnregisteredAttr.mk "!test.test<bar>" true none, by grind⟩ true
 
 #assert expectErrorType "!foo.bar" "type '!foo.bar' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
 #assert expectErrorType "!foo<bar>" "type '!foo' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
@@ -193,8 +199,43 @@ macro "#assert " e:term : command =>
 
 /-! ## Unregistered dialect attribute -/
 
-#assert expectSuccessAttr "#foo<bar>" (UnregisteredAttr.mk "#foo<bar>" false) true
-#assert expectSuccessAttr "#test.test<bar>" (UnregisteredAttr.mk "#test.test<bar>" false) true
+#assert expectSuccessAttr "#foo<bar>" (UnregisteredAttr.mk "#foo<bar>" false none) true
+#assert expectSuccessAttr "#test.test<bar>" (UnregisteredAttr.mk "#test.test<bar>" false none) true
+#assert expectSuccessAttr "#foo.bar" (UnregisteredAttr.mk "#foo.bar" false none) true
+#assert expectSuccessAttr "#foo.bar<baz> : i32"
+  (UnregisteredAttr.mk "#foo.bar<baz>" false (some (IntegerType.mk 32 : Attribute))) true
+#assert expectSuccessAttr "#foo.zero : !foo.ty"
+  (UnregisteredAttr.mk "#foo.zero" false (some (UnregisteredAttr.mk "!foo.ty" true none : Attribute))) true
+#assert expectSuccessAttr "#foo.int<1> : !foo.int<s, 32>"
+  (UnregisteredAttr.mk "#foo.int<1>" false
+    (some (UnregisteredAttr.mk "!foo.int<s, 32>" true none : Attribute))) true
+#assert expectSuccessAttr "#foo.bar<1> : !foo.ptr<!foo.int<s, 32>>"
+  (UnregisteredAttr.mk "#foo.bar<1>" false
+    (some (UnregisteredAttr.mk "!foo.ptr<!foo.int<s, 32>>" true none : Attribute))) true
+#assert expectSuccessAttr "#foo<bar> : i1"
+  (UnregisteredAttr.mk "#foo<bar>" false (some (IntegerType.mk 1 : Attribute))) true
+#assert expectSuccessAttr "#foo.bar : (i32) -> i32"
+  (UnregisteredAttr.mk "#foo.bar" false (some (.functionType
+    (FunctionType.mk #[(IntegerType.mk 32 : Attribute)] #[(IntegerType.mk 32 : Attribute)]
+      (isVarArg := false))))) true
+-- A `:` must be followed by a type.
+#assert expectErrorAttr "#foo.bar<baz> :" "type expected" (some 15) true
+#assert expectErrorAttr "#foo.bar : 5" "type expected" (some 11) true
+-- The flag is still required when the attribute has no body or carries a type.
+#assert expectErrorAttr "#foo.bar" "attribute is not registered. Consider using --allow-unregistered-dialect." (some 0) false
+#assert expectErrorAttr "#foo.bar<baz> : i32" "attribute is not registered. Consider using --allow-unregistered-dialect." (some 0) false
+-- Printing reproduces the source text, with the trailing type after the body.
+#assert expectRoundTripAttr "#foo.bar" true
+#assert expectRoundTripAttr "#foo.bar<baz>" true
+#assert expectRoundTripAttr "#foo.bar<baz> : i32" true
+#assert expectRoundTripAttr "#foo.zero : !foo.ptr<!foo.int<s, 32>>" true
+-- Equality takes the trailing type into account.
+#assert (UnregisteredAttr.mk "#foo.bar" false (some (IntegerType.mk 32 : Attribute))
+  = UnregisteredAttr.mk "#foo.bar" false (some (IntegerType.mk 32 : Attribute)))
+#assert (UnregisteredAttr.mk "#foo.bar" false (some (IntegerType.mk 32 : Attribute))
+  ≠ UnregisteredAttr.mk "#foo.bar" false none)
+#assert (UnregisteredAttr.mk "#foo.bar" false (some (IntegerType.mk 32 : Attribute))
+  ≠ UnregisteredAttr.mk "#foo.bar" false (some (IntegerType.mk 64 : Attribute)))
 
 #assert expectErrorAttr "#foo<bar>" "attribute '#foo' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
 #assert expectErrorAttr "#test.test<bar>" "attribute '#test.test' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
@@ -258,24 +299,24 @@ macro "#assert " e:term : command =>
 
 -- Standalone struct: both forms parse identically, with or without the flag.
 #assert expectSuccessType "!llvm.struct<(i32, f32)>"
-  ⟨UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true, by grind⟩ false
+  ⟨UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true none, by grind⟩ false
 #assert expectSuccessType "!llvm.struct<(i32, f32)>"
-  ⟨UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true, by grind⟩ true
+  ⟨UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true none, by grind⟩ true
 -- Literal struct nested in an array (original `!llvm.array<N x struct<...>>` bug).
 #assert expectSuccessType "!llvm.array<2 x struct<(i32, f32)>>"
-  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true : Attribute)) true
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true none : Attribute)) true
 #assert expectSuccessType "!llvm.array<2 x struct<(i32, f32)>>"
-  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true : Attribute)) false
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true none : Attribute)) false
 -- The bare nested form and the prefixed nested form are equivalent.
 #assert expectSuccessType "!llvm.array<2 x !llvm.struct<(i32, f32)>>"
-  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true : Attribute)) false
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.struct<(i32, f32)>" true none : Attribute)) false
 -- Identified (named) struct: the name is preserved verbatim inside the text.
 #assert expectSuccessType "!llvm.array<23 x struct<\"struct.et_info\", (i8, i8)>>"
   (LLVM.ArrayType.mk 23
-    (UnregisteredAttr.mk "!llvm.struct<\"struct.et_info\", (i8, i8)>" true : Attribute)) true
+    (UnregisteredAttr.mk "!llvm.struct<\"struct.et_info\", (i8, i8)>" true none : Attribute)) true
 -- Packed struct nested in an array.
 #assert expectSuccessType "!llvm.array<4 x struct<packed (i8, i32)>>"
-  (LLVM.ArrayType.mk 4 (UnregisteredAttr.mk "!llvm.struct<packed (i8, i32)>" true : Attribute)) true
+  (LLVM.ArrayType.mk 4 (UnregisteredAttr.mk "!llvm.struct<packed (i8, i32)>" true none : Attribute)) true
 
 /-! ## LLVM Function type -/
 #assert expectSuccessType "!llvm.func<i32 (i32)>"

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -222,15 +222,6 @@ structure DenseElementsAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
-  An attribute from an unknown dialect.
-  It can be either a type attribute or a non-type attribute.
--/
-structure UnregisteredAttr where
-  value : String
-  isType : Bool
-deriving Inhabited, Repr, DecidableEq, Hashable
-
-/--
   A flat symbol reference attribute, e.g., `@foo` or `@"my.func"`.
   The value stores the raw text including the `@` prefix.
 -/
@@ -446,6 +437,23 @@ structure Match.OptionalType where
 deriving Repr, Hashable
 
 /--
+  An attribute from an unknown dialect, kept as its source text.
+  It can be either a type attribute or a non-type attribute.
+
+  A non-type attribute may carry a trailing `: type`, as in
+  `#foo.bar<baz> : i32` or `#foo.bar : !foo.ty`. MLIR's generic parser accepts
+  this suffix on any dialect attribute and hands the type to the dialect, so it
+  is parsed structurally here and printed back after the body; this mirrors
+  `mlir::OpaqueAttr`. `type` is always `none` when `isType` is true, as types
+  never carry a trailing type.
+-/
+structure UnregisteredAttr where
+  value : String
+  isType : Bool
+  type : Option Attribute := none
+deriving Inhabited, Repr, Hashable
+
+/--
   A data structure that represents compile-time information in the IR.
   Attributes are used either as type annotations for SSA values, or
   as extra information stored in operations.
@@ -590,6 +598,10 @@ theorem Match.OptionalType.sizeOf_innerType {t : Match.OptionalType} :
     sizeOf t.innerType < sizeOf t := by
   grind [cases Match.OptionalType]
 
+theorem UnregisteredAttr.sizeOf_type {a : UnregisteredAttr} (h : a.type = some t) :
+    sizeOf t < sizeOf a := by
+  grind [cases UnregisteredAttr]
+
 /-!
   ## DecidableEq instances
 -/
@@ -662,6 +674,25 @@ decreasing_by
   have := @Match.OptionalType.sizeOf_innerType
   grind
 
+def UnregisteredAttr.decEq (attr1 attr2 : UnregisteredAttr) : Decidable (attr1 = attr2) :=
+  let type1 := attr1.type
+  let type2 := attr2.type
+  if _ : attr1.value = attr2.value ∧ attr1.isType = attr2.isType then
+    match h1 : type1, h2 : type2 with
+    | none, none => isTrue (by grind [cases UnregisteredAttr])
+    | some t1, some t2 =>
+      match Attribute.decEq t1 t2 with
+      | isTrue _ => isTrue (by grind [cases UnregisteredAttr])
+      | isFalse _ => isFalse (by grind)
+    | none, some _ => isFalse (by grind)
+    | some _, none => isFalse (by grind)
+  else
+    isFalse (by grind)
+termination_by sizeOf attr1
+decreasing_by
+  have := @UnregisteredAttr.sizeOf_type
+  grind
+
 def DictionaryAttr.decEq (dict1 dict2 : DictionaryAttr) : Decidable (dict1 = dict2) :=
   let entries1 := dict1.entries
   let entries2 := dict2.entries
@@ -729,7 +760,7 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
   case unregisteredAttr.unregisteredAttr attr1 attr2 =>
-    exact (match decEq attr1 attr2 with
+    exact (match UnregisteredAttr.decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
   case functionType.functionType type1 type2 =>
@@ -845,6 +876,7 @@ instance : DecidableEq FunctionType := FunctionType.decEq
 instance : DecidableEq LLVMFunctionType := LLVMFunctionType.decEq
 instance : DecidableEq ArrayAttr := ArrayAttr.decEq
 instance : DecidableEq DictionaryAttr := DictionaryAttr.decEq
+instance : DecidableEq UnregisteredAttr := UnregisteredAttr.decEq
 
 /-!
   ## ToString implementation
@@ -959,9 +991,6 @@ instance : ToString DenseArrayAttr where
 
 instance : ToString DenseElementsAttr where
   toString attr := s!"dense<{attr.value}> : {attr.type}"
-
-instance : ToString UnregisteredAttr where
-  toString attr := attr.value
 
 instance : ToString FlatSymbolRefAttr where
   toString attr := attr.value
@@ -1111,6 +1140,14 @@ termination_by sizeOf type
 decreasing_by
   apply Match.OptionalType.sizeOf_innerType
 
+def UnregisteredAttr.toString (attr : UnregisteredAttr) : String :=
+  match _h : attr.type with
+  | none => attr.value
+  | some type => s!"{attr.value} : {Attribute.toString type}"
+termination_by sizeOf attr
+decreasing_by
+  exact UnregisteredAttr.sizeOf_type _h
+
 /--
   Convert an attribute to a string representation.
 -/
@@ -1140,7 +1177,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .denseElementsAttr attr => ToString.toString attr
   | .denseArrayAttr attr => ToString.toString attr
   | .dictionaryAttr attr => attr.toString
-  | .unregisteredAttr attr => ToString.toString attr
+  | .unregisteredAttr attr => attr.toString
   | .flatSymbolRefAttr attr => ToString.toString attr
   | .functionType type => type.toString
   | .modArithType type => ToString.toString type
@@ -1182,6 +1219,9 @@ instance : ToString LLVM.ArrayType where
 
 instance : ToString Match.OptionalType where
   toString := Match.OptionalType.toString
+
+instance : ToString UnregisteredAttr where
+  toString := UnregisteredAttr.toString
 
 /-! ## Attribute Subtype Interface -/
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -352,13 +352,16 @@ partial def parseOptionalDialectType : AttrParserM (Option TypeAttr) := do
     let endPos := (← peekToken).slice.stop
     parsePunctuation ">"
     let value := (Slice.mk startPos endPos).of (← getThe ParserState).input
-    return some (⟨UnregisteredAttr.mk (String.fromUTF8! value) true, by grind⟩)
+    return some (⟨UnregisteredAttr.mk (String.fromUTF8! value) true none, by grind⟩)
   else
-    return some (⟨UnregisteredAttr.mk ("!" ++ String.fromUTF8! dialectName) true, by grind⟩)
+    return some (⟨UnregisteredAttr.mk ("!" ++ String.fromUTF8! dialectName) true none, by grind⟩)
 
 /--
   Parse a dialect attribute, if present.
-  A dialect attribute has the form `#dialect.name<body>`.
+  A dialect attribute has the form `#dialect.name` or `#dialect.name<body>`. Attributes VeIR
+  understands are decoded; any other one is kept as an `UnregisteredAttr` when unregistered
+  dialects are allowed. Its optional trailing `: type` is parsed by `parseOptionalAttribute`,
+  since the type parser is defined further down.
 -/
 partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   let startPos ← getPos
@@ -423,12 +426,14 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
   if !(← getThe AttrParserState).allowUnregisteredDialect then
     throwAt startPos s!"attribute '#{String.fromUTF8! dialectName}' is not registered. \
       Consider using --allow-unregistered-dialect."
-  parsePunctuation "<"
+  /- The body is optional: `#foo.bar` is as valid as `#foo.bar<baz>`. -/
+  if !(← parseOptionalPunctuation "<") then
+    return some (UnregisteredAttr.mk ("#" ++ String.fromUTF8! dialectName) false none)
   let _ ← parseUnregisteredAttrBody
   let endPos := (← peekToken).slice.stop
   parsePunctuation ">"
   let value := (Slice.mk startPos endPos).of (← getThe ParserState).input
-  return some (UnregisteredAttr.mk (String.fromUTF8! value) false)
+  return some (UnregisteredAttr.mk (String.fromUTF8! value) false none)
 
 /--
   Parse a flat symbol reference attribute, if present.
@@ -799,7 +804,7 @@ partial def parseOptionalLLVMStructType (short := false) : AttrParserM (Option T
   let endPos := (← peekToken).slice.stop
   parsePunctuation ">"
   let body := (Slice.mk startPos endPos).of (← getThe ParserState).input
-  return some ⟨UnregisteredAttr.mk ("!llvm.struct" ++ String.fromUTF8! body) true, by grind⟩
+  return some ⟨UnregisteredAttr.mk ("!llvm.struct" ++ String.fromUTF8! body) true none, by grind⟩
 
 /--
   Parse a type within an LLVM-dialect type body, accepting the LLVM "pretty-print"
@@ -1010,13 +1015,24 @@ partial def parseOptionalDictionaryAttr : AttrParserM (Option DictionaryAttr) :=
   return some (DictionaryAttr.fromArray entries)
 
 /--
+  Parse the optional trailing `: type` of an unregistered dialect attribute.
+  MLIR lets any dialect attribute carry one, e.g. `#foo.bar<baz> : i32`. Nothing else can
+  follow a dialect attribute with a `:`, so the token is unambiguous.
+-/
+partial def parseOptionalUnregisteredAttrType (attr : Attribute) : AttrParserM Attribute := do
+  let .unregisteredAttr ⟨value, false, none⟩ := attr | return attr
+  if ← parseOptionalPunctuation ":" then
+    return (UnregisteredAttr.mk value false (some (← parseType).val) : Attribute)
+  return attr
+
+/--
   Parse an attribute, if present.
 -/
 partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
   if let some feltConstAttr ← parseOptionalFeltConstAttr then
     return some feltConstAttr
   if let some dialectAttr ← parseOptionalDialectAttr then
-    return some dialectAttr
+    return some (← parseOptionalUnregisteredAttrType dialectAttr)
   else if let some locationAttr ← parseOptionalLocationAttr then
     return some locationAttr
   else if let some type ← parseOptionalType then


### PR DESCRIPTION
MLIR's generic parser accepts two forms of dialect attribute that VeIR rejected: the body may be omitted (`#foo.bar`), and any dialect attribute may carry a trailing `: type` (`#foo.bar<baz> : i32`, `#foo.int<1> : !foo.int<s, 32>`). Both show up in IR from dialects VeIR does not register, typically as typed constants, and `veir-opt --allow-unregistered-dialect` failed on them.

The changes stores the trailing type structurally on `UnregisteredAttr` and prints it back after the body, mirroring `mlir::OpaqueAttr`. Types never carry one, so the field is always `none` when `isType` is true.