### PR TITLE
fix(parser): accept vector in dense elements attributes

### DIFF
--- a/Test/Builtin/parse_zeroed_array_initializers.mlir
+++ b/Test/Builtin/parse_zeroed_array_initializers.mlir
@@ -4,5 +4,9 @@
 "builtin.module"() ({
     %1 = "llvm.mlir.constant"() <{value = dense<0> : tensor<4xi8>}> : () -> !llvm.array<4 x i8>
     // CHECK: "llvm.mlir.constant"() <{"value" = dense<0> : tensor<4xi8>}> : () -> !llvm.array<4 x i8>
+    %2 = "llvm.mlir.constant"() <{value = dense<[32, 64]> : vector<2xi64>}> : () -> !llvm.array<2 x i64>
+    // CHECK: "llvm.mlir.constant"() <{"value" = dense<[32, 64]> : vector<2xi64>}> : () -> !llvm.array<2 x i64>
+    %3 = "llvm.mlir.constant"() <{value = dense<0> : vector<[4]xi8>}> : () -> !llvm.array<4 x i8>
+    // CHECK: "llvm.mlir.constant"() <{"value" = dense<0> : vector<[4]xi8>}> : () -> !llvm.array<4 x i8>
 }) : () -> ()
 

--- a/Test/Verifier/llvm_constant_dense_vector_element_type_mismatch.mlir
+++ b/Test/Verifier/llvm_constant_dense_vector_element_type_mismatch.mlir
@@ -1,0 +1,7 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  %0 = "llvm.mlir.constant"() <{value = dense<0> : vector<4xi16>}> : () -> !llvm.array<4 x i8>
+}) : () -> ()
+
+// CHECK: dense elements type 'i16' does not match array element type 'i8'

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -180,6 +180,16 @@ macro "#assert " e:term : command =>
 #assert expectSuccessAttr "array<i16: 0>" (DenseArrayAttr.mk (IntegerType.mk 16) #[0])
 #assert expectErrorAttr "array<>" "integer type expected in dense array attribute" (some 6)
 
+/-! ## Dense elements attribute -/
+
+#assert expectSuccessAttr "dense<0> : tensor<4xi8>" (DenseElementsAttr.mk "0" "tensor<4xi8>")
+#assert expectSuccessAttr "dense<0> : vector<4xi8>" (DenseElementsAttr.mk "0" "vector<4xi8>")
+#assert expectSuccessAttr "dense<[32, 64]> : vector<2xi64>"
+  (DenseElementsAttr.mk "[32, 64]" "vector<2xi64>")
+#assert expectSuccessAttr "dense<0> : vector<[4]xi8>" (DenseElementsAttr.mk "0" "vector<[4]xi8>")
+#assert expectErrorAttr "dense<0> : memref<4xi8>"
+  "'tensor' or 'vector' type expected in dense elements attribute" (some 11)
+
 /-! ## Unregistered dialect type -/
 
 #assert expectSuccessType "!foo.bar" ⟨UnregisteredAttr.mk "!foo.bar" true, by grind⟩ true

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -857,7 +857,8 @@ partial def parseType (errorMsg : String := "type expected") : AttrParserM TypeA
 
 /--
   Parse a dense elements attribute, if present.
-  Its syntax is `dense<value> : type`, e.g. `dense<0> : tensor<4xi8>`.
+  Its syntax is `dense<value> : type`, e.g. `dense<0> : tensor<4xi8>`
+  or `dense<[32, 64]> : vector<2xi64>`.
   Both the value body and the type are stored as raw strings pending full
   tensor/vector type support.
 -/
@@ -868,10 +869,12 @@ partial def parseOptionalDenseElementsAttr : AttrParserM (Option DenseElementsAt
   let value ← parseUnregisteredAttrBody
   parsePunctuation ">"
   parsePunctuation ":"
-  -- tensor<4xi8> is an unregistered type: capture it as a balanced string
+  -- tensor<4xi8> and vector<2xi64> are unregistered types: capture them as a balanced string
   -- using the same scheme as parseOptionalDialectAttr's fallback case.
   let typeStartPos ← getPos
-  parseKeyword "tensor".toByteArray
+  if !(← parseOptionalKeyword "tensor".toByteArray) then
+    parseKeyword "vector".toByteArray
+      "'tensor' or 'vector' type expected in dense elements attribute"
   parsePunctuation "<"
   let _ ← parseUnregisteredAttrBody
   let typeEndPos := (← peekToken).slice.stop

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -338,7 +338,7 @@ def OperationPtr.checkIsNonNullIntegerType (op : OperationPtr)
 def denseElementsElementType? (typeStr : String) : Option String :=
   let s := typeStr.replace " " ""
   let segments := s.splitOn "x"
-  if "tensor<".isPrefixOf s && s.endsWith ">" && segments.length ≥ 2 then
+  if ("tensor<".isPrefixOf s || "vector<".isPrefixOf s) && s.endsWith ">" && segments.length ≥ 2 then
     some ((segments.getLast!.splitOn ">").head!)
   else
     none


### PR DESCRIPTION
Closes #940.

```mlir
%0 = "llvm.mlir.constant"() <{value = dense<[32, 64]> : vector<2xi64>}> : () -> !llvm.array<2 x i64>
```

Actual:

```
error: expected keyword 'tensor'
```

Expected: round-trips, as the `tensor` spelling already does.

A dense attribute may carry a tensor or a vector type. Both the parser and the
verifier's element-type check hardcoded `tensor`. The verifier needs `vector`
too, since it skips types it does not recognize.
