### PR TITLE
cir: lower the cir integer core to arith, cf and llvm

### DIFF
--- a/Test/Interpreter/Cir/add_mul.mlir
+++ b/Test/Interpreter/Cir/add_mul.mlir
@@ -1,0 +1,15 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// (7 + 5) * 3 = 36.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "main"}> ({
+    %a = "cir.const"() <{value = #cir.int<7> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %b = "cir.const"() <{value = #cir.int<5> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %c = "cir.const"() <{value = #cir.int<3> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %s = "cir.add"(%a, %b) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %p = "cir.mul"(%s, %c) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%p) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000024#32]

--- a/Test/Interpreter/Cir/cast.mlir
+++ b/Test/Interpreter/Cir/cast.mlir
@@ -1,0 +1,20 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// 300 narrowed to s8 is 44, widened back to s32 is 44; int_to_bool then bool_to_int of 44 is 1; select on that picks 44 + 1 = 45; minus and not give -(45) and ~(-45) = 44.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "main"}> ({
+    %big = "cir.const"() <{value = #cir.int<300> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %one = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %narrow = "cir.cast"(%big) <{kind = 27 : i32}> : (!cir.int<s, 32>) -> !cir.int<s, 8>
+    %wide = "cir.cast"(%narrow) <{kind = 27 : i32}> : (!cir.int<s, 8>) -> !cir.int<s, 32>
+    %b = "cir.cast"(%wide) <{kind = 28 : i32}> : (!cir.int<s, 32>) -> !cir.bool
+    %bi = "cir.cast"(%b) <{kind = 38 : i32}> : (!cir.bool) -> !cir.int<s, 32>
+    %sum = "cir.add"(%wide, %bi) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %sel = "cir.select"(%b, %sum, %one) : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %neg = "cir.minus"(%sel) <{no_signed_wrap = false}> : (!cir.int<s, 32>) -> !cir.int<s, 32>
+    %not = "cir.not"(%neg) : (!cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%not) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x0000002c#32]

--- a/Test/Interpreter/Cir/cmp_branch.mlir
+++ b/Test/Interpreter/Cir/cmp_branch.mlir
@@ -1,0 +1,21 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// 3 < 5 is true, so the true branch returns 3 + 100 = 103.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "main"}> ({
+    %a = "cir.const"() <{value = #cir.int<3> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %b = "cir.const"() <{value = #cir.int<5> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %k = "cir.const"() <{value = #cir.int<100> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %lt = "cir.cmp"(%a, %b) <{kind = 0 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+    "cir.brcond"(%lt, %a, %b)[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 1, 1, 1>}> : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> ()
+  ^bb1(%t : !cir.int<s, 32>):
+    %x = "cir.add"(%t, %k) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.br"(%x)[^bb3] : (!cir.int<s, 32>) -> ()
+  ^bb2(%f : !cir.int<s, 32>):
+    "cir.br"(%f)[^bb3] : (!cir.int<s, 32>) -> ()
+  ^bb3(%r : !cir.int<s, 32>):
+    "cir.return"(%r) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000067#32]

--- a/Test/Interpreter/Cir/loop.mlir
+++ b/Test/Interpreter/Cir/loop.mlir
@@ -1,0 +1,20 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// sum of 1..10 through a flat loop = 55.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "main"}> ({
+    %zero = "cir.const"() <{value = #cir.int<0> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %one = "cir.const"() <{value = #cir.int<1> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %ten = "cir.const"() <{value = #cir.int<10> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    "cir.br"(%zero, %one)[^loop] : (!cir.int<s, 32>, !cir.int<s, 32>) -> ()
+  ^loop(%acc : !cir.int<s, 32>, %i : !cir.int<s, 32>):
+    %acc2 = "cir.add"(%acc, %i) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %i2 = "cir.add"(%i, %one) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %more = "cir.cmp"(%i2, %ten) <{kind = 1 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+    "cir.brcond"(%more, %acc2, %i2, %acc2)[^loop, ^done] <{operandSegmentSizes = array<i32: 1, 2, 1>}> : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>, !cir.int<s, 32>) -> ()
+  ^done(%r : !cir.int<s, 32>):
+    "cir.return"(%r) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000037#32]

--- a/Test/Interpreter/Cir/min_max_xor.mlir
+++ b/Test/Interpreter/Cir/min_max_xor.mlir
@@ -1,0 +1,17 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// min(9, 4) = 4, max(4, 7) = 7, 7 xor 2 = 5.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "main"}> ({
+    %a = "cir.const"() <{value = #cir.int<9> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %b = "cir.const"() <{value = #cir.int<4> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %c = "cir.const"() <{value = #cir.int<7> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %d = "cir.const"() <{value = #cir.int<2> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %mn = "cir.min"(%a, %b) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %mx = "cir.max"(%mn, %c) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %x = "cir.xor"(%mx, %d) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%x) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000005#32]

--- a/Test/Interpreter/Cir/signed_div_rem.mlir
+++ b/Test/Interpreter/Cir/signed_div_rem.mlir
@@ -1,0 +1,17 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// -7 / 2 = -3 and -7 rem 2 = -1, combined as div * 10 + rem = -31.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<s, 32>>, sym_name = "main"}> ({
+    %a = "cir.const"() <{value = #cir.int<-7> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %b = "cir.const"() <{value = #cir.int<2> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %ten = "cir.const"() <{value = #cir.int<10> : !cir.int<s, 32>}> : () -> !cir.int<s, 32>
+    %d = "cir.div"(%a, %b) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %r = "cir.rem"(%a, %b) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %d10 = "cir.mul"(%d, %ten) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %res = "cir.add"(%d10, %r) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%res) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0xffffffe1#32]

--- a/Test/Interpreter/Cir/unsigned.mlir
+++ b/Test/Interpreter/Cir/unsigned.mlir
@@ -1,0 +1,22 @@
+// RUN: veir-opt %s -p=cir > %t.mlir && veir-interpret %t.mlir | filecheck %s
+
+// 200 + 100 wraps to 44 on u8; 255 / 2 = 127 unsigned; (44 | 127) & 0x0f = 15; 15 >> 1 = 7; 7 << 2 = 28.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<() -> !cir.int<u, 8>>, sym_name = "main"}> ({
+    %a = "cir.const"() <{value = #cir.int<200> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %b = "cir.const"() <{value = #cir.int<100> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %m = "cir.const"() <{value = #cir.int<255> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %two = "cir.const"() <{value = #cir.int<2> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %mask = "cir.const"() <{value = #cir.int<15> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %one = "cir.const"() <{value = #cir.int<1> : !cir.int<u, 8>}> : () -> !cir.int<u, 8>
+    %s = "cir.add"(%a, %b) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %d = "cir.div"(%m, %two) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %o = "cir.or"(%s, %d) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %n = "cir.and"(%o, %mask) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %r = "cir.shift"(%n, %one) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %l = "cir.shift"(%r, %two) <{isShiftleft}> : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    "cir.return"(%l) : (!cir.int<u, 8>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x1c#8]

--- a/Test/Passes/CastsReconciliation/basic.mlir
+++ b/Test/Passes/CastsReconciliation/basic.mlir
@@ -252,4 +252,40 @@
         "func.return"() : () -> ()
     }) : () -> ()
 
+
+    "func.func"()  <{function_type = (i32) -> (), sym_name = "f19"}> ({
+      ^1(%0 : i32):
+        // `i32 -> !cir.int<s, 32> -> i32` keeps every bit, so the round trip is the identity.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (i32) -> !cir.int<s, 32>
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (!cir.int<s, 32>) -> i32
+        "test.test"(%2) : (i32) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : i32):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (i32) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    "func.func"()  <{function_type = (!cir.bool) -> (), sym_name = "f20"}> ({
+      ^1(%0 : !cir.bool):
+        // `!cir.bool -> i1 -> !cir.bool` is the identity as well.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!cir.bool) -> i1
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i1) -> !cir.bool
+        "test.test"(%2) : (!cir.bool) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !cir.bool):
+        // CHECK-NEXT:   "test.test"([[ARG]]) : (!cir.bool) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
+    "func.func"()  <{function_type = (!cir.int<s, 32>) -> (), sym_name = "f21"}> ({
+      ^1(%0 : !cir.int<s, 32>):
+        // `!cir.int<s, 32> -> i64 -> !cir.int<s, 32>` changes the width, so the casts stay.
+        %1 = "builtin.unrealized_conversion_cast"(%0) : (!cir.int<s, 32>) -> i64
+        %2 = "builtin.unrealized_conversion_cast"(%1) : (i64) -> !cir.int<s, 32>
+        "test.test"(%2) : (!cir.int<s, 32>) -> ()
+        // CHECK:        ^{{.*}}([[ARG:%.*]] : !cir.int<s, 32>):
+        // CHECK-NEXT:   [[C1:%.*]] = "builtin.unrealized_conversion_cast"([[ARG]]) : (!cir.int<s, 32>) -> i64
+        // CHECK-NEXT:   [[C2:%.*]] = "builtin.unrealized_conversion_cast"([[C1]]) : (i64) -> !cir.int<s, 32>
+        // CHECK-NEXT:   "test.test"([[C2]]) : (!cir.int<s, 32>) -> ()
+        "func.return"() : () -> ()
+    }) : () -> ()
+
 }) : () -> ()

--- a/Test/Passes/CirToStd/binops.mlir
+++ b/Test/Passes/CirToStd/binops.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s -p=cir-to-std | filecheck %s
+// RUN: veir-opt %s -p=cir-to-std,reconcile-cast | filecheck %s
 
 "builtin.module"() ({
   "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>>, sym_name = "f"}> ({
@@ -14,13 +14,25 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32, i8) -> i32>, "sym_name" = "f"}> ({
-// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i8):
-// CHECK-NEXT: %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT: %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT: %{{.*}} = "arith.extui"(%{{.*}}) : (i8) -> i32
-// CHECK-NEXT: %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-// CHECK-NEXT: %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT: %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
-// CHECK-NEXT: "cir.return"(%{{.*}}) : (i32) -> ()
+// The function boundary is left alone: it belongs to `coerce-cir-function-boundaries`.
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>>, "sym_name" = "f"}> ({
+// CHECK-NEXT: ^{{.*}}([[A:%.*]] : !cir.int<s, 32>, [[B:%.*]] : !cir.int<u, 8>):
+
+// The argument casts are kept; the casts between lowered operations are reconciled away.
+// CHECK-NEXT: [[A0:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[A1:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[SUM:%.*]] = "arith.addi"([[A0]], [[A1]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[A2:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[DIV:%.*]] = "arith.divsi"([[SUM]], [[A2]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[B0:%.*]] = "builtin.unrealized_conversion_cast"([[B]]) : (!cir.int<u, 8>) -> i8
+// CHECK-NEXT: [[AMT:%.*]] = "arith.extui"([[B0]]) : (i8) -> i32
+// CHECK-NEXT: [[SHR:%.*]] = "arith.shrsi"([[DIV]], [[AMT]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[A3:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[LT:%.*]] = "arith.cmpi"([[SHR]], [[A3]]) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT: [[A4:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[SEL:%.*]] = "arith.select"([[LT]], [[SHR]], [[A4]]) : (i1, i32, i32) -> i32
+
+// The result cast is kept for the still `cir`-typed `cir.return`.
+// CHECK-NEXT: [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[SEL]]) : (i32) -> !cir.int<s, 32>
+// CHECK-NEXT: "cir.return"([[RES]]) : (!cir.int<s, 32>) -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Passes/CirToStd/binops.mlir
+++ b/Test/Passes/CirToStd/binops.mlir
@@ -1,0 +1,26 @@
+// RUN: veir-opt %s -p=cir-to-std | filecheck %s
+
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>>, sym_name = "f"}> ({
+  ^bb0(%a : !cir.int<s, 32>, %b : !cir.int<u, 8>):
+    %s = "cir.add"(%a, %a) <{no_signed_wrap, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %d = "cir.div"(%s, %a) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %u = "cir.div"(%b, %b) : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.int<u, 8>
+    %sh = "cir.shift"(%d, %b) : (!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>
+    %lt = "cir.cmp"(%sh, %a) <{kind = 0 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+    %ult = "cir.cmp"(%u, %b) <{kind = 0 : i32}> : (!cir.int<u, 8>, !cir.int<u, 8>) -> !cir.bool
+    %sel = "cir.select"(%lt, %sh, %a) : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%sel) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32, i8) -> i32>, "sym_name" = "f"}> ({
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i8):
+// CHECK-NEXT: %{{.*}} = "arith.addi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT: %{{.*}} = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT: %{{.*}} = "arith.extui"(%{{.*}}) : (i8) -> i32
+// CHECK-NEXT: %{{.*}} = "arith.shrsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
+// CHECK-NEXT: %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT: %{{.*}} = "arith.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (i1, i32, i32) -> i32
+// CHECK-NEXT: "cir.return"(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/Passes/CirToStd/branches.mlir
+++ b/Test/Passes/CirToStd/branches.mlir
@@ -1,4 +1,4 @@
-// RUN: veir-opt %s -p=cir-to-std | filecheck %s
+// RUN: veir-opt %s -p=cir-to-std,reconcile-cast | filecheck %s
 
 "builtin.module"() ({
   "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, sym_name = "f"}> ({
@@ -14,15 +14,24 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32) -> i32>, "sym_name" = "f"}> ({
-// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
-// CHECK-NEXT: %{{.*}} = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
-// CHECK-NEXT: %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT: "cf.cond_br"(%{{.*}}, %{{.*}}) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
-// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
-// CHECK-NEXT: "cf.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()
+// The function boundary is left alone: it belongs to `coerce-cir-function-boundaries`.
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, "sym_name" = "f"}> ({
+// CHECK-NEXT: ^{{.*}}([[A:%.*]] : !cir.int<s, 32>):
+// CHECK-NEXT: [[A0:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[ZERO:%.*]] = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-NEXT: [[COND:%.*]] = "arith.cmpi"([[A0]], [[ZERO]]) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
+
+// The forwarded operand is cast to the retyped block argument; the block arguments of the
+// successors are already `i32`, so no cast survives inside them.
+// CHECK-NEXT: [[A1:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: "cf.cond_br"([[COND]], [[A1]]) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
+// CHECK-NEXT: ^{{.*}}([[X:%.*]] : i32):
+// CHECK-NEXT: "cf.br"([[X]]) [^{{.*}}] : (i32) -> ()
 // CHECK-NEXT: ^{{.*}}():
 // CHECK-NEXT: "llvm.unreachable"() : () -> ()
-// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
-// CHECK-NEXT: "cir.return"(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT: ^{{.*}}([[R:%.*]] : i32):
+
+// The result cast is kept for the still `cir`-typed `cir.return`.
+// CHECK-NEXT: [[RES:%.*]] = "builtin.unrealized_conversion_cast"([[R]]) : (i32) -> !cir.int<s, 32>
+// CHECK-NEXT: "cir.return"([[RES]]) : (!cir.int<s, 32>) -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Passes/CirToStd/branches.mlir
+++ b/Test/Passes/CirToStd/branches.mlir
@@ -1,0 +1,28 @@
+// RUN: veir-opt %s -p=cir-to-std | filecheck %s
+
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, sym_name = "f"}> ({
+  ^bb0(%a : !cir.int<s, 32>):
+    %b = "cir.cast"(%a) <{kind = 28 : i32}> : (!cir.int<s, 32>) -> !cir.bool
+    "cir.brcond"(%b, %a)[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 1, 1, 0>}> : (!cir.bool, !cir.int<s, 32>) -> ()
+  ^bb1(%x : !cir.int<s, 32>):
+    "cir.br"(%x)[^bb3] : (!cir.int<s, 32>) -> ()
+  ^bb2:
+    "cir.unreachable"() : () -> ()
+  ^bb3(%r : !cir.int<s, 32>):
+    "cir.return"(%r) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32) -> i32>, "sym_name" = "f"}> ({
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT: %{{.*}} = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-NEXT: %{{.*}} = "arith.cmpi"(%{{.*}}, %{{.*}}) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT: "cf.cond_br"(%{{.*}}, %{{.*}}) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT: "cf.br"(%{{.*}}) [^{{.*}}] : (i32) -> ()
+// CHECK-NEXT: ^{{.*}}():
+// CHECK-NEXT: "llvm.unreachable"() : () -> ()
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : i32):
+// CHECK-NEXT: "cir.return"(%{{.*}}) : (i32) -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Test/Passes/CirToStd/unsupported_cast.mlir
+++ b/Test/Passes/CirToStd/unsupported_cast.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s -p=cir-to-std 2>&1 | filecheck %s
+
+// A bitcast (kind 1) round-trips but has no lowering.
+// CHECK: Error while applying cir-to-std lowering
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<u, 32>>, sym_name = "f"}> ({
+  ^bb0(%a : !cir.int<s, 32>):
+    %p = "cir.cast"(%a) <{kind = 1 : i32}> : (!cir.int<s, 32>) -> !cir.int<u, 32>
+    "cir.return"(%p) : (!cir.int<u, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/CirToStd/unsupported_saturated.mlir
+++ b/Test/Passes/CirToStd/unsupported_saturated.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s -p=cir-to-std 2>&1 | filecheck %s
+
+// Saturating arithmetic has no arith counterpart.
+// CHECK: Error while applying cir-to-std lowering
+
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, sym_name = "f"}> ({
+  ^bb0(%a : !cir.int<s, 32>):
+    %s = "cir.add"(%a, %a) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%s) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/FunctionBoundaryCoercion/cir.mlir
+++ b/Test/Passes/FunctionBoundaryCoercion/cir.mlir
@@ -1,0 +1,24 @@
+// RUN: veir-opt %s -p=coerce-cir-function-boundaries,reconcile-cast | filecheck %s
+
+"builtin.module"() ({
+
+  // `cir` function boundaries are coerced to the builtin integer of the same width.
+  // The pre-existing `!cir.int <-> iN` and `!cir.bool <-> i1` boundary casts then form
+  // identity round trips and are reconciled away, so the `arith` ops consume the function
+  // arguments directly and the function returns the `arith.cmpi` result.
+  "cir.func"() <{sym_name = "arith_lt", function_type = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.bool>}> ({
+  ^bb(%a : !cir.int<s, 32>, %b : !cir.int<u, 8>):
+    %ai = "builtin.unrealized_conversion_cast"(%a) : (!cir.int<s, 32>) -> i32
+    %bi = "builtin.unrealized_conversion_cast"(%b) : (!cir.int<u, 8>) -> i8
+    %bw = "arith.extui"(%bi) : (i8) -> i32
+    %lt = "arith.cmpi"(%ai, %bw) <{predicate = 2 : i64}> : (i32, i32) -> i1
+    %out = "builtin.unrealized_conversion_cast"(%lt) : (i1) -> !cir.bool
+    "cir.return"(%out) : (!cir.bool) -> ()
+    // CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32, i8) -> i1>, "sym_name" = "arith_lt"}>
+    // CHECK-NEXT: ^{{.*}}([[A:%.*]] : i32, [[B:%.*]] : i8):
+    // CHECK-NEXT:   [[BW:%.*]] = "arith.extui"([[B]]) : (i8) -> i32
+    // CHECK-NEXT:   [[LT:%.*]] = "arith.cmpi"([[A]], [[BW]]) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+    // CHECK-NEXT:   "cir.return"([[LT]]) : (i1) -> ()
+  }) : () -> ()
+
+}) : () -> ()

--- a/Test/Passes/pass_group_cir.mlir
+++ b/Test/Passes/pass_group_cir.mlir
@@ -1,0 +1,54 @@
+// RUN: veir-opt %s -p=cir | filecheck %s
+
+// The `cir` pass group lowers the `cir` integer core all the way to `arith`, `cf` and
+// `llvm`: ops and branches are lowered, `cir` function boundaries are coerced to the
+// builtin integer of the same width, and the resulting cast round trips are reconciled
+// away. Only the `cir.func`/`cir.return` shell keeps its `cir` spelling.
+
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>>, sym_name = "binops"}> ({
+  ^bb0(%a : !cir.int<s, 32>, %b : !cir.int<u, 8>):
+    %s = "cir.add"(%a, %a) <{no_signed_wrap, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %d = "cir.div"(%s, %a) : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %sh = "cir.shift"(%d, %b) : (!cir.int<s, 32>, !cir.int<u, 8>) -> !cir.int<s, 32>
+    %lt = "cir.cmp"(%sh, %a) <{kind = 0 : i32}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.bool
+    %sel = "cir.select"(%lt, %sh, %a) : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%sel) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, sym_name = "branches"}> ({
+  ^bb0(%a : !cir.int<s, 32>):
+    %b = "cir.cast"(%a) <{kind = 28 : i32}> : (!cir.int<s, 32>) -> !cir.bool
+    "cir.brcond"(%b, %a)[^bb1, ^bb2] <{operandSegmentSizes = array<i32: 1, 1, 0>}> : (!cir.bool, !cir.int<s, 32>) -> ()
+  ^bb1(%x : !cir.int<s, 32>):
+    "cir.br"(%x)[^bb3] : (!cir.int<s, 32>) -> ()
+  ^bb2:
+    "cir.unreachable"() : () -> ()
+  ^bb3(%r : !cir.int<s, 32>):
+    "cir.return"(%r) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32, i8) -> i32>, "sym_name" = "binops"}> ({
+// CHECK-NEXT: ^{{.*}}([[A:%.*]] : i32, [[B:%.*]] : i8):
+// CHECK-NEXT: [[SUM:%.*]] = "arith.addi"([[A]], [[A]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[DIV:%.*]] = "arith.divsi"([[SUM]], [[A]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[AMT:%.*]] = "arith.extui"([[B]]) : (i8) -> i32
+// CHECK-NEXT: [[SHR:%.*]] = "arith.shrsi"([[DIV]], [[AMT]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[LT:%.*]] = "arith.cmpi"([[SHR]], [[A]]) <{"predicate" = 2 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT: [[SEL:%.*]] = "arith.select"([[LT]], [[SHR]], [[A]]) : (i1, i32, i32) -> i32
+// CHECK-NEXT: "cir.return"([[SEL]]) : (i32) -> ()
+// CHECK-NEXT: }) : () -> ()
+
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(i32) -> i32>, "sym_name" = "branches"}> ({
+// CHECK-NEXT: ^{{.*}}([[A:%.*]] : i32):
+// CHECK-NEXT: [[ZERO:%.*]] = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
+// CHECK-NEXT: [[COND:%.*]] = "arith.cmpi"([[A]], [[ZERO]]) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
+// CHECK-NEXT: "cf.cond_br"([[COND]], [[A]]) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
+// CHECK-NEXT: ^{{.*}}([[X:%.*]] : i32):
+// CHECK-NEXT: "cf.br"([[X]]) [^{{.*}}] : (i32) -> ()
+// CHECK-NEXT: ^{{.*}}():
+// CHECK-NEXT: "llvm.unreachable"() : () -> ()
+// CHECK-NEXT: ^{{.*}}([[R:%.*]] : i32):
+// CHECK-NEXT: "cir.return"([[R]]) : (i32) -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -1799,6 +1799,8 @@ def interpretOp' (opType : OpCode) (properties : propertiesOf opType)
     return (vals, mem, act)
   | .func .return => do
     return (#[], mem, some (.return operands))
+  | .cir .return => do
+    return (#[], mem, some (.return operands))
   | .builtin .unrealized_conversion_cast => do
     let some resType := resultTypes[0]? | none
     match resType.val, operands.toList with

--- a/Veir/Passes/CastsReconciliation/Reconciliation.lean
+++ b/Veir/Passes/CastsReconciliation/Reconciliation.lean
@@ -34,6 +34,16 @@ def isPreservingModArithToIntCast (inputType interType : TypeAttr) : Bool :=
   | .integerType _, .modArithType _ => True
   | _, _ => false
 
+/- We reconcile casts from `!cir.int<s|u, N>` to `iN` and from `!cir.bool` to `i1` (and back):
+   the lowering keeps every bit, so the round trip is the identity. -/
+def isCirToIntRoundTrip (inputType interType : TypeAttr) : Bool :=
+  match inputType.val, interType.val with
+  | .cirIntType it, .integerType i => i.bitwidth = it.width
+  | .integerType i, .cirIntType it => i.bitwidth = it.width
+  | .cirBoolType _, .integerType i => i.bitwidth = 1
+  | .integerType i, .cirBoolType _ => i.bitwidth = 1
+  | _, _ => false
+
 
 /-- Reconciles round-trip casts of the form X->Y->X if allowed for these types by `legal X Y`.
 
@@ -111,6 +121,7 @@ def CastReconcilePass.impl (ctx : WfIRContext OpCode) (op : OperationPtr) (_ : o
     .fromLocalRewrite (reconcilePairingCastLocal isRegToI64RoundTrip),
     .fromLocalRewrite (reconcilePairingCastLocal isRiscvRegToPtrCast),
     .fromLocalRewrite (reconcilePairingCastLocal isPreservingModArithToIntCast),
+    .fromLocalRewrite (reconcilePairingCastLocal isCirToIntRoundTrip),
     .fromLocalRewrite reconcileRegIntCastLocal]
   match RewritePattern.applyInContext pattern ctx with
   | none => throw "Error while applying cast reconciliation"

--- a/Veir/Passes/CirToStd.lean
+++ b/Veir/Passes/CirToStd.lean
@@ -1,0 +1,424 @@
+module
+
+public import Veir.Pass
+public import Veir.PatternRewriter.Basic
+import Veir.Passes.Matching
+import Veir.Passes.DCE.dce
+import Veir.Interfaces.FunctionInterfaces
+
+namespace Veir
+
+/-!
+  # CirToStd pass
+
+  Lowers the `cir` dialect's integer core into the `arith`, `cf` and `llvm` dialects.
+  `cir.func` and `cir.return` stay in place: the rewriter cannot change an operation's
+  opcode or move its region, so the function operation keeps its `cir` spelling while its
+  boundary types are converted.
+
+  Since VeIR has no dialect-conversion framework, the pass works in four phases:
+  1. each `cir` value operation is rewritten in place, casting its operands to the builtin
+     type with `builtin.unrealized_conversion_cast`, emitting the `arith` operation, and
+     casting the result back;
+  2. function boundaries (entry-block arguments, return operands, `function_type`) are
+     converted;
+  3. the arguments of every other block, and the operands of the branches feeding them,
+     are converted;
+  4. the cast pairs that cancel are reconciled and dead casts removed.
+-/
+
+/-! ## Types -/
+
+/-- The builtin type a `cir` type lowers to, or `none` for types this pass leaves alone. -/
+def cirTypeToStd (t : TypeAttr) : Option TypeAttr :=
+  match t.val with
+  | .cirIntType it => some (IntegerType.mk it.width : TypeAttr)
+  | .cirBoolType _ => some (IntegerType.mk 1 : TypeAttr)
+  | _ => none
+
+/-- Whether a `cir` type and a builtin type are each other's lowering. -/
+def isCirRoundTrip (inputType interType : TypeAttr) : Bool :=
+  match inputType.val, interType.val with
+  | .cirIntType it, .integerType i => i.bitwidth = it.width
+  | .integerType i, .cirIntType it => i.bitwidth = it.width
+  | .cirBoolType _, .integerType i => i.bitwidth = 1
+  | .integerType i, .cirBoolType _ => i.bitwidth = 1
+  | _, _ => false
+
+/-- The signedness of a `!cir.int` type; `!cir.bool` counts as unsigned. -/
+def cirIsSigned (t : TypeAttr) : Bool :=
+  match t.val with
+  | .cirIntType it => it.isSigned
+  | _ => false
+
+/-! ## Casts and helpers -/
+
+/-- Emit `unrealized_conversion_cast v : !cir.* → builtin`. -/
+def castToStd (rewriter : PatternRewriter OpCode) (v : ValuePtr) (ip : InsertPoint) :
+    Option (PatternRewriter OpCode × ValuePtr) := do
+  let stdType ← cirTypeToStd (v.getType! rewriter.ctx.raw)
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
+    #[stdType] #[v] #[] #[] () (some ip)
+  return (rewriter, (castOp.getResult 0 : ValuePtr))
+
+/-- Emit `unrealized_conversion_cast x : builtin → ty`, where `ty` is a `cir` type. -/
+def castToCir (rewriter : PatternRewriter OpCode) (x : ValuePtr) (ty : TypeAttr)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let (rewriter, castOp) ← rewriter.createOp! (.builtin .unrealized_conversion_cast)
+    #[ty] #[x] #[] #[] () (some ip)
+  return (rewriter, (castOp.getResult 0 : ValuePtr))
+
+/-- Emit `arith.constant c : i<width>`. -/
+def emitStdConstant (rewriter : PatternRewriter OpCode) (c : Int) (width : Nat)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let ty : TypeAttr := IntegerType.mk width
+  let props : ArithConstantProperties := { value := IntegerAttr.mk c (IntegerType.mk width) }
+  let (rewriter, c) ← rewriter.createOp! (.arith .constant) #[ty] #[] #[] #[] props (some ip)
+  return (rewriter, (c.getResult 0 : ValuePtr))
+
+/-- Emit an `arith` operation `arithOp` with result type `ty` on `operands`. -/
+def emitArith (rewriter : PatternRewriter OpCode) (arithOp : Arith)
+    (props : Arith.propertiesOf arithOp) (ty : TypeAttr) (operands : Array ValuePtr)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let (rewriter, r) ← rewriter.createOp! (.arith arithOp) #[ty] operands #[] #[] props (some ip)
+  return (rewriter, (r.getResult 0 : ValuePtr))
+
+def noOverflow : ArithIntegerOverflowFlagsProperties := { attr := { nsw := false, nuw := false } }
+
+/-- Bring an integer value to `width` bits, zero-extending or truncating as needed. -/
+def resizeUnsigned (rewriter : PatternRewriter OpCode) (v : ValuePtr) (width : Nat)
+    (ip : InsertPoint) : Option (PatternRewriter OpCode × ValuePtr) := do
+  let .integerType vt := (v.getType! rewriter.ctx.raw).val | none
+  let ty : TypeAttr := IntegerType.mk width
+  if vt.bitwidth < width then
+    emitArith rewriter .extui { nneg := false } ty #[v] ip
+  else if vt.bitwidth > width then
+    emitArith rewriter .trunci noOverflow ty #[v] ip
+  else
+    return (rewriter, v)
+
+/-! ## Value operations
+
+A `StdBuilder` receives the operands already cast to their builtin types, the original
+`cir` operand types (for signedness), and the builtin result type, and emits the builtin
+computation.
+-/
+
+abbrev StdBuilder :=
+  (rewriter : PatternRewriter OpCode) → (operands : Array ValuePtr) →
+  (cirOperandTypes : Array TypeAttr) → (resultType : TypeAttr) → (ip : InsertPoint) →
+  Option (PatternRewriter OpCode × ValuePtr)
+
+/--
+  Lower a single-result `cir` operation `cirOp` with `numOperands` operands: cast the operands
+  to builtin types, run `build`, cast the result back to the operation's `cir` result type,
+  and erase the operation. `build` may inspect the properties; returning `none` from it aborts
+  the pass, which is how unsupported flags are reported.
+-/
+def lowerValueOp (cirOp : Cir) (numOperands : Nat)
+    (build : Cir.propertiesOf cirOp → StdBuilder)
+    (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  let some (operands, props) := matchOp op rewriter.ctx.raw cirOp numOperands
+    | return rewriter
+  let ip := InsertPoint.before op
+  let cirResultType := (op.getResult 0 : ValuePtr).getType! rewriter.ctx.raw
+  let some stdResultType := cirTypeToStd cirResultType | none
+  let cirOperandTypes := operands.map (·.getType! rewriter.ctx.raw)
+  let mut rw := rewriter
+  let mut stdOperands : Array ValuePtr := #[]
+  for v in operands do
+    let (rw', s) ← castToStd rw v ip
+    rw := rw'
+    stdOperands := stdOperands.push s
+  let (rewriter, result) ← build props rw stdOperands cirOperandTypes stdResultType ip
+  let (rewriter, back) ← castToCir rewriter result cirResultType ip
+  let rewriter := rewriter.replaceValue! (op.getResult 0) back
+  return rewriter.eraseOp! op
+
+/-- `cir.const` → `arith.constant`. -/
+def lowerConst := lowerValueOp .const 0 fun props rewriter _ _ resultType ip => do
+  let .integerType rt := resultType.val | none
+  match props.value with
+  | .int attr => emitStdConstant rewriter attr.value rt.bitwidth ip
+  | .bool attr => emitStdConstant rewriter (if attr.value then 1 else 0) rt.bitwidth ip
+
+/-- `cir.add` → `arith.addi`; the saturating form is rejected. -/
+def lowerAdd := lowerValueOp .add 2 fun props rewriter operands _ resultType ip => do
+  if props.flagSet "saturated" then none
+  emitArith rewriter .addi noOverflow resultType operands ip
+
+/-- `cir.sub` → `arith.subi`; the saturating form is rejected. -/
+def lowerSub := lowerValueOp .sub 2 fun props rewriter operands _ resultType ip => do
+  if props.flagSet "saturated" then none
+  emitArith rewriter .subi noOverflow resultType operands ip
+
+/-- A binary operation whose `arith` counterpart does not depend on signedness. -/
+def lowerBinOp (cirOp : Cir) (arithOp : Arith) (props : Arith.propertiesOf arithOp) :=
+  lowerValueOp cirOp 2 fun _ rewriter operands _ resultType ip =>
+    emitArith rewriter arithOp props resultType operands ip
+
+def lowerMul := lowerBinOp .mul .muli noOverflow
+def lowerAnd := lowerBinOp .and .andi ()
+def lowerOr := lowerBinOp .or .ori { disjoint := false }
+def lowerXor := lowerBinOp .xor .xori ()
+
+/-- A binary operation whose `arith` counterpart is chosen by the operands' signedness. -/
+def lowerSignedBinOp (cirOp : Cir) (signedOp unsignedOp : Arith)
+    (signedProps : Arith.propertiesOf signedOp) (unsignedProps : Arith.propertiesOf unsignedOp) :=
+  lowerValueOp cirOp 2 fun _ rewriter operands cirTypes resultType ip =>
+    if cirIsSigned cirTypes[0]! then
+      emitArith rewriter signedOp signedProps resultType operands ip
+    else
+      emitArith rewriter unsignedOp unsignedProps resultType operands ip
+
+def lowerDiv := lowerSignedBinOp .div .divsi .divui { exact := false } { exact := false }
+def lowerRem := lowerSignedBinOp .rem .remsi .remui () ()
+def lowerMin := lowerSignedBinOp .min .minsi .minui () ()
+def lowerMax := lowerSignedBinOp .max .maxsi .maxui () ()
+
+/-- `cir.shift` → `arith.shli`, or `shrsi`/`shrui` by the value's signedness. -/
+def lowerShift := lowerValueOp .shift 2 fun props rewriter operands cirTypes resultType ip => do
+  let .integerType rt := resultType.val | none
+  let (rewriter, amount) ← resizeUnsigned rewriter operands[1]! rt.bitwidth ip
+  let operands := #[operands[0]!, amount]
+  if props.isShiftleft then
+    emitArith rewriter .shli noOverflow resultType operands ip
+  else if cirIsSigned cirTypes[0]! then
+    emitArith rewriter .shrsi { exact := false } resultType operands ip
+  else
+    emitArith rewriter .shrui { exact := false } resultType operands ip
+
+/-- `cir.not` → `arith.xori` with all ones. -/
+def lowerNot := lowerValueOp .not 1 fun _ rewriter operands _ resultType ip => do
+  let .integerType rt := resultType.val | none
+  let (rewriter, ones) ← emitStdConstant rewriter (-1) rt.bitwidth ip
+  emitArith rewriter .xori () resultType #[operands[0]!, ones] ip
+
+/-- `cir.minus` → `arith.subi` from zero. -/
+def lowerMinus := lowerValueOp .minus 1 fun _ rewriter operands _ resultType ip => do
+  let .integerType rt := resultType.val | none
+  let (rewriter, zero) ← emitStdConstant rewriter 0 rt.bitwidth ip
+  emitArith rewriter .subi noOverflow resultType #[zero, operands[0]!] ip
+
+/-- The `arith.cmpi` predicate for a `cir.cmp` kind on operands of the given signedness. -/
+def cmpPredicate (kind : CirCmpKind) (signed : Bool) : Data.LLVM.IntPred :=
+  match kind, signed with
+  | .eq, _ => .eq
+  | .ne, _ => .ne
+  | .lt, true => .slt
+  | .lt, false => .ult
+  | .le, true => .sle
+  | .le, false => .ule
+  | .gt, true => .sgt
+  | .gt, false => .ugt
+  | .ge, true => .sge
+  | .ge, false => .uge
+
+/-- `cir.cmp` → `arith.cmpi`. -/
+def lowerCmp := lowerValueOp .cmp 2 fun props rewriter operands cirTypes resultType ip =>
+  emitArith rewriter .cmpi { predicate := cmpPredicate props.kind (cirIsSigned cirTypes[0]!) }
+    resultType operands ip
+
+/-- `cir.select` → `arith.select`. -/
+def lowerSelect := lowerValueOp .select 3 fun _ rewriter operands _ resultType ip =>
+  emitArith rewriter .select () resultType operands ip
+
+/-- `cir.cast` for the integral, int_to_bool and bool_to_int kinds. -/
+def lowerCast := lowerValueOp .cast 1 fun props rewriter operands cirTypes resultType ip => do
+  let src := operands[0]!
+  let .integerType st := (src.getType! rewriter.ctx.raw).val | none
+  let .integerType rt := resultType.val | none
+  match props.kind with
+  | .integral | .bool_to_int =>
+    if st.bitwidth = rt.bitwidth then
+      return (rewriter, src)
+    else if st.bitwidth < rt.bitwidth then
+      if cirIsSigned cirTypes[0]! then
+        emitArith rewriter .extsi () resultType #[src] ip
+      else
+        emitArith rewriter .extui { nneg := false } resultType #[src] ip
+    else
+      emitArith rewriter .trunci noOverflow resultType #[src] ip
+  | .int_to_bool =>
+    let (rewriter, zero) ← emitStdConstant rewriter 0 st.bitwidth ip
+    emitArith rewriter .cmpi { predicate := .ne } resultType #[src, zero] ip
+  | .other _ => none
+
+/-! ## Terminators -/
+
+/-- `cir.br` → `cf.br`, forwarding the operands unchanged. -/
+def lowerBr (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  if op.getOpType! rewriter.ctx.raw ≠ .cir .br then return rewriter
+  let (rewriter, _) ← rewriter.createOp! (.cf .br) #[] (op.getOperands! rewriter.ctx.raw)
+    (op.getSuccessors! rewriter.ctx.raw) #[] () (some (InsertPoint.before op))
+  return rewriter.eraseOp! op
+
+/-- `cir.brcond` → `cf.cond_br`, casting only the condition. -/
+def lowerBrCond (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  if op.getOpType! rewriter.ctx.raw ≠ .cir .brcond then return rewriter
+  let props : CirBrCondProperties := op.getProperties! rewriter.ctx.raw Cir.brcond
+  let operands := op.getOperands! rewriter.ctx.raw
+  let ip := InsertPoint.before op
+  let (rewriter, cond) ← castToStd rewriter operands[0]! ip
+  let cfProps : CondBrProperties :=
+    { branch_weights := { elementType := { bitwidth := 32 }, values := #[] }
+      operandSegmentSizes := props.operandSegmentSizes }
+  let (rewriter, _) ← rewriter.createOp! (.cf .cond_br) #[]
+    (#[cond] ++ operands.extract 1 operands.size) (op.getSuccessors! rewriter.ctx.raw) #[]
+    cfProps (some ip)
+  return rewriter.eraseOp! op
+
+/-- `cir.unreachable` → `llvm.unreachable`. -/
+def lowerUnreachable (rewriter : PatternRewriter OpCode) (op : OperationPtr)
+    (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
+  if op.getOpType! rewriter.ctx.raw ≠ .cir .unreachable then return rewriter
+  let (rewriter, _) ← rewriter.createOp! (.llvm .unreachable) #[] #[] #[] #[] ()
+    (some (InsertPoint.before op))
+  return rewriter.eraseOp! op
+
+/-! ## Boundaries -/
+
+/--
+  Convert one `cir.func`'s boundary: entry-block arguments, `cir.return` operands and the
+  `function_type`, bridging with casts. This mirrors `coerceFunction` in the function
+  boundary coercion pass, specialised to the `cir` type map.
+-/
+def convertCirFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
+    WfIRContext OpCode := Id.run do
+  let mut ctx := ctx
+  let some entry := FunctionOpInterface.getEntryBlock? funcOp ctx.raw | return ctx
+  let mut outputs : Array Attribute := FunctionOpInterface.getResultTypes! funcOp ctx.raw
+  -- (1) Entry-block arguments: retype in place and cast back to the original type.
+  let mut inputs : Array Attribute := #[]
+  for i in List.range (entry.getNumArguments! ctx.raw) do
+    let bap : BlockArgumentPtr := { block := entry, index := i }
+    let origType := (ValuePtr.blockArgument bap).getType! ctx.raw
+    match cirTypeToStd origType with
+    | some newType =>
+      ctx := WfRewriter.setType! ctx bap newType
+      let ip := InsertPoint.atStart! entry ctx.raw
+      let some (ctx', cast) := WfRewriter.createOp! ctx (OpCode.builtin .unrealized_conversion_cast)
+        #[origType] #[] #[] #[] () (some ip) | return ctx
+      let ctx' := WfRewriter.replaceValue! ctx' bap (cast.getResult 0)
+      ctx := WfRewriter.pushOperand! ctx' cast bap
+      inputs := inputs.push newType.val
+    | none =>
+      inputs := inputs.push origType.val
+  -- (2) Return operands: cast to the builtin type before the return.
+  let returnOps := ctx.raw.operations.keys.filter fun o =>
+    o.getOpType! ctx.raw == .cir .return && o.getParentOp! ctx.raw == some funcOp
+  for retOp in returnOps do
+    for j in List.range (retOp.getNumOperands! ctx.raw) do
+      let opVal := retOp.getOperand! ctx.raw j
+      match cirTypeToStd (opVal.getType! ctx.raw) with
+      | some newType =>
+        let some (ctx', cast) := WfRewriter.createOp! ctx
+          (OpCode.builtin .unrealized_conversion_cast) #[newType] #[opVal] #[] #[] ()
+          (some (InsertPoint.before retOp)) | return ctx
+        ctx := WfRewriter.replaceOperand! ctx' ⟨retOp, j⟩ (cast.getResult 0)
+        outputs := outputs.set! j newType.val
+      | none => pure ()
+  -- (3) The declared function type follows the converted boundary.
+  return FunctionOpInterface.setFunctionType! ctx funcOp inputs outputs
+
+/--
+  Convert the arguments of a block with predecessors: cast the forwarded operands of every
+  predecessor branch, then retype the arguments and cast them back at the block start.
+  This mirrors `convertBlock` in the RISC-V branch selection.
+-/
+def convertCirBlock (ctx : WfIRContext OpCode) (block : BlockPtr) : WfIRContext OpCode := Id.run do
+  let mut ctx := ctx
+  if (block.get! ctx.raw).firstUse == none then return ctx
+  let coercible := (List.range (block.getNumArguments! ctx.raw)).any fun i =>
+    (cirTypeToStd ((ValuePtr.blockArgument { block, index := i }).getType! ctx.raw)).isSome
+  if !coercible then return ctx
+  -- Collect the predecessors first: rewriting them mutates the use chain.
+  let mut predOps : Array OperationPtr := #[]
+  let mut currentPredUse := (block.get! ctx.raw).firstUse
+  while let some blockop := currentPredUse do
+    let blockOperand := blockop.get! ctx.raw
+    currentPredUse := blockOperand.nextUse
+    if !predOps.contains blockOperand.owner then
+      predOps := predOps.push blockOperand.owner
+  for predOp in predOps do
+    for j in List.range (predOp.getNumOperands! ctx.raw) do
+      let opVal := predOp.getOperand! ctx.raw j
+      match cirTypeToStd (opVal.getType! ctx.raw) with
+      | some newType =>
+        let some (ctx', cast) := WfRewriter.createOp! ctx
+          (OpCode.builtin .unrealized_conversion_cast) #[newType] #[opVal] #[] #[] ()
+          (some (InsertPoint.before predOp)) | return ctx
+        ctx := WfRewriter.replaceOperand! ctx' ⟨predOp, j⟩ (cast.getResult 0)
+      | none => pure ()
+  for i in List.range (block.getNumArguments! ctx.raw) do
+    let bap : BlockArgumentPtr := { block, index := i }
+    let origType := (ValuePtr.blockArgument bap).getType! ctx.raw
+    let some newType := cirTypeToStd origType | continue
+    ctx := WfRewriter.setType! ctx bap newType
+    let ip := InsertPoint.atStart! block ctx.raw
+    let some (ctx', cast) := WfRewriter.createOp! ctx (OpCode.builtin .unrealized_conversion_cast)
+      #[origType] #[] #[] #[] () (some ip) | return ctx
+    let ctx' := WfRewriter.replaceValue! ctx' bap (cast.getResult 0)
+    ctx := WfRewriter.pushOperand! ctx' cast bap
+  return ctx
+
+/-! ## Reconciliation -/
+
+/--
+  Reconcile `X → Y → X` cast round trips between `cir` and builtin types. The parent cast is
+  left to DCE, as a `LocalRewritePattern` may only erase the matched operation.
+-/
+def reconcileCirCastLocal (ctx : WfIRContext OpCode) (op : OperationPtr) :
+    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
+  let some input := matchCastOp op ctx.raw | return (ctx, none)
+  let interType := input.getType! ctx.raw
+  let resultType := ((op.getResult 0).get! ctx.raw).type
+  let .opResult op' := input | return (ctx, none)
+  let some parentInput := matchCastOp op'.op ctx.raw | return (ctx, none)
+  let inputType := parentInput.getType! ctx.raw
+  if resultType ≠ inputType then return (ctx, none)
+  if !isCirRoundTrip inputType interType then return (ctx, none)
+  return (ctx, some (#[], #[parentInput]))
+
+/-! ## Pass implementation -/
+
+def CirToStdPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
+    (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
+  -- (1) Value operations and terminators.
+  let lowering := RewritePattern.GreedyRewritePattern #[
+    lowerConst, lowerAdd, lowerSub, lowerMul, lowerDiv, lowerRem,
+    lowerAnd, lowerOr, lowerXor, lowerShift, lowerNot, lowerMinus,
+    lowerMin, lowerMax, lowerCmp, lowerSelect, lowerCast,
+    lowerBr, lowerBrCond, lowerUnreachable
+  ]
+  let some lowered := RewritePattern.applyInContext lowering ctx
+    | throw "Error while applying cir-to-std lowering (unsupported operation or flag)"
+  -- (2) Function boundaries, (3) block arguments.
+  let mut converted := lowered
+  let funcOps := converted.raw.operations.keys.filter fun o =>
+    o.getOpType! converted.raw == .cir .func
+  for funcOp in funcOps do
+    converted := convertCirFunction converted funcOp
+  for block in converted.raw.blocks.keys do
+    converted := convertCirBlock converted block
+  -- (4) Cancel cast round trips and drop the dead casts they leave behind.
+  let reconcile := RewritePattern.GreedyRewritePattern #[
+    .fromLocalRewrite reconcileCirCastLocal, eliminateDeadOp]
+  let some reconciled := RewritePattern.applyInContext reconcile converted
+    | throw "Error while reconciling casts after cir-to-std lowering"
+  -- Nothing but the function shell may remain.
+  for o in reconciled.raw.operations.keys do
+    if let .cir cirOp := o.getOpType! reconciled.raw then
+      if cirOp ≠ .func && cirOp ≠ .return then
+        throw s!"cir-to-std: operation '{String.fromUTF8! (IsOpCode.name cirOp)}' was not lowered"
+  return reconciled
+
+public def CirToStdPass : Pass OpCode :=
+  { name := "cir-to-std"
+    description := "Lower the cir dialect's integer core to the arith, cf and llvm dialects."
+    run := fun _ => CirToStdPass.impl }
+
+end Veir

--- a/Veir/Passes/CirToStd.lean
+++ b/Veir/Passes/CirToStd.lean
@@ -3,8 +3,6 @@ module
 public import Veir.Pass
 public import Veir.PatternRewriter.Basic
 import Veir.Passes.Matching
-import Veir.Passes.DCE.dce
-import Veir.Interfaces.FunctionInterfaces
 
 namespace Veir
 
@@ -13,18 +11,16 @@ namespace Veir
 
   Lowers the `cir` dialect's integer core into the `arith`, `cf` and `llvm` dialects.
   `cir.func` and `cir.return` stay in place: the rewriter cannot change an operation's
-  opcode or move its region, so the function operation keeps its `cir` spelling while its
-  boundary types are converted.
+  opcode or move its region, so the function operation keeps its `cir` spelling.
 
-  Since VeIR has no dialect-conversion framework, the pass works in four phases:
-  1. each `cir` value operation is rewritten in place, casting its operands to the builtin
-     type with `builtin.unrealized_conversion_cast`, emitting the `arith` operation, and
-     casting the result back;
-  2. function boundaries (entry-block arguments, return operands, `function_type`) are
-     converted;
-  3. the arguments of every other block, and the operands of the branches feeding them,
-     are converted;
-  4. the cast pairs that cancel are reconciled and dead casts removed.
+  Since VeIR has no dialect-conversion framework, this pass follows `mod-arith-to-arith`:
+  each `cir` value operation is rewritten in place, casting its operands to the builtin type
+  with `builtin.unrealized_conversion_cast`, emitting the `arith` operation, and casting the
+  result back. Branches are lowered to `cf` together with the arguments of the blocks they
+  target, as `isel-br-riscv64` does, since a branch's operand types must match its
+  successor's argument types. The function boundary is left to
+  `coerce-cir-function-boundaries` and the cast round trips to `reconcile-cast`; the `cir`
+  pass group chains them.
 -/
 
 /-! ## Types -/
@@ -35,15 +31,6 @@ def cirTypeToStd (t : TypeAttr) : Option TypeAttr :=
   | .cirIntType it => some (IntegerType.mk it.width : TypeAttr)
   | .cirBoolType _ => some (IntegerType.mk 1 : TypeAttr)
   | _ => none
-
-/-- Whether a `cir` type and a builtin type are each other's lowering. -/
-def isCirRoundTrip (inputType interType : TypeAttr) : Bool :=
-  match inputType.val, interType.val with
-  | .cirIntType it, .integerType i => i.bitwidth = it.width
-  | .integerType i, .cirIntType it => i.bitwidth = it.width
-  | .cirBoolType _, .integerType i => i.bitwidth = 1
-  | .integerType i, .cirBoolType _ => i.bitwidth = 1
-  | _, _ => false
 
 /-- The signedness of a `!cir.int` type; `!cir.bool` counts as unsigned. -/
 def cirIsSigned (t : TypeAttr) : Bool :=
@@ -279,55 +266,13 @@ def lowerUnreachable (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (some (InsertPoint.before op))
   return rewriter.eraseOp! op
 
-/-! ## Boundaries -/
-
-/--
-  Convert one `cir.func`'s boundary: entry-block arguments, `cir.return` operands and the
-  `function_type`, bridging with casts. This mirrors `coerceFunction` in the function
-  boundary coercion pass, specialised to the `cir` type map.
--/
-def convertCirFunction (ctx : WfIRContext OpCode) (funcOp : OperationPtr) :
-    WfIRContext OpCode := Id.run do
-  let mut ctx := ctx
-  let some entry := FunctionOpInterface.getEntryBlock? funcOp ctx.raw | return ctx
-  let mut outputs : Array Attribute := FunctionOpInterface.getResultTypes! funcOp ctx.raw
-  -- (1) Entry-block arguments: retype in place and cast back to the original type.
-  let mut inputs : Array Attribute := #[]
-  for i in List.range (entry.getNumArguments! ctx.raw) do
-    let bap : BlockArgumentPtr := { block := entry, index := i }
-    let origType := (ValuePtr.blockArgument bap).getType! ctx.raw
-    match cirTypeToStd origType with
-    | some newType =>
-      ctx := WfRewriter.setType! ctx bap newType
-      let ip := InsertPoint.atStart! entry ctx.raw
-      let some (ctx', cast) := WfRewriter.createOp! ctx (OpCode.builtin .unrealized_conversion_cast)
-        #[origType] #[] #[] #[] () (some ip) | return ctx
-      let ctx' := WfRewriter.replaceValue! ctx' bap (cast.getResult 0)
-      ctx := WfRewriter.pushOperand! ctx' cast bap
-      inputs := inputs.push newType.val
-    | none =>
-      inputs := inputs.push origType.val
-  -- (2) Return operands: cast to the builtin type before the return.
-  let returnOps := ctx.raw.operations.keys.filter fun o =>
-    o.getOpType! ctx.raw == .cir .return && o.getParentOp! ctx.raw == some funcOp
-  for retOp in returnOps do
-    for j in List.range (retOp.getNumOperands! ctx.raw) do
-      let opVal := retOp.getOperand! ctx.raw j
-      match cirTypeToStd (opVal.getType! ctx.raw) with
-      | some newType =>
-        let some (ctx', cast) := WfRewriter.createOp! ctx
-          (OpCode.builtin .unrealized_conversion_cast) #[newType] #[opVal] #[] #[] ()
-          (some (InsertPoint.before retOp)) | return ctx
-        ctx := WfRewriter.replaceOperand! ctx' ⟨retOp, j⟩ (cast.getResult 0)
-        outputs := outputs.set! j newType.val
-      | none => pure ()
-  -- (3) The declared function type follows the converted boundary.
-  return FunctionOpInterface.setFunctionType! ctx funcOp inputs outputs
+/-! ## Block arguments -/
 
 /--
   Convert the arguments of a block with predecessors: cast the forwarded operands of every
   predecessor branch, then retype the arguments and cast them back at the block start.
-  This mirrors `convertBlock` in the RISC-V branch selection.
+  This mirrors `convertBlock` in the RISC-V branch selection. Entry blocks have no
+  predecessors and are left to `coerce-cir-function-boundaries`.
 -/
 def convertCirBlock (ctx : WfIRContext OpCode) (block : BlockPtr) : WfIRContext OpCode := Id.run do
   let mut ctx := ctx
@@ -365,29 +310,10 @@ def convertCirBlock (ctx : WfIRContext OpCode) (block : BlockPtr) : WfIRContext 
     ctx := WfRewriter.pushOperand! ctx' cast bap
   return ctx
 
-/-! ## Reconciliation -/
-
-/--
-  Reconcile `X → Y → X` cast round trips between `cir` and builtin types. The parent cast is
-  left to DCE, as a `LocalRewritePattern` may only erase the matched operation.
--/
-def reconcileCirCastLocal (ctx : WfIRContext OpCode) (op : OperationPtr) :
-    Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some input := matchCastOp op ctx.raw | return (ctx, none)
-  let interType := input.getType! ctx.raw
-  let resultType := ((op.getResult 0).get! ctx.raw).type
-  let .opResult op' := input | return (ctx, none)
-  let some parentInput := matchCastOp op'.op ctx.raw | return (ctx, none)
-  let inputType := parentInput.getType! ctx.raw
-  if resultType ≠ inputType then return (ctx, none)
-  if !isCirRoundTrip inputType interType then return (ctx, none)
-  return (ctx, some (#[], #[parentInput]))
-
 /-! ## Pass implementation -/
 
 def CirToStdPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
     (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
-  -- (1) Value operations and terminators.
   let lowering := RewritePattern.GreedyRewritePattern #[
     lowerConst, lowerAdd, lowerSub, lowerMul, lowerDiv, lowerRem,
     lowerAnd, lowerOr, lowerXor, lowerShift, lowerNot, lowerMinus,
@@ -396,25 +322,16 @@ def CirToStdPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
   ]
   let some lowered := RewritePattern.applyInContext lowering ctx
     | throw "Error while applying cir-to-std lowering (unsupported operation or flag)"
-  -- (2) Function boundaries, (3) block arguments.
+  -- The lowered branches still forward `cir` values: retype the blocks they target.
   let mut converted := lowered
-  let funcOps := converted.raw.operations.keys.filter fun o =>
-    o.getOpType! converted.raw == .cir .func
-  for funcOp in funcOps do
-    converted := convertCirFunction converted funcOp
   for block in converted.raw.blocks.keys do
     converted := convertCirBlock converted block
-  -- (4) Cancel cast round trips and drop the dead casts they leave behind.
-  let reconcile := RewritePattern.GreedyRewritePattern #[
-    .fromLocalRewrite reconcileCirCastLocal, eliminateDeadOp]
-  let some reconciled := RewritePattern.applyInContext reconcile converted
-    | throw "Error while reconciling casts after cir-to-std lowering"
   -- Nothing but the function shell may remain.
-  for o in reconciled.raw.operations.keys do
-    if let .cir cirOp := o.getOpType! reconciled.raw then
+  for o in converted.raw.operations.keys do
+    if let .cir cirOp := o.getOpType! converted.raw then
       if cirOp ≠ .func && cirOp ≠ .return then
         throw s!"cir-to-std: operation '{String.fromUTF8! (IsOpCode.name cirOp)}' was not lowered"
-  return reconciled
+  return converted
 
 public def CirToStdPass : Pass OpCode :=
   { name := "cir-to-std"

--- a/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
+++ b/Veir/Passes/FunctionBoundaryCoercion/Coercion.lean
@@ -7,19 +7,21 @@ namespace Veir
 
 /-! ## Coercing function boundaries
 
-  Rewrite each `func.func`/`llvm.func`'s arguments and return values to a coerced type,
-  inserting`unrealized_conversion_cast`s to bridge to/from the original types.
+  Rewrite each `func.func`/`llvm.func`/`cir.func`'s arguments and return values to a coerced
+  type, inserting`unrealized_conversion_cast`s to bridge to/from the original types.
 
   The coercion applied is selected by a `BoundaryCoercion` flag;
   each variant is  exposed as its own pass:
   - `.riscvReg`: i32-, i64-, and pointer-typed boundaries become `!riscv.reg`.
   - `.modArithToInt legalizeWidth`: `!mod_arith.int<q : iN>`-typed boundaries become `i(legalizeWidth N)`
+  - `.cirToStd`: `!cir.int<s|u, N>`- and `!cir.bool`-typed boundaries become `iN` and `i1`
 -/
 
 /-- Selects which boundary coercion the shared implementation applies. -/
 inductive BoundaryCoercion where
   | riscvReg
   | modArithToInt (legalizeWidth : Nat → Nat)
+  | cirToStd
 
 /-- The type a boundary value of type `t` is coerced to, or `none` to leave it alone. -/
 def BoundaryCoercion.target : BoundaryCoercion → TypeAttr → Option TypeAttr
@@ -33,17 +35,23 @@ def BoundaryCoercion.target : BoundaryCoercion → TypeAttr → Option TypeAttr
     match t.val with
     | .modArithType mt => some (IntegerType.mk (legalizeWidth mt.bitwidth) : TypeAttr)
     | _ => none
+  | .cirToStd, t =>
+    match t.val with
+    | .cirIntType it => some (IntegerType.mk it.width : TypeAttr)
+    | .cirBoolType _ => some (IntegerType.mk 1 : TypeAttr)
+    | _ => none
 
 /-- The return-terminator opcode paired with a function op (`func.return` for
-    `func.func`, `llvm.return` for `llvm.func`). -/
+    `func.func`, `llvm.return` for `llvm.func`, `cir.return` for `cir.func`). -/
 def returnOpCodeFor : OpCode → OpCode
   | .llvm .func => .llvm .return
+  | .cir .func => .cir .return
   | _ => .func .return
 
 set_option warn.sorry false in
 /-- Coerce one function's arguments and return values as dictated by `coercion`,
-    inserting bridging casts and rewriting the `function_type` to match. Handles both
-    `func.func` and `llvm.func`. -/
+    inserting bridging casts and rewriting the `function_type` to match. Handles
+    `func.func`, `llvm.func` and `cir.func`. -/
 def coerceFunction (coercion : BoundaryCoercion) (ctx : WfIRContext OpCode)
     (funcOp : OperationPtr) : ExceptT String IO (WfIRContext OpCode) := do
   -- Shadow the parameter: from here on `ctx` always names the latest version, with no
@@ -124,3 +132,8 @@ public def CoerceModArithFunctionBoundariesPass : Pass OpCode :=
       CoerceFunctionBoundariesPass.impl
         (.modArithToInt
           (if (options.get? "pow2-width").getD false then Nat.nextPowerOfTwo else id)) }
+
+public def CoerceCirFunctionBoundariesPass : Pass OpCode :=
+  { name := "coerce-cir-function-boundaries"
+    description := "Coerce `!cir.int` and `!cir.bool` function boundaries to the builtin integer of the same width."
+    run := fun _ => CoerceFunctionBoundariesPass.impl .cirToStd }

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -36,6 +36,7 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
      CastReconcilePass,
      CoerceFunctionBoundariesToRiscvRegPass,
      CoerceModArithFunctionBoundariesPass,
+     CoerceCirFunctionBoundariesPass,
      RISCV.Combine,
      ModArithToArithPass,
      ArithToLLVMPass,
@@ -59,7 +60,8 @@ def passGroups : Std.HashMap String String :=
         "mod-arith-to-arith{barrett pow2-width},cse,coerce-mod-arith-function-boundaries{pow2-width},reconcile-cast,canonicalize,cse,dce"
     |>.insert "riscv"
         "legalize,isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,coerce-function-boundaries-to-riscv-reg,reconcile-cast,riscv-combine,dce"
-    |>.insert "cir" "cir-to-std,canonicalize,cse,dce"
+    |>.insert "cir"
+        "cir-to-std,cse,coerce-cir-function-boundaries,reconcile-cast,canonicalize,cse,dce"
 
 /--
   A human-readable description of every pass group and the passes it expands to,

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -16,6 +16,7 @@ import Veir.Passes.ModArithToArith
 import Veir.Passes.ArithToLLVM
 import Veir.Passes.Canonicalize
 import Veir.Passes.Legalization
+import Veir.Passes.CirToStd
 
 open Veir.Parser
 open Veir.Parser.ParserError
@@ -39,7 +40,8 @@ def availablePasses : Std.HashMap String (Pass OpCode) :=
      ModArithToArithPass,
      ArithToLLVMPass,
      CanonicalizePass,
-     LegalizePass ] : List (Pass OpCode)).foldl
+     LegalizePass,
+     CirToStdPass ] : List (Pass OpCode)).foldl
     (fun m pass => m.insert pass.name pass)
     (Std.HashMap.emptyWithCapacity 16)
 
@@ -57,6 +59,7 @@ def passGroups : Std.HashMap String String :=
         "mod-arith-to-arith{barrett pow2-width},cse,coerce-mod-arith-function-boundaries{pow2-width},reconcile-cast,canonicalize,cse,dce"
     |>.insert "riscv"
         "legalize,isel-sdag-riscv64,isel-br-riscv64,isel-riscv64,coerce-function-boundaries-to-riscv-reg,reconcile-cast,riscv-combine,dce"
+    |>.insert "cir" "cir-to-std,canonicalize,cse,dce"
 
 /--
   A human-readable description of every pass group and the passes it expands to,


### PR DESCRIPTION
PR adds `cir-to-std`, which gives the cir dialect its semantics by lowering to `arith`, `cf` and `llvm`. It follows the `mod-arith-to-arith` approach, since VeIR has no dialect-conversion framework: each value operation is rewritten in place with unrealized_conversion_casts at the type boundary, function and block boundaries are retyped with bridging casts, and the cast pairs are reconciled in the same pass so no cir type survives. Signedness selects the arith operation (divsi/divui, shrsi/shrui, signed or unsigned cmpi predicates); saturating arithmetic and cast kinds without a lowering are rejected.

cir.func and cir.return stay in place, because the rewriter cannot change an opcode or move a region between operations. cir.func implements the function interface and cir.return gets the same interpreter arm as func.return, so veir-opt -p=cir | veir-interpret runs lowered programs; the cir pass group expands to cir-to-std,canonicalize,cse,dce. Tests cover signed and unsigned arithmetic, comparisons with branches, a flat loop, casts, and the two rejected cases. 

Not covered yet: pointers and memory operations, cir.call, and structured control flow.