### PR TITLE
feat(HW): Add support for hw.instance

### DIFF
--- a/Test/HW/instance.mlir
+++ b/Test/HW/instance.mlir
@@ -1,0 +1,30 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "hw.module"() <{comment = "", module_type = !hw.modty<input a : i8, input b : i8, output out : i8>, parameters = [], per_port_attrs = [], result_locs = [loc(unknown)], sym_name = "add2"}> ({
+  ^bb0(%arg3: i8, %arg4: i8):
+    %2 = "comb.add"(%arg3, %arg4) : (i8, i8) -> i8
+    "hw.output"(%2) : (i8) -> ()
+  }) {sym_visibility = "private"} : () -> ()
+  "hw.module"() <{comment = "", module_type = !hw.modty<input a : i8, input b : i8, input c : i8, output out : i8>, parameters = [], per_port_attrs = [], result_locs = [loc(unknown)], sym_name = "add3"}> ({
+  ^bb0(%arg0: i8, %arg1: i8, %arg2: i8):
+    %0 = "hw.instance"(%arg0, %arg1) <{argNames = ["a", "b"], instanceName = "a0", moduleName = @add2, parameters = [], resultNames = ["out"]}> {sv.namehint = "s"} : (i8, i8) -> i8
+    %1 = "hw.instance"(%arg2, %0) <{argNames = ["a", "b"], instanceName = "a1", moduleName = @add2, parameters = [], resultNames = ["out"]}> : (i8, i8) -> i8
+    "hw.output"(%1) : (i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "builtin.module"() ({
+// CHECK-NEXT:   ^{{.*}}():
+// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<input a : i8, input b : i8, output out : i8>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "add2"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i8, %{{.*}} : i8):
+// CHECK-NEXT:         %{{.*}} = "comb.add"(%{{.*}}, %{{.*}}) : (i8, i8) -> i8
+// CHECK-NEXT:         "hw.output"(%{{.*}}) : (i8) -> ()
+// CHECK-NEXT:     }) {"sym_visibility" = "private"} : () -> ()
+// CHECK-NEXT:     "hw.module"() <{"module_type" = !hw.modty<input a : i8, input b : i8, input c : i8, output out : i8>, "parameters" = [], "per_port_attrs" = [], "sym_name" = "add3"}> ({
+// CHECK-NEXT:       ^{{.*}}(%{{.*}} : i8, %{{.*}} : i8, %{{.*}} : i8):
+// CHECK-NEXT:         %{{.*}} = "hw.instance"(%{{.*}}, %{{.*}}) <{"argNames" = ["a", "b"], "instanceName" = "a0", "moduleName" = @add2, "parameters" = [], "resultNames" = ["out"]}> {"sv.namehint" = "s"} : (i8, i8) -> i8
+// CHECK-NEXT:         %{{.*}} = "hw.instance"(%{{.*}}, %{{.*}}) <{"argNames" = ["a", "b"], "instanceName" = "a1", "moduleName" = @add2, "parameters" = [], "resultNames" = ["out"]}> : (i8, i8) -> i8
+// CHECK-NEXT:         "hw.output"(%{{.*}}) : (i8) -> ()
+// CHECK-NEXT:     }) : () -> ()
+// CHECK-NEXT: }) : () -> ()

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -16,6 +16,7 @@ inductive HW where
 | constant
 | module
 | output
+| instance
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[expose, properties_of]
@@ -23,6 +24,7 @@ def HW.propertiesOf (op : HW) : Type :=
 match op with
 | .constant => HWConstantProperties
 | .module => HWModuleProperties
+| .instance => HWInstanceProperties
 | _ => Unit
 
 def HW.fromAttrDict
@@ -31,6 +33,7 @@ def HW.fromAttrDict
   cases op
   case constant => exact HWConstantProperties.fromAttrDict attrDict
   case module => exact HWModuleProperties.fromAttrDict attrDict
+  case «instance» => exact HWInstanceProperties.fromAttrDict attrDict
   all_goals exact .ok ()
 
 def HW.toAttrDict
@@ -45,6 +48,14 @@ def HW.toAttrDict
     let dict := dict.insert "module_type".toUTF8 (.hwModuleType props.module_type)
     let dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
     let dict := dict.insert "per_port_attrs".toUTF8 (.arrayAttr props.per_port_attrs)
+    let dict := dict.insert "parameters".toUTF8 (.arrayAttr props.parameters)
+    dict
+  | .instance => Id.run do
+    let dict := Std.HashMap.emptyWithCapacity 5
+    let dict := dict.insert "instanceName".toUTF8 (.stringAttr props.instanceName)
+    let dict := dict.insert "moduleName".toUTF8 (.flatSymbolRefAttr props.moduleName)
+    let dict := dict.insert "argNames".toUTF8 (.arrayAttr props.argNames)
+    let dict := dict.insert "resultNames".toUTF8 (.arrayAttr props.resultNames)
     let dict := dict.insert "parameters".toUTF8 (.arrayAttr props.parameters)
     dict
   | _ => Std.HashMap.emptyWithCapacity 0
@@ -105,6 +116,12 @@ def HW.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     pure ()
   | .output => do
     op.verifyTerminatorCounts ctx opIn 0
+    pure ()
+  | .instance => do
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
     pure ()
 
 /-- Materialize integer results as `hw.constant`. -/

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -36,6 +36,10 @@ def HW.fromAttrDict
   case «instance» => exact HWInstanceProperties.fromAttrDict attrDict
   all_goals exact .ok ()
 
+/--
+We chose not to add support for `inner_sym` and `doNotPrint` for `instance`
+because we don't have support for circt::hw::InnerSymAttr and mlir::UnitAttr yet.
+-/
 def HW.toAttrDict
     (op : HW) (props : HW.propertiesOf op) :
     Std.HashMap ByteArray Attribute :=

--- a/Veir/Dialects/HW/OpInfo.lean
+++ b/Veir/Dialects/HW/OpInfo.lean
@@ -27,6 +27,10 @@ match op with
 | .instance => HWInstanceProperties
 | _ => Unit
 
+/--
+We chose not to add support for `inner_sym` and `doNotPrint` for `instance`
+because we don't have support for circt::hw::InnerSymAttr and mlir::UnitAttr yet.
+-/
 def HW.fromAttrDict
     (op : HW) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String (HW.propertiesOf op) := by
@@ -36,10 +40,6 @@ def HW.fromAttrDict
   case «instance» => exact HWInstanceProperties.fromAttrDict attrDict
   all_goals exact .ok ()
 
-/--
-We chose not to add support for `inner_sym` and `doNotPrint` for `instance`
-because we don't have support for circt::hw::InnerSymAttr and mlir::UnitAttr yet.
--/
 def HW.toAttrDict
     (op : HW) (props : HW.propertiesOf op) :
     Std.HashMap ByteArray Attribute :=

--- a/Veir/Dialects/HW/Properties.lean
+++ b/Veir/Dialects/HW/Properties.lean
@@ -34,6 +34,14 @@ structure HWModuleProperties where
   parameters : ArrayAttr
 deriving Inhabited, Repr, Hashable, DecidableEq
 
+structure HWInstanceProperties where
+  instanceName : StringAttr
+  moduleName : FlatSymbolRefAttr
+  argNames : ArrayAttr
+  resultNames : ArrayAttr
+  parameters : ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
 def HWModuleProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String HWModuleProperties := do
   let some module_type := attrDict["module_type".toUTF8]? | throw "hw.module: requires attribute 'module_type'"
@@ -49,6 +57,26 @@ def HWModuleProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
   let .arrayAttr parameters := parameters | throw s!"hw.module: expected 'parameters' to be an array attribute, but got {parameters}"
 
   return { module_type, sym_name, per_port_attrs, parameters }
+
+def HWInstanceProperties.fromAttrDict
+    (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String HWInstanceProperties := do
+  let some instanceName := attrDict["instanceName".toUTF8]? | throw "hw.instance: requires attribute 'instanceName'"
+  let .stringAttr instanceName := instanceName | throw s!"hw.instance: expected 'instanceName' to be a string attribute, but got {instanceName}"
+
+  let some moduleName := attrDict["moduleName".toUTF8]? | throw "hw.instance: requires attribute 'moduleName'"
+  let .flatSymbolRefAttr moduleName := moduleName | throw s!"hw.instance: expected 'moduleName' to be a flat symbol reference attribute, but got {moduleName}"
+
+  let some argNames := attrDict["argNames".toUTF8]? | throw "hw.instance: requires attribute 'argNames'"
+  let .arrayAttr argNames := argNames | throw s!"hw.instance: expected 'argNames' to be an array attribute, but got {argNames}"
+
+  let some resultNames := attrDict["resultNames".toUTF8]? | throw "hw.instance: requires attribute 'resultNames'"
+  let .arrayAttr resultNames := resultNames | throw s!"hw.instance: expected 'resultNames' to be an array attribute, but got {resultNames}"
+
+  let some parameters := attrDict["parameters".toUTF8]? | throw "hw.instance: requires attribute 'parameters'"
+  let .arrayAttr parameters := parameters | throw s!"hw.instance: expected 'parameters' to be an array attribute, but got {parameters}"
+
+  return { instanceName, moduleName, argNames, resultNames, parameters }
 
 end
 


### PR DESCRIPTION
This patch adds support to `instanceName`, `moduleName`, `argNames`, `resultNames`, and `parameters` attributes from the `hw` dialect. 

Fixes #1318
