### PR TITLE
feat(llzk): add Constrain dialect

### DIFF
--- a/Test/LLZK/Constrain/identity.mlir
+++ b/Test/LLZK/Constrain/identity.mlir
@@ -1,0 +1,17 @@
+// RUN: VEIR_ROUNDTRIP
+
+// CHECK:       "builtin.module"() ({
+"builtin.module"() ({
+  // CHECK:         "function.def"() <{"function_type" = (!felt.type, !felt.type, index) -> (), "sym_name" = "constrain_identity"}> ({
+  "function.def"() <{sym_name = "constrain_identity", function_type = (!felt.type, !felt.type, index) -> ()}> ({
+  // CHECK-NEXT:    ^{{.*}}(%{{.*}}: !felt.type, %{{.*}}: !felt.type, %{{.*}}: index):
+  ^bb0(%a: !felt.type, %b: !felt.type, %i: index):
+    // CHECK-NEXT:      "constrain.eq"(%{{.*}}, %{{.*}}) : (!felt.type, !felt.type) -> ()
+    "constrain.eq"(%a, %b) : (!felt.type, !felt.type) -> ()
+    // CHECK-NEXT:      "constrain.eq"(%{{.*}}, %{{.*}}) : (index, index) -> ()
+    "constrain.eq"(%i, %i) : (index, index) -> ()
+    // CHECK-NEXT:      "function.return"() : () -> ()
+    "function.return"() : () -> ()
+  // CHECK-NEXT:    }) {function.allow_constraint} : () -> ()
+  }) {function.allow_constraint} : () -> ()
+}) : () -> ()

--- a/Test/LLZK/Constrain/invalid.mlir
+++ b/Test/LLZK/Constrain/invalid.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "function.def"() <{sym_name = "invalid_constrain", function_type = (!felt.type<"babybear">, !felt.type<"bn254">) -> ()}> ({
+  ^bb0(%a: !felt.type<"babybear">, %b: !felt.type<"bn254">):
+    // CHECK: Error verifying input program: constrain.eq: expected operands to have the same type
+    "constrain.eq"(%a, %b) : (!felt.type<"babybear">, !felt.type<"bn254">) -> ()
+    "function.return"() : () -> ()
+  }) {function.allow_constraint} : () -> ()
+}) : () -> ()

--- a/Test/LLZK/Constrain/iszero.mlir
+++ b/Test/LLZK/Constrain/iszero.mlir
@@ -1,0 +1,31 @@
+// RUN: VEIR_ROUNDTRIP
+
+// Circomlib IsZero constraint system, adapted from
+// llzk-lib/test/Conversions/llzk_to_smt_no_cf_iszero.llzk:
+//   out = -in * inv + 1
+//   in * out = 0
+
+// CHECK:       "builtin.module"() ({
+"builtin.module"() ({
+  // CHECK:         "function.def"
+  "function.def"() <{sym_name = "main", function_type = () -> ()}> ({
+    %in = "felt.const"() <{value = #felt<const 2 : <"babybear">> : !felt.type<"babybear">}> : () -> !felt.type<"babybear">
+    %out = "felt.const"() <{value = #felt<const 0 : <"babybear">> : !felt.type<"babybear">}> : () -> !felt.type<"babybear">
+    %inv = "felt.const"() <{value = #felt<const 1006632961 : <"babybear">> : !felt.type<"babybear">}> : () -> !felt.type<"babybear">
+    // CHECK:           %[[NEG:[0-9a-zA-Z_]+]] = "felt.neg"(%{{.*}})
+    %0 = "felt.neg"(%in) : (!felt.type<"babybear">) -> !felt.type<"babybear">
+    // CHECK-NEXT:      %[[PROD:[0-9a-zA-Z_]+]] = "felt.mul"(%[[NEG]], %{{.*}})
+    %1 = "felt.mul"(%0, %inv) : (!felt.type<"babybear">, !felt.type<"babybear">) -> !felt.type<"babybear">
+    %c1 = "felt.const"() <{value = #felt<const 1 : <"babybear">> : !felt.type<"babybear">}> : () -> !felt.type<"babybear">
+    // CHECK:           %[[SUM:[0-9a-zA-Z_]+]] = "felt.add"(%[[PROD]], %{{.*}})
+    %2 = "felt.add"(%1, %c1) : (!felt.type<"babybear">, !felt.type<"babybear">) -> !felt.type<"babybear">
+    // CHECK-NEXT:      "constrain.eq"(%{{.*}}, %[[SUM]])
+    "constrain.eq"(%out, %2) : (!felt.type<"babybear">, !felt.type<"babybear">) -> ()
+    %3 = "felt.mul"(%in, %out) : (!felt.type<"babybear">, !felt.type<"babybear">) -> !felt.type<"babybear">
+    %c0 = "felt.const"() <{value = #felt<const 0 : <"babybear">> : !felt.type<"babybear">}> : () -> !felt.type<"babybear">
+    // CHECK:           "constrain.eq"(%{{.*}}, %{{.*}})
+    "constrain.eq"(%3, %c0) : (!felt.type<"babybear">, !felt.type<"babybear">) -> ()
+    // CHECK-NEXT:      "function.return"() : () -> ()
+    "function.return"() : () -> ()
+  }) {function.allow_constraint, function.allow_non_native_field_ops} : () -> ()
+}) : () -> ()

--- a/Veir/Dialects/LLZK/Constrain/OpInfo.lean
+++ b/Veir/Dialects/LLZK/Constrain/OpInfo.lean
@@ -1,0 +1,95 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Verifier.Basic
+meta import Veir.Meta.OpCode
+
+namespace Veir
+
+public section
+
+namespace LLZK
+
+@[opcodes]
+inductive Constrain where
+| eq
+/-- `constrain.in %arr, %tuple` — lookup-containment constraint. -/
+| «in»
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+end LLZK
+
+@[expose, properties_of]
+def LLZK.Constrain.propertiesOf (_op : LLZK.Constrain) : Type := Unit
+
+private def noProperties (opName : String) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String Unit :=
+  if attrDict.size > 0 then
+    let plural := if attrDict.size = 1 then "property" else "properties"
+    .error s!"{opName}: expected no properties, but got {attrDict.size} {plural}"
+  else
+    .ok ()
+
+def LLZK.Constrain.fromAttrDict
+    (op : LLZK.Constrain) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (LLZK.Constrain.propertiesOf op) :=
+  match op with
+  | .eq => noProperties "constrain.eq" attrDict
+  | .«in» => noProperties "constrain.in" attrDict
+
+def LLZK.Constrain.toAttrDict
+    (_op : LLZK.Constrain) (_props : LLZK.Constrain.propertiesOf _op) :
+    Std.HashMap ByteArray Attribute :=
+  Std.HashMap.emptyWithCapacity 0
+
+/--
+`constrain.eq` and `constrain.in` emit constraints into the circuit. They
+have no results, so they must report an effect or DCE would erase the
+constraint system.
+-/
+def LLZK.Constrain.getEffects
+    (_op : LLZK.Constrain) (_props : LLZK.Constrain.propertiesOf _op) : MemoryEffects :=
+  .write
+
+def LLZK.Constrain.isConstantLike (_op : LLZK.Constrain) : Bool := false
+
+def LLZK.Constrain.hasSSADominance (_op : LLZK.Constrain) (_index : Nat) : Bool := true
+
+#generate_dialect LLZK.Constrain
+
+instance : IsOpCode LLZK.Constrain where
+  fromName := LLZK.Constrain.fromName
+  name := LLZK.Constrain.name
+  propertiesOf := LLZK.Constrain.propertiesOf
+  fromAttrDict := LLZK.Constrain.fromAttrDict
+  toAttrDict := LLZK.Constrain.toAttrDict
+
+/-- The scalar types accepted by `constrain.eq` before aggregate types are registered. -/
+private def Attribute.isSupportedLLZKConstrainEqType (type : Attribute) : Bool :=
+  match type with
+  | .integerType intType => intType.bitwidth = 1
+  | .indexType _ | .feltType _ => true
+  | _ => false
+
+def LLZK.Constrain.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo LLZK.Constrain] (opType : LLZK.Constrain) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .eq => do
+    op.verifyPlainOpCounts ctx opIn 2 0
+    let operandType ← op.verifyOperandTypesMatch ctx 0 1
+      "constrain.eq: expected operands to have the same type"
+    if !operandType.val.isSupportedLLZKConstrainEqType then
+      throw s!"constrain.eq: unsupported operand type {operandType}"
+  | .«in» => op.verifyPlainOpCounts ctx opIn 2 0
+
+instance : HasOpInfo LLZK.Constrain where
+  verifyLocalInvariants := LLZK.Constrain.verifyLocalInvariants
+  getEffects := LLZK.Constrain.getEffects
+  isConstantLike := LLZK.Constrain.isConstantLike
+  hasSSADominance := LLZK.Constrain.hasSSADominance
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -40,6 +40,7 @@ match opCode with
 | .ram op => LLZK.Ram.propertiesOf op
 | .cast op => LLZK.Cast.propertiesOf op
 | .bool op => LLZK.Bool.propertiesOf op
+| .constrain op => LLZK.Constrain.propertiesOf op
 | .global op => LLZK.Global.propertiesOf op
 | .function op => LLZK.Function.propertiesOf op
 
@@ -74,6 +75,7 @@ def OpCode.getEffects (opCode : OpCode) (props : _propertiesOf opCode) : MemoryE
   | .ram op, props => LLZK.Ram.getEffects op props
   | .cast op, props => LLZK.Cast.getEffects op props
   | .bool op, props => LLZK.Bool.getEffects op props
+  | .constrain op, props => LLZK.Constrain.getEffects op props
   | .global op, props => LLZK.Global.getEffects op props
   | .function op, props => LLZK.Function.getEffects op props
 
@@ -106,6 +108,7 @@ def OpCode.getRegionKind (opCode : OpCode) (index : Nat) : RegionKind :=
   | .ram op => HasOpInfo.getRegionKind op index
   | .cast op => HasOpInfo.getRegionKind op index
   | .bool op => HasOpInfo.getRegionKind op index
+  | .constrain op => HasOpInfo.getRegionKind op index
   | .global op => HasOpInfo.getRegionKind op index
   | .function op => HasOpInfo.getRegionKind op index
 
@@ -139,6 +142,7 @@ def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
   | .ram op => LLZK.Ram.hasSSADominance op index
   | .cast op => LLZK.Cast.hasSSADominance op index
   | .bool op => LLZK.Bool.hasSSADominance op index
+  | .constrain op => LLZK.Constrain.hasSSADominance op index
   | .global op => LLZK.Global.hasSSADominance op index
   | .function op => LLZK.Function.hasSSADominance op index
 
@@ -173,6 +177,7 @@ def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
   | .ram op => HasOpInfo.hasNoTerminator op index
   | .cast op => HasOpInfo.hasNoTerminator op index
   | .bool op => HasOpInfo.hasNoTerminator op index
+  | .constrain op => HasOpInfo.hasNoTerminator op index
   | .global op => HasOpInfo.hasNoTerminator op index
   | .function op => HasOpInfo.hasNoTerminator op index
 
@@ -203,6 +208,7 @@ def OpCode.isIsolatedFromAbove (opCode : OpCode) : Bool :=
   | .ram op => HasOpInfo.isIsolatedFromAbove op
   | .cast op => HasOpInfo.isIsolatedFromAbove op
   | .bool op => HasOpInfo.isIsolatedFromAbove op
+  | .constrain op => HasOpInfo.isIsolatedFromAbove op
   | .global op => HasOpInfo.isIsolatedFromAbove op
   | .function op => HasOpInfo.isIsolatedFromAbove op
 
@@ -237,6 +243,7 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .ram op => HasOpInfo.isTerminator op
   | .cast op => HasOpInfo.isTerminator op
   | .bool op => HasOpInfo.isTerminator op
+  | .constrain op => HasOpInfo.isTerminator op
   | .global op => HasOpInfo.isTerminator op
   | .function op => HasOpInfo.isTerminator op
 
@@ -274,6 +281,7 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | .ram op => LLZK.Ram.isConstantLike op
   | .cast op => LLZK.Cast.isConstantLike op
   | .bool op => LLZK.Bool.isConstantLike op
+  | .constrain op => LLZK.Constrain.isConstantLike op
   | .global op => LLZK.Global.isConstantLike op
   | .function op => LLZK.Function.isConstantLike op
 
@@ -307,6 +315,7 @@ def OpCode.propagatesPoison (opCode : OpCode) : Bool :=
   | .ram op => HasOpInfo.propagatesPoison op
   | .cast op => HasOpInfo.propagatesPoison op
   | .bool op => HasOpInfo.propagatesPoison op
+  | .constrain op => HasOpInfo.propagatesPoison op
   | .global op => HasOpInfo.propagatesPoison op
   | .function op => HasOpInfo.propagatesPoison op
 
@@ -337,6 +346,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   | .ram op => LLZK.Ram.fromAttrDict op attrDict
   | .cast op => LLZK.Cast.fromAttrDict op attrDict
   | .bool op => LLZK.Bool.fromAttrDict op attrDict
+  | .constrain op => LLZK.Constrain.fromAttrDict op attrDict
   | .global op => LLZK.Global.fromAttrDict op attrDict
   | .function op => LLZK.Function.fromAttrDict op attrDict
 
@@ -371,6 +381,7 @@ def Properties.toAttrDict
   | .ram op, props => LLZK.Ram.toAttrDict op props
   | .cast op, props => LLZK.Cast.toAttrDict op props
   | .bool op, props => LLZK.Bool.toAttrDict op props
+  | .constrain op, props => LLZK.Constrain.toAttrDict op props
   | .global op, props => LLZK.Global.toAttrDict op props
   | .function op, props => LLZK.Function.toAttrDict op props
 
@@ -408,6 +419,7 @@ def OpCode.functionInterface? (opCode : OpCode) : Option (FunctionOpInterface (_
   | .ram op => HasOpInfo.functionInterface? op
   | .cast op => HasOpInfo.functionInterface? op
   | .bool op => HasOpInfo.functionInterface? op
+  | .constrain op => HasOpInfo.functionInterface? op
   | .global op => HasOpInfo.functionInterface? op
   | .function op => HasOpInfo.functionInterface? op
 
@@ -441,6 +453,7 @@ def OpCode.verifyLocalInvariants (opCode : OpCode) (op : OperationPtr)
   | .ram opType => LLZK.Ram.verifyLocalInvariants opType op ctx opIn
   | .cast opType => LLZK.Cast.verifyLocalInvariants opType op ctx opIn
   | .bool opType => LLZK.Bool.verifyLocalInvariants opType op ctx opIn
+  | .constrain opType => LLZK.Constrain.verifyLocalInvariants opType op ctx opIn
   | .global opType => LLZK.Global.verifyLocalInvariants opType op ctx opIn
   | .function opType => LLZK.Function.verifyLocalInvariants opType op ctx opIn
 
@@ -477,7 +490,7 @@ def OpCode.materializeConstant (opCode : OpCode) (value : RuntimeValue)
     | .riscv_cf _ | .riscv_stack _ | .rv64 _ | .cf _ | .builtin _
     | .verif _
     | .func _ | .datapath _ | .pdl _ | .test _ | .cir _ | .io _ | .string _
-    | .include _ | .ram _ | .cast _ | .bool _ | .global _ | .function _ => none
+    | .include _ | .ram _ | .cast _ | .bool _ | .constrain _ | .global _ | .function _ => none
   guard materialized.fst.isConstantLike
   return materialized
 

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -32,6 +32,7 @@ public import Veir.Dialects.LLZK.Include.OpInfo
 public import Veir.Dialects.LLZK.RAM.OpInfo
 public import Veir.Dialects.LLZK.Cast.OpInfo
 public import Veir.Dialects.LLZK.Bool.OpInfo
+public import Veir.Dialects.LLZK.Constrain.OpInfo
 public import Veir.Dialects.LLZK.Global.OpInfo
 public import Veir.Dialects.LLZK.Function.OpInfo
 public import Veir.Dialects.Cir.OpInfo


### PR DESCRIPTION
Adds LLZK's `constrain` dialect, which finally lets us express the `iszero.mlir` test we identified during VERIFY 2026 as an ideal test case for "advanced" integer range analysis.

PS: The original vibe-port of LLZK had some partial semantics for Constrain, but not using the Veir interpreter, and trying to vibe-convert made it clear that this needs some careful consideration, so I've dropped the semantics bit for now.