### PR TITLE
chore: allow unregistered dialects in MLIR_UNREGISTERED_ROUNDTRIP

### DIFF
--- a/Test/lit.cfg
+++ b/Test/lit.cfg
@@ -53,7 +53,7 @@ if mlir_opt:
     config.substitutions.append(("MLIR_ROUNDTRIP",
      f"mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt{exe_suffix} | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt{exe_suffix} | filecheck %s"))
     config.substitutions.append(("MLIR_UNREGISTERED_ROUNDTRIP",
-     f"mlir-opt --mlir-print-op-generic --mlir-print-local-scope %s | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | mlir-opt --mlir-print-op-generic --mlir-print-local-scope | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | filecheck %s"))
+     f"mlir-opt --mlir-print-op-generic --mlir-print-local-scope --allow-unregistered-dialect %s | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | mlir-opt --mlir-print-op-generic --mlir-print-local-scope --allow-unregistered-dialect | .lake/build/bin/veir-opt{exe_suffix} --allow-unregistered-dialect | filecheck %s"))
     # Assert that `mlir-opt` rejects the input. We only check that it fails
     # (non-zero exit), not the exact diagnostic, since:
 	# 1. The message might not be stable across `mlir-opt` versions.


### PR DESCRIPTION
We forgot to allow unregistered dialects in mlir-opt, but some test cases benefit of operations that do not need to exist in mlir.