### PR TITLE
parser: support MLIR type aliases

### DIFF
--- a/Test/Parsing/type-alias-redefinition.mlir
+++ b/Test/Parsing/type-alias-redefinition.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+// RUN: MLIR_INVALID
+
+!int = i32
+!int = i64
+"builtin.module"() ({
+^bb0:
+}) : () -> ()
+
+// CHECK:type-alias-redefinition.mlir:5:1: error: redefinition of type alias id 'int'
+// CHECK-NEXT:!int = i64
+// CHECK-NEXT:^

--- a/Test/Parsing/type-alias-reserved-name.mlir
+++ b/Test/Parsing/type-alias-reserved-name.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+// RUN: MLIR_INVALID
+
+!my.int = i32
+"builtin.module"() ({
+^bb0:
+}) : () -> ()
+
+// CHECK:type-alias-reserved-name.mlir:4:1: error: type names with a '.' are reserved for dialect-defined names
+// CHECK-NEXT:!my.int = i32
+// CHECK-NEXT:^

--- a/Test/Parsing/type-alias-undefined.mlir
+++ b/Test/Parsing/type-alias-undefined.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s --strict-whitespace
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+    "func.return"() : () -> !int
+}) : () -> ()
+
+// CHECK:type-alias-undefined.mlir:5:29: error: undefined symbol alias id 'int'
+// CHECK-NEXT:    "func.return"() : () -> !int
+// CHECK-NEXT:                            ^

--- a/Test/Parsing/type-alias.mlir
+++ b/Test/Parsing/type-alias.mlir
@@ -1,0 +1,24 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+// Aliases precede the top-level operation, may build on earlier ones, and resolve
+// wherever a type appears, including attribute element types. The printer expands them.
+!int = i32
+!ptr = !llvm.ptr
+!fn = (!int, !ptr) -> !int
+"builtin.module"() ({
+  "func.func"() <{function_type = !fn, sym_name = "f"}> ({
+  ^bb0(%a: !int, %p: !ptr):
+    %c = "arith.constant"() <{value = 1 : !int}> : () -> !int
+    %s = "arith.addi"(%a, %c) : (!int, !int) -> !int
+    %g = "llvm.getelementptr"(%p, %a) <{elem_type = !int, rawConstantIndices = array<!int: -2147483648>}> : (!ptr, !int) -> !ptr
+    "func.return"(%s) : (!int) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "func.func"() <{"function_type" = (i32, !llvm.ptr) -> i32, "sym_name" = "f"}> ({
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32, %{{.*}} : !llvm.ptr):
+// CHECK-NEXT: %{{.*}} = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+// CHECK-NEXT: %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT: %{{.*}} = "llvm.getelementptr"(%{{.*}}, %{{.*}}) <{"elem_type" = i32, "noWrapFlags" = 0 : i32, "rawConstantIndices" = array<i32: -2147483648>}> : (!llvm.ptr, i32) -> !llvm.ptr
+// CHECK-NEXT: "func.return"(%{{.*}}) : (i32) -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -23,6 +23,26 @@ def testType (s : String) (allowUnregisteredDialect : Bool := false) :
   let parser ← ParserState.fromInput (s.toByteArray)
   parseType.run' { allowUnregisteredDialect } parser
 
+/-- Build the alias map of an `AttrParserState` from `(name, type)` pairs. -/
+def aliasMap (aliases : List (String × TypeAttr)) : Std.HashMap ByteArray TypeAttr :=
+  aliases.foldl (fun map (name, type) => map.insert name.toByteArray type) {}
+
+/--
+  Run parseType on the given input string with the given type aliases in scope.
+-/
+def testTypeWithAliases (s : String) (aliases : List (String × TypeAttr))
+    (allowUnregisteredDialect : Bool := false) : Except ParserError TypeAttr := do
+  let parser ← ParserState.fromInput (s.toByteArray)
+  parseType.run' { allowUnregisteredDialect, typeAliases := aliasMap aliases } parser
+
+/--
+  Run parseAttribute on the given input string with the given type aliases in scope.
+-/
+def testAttrWithAliases (s : String) (aliases : List (String × TypeAttr))
+    (allowUnregisteredDialect : Bool := false) : Except ParserError Attribute := do
+  let parser ← ParserState.fromInput (s.toByteArray)
+  parseAttribute.run' { allowUnregisteredDialect, typeAliases := aliasMap aliases } parser
+
 /--
   Run parseOptionalAttr on the given input string.
 -/
@@ -190,6 +210,46 @@ macro "#assert " e:term : command =>
 #assert expectErrorType "!foo<bar>" "type '!foo' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
 #assert expectErrorType "!test.test<bar>" "type '!test.test' is not registered. Consider using --allow-unregistered-dialect." (some 0) false
 
+
+/-! ## Type aliases -/
+
+-- An alias resolves to its definition and needs no unregistered-dialect flag.
+#assert (testTypeWithAliases "!int" [("int", IntegerType.mk 32)] = .ok (IntegerType.mk 32))
+#assert (testTypeWithAliases "!int" [("int", IntegerType.mk 32)] true = .ok (IntegerType.mk 32))
+-- Aliases resolve inside compound types.
+#assert (testTypeWithAliases "!llvm.array<2 x !int>" [("int", IntegerType.mk 32)]
+  = .ok (LLVM.ArrayType.mk 2 (IntegerType.mk 32 : Attribute)))
+#assert ((testTypeWithAliases "(!int) -> !int" [("int", IntegerType.mk 32)]).map (·.val)
+  = .ok (.functionType (FunctionType.mk #[(IntegerType.mk 32 : Attribute)]
+      #[(IntegerType.mk 32 : Attribute)] (isVarArg := false))))
+-- An alias may stand for a dialect type.
+#assert (testTypeWithAliases "!p" [("p", LLVM.PointerType.mk)] = .ok LLVM.PointerType.mk)
+-- An undefined alias is an error whether or not unregistered dialects are allowed.
+#assert ((testTypeWithAliases "!int" []).mapError errorInfo
+  = .error ("undefined symbol alias id 'int'", some 0))
+#assert ((testTypeWithAliases "!int" [] true).mapError errorInfo
+  = .error ("undefined symbol alias id 'int'", some 0))
+-- A dialect dot or an adjacent body is a dialect type, not an alias; rejected here as unregistered.
+#assert ((testTypeWithAliases "!foo.bar" [("foo", IntegerType.mk 32)]).mapError errorInfo
+  = .error ("type '!foo.bar' is not registered. Consider using --allow-unregistered-dialect.", some 0))
+#assert ((testTypeWithAliases "!foo<bar>" [("foo", IntegerType.mk 32)]).mapError errorInfo
+  = .error ("type '!foo' is not registered. Consider using --allow-unregistered-dialect.", some 0))
+#assert ((testTypeWithAliases "!foo <bar>" [] true).mapError errorInfo
+  = .error ("undefined symbol alias id 'foo'", some 0))
+-- Aliases also resolve where a specific builtin type is required.
+#assert (testAttrWithAliases "1 : !int" [("int", IntegerType.mk 32)]
+  = .ok (IntegerAttr.mk 1 (IntegerType.mk 32)))
+#assert (testAttrWithAliases "array<!int: 1, 2>" [("int", IntegerType.mk 32)]
+  = .ok (DenseArrayAttr.mk (IntegerType.mk 32) #[1, 2]))
+#assert (testTypeWithAliases "!cuda_tile.ptr<!int>" [("int", IntegerType.mk 32)]
+  = .ok (CudaTile.PointerType.mk (IntegerType.mk 32)))
+#assert (testTypeWithAliases "!hw.modty<input a : !int>" [("int", IntegerType.mk 32)]
+  = .ok (HW.ModuleType.mk #[{ dir := .input, name := "a", type := IntegerType.mk 32 }]))
+-- An alias for another kind of type is rejected at the alias with the position's own message.
+#assert ((testAttrWithAliases "array<!p: 1>" [("p", LLVM.PointerType.mk)]).mapError errorInfo
+  = .error ("integer type expected in dense array attribute", some 6))
+#assert ((testAttrWithAliases "1 : !p" [("p", LLVM.PointerType.mk)]).mapError errorInfo
+  = .error ("integer type expected after ':' in integer attribute", some 4))
 
 /-! ## Unregistered dialect attribute -/
 

--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -404,3 +404,64 @@ info: "builtin.module"() ({
 #eval! testParseOp r#""builtin.module"() ({
   "test.test"(%a) : (i32) -> ()
 }) : () -> ()"#
+
+/-! ## Type aliases -/
+
+/--
+  info: "builtin.module"() ({
+  ^4():
+    "func.func"() <{"function_type" = (i32) -> i32, "sym_name" = "f"}> ({
+      ^6(%arg6_0 : i32):
+        %7 = "arith.constant"() <{"value" = 1 : i32}> : () -> i32
+        %8 = "arith.addi"(%arg6_0, %7) : (i32, i32) -> i32
+        "func.return"(%8) : (i32) -> ()
+    }) : () -> ()
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! testParseOp r#"!int = i32
+!fn = (!int) -> !int
+"builtin.module"() ({
+  "func.func"() <{function_type = !fn, sym_name = "f"}> ({
+  ^bb0(%a: !int):
+    %c = "arith.constant"() <{value = 1 : !int}> : () -> !int
+    %s = "arith.addi"(%a, %c) : (!int, !int) -> !int
+    "func.return"(%s) : (!int) -> ()
+  }) : () -> ()
+}) : () -> ()"#
+
+/--
+  error: redefinition of type alias id 'int'
+-/
+#guard_msgs in
+#eval! testParseOp r#"!int = i32
+!int = i64
+"builtin.module"() ({}) : () -> ()"#
+
+/--
+  error: type names with a '.' are reserved for dialect-defined names
+-/
+#guard_msgs in
+#eval! testParseOp r#"!my.int = i32
+"builtin.module"() ({}) : () -> ()"#
+
+/--
+  error: expected '=' in type alias definition
+-/
+#guard_msgs in
+#eval! testParseOp r#"!int i32
+"builtin.module"() ({}) : () -> ()"#
+
+/--
+  error: undefined symbol alias id 'other'
+-/
+#guard_msgs in
+#eval! testParseOp r#"!int = !other
+"builtin.module"() ({}) : () -> ()"#
+
+/--
+  error: type '!foo.bar' is not registered. Consider using --allow-unregistered-dialect.
+-/
+#guard_msgs in
+#eval! testParseOp r#"!t = !foo.bar
+"builtin.module"() ({}) : () -> ()"#

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.Parser.Parser
 public import Veir.IR.Attribute
+public import Std.Data.HashMap
 
 public section
 
@@ -15,6 +16,8 @@ open Veir.Parser.ParserError
 
 structure AttrParserState where
   allowUnregisteredDialect : Bool := false
+  /-- Type aliases in scope, keyed by name without the `!`. -/
+  typeAliases : Std.HashMap ByteArray TypeAttr := {}
 
 abbrev AttrParserM := StateT AttrParserState (EStateM ParserError ParserState)
 
@@ -121,14 +124,51 @@ def parseOptionalRegisterType : AttrParserM (Option RegisterType) := do
     return some $ RegisterType.mk none
 
 /--
+  Resolve a just-consumed `!name` as a type alias. Returns `none` when the name denotes a dialect
+  type instead, i.e. it contains a `.` or is directly followed by `<body>`.
+-/
+def resolveOptionalTypeAlias (startPos : Location) (name : ByteArray) :
+    AttrParserM (Option TypeAttr) := do
+  let next ← peekToken
+  -- `startPos + 1 + name.size` is the end of the `!name` token, so this `<` has no space before it.
+  let hasBody := next.kind == .less
+    && next.slice.start.byteOffset == startPos.byteOffset + 1 + name.size
+  if hasBody || name.toList.contains '.'.toUInt8 then
+    return none
+  let some type := (← getThe AttrParserState).typeAliases[name]?
+    | throwAt startPos s!"undefined symbol alias id '{String.fromUTF8! name}'"
+  return some type
+
+/--
+  Parse a builtin type via `parseOptional`, or a `!name` alias whose definition is an `α`. Used
+  where MLIR requires a specific builtin type but still accepts an alias for it, e.g. the type of
+  `1 : i32` or the element type of `array<i32: 1, 2>`.
+-/
+def parseBuiltinTypeOrAlias {α : Type} [IsTypeAttr α] (parseOptional : AttrParserM (Option α))
+    (errorMsg : String) : AttrParserM α := do
+  if let some type ← parseOptional then
+    return type
+  let startPos ← getPos
+  let some name ← parseOptionalPrefixedKeyword .exclamationIdent | throwAtCurrentPos errorMsg
+  let some type := (← resolveOptionalTypeAlias startPos name).bind (·.cast? α)
+    | throwAt startPos errorMsg
+  return type
+
+/--
   Parse an integer type, throwing an error if it is not present.
   An integer type is represented as `i` followed by a positive integer indicating
-  its width, e.g., `i32`.
+  its width, e.g., `i32`, or by a type alias standing for one.
 -/
-def parseIntegerType (errorMsg : String := "integer type expected") : AttrParserM IntegerType := do
-  match ← parseOptionalIntegerType with
-  | some integerType => return integerType
-  | none => throwAtCurrentPos errorMsg
+def parseIntegerType (errorMsg : String := "integer type expected") : AttrParserM IntegerType :=
+  parseBuiltinTypeOrAlias parseOptionalIntegerType errorMsg
+
+/--
+  Parse a float type, throwing an error if it is not present.
+  A float type is represented as `f` followed by its width, e.g., `f64`, or by a type alias
+  standing for one.
+-/
+def parseFloatType (errorMsg : String := "float type expected") : AttrParserM FloatType :=
+  parseBuiltinTypeOrAlias parseOptionalFloatType errorMsg
 
 /--
   Parse a register type, throwing an error if it is not present.
@@ -175,8 +215,7 @@ def parseOptionalFloatAttr : AttrParserM (Option FloatAttr) := do
   if str ≠ "1.0" then
     throwAtCurrentPos s!"unsupported floating-point literal '{str}', only '1.0 : f64' is supported"
   parsePunctuation ":"
-  let some floatType ← parseOptionalFloatType
-    | throwAtCurrentPos "float type expected after ':' in float attribute"
+  let floatType ← parseFloatType "float type expected after ':' in float attribute"
   if floatType.bitwidth ≠ 64 then
     throwAtCurrentPos "unsupported float type, only f64 is supported"
   return some (Veir.FloatAttr.mk 1.0 floatType)
@@ -337,13 +376,16 @@ private def parseUnregisteredAttrBody (endToken : TokenKind := .greater)
   | none => throwAt startPos "failed converting attribute body to string"
 
 /--
-  Parse a dialect type, if present.
-  A dialect attribute has the form `!dialect.name` or `!dialect.name<body>`.
+  Parse a dialect type or a type alias, if present.
+  A dialect type has the form `!dialect.name`, `!dialect.name<body>` or `!name<body>`; a bare
+  `!name` is an alias.
 -/
 partial def parseOptionalDialectType : AttrParserM (Option TypeAttr) := do
   let startPos ← getPos
   let dialectName ← parseOptionalPrefixedKeyword .exclamationIdent
   let some dialectName := dialectName | return none
+  if let some type ← resolveOptionalTypeAlias startPos dialectName then
+    return some type
   if !(← getThe AttrParserState).allowUnregisteredDialect then
     throwAt startPos s!"type '!{String.fromUTF8! dialectName}' is not registered. \
       Consider using --allow-unregistered-dialect."
@@ -561,8 +603,7 @@ partial def parseOptionalCudaTilePointerType : AttrParserM (Option TypeAttr) := 
   if typeName ≠ "cuda_tile.ptr".toByteArray then return none
   let _ ← consumeToken
   parsePunctuation "<"
-  let some intTy ← parseOptionalIntegerType
-    | throwAtCurrentPos "integer type expected"
+  let intTy ← parseIntegerType
   parsePunctuation ">"
   return some (CudaTile.PointerType.mk intTy)
 

--- a/Veir/Parser/MlirParser.lean
+++ b/Veir/Parser/MlirParser.lean
@@ -81,6 +81,8 @@ structure MlirParserState (OpInfo : Type) [HasOpInfo OpInfo] where
   blocks : Std.HashMap ByteArray BlockEntry
   /-- Whether to accept ops/types/attrs from unregistered dialects. -/
   allowUnregisteredDialect : Bool := false
+  /-- Type aliases defined so far, keyed by name without the `!`. -/
+  typeAliases : Std.HashMap ByteArray TypeAttr := {}
   deriving Inhabited
 
 def MlirParserState.fromContext (ctx : WfIRContext OpInfo)
@@ -509,12 +511,19 @@ def resolveOperand (operand : UnresolvedOperand) (expectedType : TypeAttr) :
               pos := some operand.pos } : ParserError).addNote defPos "value defined here")
   return value
 
+/-- The attribute parser state derived from the current parser state. -/
+def attrParserState : MlirParserM OpInfo AttrParserState := do
+  let state ← get
+  return {
+    allowUnregisteredDialect := state.allowUnregisteredDialect
+    typeAliases := state.typeAliases
+  }
+
 /--
   Parse a type, if present.
 -/
 def parseOptionalType : MlirParserM OpInfo (Option TypeAttr) := do
-  let allowUnregisteredDialect := (← get).allowUnregisteredDialect
-  match AttrParser.parseOptionalType.run { allowUnregisteredDialect } (← getThe ParserState) with
+  match AttrParser.parseOptionalType.run (← attrParserState) (← getThe ParserState) with
   | .ok (ty, _, parserState) =>
     set parserState
     return ty
@@ -566,8 +575,7 @@ def parseOpProperties (opCode : OpInfo) : MlirParserM OpInfo (propertiesOf opCod
     match IsOpCode.fromAttrDict opCode {} with
     | .ok properties => return properties
     | .error err => throwAtCurrentPos err
-  let allowUnregisteredDialect := (← get).allowUnregisteredDialect
-  match AttrParser.parseAttributeDictionary.run { allowUnregisteredDialect } (← getThe ParserState) with
+  match AttrParser.parseAttributeDictionary.run (← attrParserState) (← getThe ParserState) with
   | .ok (properties, _, parserState) =>
     set parserState
     parsePunctuation ">"
@@ -598,7 +606,7 @@ private def optionallySetUnregisteredOpName (opCode : OpInfo)
   to parse valid MLIR syntax.
 -/
 def parseOpAttributes : MlirParserM OpInfo DictionaryAttr := do
-  match AttrParser.parseOptionalAttributeDictionary.run { allowUnregisteredDialect := (← get).allowUnregisteredDialect } (← getThe ParserState) with
+  match AttrParser.parseOptionalAttributeDictionary.run (← attrParserState) (← getThe ParserState) with
   | .ok (attrs, _, parserState) =>
     set parserState
     match attrs with
@@ -796,8 +804,28 @@ def checkNoUnresolvedForwardValues : MlirParserM OpInfo Unit := do
   for (valueName, fwd) in (← get).forwardValues do
     throwAt fwd.loc s!"use of undefined value %{String.fromUTF8! valueName}"
 
-/-- Parse a top-level operation and report any unresolved SSA forward references. -/
+/--
+  Parse the `!name = type` alias definitions preceding the top-level operation. As in MLIR, a
+  definition may use earlier aliases, a name may not be redefined, and names containing a `.` are
+  reserved for dialect types.
+-/
+def parseTypeAliasDefs : MlirParserM OpInfo Unit := do
+  repeat
+    let startPos ← getPos
+    let some name ← parseOptionalPrefixedKeyword .exclamationIdent | break
+    if (← get).typeAliases.contains name then
+      throwAt startPos s!"redefinition of type alias id '{String.fromUTF8! name}'"
+    if name.toList.contains '.'.toUInt8 then
+      throwAt startPos "type names with a '.' are reserved for dialect-defined names"
+    parsePunctuation "=" "expected '=' in type alias definition"
+    let type ← parseType
+    modify fun state => { state with typeAliases := state.typeAliases.insert name type }
+
+/--
+  Parse the top-level alias definitions and operation, and report unresolved forward references.
+-/
 partial def parseTopLevelOp : MlirParserM OpInfo OperationPtr := do
+  parseTypeAliasDefs
   let op ← parseOp none
   checkNoUnresolvedForwardValues
   return op


### PR DESCRIPTION
MLIR files commonly start with `!name = type` aliases and use `!name` in place of the type. VeIR rejected both. This parses the alias definitions before the top-level operation and resolves `!name` wherever a type is parsed, including in typed attributes such as `1 : !int` and `array<!int: 1, 2>`. As in MLIR, a name may not be redefined or contain `a .`, an undefined alias is an error, and a `!name` directly followed by `<` is still a dialect type. The printer expands aliases; no `!name = type` lines are emitted.

Not covered yet: attribute `aliases (#name = attr)`, and aliases inside bodies VeIR keeps as text (`dense<..> : tensor<2x!int>, !llvm.struct<(!int)>, unregistered !foo<!int>`), which are printed verbatim. Aliases after the top-level operation are ignored currently and will be supported in follow-up PRs.