### PR TITLE
feat(pass): add `apply-patterns` pass

### DIFF
--- a/Test/Passes/ApplyPatterns/select_patterns.mlir
+++ b/Test/Passes/ApplyPatterns/select_patterns.mlir
@@ -1,0 +1,27 @@
+// RUN: veir-opt %s '-p=apply-patterns{muli-two-to-addi}' | filecheck %s --check-prefix=SELECTED
+// RUN: veir-opt %s '-p=apply-patterns{addi-zero-to-x}' | filecheck %s --check-prefix=UNSELECTED
+
+"builtin.module"() ({
+  "func.func"() <{function_type = () -> (), sym_name = "main"}> ({
+    ^bb0():
+      %two = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
+      %x = "test.test"() : () -> i32
+      %mul_two = "llvm.mul"(%x, %two) : (i32, i32) -> i32
+      "test.test"(%mul_two) : (i32) -> ()
+      "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// The muli-two-to-addi is selected, so the optimization triggered
+
+// SELECTED:     %[[X:.*]] = "test.test"() : () -> i32
+// SELECTED-NEXT: %[[ADD:.*]] = "llvm.add"(%[[X]], %[[X]]) : (i32, i32) -> i32
+// SELECTED-NEXT: "test.test"(%[[ADD]]) : (i32) -> ()
+// SELECTED-NOT: "llvm.mul"
+
+// The muli-two-to-addi is unselected, so the optimization did not trigger
+
+// UNSELECTED:     %[[TWO:.*]] = "llvm.mlir.constant"() <{"value" = 2 : i32}> : () -> i32
+// UNSELECTED-NEXT: %[[X:.*]] = "test.test"() : () -> i32
+// UNSELECTED-NEXT: %[[MUL:.*]] = "llvm.mul"(%[[X]], %[[TWO]]) : (i32, i32) -> i32
+// UNSELECTED-NEXT: "test.test"(%[[MUL]]) : (i32) -> ()

--- a/Veir/Passes/ApplyPatterns.lean
+++ b/Veir/Passes/ApplyPatterns.lean
@@ -1,0 +1,58 @@
+module
+
+public import Veir.Pass
+public import Veir.PatternRewriter.Basic
+
+import all Veir.Passes.InstCombine
+
+namespace Veir
+
+/-!
+  # Apply patterns pass
+
+  Applies a command-line-selected set of peephole rewrite patterns. Each pattern is
+  exposed as a boolean pass option and is disabled by default, so a pipeline can
+  request exactly the desired rewrites, for example:
+
+  `apply-patterns{muli-two-to-addi addi-zero-to-x}`
+
+  Currently, only the patterns from `Veir.Passes.InstCombine` are available.
+-/
+
+/-- The peephole patterns selectable through `ApplyPatternsPass`. -/
+def applyPatterns : List (String × RewritePattern OpCode) := [
+  ("muli-two-to-addi", mulITwoToAddi),
+  ("muli-zero-to-cst", mulIZeroToCst),
+  ("muli-one-to-x", mulIOneToX),
+  ("addi-zero-to-x", addiZeroToX),
+  ("subi-zero-to-x", subiZeroToX),
+  ("subi-self-to-zero", subiSelfToZero),
+  ("andi-self-to-x", andiSelfToX),
+  ("andi-zero-to-zero", andiZeroToZero),
+  ("ori-zero-to-x", oriZeroToX),
+  ("ori-self-to-x", oriSelfToX),
+  ("xori-zero-to-x", xoriZeroToX),
+  ("xori-self-to-zero", xoriSelfToZero),
+  ("not-not-to-x", notNotToX),
+  ("de-morgan-and-to-or", deMorganAndToOr),
+  ("de-morgan-or-to-and", deMorganOrToAnd)
+]
+
+def ApplyPatternsPass.impl (options : PassOptions) (ctx : WfIRContext OpCode)
+    (op : OperationPtr) (_ : op.InBounds ctx.raw) :
+    ExceptT String IO (WfIRContext OpCode) := do
+  let patterns := applyPatterns.foldl (init := #[]) fun selected (name, pattern) =>
+    if (options.get? name).getD false then selected.push pattern else selected
+  let pattern := RewritePattern.GreedyRewritePattern patterns
+  match RewritePattern.applyInContext pattern ctx with
+  | none => throw "Error while applying pattern rewrites"
+  | some ctx => pure ctx
+
+public def ApplyPatternsPass : Pass OpCode :=
+  { name := "apply-patterns"
+    description := "Apply a selected set of peephole rewrite patterns."
+    options := .ofList (applyPatterns.map fun (name, _) =>
+      (name, { description := s!"Enable the '{name}' rewrite pattern." }))
+    run := ApplyPatternsPass.impl }
+
+end Veir

--- a/VeirOpt.lean
+++ b/VeirOpt.lean
@@ -4,6 +4,7 @@ import Veir.Panic
 
 import Veir.Passes.PrintIR
 import Veir.Passes.InstCombine
+import Veir.Passes.ApplyPatterns
 import Veir.Passes.CSE
 import Veir.Passes.InstructionSelection.RISCV64
 import Veir.Passes.InstructionSelection.RISCV64Sdag
@@ -27,6 +28,7 @@ open Veir
 def availablePasses : Std.HashMap String (Pass OpCode) :=
   ([ PrintIRPass,
      InstCombinePass,
+     ApplyPatternsPass,
      CSEPass,
      IselRISCV64,
      IselSDAG,


### PR DESCRIPTION
This pass takes as input a set of strings that represent peephole rewrites, and apply the peephole rewrites until a fixpoint in the given IR.

It is currently limited to `Veir.Passes.InstCombine` rules, but the goal is to extend it with all available peephole rewrites in the future.