### PR TITLE
parser: Add CIR type and attribute support to VeIR

### DIFF
--- a/Test/Cir/types.mlir
+++ b/Test/Cir/types.mlir
@@ -1,0 +1,18 @@
+// RUN: VEIR_ROUNDTRIP
+
+// ClangIR types and typed constants parse and print in their ClangIR spelling. The ops are
+// still generic here; the cir dialect's own ops arrive in a later change.
+"builtin.module"() ({
+  "func.func"() <{function_type = (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>, sym_name = "types"}> ({
+  ^bb0(%a : !cir.int<s, 32>, %b : !cir.bool):
+    %0 = "test.test"(%a, %b) {fn = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, void_fn = !cir.func<()>} : (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>
+    "test.test"() {i = #cir.int<-7> : !cir.int<s, 64>, b = #cir.bool<true> : !cir.bool} : () -> ()
+    "func.return"(%0) : (!cir.int<u, 8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "func.func"() <{"function_type" = (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>, "sym_name" = "types"}> ({
+// CHECK-NEXT:   ^{{.*}}([[A:%.*]] : !cir.int<s, 32>, [[B:%.*]] : !cir.bool):
+// CHECK-NEXT:     [[R:%.*]] = "test.test"([[A]], [[B]]) {"fn" = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, "void_fn" = !cir.func<()>} : (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>
+// CHECK-NEXT:     "test.test"() {"b" = #cir.bool<true> : !cir.bool, "i" = #cir.int<-7> : !cir.int<s, 64>} : () -> ()
+// CHECK-NEXT:     "func.return"([[R]]) : (!cir.int<u, 8>) -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -219,6 +219,33 @@ macro "#assert " e:term : command =>
 #assert expectErrorType "!mod_arith.int<17>" "Expected punctuation ':'" (some 17)
 #assert expectErrorType "!mod_arith.int<17 : x>" "integer type expected after ':' in integer attribute" (some 20)
 
+/-! ## ClangIR types -/
+
+#assert expectSuccessType "!cir.int<s, 32>" (CirIntType.mk true 32)
+#assert expectSuccessType "!cir.int<u, 8>" (CirIntType.mk false 8)
+#assert expectSuccessAttr "!cir.int<s, 32>" (CirIntType.mk true 32)
+#assert expectSuccessType "!cir.bool" (CirBoolType.mk)
+#assert expectSuccessType "!cir.func<()>" (CirFuncType.mk (FunctionType.mk #[] #[] false))
+#assert expectSuccessType "!cir.func<(!cir.int<s, 32>, !cir.bool) -> !cir.int<s, 32>>"
+  (CirFuncType.mk (FunctionType.mk
+    #[(CirIntType.mk true 32 : Attribute), (CirBoolType.mk : Attribute)]
+    #[(CirIntType.mk true 32 : Attribute)] false))
+#assert expectSuccessType "!cir.func<(!cir.int<s, 32>, ...) -> !cir.int<s, 32>>"
+  (CirFuncType.mk (FunctionType.mk
+    #[(CirIntType.mk true 32 : Attribute)] #[(CirIntType.mk true 32 : Attribute)] true))
+#assert expectErrorType "!cir.int<x, 32>" "cir.int signedness expected ('s' or 'u')" (some 9)
+#assert expectErrorType "!cir.int<s>" "Expected punctuation ','" (some 10)
+#assert expectErrorType "!cir.int<s, 0>" "cir.int bitwidth must be positive" (some 13)
+
+/-! ## ClangIR attributes -/
+
+#assert expectSuccessAttr "#cir.int<42> : !cir.int<s, 32>" (CirIntAttr.mk 42 (CirIntType.mk true 32))
+#assert expectSuccessAttr "#cir.int<-1> : !cir.int<s, 8>" (CirIntAttr.mk (-1) (CirIntType.mk true 8))
+#assert expectSuccessAttr "#cir.bool<true> : !cir.bool" (CirBoolAttr.mk true)
+#assert expectSuccessAttr "#cir.bool<false> : !cir.bool" (CirBoolAttr.mk false)
+#assert expectErrorAttr "#cir.int<42>" "Expected punctuation ':'" (some 12)
+#assert expectErrorAttr "#cir.int<42> : i32" "#cir.int<N> expects a !cir.int type annotation" (some 15)
+
 /-! ## PDL handle types -/
 #assert expectSuccessType "!pdl.attribute" (PDL.AttributeType.mk)
 #assert expectSuccessType "!pdl.range<value>" (PDL.RangeType.mk .value)

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -314,6 +314,32 @@ structure FeltConstAttr where
   fieldType : FeltType
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/-! ## ClangIR (`cir`) types and attributes -/
+
+/-- The `!cir.int<s, N>` / `!cir.int<u, N>` type from ClangIR. -/
+structure CirIntType where
+  isSigned : Bool
+  width : Nat
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/-- The builtin integer type a `!cir.int` lowers to (signedness is dropped). -/
+def CirIntType.toIntegerType (type : CirIntType) : IntegerType := { bitwidth := type.width }
+
+/-- The `!cir.bool` type from ClangIR. -/
+structure CirBoolType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/-- The `#cir.int<N> : !cir.int<s|u, W>` attribute from ClangIR. -/
+structure CirIntAttr where
+  value : Int
+  type : CirIntType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/-- The `#cir.bool<true|false> : !cir.bool` attribute from ClangIR. -/
+structure CirBoolAttr where
+  value : Bool
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 namespace LLVM
 
 structure VoidType
@@ -399,6 +425,14 @@ deriving Inhabited, Repr, Hashable
   the Lean type level while reusing their common representation.
 -/
 structure LLVMFunctionType where
+  functionType : FunctionType
+deriving Inhabited, Repr, Hashable
+
+/--
+  The payload of a ClangIR function type `!cir.func<(inputs) -> result>`.
+  A function without results is spelled `!cir.func<(inputs)>`.
+-/
+structure CirFuncType where
   functionType : FunctionType
 deriving Inhabited, Repr, Hashable
 
@@ -509,6 +543,16 @@ inductive Attribute
 | feltType (type : FeltType)
 /-- LLZK felt-const attribute (`#felt<const N> : !felt.type`) -/
 | feltConstAttr (attr : FeltConstAttr)
+/-- ClangIR integer type (`!cir.int<s|u, N>`) -/
+| cirIntType (type : CirIntType)
+/-- ClangIR boolean type (`!cir.bool`) -/
+| cirBoolType (type : CirBoolType)
+/-- ClangIR function type (`!cir.func<(..) -> T>`) -/
+| cirFuncType (type : CirFuncType)
+/-- ClangIR integer attribute (`#cir.int<N> : !cir.int<..>`) -/
+| cirIntAttr (attr : CirIntAttr)
+/-- ClangIR boolean attribute (`#cir.bool<b> : !cir.bool`) -/
+| cirBoolAttr (attr : CirBoolAttr)
 /-- LLVM void type -/
 | llvmVoidType (type : LLVM.VoidType)
 /-- LLVM byte type -/
@@ -574,6 +618,10 @@ theorem LLVMFunctionType.sizeOf_functionType {ft : LLVMFunctionType} :
     sizeOf ft.functionType < sizeOf ft := by
   grind [cases LLVMFunctionType]
 
+theorem CirFuncType.sizeOf_functionType {ft : CirFuncType} :
+    sizeOf ft.functionType < sizeOf ft := by
+  grind [cases CirFuncType]
+
 theorem ArrayAttr.sizeOf_elems_value {aa : ArrayAttr} (hx : x ∈ aa.value) :
     sizeOf x < sizeOf aa := by
   grind [Array.sizeOf_lt_of_mem hx, cases ArrayAttr]
@@ -624,6 +672,14 @@ def LLVMFunctionType.decEq (type1 type2 : LLVMFunctionType) : Decidable (type1 =
 termination_by sizeOf type1
 decreasing_by
   apply LLVMFunctionType.sizeOf_functionType
+
+def CirFuncType.decEq (type1 type2 : CirFuncType) : Decidable (type1 = type2) :=
+  match FunctionType.decEq type1.functionType type2.functionType with
+  | isTrue _ => isTrue (by grind [cases CirFuncType])
+  | isFalse _ => isFalse (by grind)
+termination_by sizeOf type1
+decreasing_by
+  apply CirFuncType.sizeOf_functionType
 
 def ArrayAttr.decEq (arr1 arr2 : ArrayAttr) : Decidable (arr1 = arr2) :=
   let value1 := arr1.value
@@ -780,6 +836,24 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case cirIntType.cirIntType type1 type2 =>
+    exact (match decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case cirBoolType.cirBoolType type1 type2 =>
+    exact (isTrue (by grind))
+  case cirFuncType.cirFuncType type1 type2 =>
+    exact (match CirFuncType.decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case cirIntAttr.cirIntAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case cirBoolAttr.cirBoolAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case registerType.registerType type1 type2 =>
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
@@ -843,6 +917,7 @@ end
 instance : DecidableEq Attribute := Attribute.decEq
 instance : DecidableEq FunctionType := FunctionType.decEq
 instance : DecidableEq LLVMFunctionType := LLVMFunctionType.decEq
+instance : DecidableEq CirFuncType := CirFuncType.decEq
 instance : DecidableEq ArrayAttr := ArrayAttr.decEq
 instance : DecidableEq DictionaryAttr := DictionaryAttr.decEq
 
@@ -980,6 +1055,18 @@ instance : ToString FeltConstAttr where
     | some _ => s!"#felt<const {attr.value} : {attr.fieldType}>"
     | none => s!"#felt<const {attr.value}>"
 
+instance : ToString CirIntType where
+  toString type := s!"!cir.int<{if type.isSigned then "s" else "u"}, {type.width}>"
+
+instance : ToString CirBoolType where
+  toString _ := "!cir.bool"
+
+instance : ToString CirIntAttr where
+  toString attr := s!"#cir.int<{attr.value}> : {attr.type}"
+
+instance : ToString CirBoolAttr where
+  toString attr := s!"#cir.bool<{attr.value}> : !cir.bool"
+
 instance : ToString PDL.RangeElement where
   toString element :=
     match element with
@@ -1077,6 +1164,31 @@ termination_by sizeOf type
 decreasing_by
   apply LLVMFunctionType.sizeOf_functionType
 
+/--
+  Print a function type in ClangIR spelling: `!cir.func<(inputs) -> result>`, or
+  `!cir.func<(inputs)>` when there are no results.
+-/
+def FunctionType.toCirString (type : FunctionType) : String :=
+  let paramStrs := type.inputs.toList.map Attribute.toString
+  let paramStrs := if type.isVarArg then paramStrs ++ ["..."] else paramStrs
+  let params := String.intercalate ", " paramStrs
+  match _ : type.outputs.size with
+  | 0 => s!"!cir.func<({params})>"
+  | _ =>
+    let results := String.intercalate ", " (type.outputs.toList.map Attribute.toString)
+    s!"!cir.func<({params}) -> {results}>"
+termination_by sizeOf type
+decreasing_by
+  all_goals first
+    | (apply FunctionType.sizeOf_elems_inputs; grind)
+    | (apply FunctionType.sizeOf_elems_outputs; grind)
+
+def CirFuncType.toString (type : CirFuncType) : String :=
+  type.functionType.toCirString
+termination_by sizeOf type
+decreasing_by
+  apply CirFuncType.sizeOf_functionType
+
 def FunctionType.toString (type : FunctionType) : String :=
   let inputs := String.intercalate ", " (type.inputs.toList.map Attribute.toString)
   let outputs := match _ : type.outputs.size with
@@ -1146,6 +1258,11 @@ def Attribute.toString (attr : Attribute) : String :=
   | .modArithType type => ToString.toString type
   | .feltType type => ToString.toString type
   | .feltConstAttr attr => ToString.toString attr
+  | .cirIntType type => ToString.toString type
+  | .cirBoolType type => ToString.toString type
+  | .cirFuncType type => type.toString
+  | .cirIntAttr attr => ToString.toString attr
+  | .cirBoolAttr attr => ToString.toString attr
   | .llvmVoidType type => ToString.toString type
   | .llvmPointerType type => ToString.toString type
   | .llvmArrayType type => type.toString
@@ -1170,6 +1287,9 @@ instance : ToString FunctionType where
 
 instance : ToString LLVMFunctionType where
   toString := LLVMFunctionType.toString
+
+instance : ToString CirFuncType where
+  toString := CirFuncType.toString
 
 instance : ToString ArrayAttr where
   toString := ArrayAttr.toString
@@ -1397,6 +1517,11 @@ def isType (attr : Attribute) : Bool :=
   | .modArithType _ => true
   | .feltType _ => true
   | .feltConstAttr _ => false
+  | .cirIntType _ => true
+  | .cirBoolType _ => true
+  | .cirFuncType _ => true
+  | .cirIntAttr _ => false
+  | .cirBoolAttr _ => false
   | .registerType _ => true
   | .registerAttr _ => false
   | .llvmVoidType _ => true
@@ -1466,6 +1591,16 @@ theorem isType_functionType type : (functionType type).isType = true := by rfl
 theorem isType_modArithType type : (modArithType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_feltType type : (feltType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirIntType type : (cirIntType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirBoolType type : (cirBoolType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirFuncType type : (cirFuncType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirIntAttr attr : (cirIntAttr attr).isType = false := by rfl
+@[simp, grind =]
+theorem isType_cirBoolAttr attr : (cirBoolAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_registerType type : (registerType type).isType = true := by rfl
 @[simp, grind =]
@@ -1662,6 +1797,18 @@ instance : IsTypeAttr ModArithType where
 
 instance : IsTypeAttr FeltType where
   coe type := Attribute.asType (.feltType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr CirIntType where
+  coe type := Attribute.asType (.cirIntType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr CirBoolType where
+  coe type := Attribute.asType (.cirBoolType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr CirFuncType where
+  coe type := Attribute.asType (.cirFuncType type) (by rfl)
   coe_eq_inject _ := by rfl
 
 instance : CoeDep (Option Nat → RegisterType) RegisterType.mk TypeAttr where

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -664,6 +664,82 @@ def parseOptionalFeltConstAttr : AttrParserM (Option FeltConstAttr) := do
     return some (FeltConstAttr.mk val ft)
   return some (FeltConstAttr.mk val (FeltType.mk innerFieldName))
 
+/-! ## ClangIR (`cir`) types and attributes -/
+
+/--
+  Parse ClangIR's integer type, if present.
+  Its syntax is `!cir.int<s, N>` (signed) or `!cir.int<u, N>` (unsigned).
+-/
+def parseOptionalCirIntType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "cir.int".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let isSigned ←
+    if ← parseOptionalKeyword "s".toByteArray then pure true
+    else if ← parseOptionalKeyword "u".toByteArray then pure false
+    else throwAtCurrentPos "cir.int signedness expected ('s' or 'u')"
+  parsePunctuation ","
+  let some width ← parseOptionalInteger false false
+    | throwAtCurrentPos "cir.int bitwidth expected"
+  if width ≤ 0 then throwAtCurrentPos "cir.int bitwidth must be positive"
+  parsePunctuation ">"
+  return some (CirIntType.mk isSigned width.toNat)
+
+/-- Parse ClangIR's boolean type `!cir.bool`, if present. -/
+def parseOptionalCirBoolType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "cir.bool".toByteArray then return none
+  let _ ← consumeToken
+  return some CirBoolType.mk
+
+/--
+  Parse ClangIR's integer attribute, if present.
+  Its syntax is `#cir.int<N> : !cir.int<s|u, W>`; the type annotation is mandatory.
+-/
+def parseOptionalCirIntAttr : AttrParserM (Option CirIntAttr) := do
+  let token ← peekToken
+  let .hashIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let name := { token.slice with start := token.slice.start + 1 }.of input
+  if name ≠ "cir.int".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let some value ← parseOptionalInteger false true
+    | throwAtCurrentPos "#cir.int<...> expects an integer value"
+  parsePunctuation ">"
+  parsePunctuation ":"
+  let some tyAttr ← parseOptionalCirIntType
+    | throwAtCurrentPos "#cir.int<N> expects a !cir.int type annotation"
+  let .cirIntType ty := tyAttr.val
+    | throwAtCurrentPos "#cir.int<N> expects a !cir.int type annotation"
+  return some (CirIntAttr.mk value ty)
+
+/-- Parse ClangIR's boolean attribute `#cir.bool<true|false> : !cir.bool`, if present. -/
+def parseOptionalCirBoolAttr : AttrParserM (Option CirBoolAttr) := do
+  let token ← peekToken
+  let .hashIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let name := { token.slice with start := token.slice.start + 1 }.of input
+  if name ≠ "cir.bool".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let value ←
+    if ← parseOptionalKeyword "true".toByteArray then pure true
+    else if ← parseOptionalKeyword "false".toByteArray then pure false
+    else throwAtCurrentPos "#cir.bool<...> expects `true` or `false`"
+  parsePunctuation ">"
+  parsePunctuation ":"
+  let some _ ← parseOptionalCirBoolType
+    | throwAtCurrentPos "#cir.bool<b> expects a !cir.bool type annotation"
+  return some (CirBoolAttr.mk value)
+
 /--
   Parse CIRCT's HW dialect's `ModulePort::Direction` type.
   Its syntax is `(input|output|inout)`.
@@ -863,6 +939,40 @@ partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
   return some ⟨.llvmFunctionType ft, by simp⟩
 
 /--
+  Parse ClangIR's function type, if present.
+  Its syntax is `!cir.func<(inputs) -> result>`, or `!cir.func<(inputs)>` for a function
+  without results. A trailing `...` in the inputs marks a variadic function.
+-/
+partial def parseOptionalCirFuncType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "cir.func".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let params ← parseDelimitedList .paren do
+    if (← parseOptionalToken .ellipsis).isSome then
+      return LLVMFuncParam.ellipsis
+    return LLVMFuncParam.type (← parseType)
+  if params.pop.any (· matches .ellipsis) then
+    throwAtCurrentPos "'...' is only valid as the last parameter of a cir function type"
+  let isVarArg := params.any (· matches .ellipsis)
+  let inputs := params.filterMap fun
+    | .type ty => some ty.val
+    | .ellipsis => none
+  let outputs ←
+    if ← parseOptionalPunctuation "->" then
+      match ← parseOptionalDelimitedList .paren parseType with
+      | some outputs => pure (outputs.map (·.val))
+      | none => pure #[(← parseType "cir.func result type expected").val]
+    else
+      pure #[]
+  parsePunctuation ">"
+  let ft := FunctionType.mk inputs outputs isVarArg
+  return some ⟨.cirFuncType (CirFuncType.mk ft), by simp⟩
+
+/--
   Parse a `match` optional handle type `!match.optional<...>`, if present.
 
   The wrapped type is parsed with the general type parser rather than a fixed
@@ -898,6 +1008,12 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some modArithType
   if let some feltType ← parseOptionalFeltType then
     return some feltType
+  if let some cirIntType ← parseOptionalCirIntType then
+    return some cirIntType
+  if let some cirBoolType ← parseOptionalCirBoolType then
+    return some cirBoolType
+  if let some cirFuncType ← parseOptionalCirFuncType then
+    return some cirFuncType
   if let some llvmVoidType := ← parseOptionalLLVMVoidType then
     return some llvmVoidType
   if let some llvmPointerType := ← parseOptionalLLVMPointerType then
@@ -1015,6 +1131,10 @@ partial def parseOptionalDictionaryAttr : AttrParserM (Option DictionaryAttr) :=
 partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
   if let some feltConstAttr ← parseOptionalFeltConstAttr then
     return some feltConstAttr
+  if let some cirIntAttr ← parseOptionalCirIntAttr then
+    return some cirIntAttr
+  if let some cirBoolAttr ← parseOptionalCirBoolAttr then
+    return some cirBoolAttr
   if let some dialectAttr ← parseOptionalDialectAttr then
     return some dialectAttr
   else if let some locationAttr ← parseOptionalLocationAttr then


### PR DESCRIPTION
ClangIR represents C scalar types using CIR-specific types such as `!cir.int<s, 32>`, `!cir.int<u, 8>`, and `!cir.bool`. Function signatures use `!cir.func<...>`, while constants are represented by typed attributes such as `#cir.int<N> : !cir.int<...>` and `#cir.bool<b> : !cir.bool`.

This PR adds registered CIR types and attributes following the existing felt dialect structure:

- `!cir.int` preserves integer signedness and width.
- `!cir.bool` represents CIR boolean values.
- `!cir.func` wraps the builtin FunctionType, similar to !llvm.func.
- `#cir.int` and `#cir.bool` carry their mandatory CIR type.

The CIR parsers are invoked before falling back to unregistered-dialect parsing, and printing reproduces ClangIR’s CIR syntax.

This PR only adds the type and attribute infrastructure. CIR operation support will follow in a separate PR that builds on these definitions.