### PR TITLE
feat(llzk): add constraint deduplication pass

### DIFF
--- a/Test/LLZK/Constrain/passes/dedup.mlir
+++ b/Test/LLZK/Constrain/passes/dedup.mlir
@@ -1,0 +1,27 @@
+// RUN: veir-opt -p=llzk-dedup-constraints %s | filecheck %s
+//
+// Duplicate `constrain.eq` assertions collapse to one; distinct ones survive.
+// Note %2 = a*b + 3 is asserted equal to %a twice, and once against %b.
+
+// CHECK:       "builtin.module"() ({
+"builtin.module"() ({
+  // CHECK:         "function.def"
+  "function.def"() <{sym_name = "dedup", function_type = (!felt.type, !felt.type) -> ()}> ({
+  // CHECK:         ^{{.*}}(%{{.*}}: !felt.type, %{{.*}}: !felt.type):
+  ^bb0(%a: !felt.type, %b: !felt.type):
+    // CHECK-NEXT:      %{{.*}} = "felt.mul"
+    %0 = "felt.mul"(%a, %b) : (!felt.type, !felt.type) -> !felt.type
+    // CHECK-NEXT:      %{{.*}} = "felt.const"
+    %1 = "felt.const"() <{"value" = #felt<const 3> : !felt.type}> : () -> !felt.type
+    // CHECK-NEXT:      %{{.*}} = "felt.add"
+    %2 = "felt.add"(%0, %1) : (!felt.type, !felt.type) -> !felt.type
+    // CHECK-NEXT:      "constrain.eq"
+    "constrain.eq"(%2, %a) : (!felt.type, !felt.type) -> ()
+    "constrain.eq"(%2, %a) : (!felt.type, !felt.type) -> ()
+    // CHECK-NEXT:      "constrain.eq"
+    "constrain.eq"(%2, %b) : (!felt.type, !felt.type) -> ()
+    "constrain.eq"(%2, %a) : (!felt.type, !felt.type) -> ()
+    // CHECK-NEXT:      "function.return"() : () -> ()
+    "function.return"() : () -> ()
+  }) {function.allow_constraint, function.allow_non_native_field_ops} : () -> ()
+}) : () -> ()

--- a/Veir/Passes/LLZK/DedupConstraints.lean
+++ b/Veir/Passes/LLZK/DedupConstraints.lean
@@ -1,0 +1,87 @@
+module
+
+public import Veir.Pass
+public import Veir.Dialects.LLZK.Semantics.Constraint
+import Veir.Rewriter.WfRewriter
+
+/-!
+# Constraint deduplication for LLZK
+
+Removes repeated `constrain.eq` operand pairs within each block. The pass uses a
+stateful traversal because matching depends on earlier operations.
+-/
+
+namespace Veir
+namespace LLZK
+namespace DedupConstraints
+
+public section
+
+/-- An ordered `constrain.eq` operand pair. -/
+structure Key where
+  lhs : ValuePtr
+  rhs : ValuePtr
+deriving DecidableEq, BEq, Hashable
+
+/-- `some key` when `op` is a `constrain.eq`, `none` otherwise. -/
+def key? (ctx : IRContext OpCode) (op : OperationPtr) : Option Key :=
+  match op.getOpType! ctx with
+  | .constrain .eq => some { lhs := op.getOperand! ctx 0, rhs := op.getOperand! ctx 1 }
+  | _ => none
+
+/-- Keep the first occurrence of each operand pair and erase later repeats. -/
+def dedupOps (ctx : WfIRContext OpCode) (ops : List OperationPtr)
+    (seen : Std.HashSet Key) : WfIRContext OpCode :=
+  match ops with
+  | [] => ctx
+  | op :: rest =>
+    match key? ctx.raw op with
+    | none => dedupOps ctx rest seen
+    | some k =>
+      if seen.contains k then
+        dedupOps (WfRewriter.eraseOp! ctx op) rest seen
+      else
+        dedupOps ctx rest (seen.insert k)
+
+/-- Deduplicate the `constrain.eq` operations of a single block. -/
+def dedupBlock (ctx : WfIRContext OpCode) (blk : BlockPtr)
+    (hblk : blk.InBounds ctx.raw := by grind) : WfIRContext OpCode :=
+  dedupOps ctx (Semantics.opsOf ctx blk hblk) ∅
+
+/-- Every block nested under `op`. -/
+partial def blocksUnder (ctx : IRContext OpCode) (op : OperationPtr) : Array BlockPtr := Id.run do
+  let mut acc : Array BlockPtr := #[]
+  for region in (op.get! ctx).regions do
+    let mut b := (region.get! ctx).firstBlock
+    while let some blk := b do
+      acc := acc.push blk
+      let mut o := (blk.get! ctx).firstOp
+      while let some inner := o do
+        acc := acc ++ blocksUnder ctx inner
+        o := (inner.get! ctx).next
+      b := (blk.get! ctx).next
+  return acc
+
+/-- Run deduplication over every block under `top`. -/
+def run (ctx : WfIRContext OpCode) (top : OperationPtr) : WfIRContext OpCode := Id.run do
+  let mut ctx := ctx
+  for blk in blocksUnder ctx.raw top do
+    if h : blk.InBounds ctx.raw then
+      ctx := dedupBlock ctx blk h
+  return ctx
+
+def impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : op.InBounds ctx.raw) :
+    ExceptT String IO (WfIRContext OpCode) :=
+  pure (run ctx op)
+
+end
+
+end DedupConstraints
+
+public def DedupConstraintsPass : Pass OpCode :=
+  { name := "llzk-dedup-constraints"
+    description := "Remove `constrain.eq` operations that repeat an earlier assertion in the same block."
+    run := fun _ => DedupConstraints.impl }
+
+end LLZK
+end Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -17,6 +17,7 @@ import Veir.Passes.ArithToLLVM
 import Veir.Passes.Canonicalize
 import Veir.Passes.Legalization
 import Veir.Passes.Felt.Combine
+import Veir.Passes.LLZK.DedupConstraints
 
 open Veir.Parser
 open Veir.Parser.ParserError
@@ -40,6 +41,7 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
      ModArithToArithPass,
      ArithToLLVMPass,
      CanonicalizePass,
+     LLZK.DedupConstraintsPass,
      LegalizePass,
      FeltPass.Combine ] : List (Pass OpCode)).foldl
     (fun m pass => m.insert pass.name pass)


### PR DESCRIPTION
Adds an LLZK constraint-deduplication pass that removes duplicate constraints while preserving the first occurrence, with focused pass coverage.
