### PR TITLE
ci: install split-file for lit tests

### DIFF
--- a/.github/docker/namespace-base-image.Dockerfile
+++ b/.github/docker/namespace-base-image.Dockerfile
@@ -32,9 +32,11 @@ RUN apt-get update \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
       mlir-22-tools \
+      llvm-22-tools \
       # leanc links through the system toolchain.
       build-essential \
  && ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt \
+ && ln -s /usr/bin/split-file-22 /usr/bin/split-file \
  && rm -rf /var/lib/apt/lists/*
 
 # `uv` provides both the Python interpreter and the test dependencies, so no
@@ -70,6 +72,7 @@ RUN curl -fsSL https://elan.lean-lang.org/elan-init.sh \
 # reachable as `runner`. If a run reports `command not found` for one of these,
 # the image did not build and the profile fell back to the stock base image.
 RUN mlir-opt --version \
+ && split-file --version \
  && uv --version \
  && lit --version \
  && filecheck --version \

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -56,14 +56,16 @@ jobs:
           component: main
           suite: llvm-toolchain-noble-22
 
-      - name: Install mlir-opt
+      - name: Install LLVM test tools
         uses: gerlero/apt-install@v1
         with:
-          packages: mlir-22-tools
+          packages: mlir-22-tools llvm-22-tools
 
-      - name: Rename MLIR-opt
+      - name: Expose LLVM tools
         run: |
           sudo ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt
+          sudo ln -s /usr/bin/split-file-22 /usr/bin/split-file
+          split-file --version
 
       - name: Build the project
         uses: leanprover/lean-action@v1


### PR DESCRIPTION
I think for the namespace CI, the docker file in the repo is just documentation, and @tobiasgrosser  or someone else will need to actually update/recreate the runner manually?