### PR TITLE
cir: add the CIR integer and core dialect

### DIFF
--- a/Test/Cir/identity.mlir
+++ b/Test/Cir/identity.mlir
@@ -1,0 +1,81 @@
+// RUN: VEIR_ROUNDTRIP
+
+// Every registered cir operation, in the generic form ClangIR prints after
+// `cir-opt -cir-flatten-cfg`. Flag properties keep ClangIR's spelling; a `false`
+// flag comes back as `0 : i1`.
+"builtin.module"() ({
+  "cir.func"() <{calling_conv = 0 : i32, function_type = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>>, global_visibility = 0 : i32, linkage = 0 : i32, sym_name = "ops"}> ({
+  ^bb0(%a : !cir.int<s, 32>, %u : !cir.int<u, 8>):
+    %c1 = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %cn = "cir.const"() <{value = #cir.int<-128> : !cir.int<s, 8>}> : () -> !cir.int<s, 8>
+    %cu = "cir.const"() <{value = #cir.int<255> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %t = "cir.const"() <{value = #cir.bool<true> : !cir.bool}> : () -> !cir.bool
+    %add = "cir.add"(%a, %c1) <{no_signed_wrap, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %sub = "cir.sub"(%add, %c1) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %mul = "cir.mul"(%sub, %c1) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %div = "cir.div"(%mul, %c1) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %rem = "cir.rem"(%div, %c1) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %and = "cir.and"(%u, %cu) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %or = "cir.or"(%and, %cu) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %xor = "cir.xor"(%or, %cu) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %shl = "cir.shift"(%rem, %u) <{isShiftleft}> : (!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>
+    %shr = "cir.shift"(%shl, %u) : (!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>
+    %not = "cir.not"(%t) : (!cir.bool) -> !cir.bool
+    %neg = "cir.minus"(%shr) <{no_signed_wrap = false}> : (!cir.int<s, 32>) -> !cir.int<s, 32>
+    %min = "cir.min"(%neg, %c1) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %max = "cir.max"(%min, %c1) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %lt = "cir.cmp"(%max, %c1) <{kind = 0 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+    %sel = "cir.select"(%lt, %max, %c1) : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %narrow = "cir.cast"(%sel) <{kind = 27 : i32}> : (!cir.int<s, 32>) -> !cir.int<s, 8>
+    %b = "cir.cast"(%narrow) <{kind = 28 : i32}> : (!cir.int<s, 8>) -> !cir.bool
+    %i = "cir.cast"(%b) <{kind = 38 : i32}> : (!cir.bool) -> !cir.int<s, 32>
+    "cir.brcond"(%b, %i, %cn)[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 1, 1, 1>}> : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 8>) -> ()
+  ^bb1(%x : !cir.int<s, 32>):
+    "cir.br"(%x)[^bb3] : (!cir.int<s, 32>) -> ()
+  ^bb2(%y : !cir.int<s, 8>):
+    "cir.unreachable"() : () -> ()
+  ^bb3(%r : !cir.int<s, 32>):
+    "cir.return"(%r) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+  "cir.func"() <{function_type = !cir.func<()>, sym_name = "nothing"}> ({
+    "cir.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "cir.func"() <{"calling_conv" = 0 : i32, "function_type" = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>>, "global_visibility" = 0 : i32, "linkage" = 0 : i32, "sym_name" = "ops"}> ({
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !cir.int<s, 32>, %{{.*}} : !cir.int<u, 8>):
+// CHECK-NEXT: %{{.*}} = "cir.const"() <{"value" = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.const"() <{"value" = #cir.int<-128> : !cir.int<s, 8>}> : () -> !cir.int<s, 8>
+// CHECK-NEXT: %{{.*}} = "cir.const"() <{"value" = #cir.int<255> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+// CHECK-NEXT: %{{.*}} = "cir.const"() <{"value" = #cir.bool<true> : !cir.bool}> : () -> !cir.bool
+// CHECK-NEXT: %{{.*}} = "cir.add"(%{{.*}}, %{{.*}}) <{no_signed_wrap, "no_unsigned_wrap" = 0 : i1, "saturated" = 0 : i1}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.sub"(%{{.*}}, %{{.*}}) <{"no_signed_wrap" = 0 : i1, "no_unsigned_wrap" = 0 : i1, "saturated" = 0 : i1}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.mul"(%{{.*}}, %{{.*}}) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.div"(%{{.*}}, %{{.*}}) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.rem"(%{{.*}}, %{{.*}}) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.and"(%{{.*}}, %{{.*}}) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+// CHECK-NEXT: %{{.*}} = "cir.or"(%{{.*}}, %{{.*}}) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+// CHECK-NEXT: %{{.*}} = "cir.xor"(%{{.*}}, %{{.*}}) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+// CHECK-NEXT: %{{.*}} = "cir.shift"(%{{.*}}, %{{.*}}) <{isShiftleft}> : (!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.shift"(%{{.*}}, %{{.*}}) : (!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.not"(%{{.*}}) : (!cir.bool) -> !cir.bool
+// CHECK-NEXT: %{{.*}} = "cir.minus"(%{{.*}}) <{"no_signed_wrap" = 0 : i1}> : (!cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.min"(%{{.*}}, %{{.*}}) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.max"(%{{.*}}, %{{.*}}) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.cmp"(%{{.*}}, %{{.*}}) <{"kind" = 0 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+// CHECK-NEXT: %{{.*}} = "cir.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK-NEXT: %{{.*}} = "cir.cast"(%{{.*}}) <{"kind" = 27 : i32}> : (!cir.int<s, 32>) -> !cir.int<s, 8>
+// CHECK-NEXT: %{{.*}} = "cir.cast"(%{{.*}}) <{"kind" = 28 : i32}> : (!cir.int<s, 8>) -> !cir.bool
+// CHECK-NEXT: %{{.*}} = "cir.cast"(%{{.*}}) <{"kind" = 38 : i32}> : (!cir.bool) -> !cir.int<s, 32>
+// CHECK-NEXT: "cir.brcond"(%{{.*}}, %{{.*}}, %{{.*}}) [^{{.*}}, ^{{.*}}] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 8>) -> ()
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !cir.int<s, 32>):
+// CHECK-NEXT: "cir.br"(%{{.*}}) [^{{.*}}] : (!cir.int<s, 32>) -> ()
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !cir.int<s, 8>):
+// CHECK-NEXT: "cir.unreachable"() : () -> ()
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !cir.int<s, 32>):
+// CHECK-NEXT: "cir.return"(%{{.*}}) : (!cir.int<s, 32>) -> ()
+// CHECK-NEXT: }) : () -> ()
+// CHECK-NEXT: "cir.func"() <{"function_type" = !cir.func<()>, "sym_name" = "nothing"}> ({
+// CHECK-NEXT: ^{{.*}}():
+// CHECK-NEXT: "cir.return"() : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/Cir/invalid_brcond_segments.mlir
+++ b/Test/Cir/invalid_brcond_segments.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir.brcond: true operand segment expected operand count 0, got 1
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<()>, sym_name = "f"}> ({
+    %0 = "cir.const"() <{value = #cir.bool<true> : !cir.bool}> : () -> !cir.bool
+    "cir.brcond"(%0, %0)[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 1, 1, 0>}> : (!cir.bool, !cir.bool) -> ()
+  ^bb1:
+    "cir.return"() : () -> ()
+  ^bb2:
+    "cir.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Cir/invalid_cmp_kind.mlir
+++ b/Test/Cir/invalid_cmp_kind.mlir
@@ -1,0 +1,7 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir.cmp: invalid kind 7
+"builtin.module"() ({
+  %0 = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+  %1 = "cir.cmp"(%0, %0) <{kind = 7 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+}) : () -> ()

--- a/Test/Cir/invalid_const_range.mlir
+++ b/Test/Cir/invalid_const_range.mlir
@@ -1,0 +1,6 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir.const: constant value 128 does not fit in !cir.int<s, 8>
+"builtin.module"() ({
+  %0 = "cir.const"() <{value = #cir.int<128> : !cir.int<s, 8>}> : () -> !cir.int<s, 8>
+}) : () -> ()

--- a/Test/Cir/invalid_const_type.mlir
+++ b/Test/Cir/invalid_const_type.mlir
@@ -1,0 +1,6 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir.const: Expected result type to match the constant's type
+"builtin.module"() ({
+  %0 = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<u, 32>
+}) : () -> ()

--- a/Test/Cir/invalid_operand_types.mlir
+++ b/Test/Cir/invalid_operand_types.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir.add: Expected operands to have the same type
+"builtin.module"() ({
+  %0 = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+  %1 = "cir.const"() <{value = #cir.int<1> : !cir.int<u, 32>}> : () -> !cir.int<u, 32>
+  %2 = "cir.add"(%0, %1) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<u, 32>) -> !cir.int<s, 32>
+}) : () -> ()

--- a/Test/Cir/invalid_properties.mlir
+++ b/Test/Cir/invalid_properties.mlir
@@ -1,0 +1,7 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir: expected no properties, but got 1 property
+"builtin.module"() ({
+  %0 = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+  %1 = "cir.mul"(%0, %0) <{unexpected}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+}) : () -> ()

--- a/Test/Cir/invalid_return_parent.mlir
+++ b/Test/Cir/invalid_return_parent.mlir
@@ -1,0 +1,8 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: Expected cir.return to be enclosed by cir.func
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "f"}> ({
+    "cir.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Cir/invalid_return_type.mlir
+++ b/Test/Cir/invalid_return_type.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// CHECK: cir.return operand 0 type does not match the function's declared result type
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "f"}> ({
+    %0 = "cir.const"() <{value = #cir.int<1> : !cir.int<u, 32>}> : () -> !cir.int<u, 32>
+    "cir.return"(%0) : (!cir.int<u, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Cir/types.mlir
+++ b/Test/Cir/types.mlir
@@ -1,0 +1,18 @@
+// RUN: VEIR_ROUNDTRIP
+
+// ClangIR types and typed constants parse and print in their ClangIR spelling. The ops are
+// still generic here; the cir dialect's own ops arrive in a later change.
+"builtin.module"() ({
+  "func.func"() <{function_type = (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>, sym_name = "types"}> ({
+  ^bb0(%a : !cir.int<s, 32>, %b : !cir.bool):
+    %0 = "test.test"(%a, %b) {fn = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, void_fn = !cir.func<()>} : (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>
+    "test.test"() {i = #cir.int<-7> : !cir.int<s, 64>, b = #cir.bool<true> : !cir.bool} : () -> ()
+    "func.return"(%0) : (!cir.int<u, 8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "func.func"() <{"function_type" = (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>, "sym_name" = "types"}> ({
+// CHECK-NEXT:   ^{{.*}}([[A:%.*]] : !cir.int<s, 32>, [[B:%.*]] : !cir.bool):
+// CHECK-NEXT:     [[R:%.*]] = "test.test"([[A]], [[B]]) {"fn" = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, "void_fn" = !cir.func<()>} : (!cir.int<s, 32>, !cir.bool) -> !cir.int<u, 8>
+// CHECK-NEXT:     "test.test"() {"b" = #cir.bool<true> : !cir.bool, "i" = #cir.int<-7> : !cir.int<s, 64>} : () -> ()
+// CHECK-NEXT:     "func.return"([[R]]) : (!cir.int<u, 8>) -> ()

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -219,6 +219,33 @@ macro "#assert " e:term : command =>
 #assert expectErrorType "!mod_arith.int<17>" "Expected punctuation ':'" (some 17)
 #assert expectErrorType "!mod_arith.int<17 : x>" "integer type expected after ':' in integer attribute" (some 20)
 
+/-! ## ClangIR types -/
+
+#assert expectSuccessType "!cir.int<s, 32>" (CirIntType.mk true 32)
+#assert expectSuccessType "!cir.int<u, 8>" (CirIntType.mk false 8)
+#assert expectSuccessAttr "!cir.int<s, 32>" (CirIntType.mk true 32)
+#assert expectSuccessType "!cir.bool" (CirBoolType.mk)
+#assert expectSuccessType "!cir.func<()>" (CirFuncType.mk (FunctionType.mk #[] #[] false))
+#assert expectSuccessType "!cir.func<(!cir.int<s, 32>, !cir.bool) -> !cir.int<s, 32>>"
+  (CirFuncType.mk (FunctionType.mk
+    #[(CirIntType.mk true 32 : Attribute), (CirBoolType.mk : Attribute)]
+    #[(CirIntType.mk true 32 : Attribute)] false))
+#assert expectSuccessType "!cir.func<(!cir.int<s, 32>, ...) -> !cir.int<s, 32>>"
+  (CirFuncType.mk (FunctionType.mk
+    #[(CirIntType.mk true 32 : Attribute)] #[(CirIntType.mk true 32 : Attribute)] true))
+#assert expectErrorType "!cir.int<x, 32>" "cir.int signedness expected ('s' or 'u')" (some 9)
+#assert expectErrorType "!cir.int<s>" "Expected punctuation ','" (some 10)
+#assert expectErrorType "!cir.int<s, 0>" "cir.int bitwidth must be positive" (some 13)
+
+/-! ## ClangIR attributes -/
+
+#assert expectSuccessAttr "#cir.int<42> : !cir.int<s, 32>" (CirIntAttr.mk 42 (CirIntType.mk true 32))
+#assert expectSuccessAttr "#cir.int<-1> : !cir.int<s, 8>" (CirIntAttr.mk (-1) (CirIntType.mk true 8))
+#assert expectSuccessAttr "#cir.bool<true> : !cir.bool" (CirBoolAttr.mk true)
+#assert expectSuccessAttr "#cir.bool<false> : !cir.bool" (CirBoolAttr.mk false)
+#assert expectErrorAttr "#cir.int<42>" "Expected punctuation ':'" (some 12)
+#assert expectErrorAttr "#cir.int<42> : i32" "#cir.int<N> expects a !cir.int type annotation" (some 15)
+
 /-! ## PDL handle types -/
 #assert expectSuccessType "!pdl.attribute" (PDL.AttributeType.mk)
 #assert expectSuccessType "!pdl.range<value>" (PDL.RangeType.mk .value)

--- a/UnitTest/Dialect.lean
+++ b/UnitTest/Dialect.lean
@@ -19,6 +19,9 @@ example : HasDialect OpCode Builtin := inferInstance
 #guard OpCode.name (.arith .addi) = "arith.addi".toUTF8
 #guard IsOpCode.fromName (opCode := Arith) "arith.addi".toUTF8 = some .addi
 #guard IsOpCode.name (opCode := Arith) .addi = "arith.addi".toUTF8
+#guard Cir.fromName "cir.brcond".toUTF8 = some .brcond
+#guard OpCode.fromName "cir.add".toUTF8 = some (.cir .add)
+#guard OpCode.name (.cir .unreachable) = "cir.unreachable".toUTF8
 
 /-! Dialects can define conversion functions to and from the global opcode type. -/
 abbrev Veir.Arith.from? (op : OpInfo) [HasOpInfo OpInfo] [HasDialect OpInfo Arith]

--- a/Veir/Dialects/Cir/OpInfo.lean
+++ b/Veir/Dialects/Cir/OpInfo.lean
@@ -1,0 +1,332 @@
+module
+
+public import Veir.IR.Simp
+public import Veir.IR.OpInfo
+public import Veir.Verifier.Basic
+public import Veir.Dialects.Cir.Properties
+meta import Veir.Meta.OpCode
+
+/-!
+# The `cir` dialect
+
+The integer core of ClangIR (https://llvm.github.io/clangir/): signed and unsigned integer
+scalars, booleans, and flat control flow. Structured control flow, pointers, records and
+floating point are not modelled; their operations remain unregistered.
+-/
+
+namespace Veir
+
+public section
+
+@[opcodes]
+inductive Cir where
+| func
+| return
+| const
+| add
+| sub
+| mul
+| div
+| rem
+| and
+| or
+| xor
+| shift
+| not
+| minus
+| min
+| max
+| cmp
+| select
+| cast
+| br
+| brcond
+| unreachable
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[expose, properties_of]
+def Cir.propertiesOf (op : Cir) : Type :=
+match op with
+| .func => CirFuncProperties
+| .const => CirConstProperties
+| .add | .sub | .minus => CirOverflowFlagsProperties
+| .shift => CirShiftProperties
+| .cmp => CirCmpProperties
+| .cast => CirCastProperties
+| .brcond => CirBrCondProperties
+| _ => Unit
+
+def Cir.fromAttrDict
+    (op : Cir) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Cir.propertiesOf op) :=
+  match op with
+  | .func => CirFuncProperties.fromAttrDict attrDict
+  | .const => CirConstProperties.fromAttrDict attrDict
+  | .add | .sub | .minus => CirOverflowFlagsProperties.fromAttrDict attrDict
+  | .shift => CirShiftProperties.fromAttrDict attrDict
+  | .cmp => CirCmpProperties.fromAttrDict attrDict
+  | .cast => CirCastProperties.fromAttrDict attrDict
+  | .brcond => CirBrCondProperties.fromAttrDict attrDict
+  | .return | .mul | .div | .rem | .and | .or | .xor | .not | .min | .max
+  | .select | .br | .unreachable => Cir.noProperties attrDict
+
+def Cir.toAttrDict
+    (op : Cir) (props : Cir.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .func => props.toAttrDict
+  | .const => props.toAttrDict
+  | .add | .sub | .minus => props.toAttrDict
+  | .shift => props.toAttrDict
+  | .cmp => props.toAttrDict
+  | .cast => props.toAttrDict
+  | .brcond => props.toAttrDict
+  | _ => Std.HashMap.emptyWithCapacity 0
+
+@[get_effects]
+def Cir.getEffects
+    (_op : Cir) (_props : Cir.propertiesOf _op) : MemoryEffects :=
+  .none
+
+def Cir.isConstantLike (op : Cir) : Bool :=
+  match op with
+  | .const => true
+  | _ => false
+
+def Cir.hasSSADominance (_op : Cir) (_index : Nat) : Bool :=
+  true
+
+@[is_terminator]
+def Cir.isTerminator (op : Cir) : Bool :=
+  match op with
+  | .return | .br | .brcond | .unreachable => true
+  | _ => false
+
+def Cir.isIsolatedFromAbove (op : Cir) : Bool :=
+  match op with
+  | .func => true
+  | _ => false
+
+#generate_dialect Cir
+
+instance : IsOpCode Cir where
+  fromName := Cir.fromName
+  name := Cir.name
+  propertiesOf := Cir.propertiesOf
+  fromAttrDict := Cir.fromAttrDict
+  toAttrDict := Cir.toAttrDict
+
+def Cir.functionInterface? (op : Cir) : Option (FunctionOpInterface (Cir.propertiesOf op)) :=
+  match op with
+  | .func =>
+    some
+      { getSymName := fun props => props.sym_name
+        getFunctionType := fun props => props.function_type.functionType
+        setFunctionType := fun props functionType =>
+          { props with function_type := { functionType } } }
+  | _ => none
+
+/-! ## Verifier -/
+
+/-- Verify that a type is a ClangIR integer type. -/
+def TypeAttr.verifyCirIntType (ty : TypeAttr) (msg : String) : Except String CirIntType :=
+  match ty.val with
+  | .cirIntType type => pure type
+  | type => throw s!"{msg}, but found {type} instead"
+
+/-- Verify that a type is the ClangIR boolean type. -/
+def TypeAttr.verifyCirBoolType (ty : TypeAttr) (msg : String) : Except String PUnit :=
+  match ty.val with
+  | .cirBoolType _ => pure ()
+  | type => throw s!"{msg}, but found {type} instead"
+
+/-- Verify that a type is a ClangIR integer or boolean type. -/
+def TypeAttr.verifyCirIntOrBoolType (ty : TypeAttr) (msg : String) : Except String PUnit :=
+  match ty.val with
+  | .cirIntType _ | .cirBoolType _ => pure ()
+  | type => throw s!"{msg}, but found {type} instead"
+
+/-- Verify a binary integer operation: two operands of one `!cir.int` type and a like result. -/
+def OperationPtr.verifyCirBinOp {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 2 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let operandType ← op.verifyOperandTypesMatch ctx 0 1
+    s!"{instrName}: Expected operands to have the same type"
+  let _ ← operandType.verifyCirIntType s!"{instrName}: Expected operands to have !cir.int type"
+  op.verifyResultTypeMatches ctx operandType
+    s!"{instrName}: Expected result type to match operand type"
+
+/-- Verify `cir.shift`: the amount may have a different integer type than the value. -/
+def OperationPtr.verifyCirShiftOp {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 2 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let valueType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+  let _ ← valueType.verifyCirIntType
+    s!"{instrName}: Expected the shifted value to have !cir.int type"
+  let _ ← ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyCirIntType
+    s!"{instrName}: Expected the shift amount to have !cir.int type"
+  op.verifyResultTypeMatches ctx valueType
+    s!"{instrName}: Expected result type to match the shifted value's type"
+
+/-- Verify a unary operation whose result has the operand's type. -/
+def OperationPtr.verifyCirUnaryOp {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) (allowBool : Bool) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 1 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+  if allowBool then
+    operandType.verifyCirIntOrBoolType
+      s!"{instrName}: Expected operand to have !cir.int or !cir.bool type"
+  else
+    let _ ← operandType.verifyCirIntType s!"{instrName}: Expected operand to have !cir.int type"
+  op.verifyResultTypeMatches ctx operandType
+    s!"{instrName}: Expected result type to match operand type"
+
+/-- Verify `cir.cmp`: two operands of one integer or boolean type and a `!cir.bool` result. -/
+def OperationPtr.verifyCirCmpOp {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 2 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let operandType ← op.verifyOperandTypesMatch ctx 0 1
+    s!"{instrName}: Expected operands to have the same type"
+  operandType.verifyCirIntOrBoolType
+    s!"{instrName}: Expected operands to have !cir.int or !cir.bool type"
+  ((op.getResult 0).get! ctx.raw).type.verifyCirBoolType
+    s!"{instrName}: Expected result to have !cir.bool type"
+
+/-- Verify `cir.select`: a `!cir.bool` condition and two values of one type. -/
+def OperationPtr.verifyCirSelectOp {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 3 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyCirBoolType
+    s!"{instrName}: Expected condition to have !cir.bool type"
+  let valueType ← op.verifyOperandTypesMatch ctx 1 2
+    s!"{instrName}: Expected the selected values to have the same type"
+  op.verifyResultTypeMatches ctx valueType
+    s!"{instrName}: Expected result type to match the selected values' type"
+
+/-- Verify `cir.cast` against its kind. Unmodelled kinds are only checked for arity. -/
+def OperationPtr.verifyCirCastOp {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo Cir] (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 1 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let props := op.getProperties! ctx.raw Cir.cast
+  let srcType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+  let resultType := ((op.getResult 0).get! ctx.raw).type
+  match props.kind with
+  | .integral =>
+    let _ ← srcType.verifyCirIntType
+      s!"{instrName}: Expected integral cast source to have !cir.int type"
+    let _ ← resultType.verifyCirIntType
+      s!"{instrName}: Expected integral cast result to have !cir.int type"
+  | .int_to_bool =>
+    let _ ← srcType.verifyCirIntType
+      s!"{instrName}: Expected int_to_bool cast source to have !cir.int type"
+    resultType.verifyCirBoolType
+      s!"{instrName}: Expected int_to_bool cast result to have !cir.bool type"
+  | .bool_to_int =>
+    srcType.verifyCirBoolType
+      s!"{instrName}: Expected bool_to_int cast source to have !cir.bool type"
+    let _ ← resultType.verifyCirIntType
+      s!"{instrName}: Expected bool_to_int cast result to have !cir.int type"
+  | .other _ => pure ()
+
+/-- Verify `cir.const`: the constant's type is the result type and its value fits. -/
+def OperationPtr.verifyCirConstOp {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo Cir] (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 0 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let props := op.getProperties! ctx.raw Cir.const
+  let resultType := ((op.getResult 0).get! ctx.raw).type
+  if props.value.type ≠ resultType.val then
+    throw s!"{instrName}: Expected result type to match the constant's type"
+  if let .int attr := props.value then
+    let width := attr.type.width
+    let (lo, hi) : Int × Int :=
+      if attr.type.isSigned then (-(2 ^ (width - 1)), 2 ^ (width - 1)) else (0, 2 ^ width)
+    if attr.value < lo ∨ hi ≤ attr.value then
+      throw s!"{instrName}: constant value {attr.value} does not fit in {attr.type}"
+
+/-- Verify `cir.brcond`: a `!cir.bool` condition, then the forwarded operand segments. -/
+def OperationPtr.verifyCirBrCondOp {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo Cir] (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyTerminatorCounts ctx opIn 2
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let props := op.getProperties! ctx.raw Cir.brcond
+  op.verifyCondBranchOperandSegmentSizes ctx opIn props.operandSegmentSizes 1
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyCirBoolType
+    s!"{instrName}: Expected condition to have !cir.bool type"
+
+/-- Check that a `cir.return` returns the declared result types of its enclosing `cir.func`. -/
+def OperationPtr.verifyCirReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo Cir] (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let funcOp ← op.getEnclosingFunctionOp ctx "cir.return"
+  let some .func := toDialect? Cir (funcOp.getOpType! ctx.raw)
+    | throw "Expected cir.return to be enclosed by cir.func"
+  let props : Cir.propertiesOf .func := funcOp.getProperties! ctx.raw Cir.func
+  let outputs := props.function_type.functionType.outputs
+  if op.getNumOperands ctx.raw opIn ≠ outputs.size then
+    throw s!"Expected cir.return to have {outputs.size} operand(s)"
+  let opTypes := op.getOperandTypes! ctx.raw
+  for i in [0:outputs.size] do
+    if (opTypes[i]!).val ≠ outputs[i]! then
+      throw s!"cir.return operand {i} type does not match the function's declared result type"
+
+/--
+Verify the local invariants of a `cir` operation in any operation-info type
+containing the `cir` dialect.
+-/
+@[expose]
+def Cir.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo Cir] (opType : Cir) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .func => do
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "cir.func: Expected 1 region"
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "cir.func: Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "cir.func: Expected 0 results"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "cir.func: Expected 0 successors"
+  | .return => do
+    op.verifyTerminatorCounts ctx opIn 0
+    op.verifyCirReturnTypes ctx opIn
+  | .const => op.verifyCirConstOp ctx opIn
+  | .add | .sub | .mul | .div | .rem | .and | .or | .xor | .min | .max =>
+    op.verifyCirBinOp ctx opIn
+  | .shift => op.verifyCirShiftOp ctx opIn
+  | .not => op.verifyCirUnaryOp ctx opIn true
+  | .minus => op.verifyCirUnaryOp ctx opIn false
+  | .cmp => op.verifyCirCmpOp ctx opIn
+  | .select => op.verifyCirSelectOp ctx opIn
+  | .cast => op.verifyCirCastOp ctx opIn
+  | .br => op.verifyUnconditionalBranch ctx opIn
+  | .brcond => op.verifyCirBrCondOp ctx opIn
+  | .unreachable => op.verifyPlainOpCounts ctx opIn 0 0
+
+instance : HasOpInfo Cir where
+  verifyLocalInvariants := Cir.verifyLocalInvariants
+  getEffects := Cir.getEffects
+  isConstantLike := Cir.isConstantLike
+  functionInterface? := Cir.functionInterface?
+  hasSSADominance := Cir.hasSSADominance
+  isTerminator := Cir.isTerminator
+  isIsolatedFromAbove := Cir.isIsolatedFromAbove
+
+end
+
+end Veir

--- a/Veir/Dialects/Cir/Properties.lean
+++ b/Veir/Dialects/Cir/Properties.lean
@@ -1,0 +1,260 @@
+module
+
+public import Veir.IR.Attribute
+public import Std.Data.HashMap
+
+namespace Veir
+
+public section
+
+/-! ## Enumerations
+
+ClangIR prints its enum attributes as plain `i32` integers in generic form, so each kind
+carries its ClangIR numeric code.
+-/
+
+/-- The comparison kinds of `cir.cmp`, numbered as in ClangIR's `CmpOpKind`. -/
+inductive CirCmpKind where
+  | lt
+  | le
+  | gt
+  | ge
+  | eq
+  | ne
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirCmpKind.ofNat? : Nat → Option CirCmpKind
+  | 0 => some .lt
+  | 1 => some .le
+  | 2 => some .gt
+  | 3 => some .ge
+  | 4 => some .eq
+  | 5 => some .ne
+  | _ => none
+
+def CirCmpKind.toNat : CirCmpKind → Nat
+  | .lt => 0
+  | .le => 1
+  | .gt => 2
+  | .ge => 3
+  | .eq => 4
+  | .ne => 5
+
+/--
+  The cast kinds of `cir.cast` that VeIR models, numbered as in ClangIR's `CastKind`.
+  Every other kind is kept as `other` so that it round-trips; only the lowering rejects it.
+-/
+inductive CirCastKind where
+  | integral
+  | int_to_bool
+  | bool_to_int
+  | other (code : Nat)
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirCastKind.ofNat : Nat → CirCastKind
+  | 27 => .integral
+  | 28 => .int_to_bool
+  | 38 => .bool_to_int
+  | code => .other code
+
+def CirCastKind.toNat : CirCastKind → Nat
+  | .integral => 27
+  | .int_to_bool => 28
+  | .bool_to_int => 38
+  | .other code => code
+
+/-- The value of a `cir.const`: a typed integer or boolean constant. -/
+inductive CirConstValue where
+  | int (attr : CirIntAttr)
+  | bool (attr : CirBoolAttr)
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirConstValue.toAttribute : CirConstValue → Attribute
+  | .int attr => .cirIntAttr attr
+  | .bool attr => .cirBoolAttr attr
+
+/-- The type a constant value carries, which its result must match. -/
+def CirConstValue.type : CirConstValue → Attribute
+  | .int attr => .cirIntType attr.type
+  | .bool _ => .cirBoolType {}
+
+/-! ## Helpers -/
+
+/-- Reject properties on operations whose schema carries none. -/
+def Cir.noProperties (attrDict : Std.HashMap ByteArray Attribute) : Except String Unit :=
+  if attrDict.size > 0 then
+    let plural := if attrDict.size = 1 then "property" else "properties"
+    .error s!"cir: expected no properties, but got {attrDict.size} {plural}"
+  else
+    .ok ()
+
+/-- Read a `kind = N : i32` enum property. -/
+private def getKind (opName : String) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String Nat := do
+  if attrDict.size > 1 then
+    throw s!"{opName}: expected only 'kind' property, but got {attrDict.size} properties"
+  let some attr := attrDict["kind".toUTF8]?
+    | throw s!"{opName}: missing 'kind' property"
+  let .integerAttr intAttr := attr
+    | throw s!"{opName}: expected 'kind' to be an integer attribute, but got {attr}"
+  if intAttr.type.bitwidth ≠ 32 then
+    throw s!"{opName}: expected 'kind' to be an i32 attribute, but got {attr}"
+  if intAttr.value < 0 then
+    throw s!"{opName}: invalid kind {intAttr.value}"
+  return intAttr.value.toNat
+
+private def kindAttr (kind : Nat) : Attribute :=
+  .integerAttr (IntegerAttr.mk (Int.ofNat kind) (IntegerType.mk 32))
+
+/-! ## Properties -/
+
+/--
+  Properties of `cir.func`. Its `sym_name` and `function_type` are modelled explicitly;
+  every other attribute (linkage, visibility, calling convention, ...) is preserved
+  verbatim in `extra`.
+-/
+structure CirFuncProperties where
+  sym_name : StringAttr
+  function_type : CirFuncType
+  extra : DictionaryAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirFuncProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirFuncProperties := do
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr s) => pure s
+    | some attr => throw s!"cir.func: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => throw "cir.func: missing 'sym_name' property"
+  let funcType ← match attrDict["function_type".toUTF8]? with
+    | some (.cirFuncType ft) => pure ft
+    | some attr =>
+      throw s!"cir.func: expected 'function_type' to be a !cir.func type, but got {attr}"
+    | none => throw "cir.func: missing 'function_type' property"
+  let extra := DictionaryAttr.fromArray
+    (attrDict.toArray.filter fun (k, _) => k ≠ "sym_name".toUTF8 && k ≠ "function_type".toUTF8)
+  return { sym_name := symName, function_type := funcType, extra }
+
+/-- Properties of `cir.const`. -/
+structure CirConstProperties where
+  value : CirConstValue
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirConstProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirConstProperties := do
+  if attrDict.size > 1 then
+    throw s!"cir.const: expected only 'value' property, but got {attrDict.size} properties"
+  let some attr := attrDict["value".toUTF8]?
+    | throw "cir.const: missing 'value' property"
+  match attr with
+  | .cirIntAttr intAttr => return { value := .int intAttr }
+  | .cirBoolAttr boolAttr => return { value := .bool boolAttr }
+  | attr => throw s!"cir.const: expected 'value' to be a #cir.int or #cir.bool attribute, but got {attr}"
+
+/--
+  Properties of `cir.add`, `cir.sub` and `cir.minus`. ClangIR always prints their
+  `no_signed_wrap`, `no_unsigned_wrap` and `saturated` flags; they are kept verbatim so that
+  the operation round-trips, and read with `flagSet`.
+-/
+structure CirOverflowFlagsProperties where
+  extra : DictionaryAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirOverflowFlagsProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirOverflowFlagsProperties :=
+  return { extra := DictionaryAttr.fromArray attrDict.toArray }
+
+/-- Whether a flag is set: present as a unit attribute, or as a non-zero `i1`. -/
+def CirOverflowFlagsProperties.flagSet (props : CirOverflowFlagsProperties) (key : String) :
+    Bool :=
+  match props.extra.entries.find? (fun (k, _) => k = key.toUTF8) with
+  | some (_, .unitAttr _) => true
+  | some (_, .integerAttr attr) => attr.value ≠ 0
+  | _ => false
+
+/-- Properties of `cir.shift`: `isShiftleft` is a unit attribute, absent for right shifts. -/
+structure CirShiftProperties where
+  isShiftleft : Bool
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirShiftProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirShiftProperties := do
+  if attrDict.size > 1 then
+    throw s!"cir.shift: expected only 'isShiftleft' property, but got {attrDict.size} properties"
+  match attrDict["isShiftleft".toUTF8]? with
+  | none => return { isShiftleft := false }
+  | some (.unitAttr _) => return { isShiftleft := true }
+  | some attr => throw s!"cir.shift: expected 'isShiftleft' to be a unit attribute, but got {attr}"
+
+/-- Properties of `cir.cmp`. -/
+structure CirCmpProperties where
+  kind : CirCmpKind
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirCmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirCmpProperties := do
+  let code ← getKind "cir.cmp" attrDict
+  let some kind := CirCmpKind.ofNat? code
+    | throw s!"cir.cmp: invalid kind {code}"
+  return { kind }
+
+/-- Properties of `cir.cast`. -/
+structure CirCastProperties where
+  kind : CirCastKind
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirCastProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirCastProperties := do
+  let code ← getKind "cir.cast" attrDict
+  return { kind := CirCastKind.ofNat code }
+
+/-- Properties of `cir.brcond`. -/
+structure CirBrCondProperties where
+  operandSegmentSizes : DenseArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def CirBrCondProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String CirBrCondProperties := do
+  if attrDict.size > 1 then
+    throw s!"cir.brcond: expected only 'operandSegmentSizes' property, but got {attrDict.size} properties"
+  let some sizesAttr := attrDict["operandSegmentSizes".toUTF8]?
+    | throw "cir.brcond: missing 'operandSegmentSizes' property"
+  let .denseArrayAttr sizesAttr := sizesAttr
+    | throw s!"cir.brcond: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizesAttr}"
+  return { operandSegmentSizes := sizesAttr }
+
+/-! ## Attribute dictionaries -/
+
+def CirFuncProperties.toAttrDict (props : CirFuncProperties) : Std.HashMap ByteArray Attribute :=
+  Id.run do
+    let mut dict := Std.HashMap.ofList props.extra.entries.toList
+    dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    dict := dict.insert "function_type".toUTF8 (.cirFuncType props.function_type)
+    dict
+
+def CirConstProperties.toAttrDict (props : CirConstProperties) : Std.HashMap ByteArray Attribute :=
+  (Std.HashMap.emptyWithCapacity 1).insert "value".toUTF8 props.value.toAttribute
+
+def CirOverflowFlagsProperties.toAttrDict (props : CirOverflowFlagsProperties) :
+    Std.HashMap ByteArray Attribute :=
+  Std.HashMap.ofList props.extra.entries.toList
+
+def CirShiftProperties.toAttrDict (props : CirShiftProperties) : Std.HashMap ByteArray Attribute :=
+  if props.isShiftleft then
+    (Std.HashMap.emptyWithCapacity 1).insert "isShiftleft".toUTF8 (.unitAttr UnitAttr.mk)
+  else
+    Std.HashMap.emptyWithCapacity 0
+
+def CirCmpProperties.toAttrDict (props : CirCmpProperties) : Std.HashMap ByteArray Attribute :=
+  (Std.HashMap.emptyWithCapacity 1).insert "kind".toUTF8 (kindAttr props.kind.toNat)
+
+def CirCastProperties.toAttrDict (props : CirCastProperties) : Std.HashMap ByteArray Attribute :=
+  (Std.HashMap.emptyWithCapacity 1).insert "kind".toUTF8 (kindAttr props.kind.toNat)
+
+def CirBrCondProperties.toAttrDict (props : CirBrCondProperties) :
+    Std.HashMap ByteArray Attribute :=
+  (Std.HashMap.emptyWithCapacity 1).insert "operandSegmentSizes".toUTF8
+    (.denseArrayAttr props.operandSegmentSizes)
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -33,6 +33,7 @@ match opCode with
 | .pdl op => PDL.propertiesOf op
 | .test op => Test.propertiesOf op
 | .felt op => Felt.propertiesOf op
+| .cir op => Cir.propertiesOf op
 
 /--
   What are the memory effects of an operation with this opcode and these
@@ -58,6 +59,7 @@ def OpCode.getEffects (opCode : OpCode) (props : _propertiesOf opCode) : MemoryE
   | .pdl op, props => PDL.getEffects op props
   | .test op, props => Test.getEffects op props
   | .felt op, props => Felt.getEffects op props
+  | .cir op, props => Cir.getEffects op props
 
 /--
   Return the kind of the region with the given index inside this operation.
@@ -81,6 +83,7 @@ def OpCode.getRegionKind (opCode : OpCode) (index : Nat) : RegionKind :=
   | .pdl op => HasOpInfo.getRegionKind op index
   | .test op => HasOpInfo.getRegionKind op index
   | .felt op => HasOpInfo.getRegionKind op index
+  | .cir op => HasOpInfo.getRegionKind op index
 
 /--
   Whether definitions in the indexed region of this opcode must dominate
@@ -105,6 +108,7 @@ def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
   | .pdl op => PDL.hasSSADominance op index
   | .test op => Test.hasSSADominance op index
   | .felt op => Felt.hasSSADominance op index
+  | .cir op => Cir.hasSSADominance op index
 
 /--
   Whether the indexed region of this opcode is exempt from the requirement
@@ -130,6 +134,7 @@ def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
   | .pdl op => HasOpInfo.hasNoTerminator op index
   | .test op => HasOpInfo.hasNoTerminator op index
   | .felt op => HasOpInfo.hasNoTerminator op index
+  | .cir op => HasOpInfo.hasNoTerminator op index
 
 /-- Whether this opcode carries MLIR's `IsolatedFromAbove` trait. -/
 def OpCode.isIsolatedFromAbove (opCode : OpCode) : Bool :=
@@ -151,6 +156,7 @@ def OpCode.isIsolatedFromAbove (opCode : OpCode) : Bool :=
   | .pdl op => HasOpInfo.isIsolatedFromAbove op
   | .test op => HasOpInfo.isIsolatedFromAbove op
   | .felt op => HasOpInfo.isIsolatedFromAbove op
+  | .cir op => HasOpInfo.isIsolatedFromAbove op
 
 /--
   Does this OpCode count as an MLIR basic block terminator? Dialects that do
@@ -176,6 +182,7 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .pdl op => HasOpInfo.isTerminator op
   | .test op => HasOpInfo.isTerminator op
   | .felt op => HasOpInfo.isTerminator op
+  | .cir op => HasOpInfo.isTerminator op
 
 /--
   Does this `OpCode` materialize a literal constant value, i.e. an op
@@ -204,6 +211,7 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | .pdl op => PDL.isConstantLike op
   | .test op => Test.isConstantLike op
   | .felt op => Felt.isConstantLike op
+  | .cir op => Cir.isConstantLike op
 
 /--
   Does an operation with this opcode produce a wholly poisoned result whenever
@@ -228,6 +236,7 @@ def OpCode.propagatesPoison (opCode : OpCode) : Bool :=
   | .pdl op => HasOpInfo.propagatesPoison op
   | .test op => HasOpInfo.propagatesPoison op
   | .felt op => HasOpInfo.propagatesPoison op
+  | .cir op => HasOpInfo.propagatesPoison op
 
 def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String (_propertiesOf opCode) :=
@@ -249,6 +258,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   | .pdl op => PDL.fromAttrDict op attrDict
   | .test op => Test.fromAttrDict op attrDict
   | .felt op => Felt.fromAttrDict op attrDict
+  | .cir op => Cir.fromAttrDict op attrDict
 
 /--
   Converts the properties of an operation into a dictionary of attributes.
@@ -274,6 +284,7 @@ def Properties.toAttrDict
   | .pdl op, props => PDL.toAttrDict op props
   | .test op, props => Test.toAttrDict op props
   | .felt op, props => Felt.toAttrDict op props
+  | .cir op, props => Cir.toAttrDict op props
 
 instance : IsOpCode OpCode where
   fromName := OpCode.fromName
@@ -302,6 +313,7 @@ def OpCode.functionInterface? (opCode : OpCode) : Option (FunctionOpInterface (_
   | .pdl op => HasOpInfo.functionInterface? op
   | .test op => HasOpInfo.functionInterface? op
   | .felt op => HasOpInfo.functionInterface? op
+  | .cir op => HasOpInfo.functionInterface? op
 
 #generate_has_dialect_instances OpCode
 
@@ -326,6 +338,7 @@ def OpCode.verifyLocalInvariants (opCode : OpCode) (op : OperationPtr)
   | .hw opType => HW.verifyLocalInvariants opType op ctx opIn
   | .verif opType => Verif.verifyLocalInvariants opType op ctx opIn
   | .felt opType => Felt.verifyLocalInvariants opType op ctx opIn
+  | .cir opType => Cir.verifyLocalInvariants opType op ctx opIn
 
 instance : HasOpInfo OpCode where
   verifyLocalInvariants := OpCode.verifyLocalInvariants
@@ -359,7 +372,7 @@ def OpCode.materializeConstant (opCode : OpCode) (value : RuntimeValue)
     -- fails to compile until it decides how, or whether, to materialize.
     | .riscv_cf _ | .riscv_stack _ | .rv64 _ | .cf _ | .builtin _
     | .verif _
-    | .func _ | .datapath _ | .pdl _ | .test _ => none
+    | .func _ | .datapath _ | .pdl _ | .test _ | .cir _ => none
   guard materialized.fst.isConstantLike
   return materialized
 
@@ -385,5 +398,6 @@ def OpCode.isCommutative (opCode : OpCode) : Bool :=
   | .riscv .addw | .riscv .mulw
   | .mod_arith .add | .mod_arith .mul
   | .felt .add | .felt .mul
-  | .felt .bit_and | .felt .bit_or | .felt .bit_xor => true
+  | .felt .bit_and | .felt .bit_or | .felt .bit_xor
+  | .cir .add | .cir .mul | .cir .and | .cir .or | .cir .xor | .cir .min | .cir .max => true
   | _ => false

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -314,6 +314,32 @@ structure FeltConstAttr where
   fieldType : FeltType
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+/-! ## ClangIR (`cir`) types and attributes -/
+
+/-- The `!cir.int<s, N>` / `!cir.int<u, N>` type from ClangIR. -/
+structure CirIntType where
+  isSigned : Bool
+  width : Nat
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/-- The builtin integer type a `!cir.int` lowers to (signedness is dropped). -/
+def CirIntType.toIntegerType (type : CirIntType) : IntegerType := { bitwidth := type.width }
+
+/-- The `!cir.bool` type from ClangIR. -/
+structure CirBoolType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/-- The `#cir.int<N> : !cir.int<s|u, W>` attribute from ClangIR. -/
+structure CirIntAttr where
+  value : Int
+  type : CirIntType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/-- The `#cir.bool<true|false> : !cir.bool` attribute from ClangIR. -/
+structure CirBoolAttr where
+  value : Bool
+deriving Inhabited, Repr, DecidableEq, Hashable
+
 namespace LLVM
 
 structure VoidType
@@ -399,6 +425,14 @@ deriving Inhabited, Repr, Hashable
   the Lean type level while reusing their common representation.
 -/
 structure LLVMFunctionType where
+  functionType : FunctionType
+deriving Inhabited, Repr, Hashable
+
+/--
+  The payload of a ClangIR function type `!cir.func<(inputs) -> result>`.
+  A function without results is spelled `!cir.func<(inputs)>`.
+-/
+structure CirFuncType where
   functionType : FunctionType
 deriving Inhabited, Repr, Hashable
 
@@ -509,6 +543,16 @@ inductive Attribute
 | feltType (type : FeltType)
 /-- LLZK felt-const attribute (`#felt<const N> : !felt.type`) -/
 | feltConstAttr (attr : FeltConstAttr)
+/-- ClangIR integer type (`!cir.int<s|u, N>`) -/
+| cirIntType (type : CirIntType)
+/-- ClangIR boolean type (`!cir.bool`) -/
+| cirBoolType (type : CirBoolType)
+/-- ClangIR function type (`!cir.func<(..) -> T>`) -/
+| cirFuncType (type : CirFuncType)
+/-- ClangIR integer attribute (`#cir.int<N> : !cir.int<..>`) -/
+| cirIntAttr (attr : CirIntAttr)
+/-- ClangIR boolean attribute (`#cir.bool<b> : !cir.bool`) -/
+| cirBoolAttr (attr : CirBoolAttr)
 /-- LLVM void type -/
 | llvmVoidType (type : LLVM.VoidType)
 /-- LLVM byte type -/
@@ -574,6 +618,10 @@ theorem LLVMFunctionType.sizeOf_functionType {ft : LLVMFunctionType} :
     sizeOf ft.functionType < sizeOf ft := by
   grind [cases LLVMFunctionType]
 
+theorem CirFuncType.sizeOf_functionType {ft : CirFuncType} :
+    sizeOf ft.functionType < sizeOf ft := by
+  grind [cases CirFuncType]
+
 theorem ArrayAttr.sizeOf_elems_value {aa : ArrayAttr} (hx : x ∈ aa.value) :
     sizeOf x < sizeOf aa := by
   grind [Array.sizeOf_lt_of_mem hx, cases ArrayAttr]
@@ -624,6 +672,14 @@ def LLVMFunctionType.decEq (type1 type2 : LLVMFunctionType) : Decidable (type1 =
 termination_by sizeOf type1
 decreasing_by
   apply LLVMFunctionType.sizeOf_functionType
+
+def CirFuncType.decEq (type1 type2 : CirFuncType) : Decidable (type1 = type2) :=
+  match FunctionType.decEq type1.functionType type2.functionType with
+  | isTrue _ => isTrue (by grind [cases CirFuncType])
+  | isFalse _ => isFalse (by grind)
+termination_by sizeOf type1
+decreasing_by
+  apply CirFuncType.sizeOf_functionType
 
 def ArrayAttr.decEq (arr1 arr2 : ArrayAttr) : Decidable (arr1 = arr2) :=
   let value1 := arr1.value
@@ -780,6 +836,24 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case cirIntType.cirIntType type1 type2 =>
+    exact (match decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case cirBoolType.cirBoolType type1 type2 =>
+    exact (isTrue (by grind))
+  case cirFuncType.cirFuncType type1 type2 =>
+    exact (match CirFuncType.decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case cirIntAttr.cirIntAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case cirBoolAttr.cirBoolAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case registerType.registerType type1 type2 =>
     exact (match decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
@@ -843,6 +917,7 @@ end
 instance : DecidableEq Attribute := Attribute.decEq
 instance : DecidableEq FunctionType := FunctionType.decEq
 instance : DecidableEq LLVMFunctionType := LLVMFunctionType.decEq
+instance : DecidableEq CirFuncType := CirFuncType.decEq
 instance : DecidableEq ArrayAttr := ArrayAttr.decEq
 instance : DecidableEq DictionaryAttr := DictionaryAttr.decEq
 
@@ -980,6 +1055,18 @@ instance : ToString FeltConstAttr where
     | some _ => s!"#felt<const {attr.value} : {attr.fieldType}>"
     | none => s!"#felt<const {attr.value}>"
 
+instance : ToString CirIntType where
+  toString type := s!"!cir.int<{if type.isSigned then "s" else "u"}, {type.width}>"
+
+instance : ToString CirBoolType where
+  toString _ := "!cir.bool"
+
+instance : ToString CirIntAttr where
+  toString attr := s!"#cir.int<{attr.value}> : {attr.type}"
+
+instance : ToString CirBoolAttr where
+  toString attr := s!"#cir.bool<{attr.value}> : !cir.bool"
+
 instance : ToString PDL.RangeElement where
   toString element :=
     match element with
@@ -1077,6 +1164,31 @@ termination_by sizeOf type
 decreasing_by
   apply LLVMFunctionType.sizeOf_functionType
 
+/--
+  Print a function type in ClangIR spelling: `!cir.func<(inputs) -> result>`, or
+  `!cir.func<(inputs)>` when there are no results.
+-/
+def FunctionType.toCirString (type : FunctionType) : String :=
+  let paramStrs := type.inputs.toList.map Attribute.toString
+  let paramStrs := if type.isVarArg then paramStrs ++ ["..."] else paramStrs
+  let params := String.intercalate ", " paramStrs
+  match _ : type.outputs.size with
+  | 0 => s!"!cir.func<({params})>"
+  | _ =>
+    let results := String.intercalate ", " (type.outputs.toList.map Attribute.toString)
+    s!"!cir.func<({params}) -> {results}>"
+termination_by sizeOf type
+decreasing_by
+  all_goals first
+    | (apply FunctionType.sizeOf_elems_inputs; grind)
+    | (apply FunctionType.sizeOf_elems_outputs; grind)
+
+def CirFuncType.toString (type : CirFuncType) : String :=
+  type.functionType.toCirString
+termination_by sizeOf type
+decreasing_by
+  apply CirFuncType.sizeOf_functionType
+
 def FunctionType.toString (type : FunctionType) : String :=
   let inputs := String.intercalate ", " (type.inputs.toList.map Attribute.toString)
   let outputs := match _ : type.outputs.size with
@@ -1146,6 +1258,11 @@ def Attribute.toString (attr : Attribute) : String :=
   | .modArithType type => ToString.toString type
   | .feltType type => ToString.toString type
   | .feltConstAttr attr => ToString.toString attr
+  | .cirIntType type => ToString.toString type
+  | .cirBoolType type => ToString.toString type
+  | .cirFuncType type => type.toString
+  | .cirIntAttr attr => ToString.toString attr
+  | .cirBoolAttr attr => ToString.toString attr
   | .llvmVoidType type => ToString.toString type
   | .llvmPointerType type => ToString.toString type
   | .llvmArrayType type => type.toString
@@ -1170,6 +1287,9 @@ instance : ToString FunctionType where
 
 instance : ToString LLVMFunctionType where
   toString := LLVMFunctionType.toString
+
+instance : ToString CirFuncType where
+  toString := CirFuncType.toString
 
 instance : ToString ArrayAttr where
   toString := ArrayAttr.toString
@@ -1397,6 +1517,11 @@ def isType (attr : Attribute) : Bool :=
   | .modArithType _ => true
   | .feltType _ => true
   | .feltConstAttr _ => false
+  | .cirIntType _ => true
+  | .cirBoolType _ => true
+  | .cirFuncType _ => true
+  | .cirIntAttr _ => false
+  | .cirBoolAttr _ => false
   | .registerType _ => true
   | .registerAttr _ => false
   | .llvmVoidType _ => true
@@ -1466,6 +1591,16 @@ theorem isType_functionType type : (functionType type).isType = true := by rfl
 theorem isType_modArithType type : (modArithType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_feltType type : (feltType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirIntType type : (cirIntType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirBoolType type : (cirBoolType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirFuncType type : (cirFuncType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_cirIntAttr attr : (cirIntAttr attr).isType = false := by rfl
+@[simp, grind =]
+theorem isType_cirBoolAttr attr : (cirBoolAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_registerType type : (registerType type).isType = true := by rfl
 @[simp, grind =]
@@ -1662,6 +1797,18 @@ instance : IsTypeAttr ModArithType where
 
 instance : IsTypeAttr FeltType where
   coe type := Attribute.asType (.feltType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr CirIntType where
+  coe type := Attribute.asType (.cirIntType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr CirBoolType where
+  coe type := Attribute.asType (.cirBoolType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr CirFuncType where
+  coe type := Attribute.asType (.cirFuncType type) (by rfl)
   coe_eq_inject _ := by rfl
 
 instance : CoeDep (Option Nat → RegisterType) RegisterType.mk TypeAttr where

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -26,6 +26,7 @@ public import Veir.Dialects.Verif.OpInfo
 public import Veir.Dialects.PDL.OpInfo
 public import Veir.Dialects.Test.OpInfo
 public import Veir.Dialects.LLZK.Felt.OpInfo
+public import Veir.Dialects.Cir.OpInfo
 
 open Std
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -664,6 +664,82 @@ def parseOptionalFeltConstAttr : AttrParserM (Option FeltConstAttr) := do
     return some (FeltConstAttr.mk val ft)
   return some (FeltConstAttr.mk val (FeltType.mk innerFieldName))
 
+/-! ## ClangIR (`cir`) types and attributes -/
+
+/--
+  Parse ClangIR's integer type, if present.
+  Its syntax is `!cir.int<s, N>` (signed) or `!cir.int<u, N>` (unsigned).
+-/
+def parseOptionalCirIntType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "cir.int".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let isSigned ←
+    if ← parseOptionalKeyword "s".toByteArray then pure true
+    else if ← parseOptionalKeyword "u".toByteArray then pure false
+    else throwAtCurrentPos "cir.int signedness expected ('s' or 'u')"
+  parsePunctuation ","
+  let some width ← parseOptionalInteger false false
+    | throwAtCurrentPos "cir.int bitwidth expected"
+  if width ≤ 0 then throwAtCurrentPos "cir.int bitwidth must be positive"
+  parsePunctuation ">"
+  return some (CirIntType.mk isSigned width.toNat)
+
+/-- Parse ClangIR's boolean type `!cir.bool`, if present. -/
+def parseOptionalCirBoolType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "cir.bool".toByteArray then return none
+  let _ ← consumeToken
+  return some CirBoolType.mk
+
+/--
+  Parse ClangIR's integer attribute, if present.
+  Its syntax is `#cir.int<N> : !cir.int<s|u, W>`; the type annotation is mandatory.
+-/
+def parseOptionalCirIntAttr : AttrParserM (Option CirIntAttr) := do
+  let token ← peekToken
+  let .hashIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let name := { token.slice with start := token.slice.start + 1 }.of input
+  if name ≠ "cir.int".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let some value ← parseOptionalInteger false true
+    | throwAtCurrentPos "#cir.int<...> expects an integer value"
+  parsePunctuation ">"
+  parsePunctuation ":"
+  let some tyAttr ← parseOptionalCirIntType
+    | throwAtCurrentPos "#cir.int<N> expects a !cir.int type annotation"
+  let .cirIntType ty := tyAttr.val
+    | throwAtCurrentPos "#cir.int<N> expects a !cir.int type annotation"
+  return some (CirIntAttr.mk value ty)
+
+/-- Parse ClangIR's boolean attribute `#cir.bool<true|false> : !cir.bool`, if present. -/
+def parseOptionalCirBoolAttr : AttrParserM (Option CirBoolAttr) := do
+  let token ← peekToken
+  let .hashIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let name := { token.slice with start := token.slice.start + 1 }.of input
+  if name ≠ "cir.bool".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let value ←
+    if ← parseOptionalKeyword "true".toByteArray then pure true
+    else if ← parseOptionalKeyword "false".toByteArray then pure false
+    else throwAtCurrentPos "#cir.bool<...> expects `true` or `false`"
+  parsePunctuation ">"
+  parsePunctuation ":"
+  let some _ ← parseOptionalCirBoolType
+    | throwAtCurrentPos "#cir.bool<b> expects a !cir.bool type annotation"
+  return some (CirBoolAttr.mk value)
+
 /--
   Parse CIRCT's HW dialect's `ModulePort::Direction` type.
   Its syntax is `(input|output|inout)`.
@@ -863,6 +939,40 @@ partial def parseOptionalLLVMFunctionType : AttrParserM (Option TypeAttr) := do
   return some ⟨.llvmFunctionType ft, by simp⟩
 
 /--
+  Parse ClangIR's function type, if present.
+  Its syntax is `!cir.func<(inputs) -> result>`, or `!cir.func<(inputs)>` for a function
+  without results. A trailing `...` in the inputs marks a variadic function.
+-/
+partial def parseOptionalCirFuncType : AttrParserM (Option TypeAttr) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "cir.func".toByteArray then return none
+  let _ ← consumeToken
+  parsePunctuation "<"
+  let params ← parseDelimitedList .paren do
+    if (← parseOptionalToken .ellipsis).isSome then
+      return LLVMFuncParam.ellipsis
+    return LLVMFuncParam.type (← parseType)
+  if params.pop.any (· matches .ellipsis) then
+    throwAtCurrentPos "'...' is only valid as the last parameter of a cir function type"
+  let isVarArg := params.any (· matches .ellipsis)
+  let inputs := params.filterMap fun
+    | .type ty => some ty.val
+    | .ellipsis => none
+  let outputs ←
+    if ← parseOptionalPunctuation "->" then
+      match ← parseOptionalDelimitedList .paren parseType with
+      | some outputs => pure (outputs.map (·.val))
+      | none => pure #[(← parseType "cir.func result type expected").val]
+    else
+      pure #[]
+  parsePunctuation ">"
+  let ft := FunctionType.mk inputs outputs isVarArg
+  return some ⟨.cirFuncType (CirFuncType.mk ft), by simp⟩
+
+/--
   Parse a `match` optional handle type `!match.optional<...>`, if present.
 
   The wrapped type is parsed with the general type parser rather than a fixed
@@ -898,6 +1008,12 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some modArithType
   if let some feltType ← parseOptionalFeltType then
     return some feltType
+  if let some cirIntType ← parseOptionalCirIntType then
+    return some cirIntType
+  if let some cirBoolType ← parseOptionalCirBoolType then
+    return some cirBoolType
+  if let some cirFuncType ← parseOptionalCirFuncType then
+    return some cirFuncType
   if let some llvmVoidType := ← parseOptionalLLVMVoidType then
     return some llvmVoidType
   if let some llvmPointerType := ← parseOptionalLLVMPointerType then
@@ -1015,6 +1131,10 @@ partial def parseOptionalDictionaryAttr : AttrParserM (Option DictionaryAttr) :=
 partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
   if let some feltConstAttr ← parseOptionalFeltConstAttr then
     return some feltConstAttr
+  if let some cirIntAttr ← parseOptionalCirIntAttr then
+    return some cirIntAttr
+  if let some cirBoolAttr ← parseOptionalCirBoolAttr then
+    return some cirBoolAttr
   if let some dialectAttr ← parseOptionalDialectAttr then
     return some dialectAttr
   else if let some locationAttr ← parseOptionalLocationAttr then


### PR DESCRIPTION
Depends on #1345

This PR registers the flat, integer-only subset of ClangIR as the cir dialect. It covers the IR produced for integer C functions after `cir-opt -cir-hoist-allocas -cir-flatten-cfg`, excluding pointers and calls.

The supported operations are:

func, return, const, arithmetic and bitwise binary operations, shifts, not, minus, min, max, cmp, select, cast (integral, int_to_bool, bool_to_int), br, brcond, and unreachable.

Operation properties preserve ClangIR’s generic-form representation. In particular:

- cmp and cast kinds are decoded from their i32 values.
- Shift operations recognize the isShiftleft unit attribute.
- Wrap flags on add, sub, and minus are preserved.
- Function linkage and visibility attributes pass through unchanged.

One printing difference remains: no_signed_wrap = false roundtrips as "no_signed_wrap" = 0 : i1, matching the LLVM dialect’s handling of boolean properties.

The verifier checks operand and result types for each operation, validates constants against their declared integer width, checks branch operand segments, and verifies that cir.return agrees with its enclosing cir.func.

This PR registers and validates the operations only. Their semantics will be added by the lowering pass in the follow-up PR.