### PR TITLE
feat (PBV): Support append operations.

### DIFF
--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -35,7 +35,7 @@ example {w t v: Nat} (a b : BitVec w)
   (hqw : w ≤ t)
   (hv : t = v + w)
   (bound : t ≤ 32):
-  a + b = ((exta ++ a) + (extb ++ b)).zeroExtend w
+  a + b = ((exta ++ a) + (extb ++ b)).setWidth w
   := by
   pbv_decide 16
   · bv_decide

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -29,3 +29,16 @@ example (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
   · bv_decide
   · grind
   · grind
+
+example {w t v: Nat} (a b : BitVec w)
+  (exta extb : BitVec v)
+  (hqw : w ≤ t)
+  (hv : t = v + w)
+  (bound : t ≤ 32):
+  a + b = ((exta ++ a) + (extb ++ b)).zeroExtend w
+  := by
+  pbv_decide 16
+  · bv_decide
+  · grind
+  · grind
+  · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -1,13 +1,13 @@
 import Veir.Meta.PBVDecide
 
-/-- Commutativity of addition -/
+/-- Commutativity of addition. -/
 example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
 
-/-- Commutativity of addition with definitionally-not-syntactically equal widths -/
+/-- Commutativity of addition with definitionally-not-syntactically equal widths. -/
 example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
@@ -15,9 +15,17 @@ example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
   · grind
   · grind
 
-/-- Commutativity of addition for three variables -/
+/-- Commutativity of addition for three variables. -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
   pbv_decide 4
   · bv_decide
+  · grind
+
+/-- Appending and adding. -/
+example (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
+  (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b) := by
+  pbv_decide 8
+  · bv_decide
+  · grind
   · grind

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -1,13 +1,13 @@
 import Veir.Meta.PBVDecide
 
-/-- Commutativity of addition. -/
+/-- Commutativity of addition -/
 example (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
   · bv_decide
   · grind
 
-/-- Commutativity of addition with definitionally-not-syntactically equal widths. -/
+/-- Commutativity of addition with definitionally-not-syntactically equal widths -/
 example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
   x + y = y + x := by
   pbv_decide 4
@@ -15,14 +15,14 @@ example (w : Nat) (x : BitVec (w + 0)) (y : BitVec w) (hw : w ≤ 4) :
   · grind
   · grind
 
-/-- Commutativity of addition for three variables. -/
+/-- Commutativity of addition for three variables -/
 example (w : Nat) (x y z : BitVec w) (hw : w ≤ 4) :
   x + y + z = y + x + z := by
   pbv_decide 4
   · bv_decide
   · grind
 
-/-- Appending and adding. -/
+/-- Appending and adding -/
 example (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
   (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b) := by
   pbv_decide 8
@@ -30,6 +30,7 @@ example (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
   · grind
   · grind
 
+/-- Extending, adding and truncating is the same as adding -/
 example {w t v: Nat} (a b : BitVec w)
   (exta extb : BitVec v)
   (hqw : w ≤ t)

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -45,8 +45,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 
 
 /-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
-    which is a single zero extension to `r`, since `p < q`.
--/
+    which is a single zero extension to `r`, since `p < q`. -/
 theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (h_qr : q < r)
@@ -74,8 +73,9 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
   have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
---   into a fact about the bitvector masks
-  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq h_pq
+--          into a fact about the bitvector masks
+  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq h_pq
+  have bv_q_lt_r := lt_eq_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr h_qr
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
@@ -120,8 +120,8 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
   have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
 -- Step 5B: Translate the condition on the natural number width
---   into a fact about the bitvector masks
-  have lt_pq := mask_lt_mask p_le_bw q_le_bw h_mp h_mq hpq
+--          into a fact about the bitvector masks
+  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq hpq
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
@@ -136,5 +136,45 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
     q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
                                    -- `setWidth_signExtend_eq_and_maskOfWidth`
   ] at h_xmp ⊢
+-- Step 8: BitBlast!
+  bv_decide
+
+/-- Manual trace of an append, whose result is twice as wide as its operands,
+    so the blast width has to cover `w + w` rather than just `w`. -/
+theorem trace_append (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
+  (a ++ b) + (b ++ a) = (a ++ a) + (b ++ b)
+  := by
+-- Step 1: Bound widths to the provided blast width. The blast width is 16, not
+--         8, because every append here has width `w + w`.
+  have w_le_bw : w ≤ 16 := by grind
+  have w_add_w_le_bw : w + w ≤ 16 := by grind
+-- Step 2-3: Introduce mask to replace `w` Nat var
+  apply width_elim 16 w
+  intro mw h_mw
+-- Step 4: Eliminate the parametric bv vars of width `w`
+--         enforcing width constraint with mask
+  revert a
+  apply var_elim w_le_bw
+  intro a h_amw
+  revert b
+  apply var_elim w_le_bw
+  intro b h_bmw
+-- Step 5: Convert width hypothesis to mask hypothesis
+  have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
+  have w_add_w_mask := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_bw w_le_bw w_add_w_le_bw h_mw h_mw
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
+  simp only [
+    eq_iff (o := 16),
+    setWidth_add,
+    setWidth_append_eq_or_mul_maskOfWidth_add_one (o := 16),
+    setWidth_setWidth,
+    w_add_w_le_bw,                 -- Lets simp discharge the `v + w ≤ o` side condition of
+                                   -- `setWidth_append_eq_or_mul_maskOfWidth_add_one`
+    w_le_bw,
+    ← h_mw,
+    BitVec.setWidth_eq
+  ]
+-- Step 7: Rewrite the mask into the hypotheses too
+  simp only [← h_mw] at h_amw h_bmw
 -- Step 8: BitBlast!
   bv_decide

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -45,7 +45,8 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
 
 
 /-- Manual trace of a zero extension to `q` followed by a zero extension to `r`,
-    which is a single zero extension to `r`, since `p < q`. -/
+    which is a single zero extension to `r`, since `p < q`.
+-/
 theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (h_qr : q < r)
@@ -148,33 +149,33 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
 --         8, because every append here has width `w + w`.
   have w_le_bw : w ≤ 16 := by grind
   have w_add_w_le_bw : w + w ≤ 16 := by grind
--- Step 2-3: Introduce mask to replace `w` Nat var
+-- Step 2-3: Introduce mask to replace `w` Nat var.
   apply width_elim 16 w
   intro mw h_mw
 -- Step 4: Eliminate the parametric bv vars of width `w`
---         enforcing width constraint with mask
+--         enforcing width constraint with mask.
   revert a
   apply var_elim w_le_bw
   intro a h_amw
   revert b
   apply var_elim w_le_bw
   intro b h_bmw
--- Step 5: Convert width hypothesis to mask hypothesis
+-- Step 5: Convert width hypothesis to mask hypothesis.
   have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
   have w_add_w_mask := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_bw w_le_bw w_add_w_le_bw h_mw h_mw
--- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down.
   simp only [
     eq_iff (o := 16),
     setWidth_add,
     setWidth_append_eq_or_mul_maskOfWidth_add_one (o := 16),
     setWidth_setWidth,
     w_add_w_le_bw,                 -- Lets simp discharge the `v + w ≤ o` side condition of
-                                   -- `setWidth_append_eq_or_mul_maskOfWidth_add_one`
+                                   -- `setWidth_append_eq_or_mul_maskOfWidth_add_one`.
     w_le_bw,
     ← h_mw,
     BitVec.setWidth_eq
   ]
--- Step 7: Rewrite the mask into the hypotheses too
+-- Step 7: Rewrite the mask into the hypotheses too.
   simp only [← h_mw] at h_amw h_bmw
 -- Step 8: BitBlast!
   bv_decide

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -60,6 +60,29 @@ theorem setWidth_eq_and_maskOfWidth {o w : Nat} {a : BitVec w} {b : BitVec o}
   apply BitVec.eq_of_toNat_eq
   rw [toNat_and_maskOfWidth h, BitVec.toNat_setWidth_of_le h, hab]
 
+/-- Adding one to a mask makes it a `BitVec.twoPow`. -/
+theorem maskOfWidth_add_one_eq_twoPow {o w : Nat} (h : w ≤ o) :
+    maskOfWidth o w + 1#o = BitVec.twoPow o w := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_add, toNat_maskOfWidth h, BitVec.toNat_twoPow]
+  cases o
+  · have w_zero : w = 0 := by grind
+    simp [w_zero]
+  · congr
+    simp [BitVec.toNat_ofNat, Nat.mod_eq_of_lt]
+    grind
+
+/-- A mask is `BitVec.twoPow` minus one. -/
+theorem maskOfWidth_eq_twoPow_sub_one {o w : Nat} (h : w ≤ o) :
+    maskOfWidth o w = BitVec.twoPow o w - 1#o := by
+  apply BitVec.eq_of_toNat_eq
+  grind [maskOfWidth_add_one_eq_twoPow]
+
+/-- Every mask of blast width `0` is the empty bitvector. -/
+@[simp] theorem maskOfWidth_zero_eq_zero {w : Nat} : maskOfWidth 0 w = 0#0 := by
+  apply BitVec.eq_of_toNat_eq
+  simp [maskOfWidth, Nat.mod_one]
+
 /-- The `i`th bit of `maskOfWidth o w` is enabled iff
 the index `i` is inbounds of `o` and `w`. -/
 @[simp] theorem getLsbD_maskOfWidth {o w : Nat} (i : Nat) :

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -36,27 +36,6 @@ theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h
       Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
   exact hw₁w₂
 
-/-- `≤` on the widths translates to `≤` on the masks. -/
-theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by
-  subst m₁ m₂
-  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
-      Nat.sub_le_sub_iff_right (by grind), Nat.pow_le_pow_iff_right (by grind)]
-  exact hw₁w₂
-
-/-- `≥` on the widths translates to `≥` on the masks. -/
-theorem ge_eq_ge_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ ≥ w₂) : (m₁ ≥ m₂) := by
-  grind [le_eq_le_of_eq_maskOfWidth]
-
-/-- `>` on the widths translates to `>` on the masks. -/
-theorem gt_eq_gt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ > w₂) : (m₁ > m₂) := by
-  grind [lt_eq_lt_of_eq_maskOfWidth]
-
 /-- Adding widths becomes multiplying masks: `2^(w₁ + w₂) - 1` is
 `2^w₁ * 2^w₂ - 1`, written in terms of the masks `m₁` and `m₂`. -/
 theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o}

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -25,6 +25,50 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
   apply propext
   exact ⟨fun hab => hab ▸ rfl, fun hab => BitVec.setWidth_inj h hab⟩
 
+/-! ## Translating `Nat` width relations and arithmetic into mask operations -/
+
+/-- `<` on the widths translates to `<` on the masks. -/
+theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ < w₂) : (m₁ < m₂) := by
+  subst m₁ m₂
+  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
+  exact hw₁w₂
+
+/-- `≤` on the widths translates to `≤` on the masks. -/
+theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      Nat.sub_le_sub_iff_right (by grind), Nat.pow_le_pow_iff_right (by grind)]
+  exact hw₁w₂
+
+/-- `≥` on the widths translates to `≥` on the masks. -/
+theorem ge_eq_ge_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ ≥ w₂) : (m₁ ≥ m₂) := by
+  grind [le_eq_le_of_eq_maskOfWidth]
+
+/-- `>` on the widths translates to `>` on the masks. -/
+theorem gt_eq_gt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ > w₂) : (m₁ > m₂) := by
+  grind [lt_eq_lt_of_eq_maskOfWidth]
+
+/-- Adding widths becomes multiplying masks: `2^(w₁ + w₂) - 1` is
+`2^w₁ * 2^w₂ - 1`, written in terms of the masks `m₁` and `m₂`. -/
+theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o}
+    (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
+    maskOfWidth o (w₁ + w₂) = (m₁ + 1#o) * (m₂ + 1#o) - 1#o := by
+  cases o
+  · simp [hm₁, hm₂, maskOfWidth_zero_eq_zero]
+  · rw [hm₁, maskOfWidth_add_one_eq_twoPow h₁, hm₂, maskOfWidth_add_one_eq_twoPow h₂,
+      BitVec.twoPow_mul_twoPow_eq]
+    apply maskOfWidth_eq_twoPow_sub_one h₁₂
+
 /-! ## Pushing `setWidth o` towards the leaves — leaves and width changes -/
 
 theorem setWidth_setWidth {w o : Nat} (h : w ≤ o) :
@@ -65,6 +109,32 @@ theorem setWidth_signExtend_eq_and_maskOfWidth {t v o : Nat} (hvo : v ≤ o) :
     rw [BitVec.getLsbD_of_ge a i (by lia)]
     cases hmsb : a.msb <;>
       simp [hiv, getLsbD_maskOfWidth, Bool.and_comm]
+
+/-- `a ++ b` shifts `a` up by the width of `b`; at the blast width that shift
+is a multiplication by `2^w = maskOfWidth o w + 1`, and the two halves no
+longer overlap, so they can be recombined with `|||`. -/
+theorem setWidth_append_eq_or_mul_maskOfWidth_add_one {w o : Nat} (h : w ≤ o) :
+    ∀ {v : Nat} (a : BitVec v) (b : BitVec w), v + w ≤ o →
+      (a ++ b).setWidth o
+        = ((a.setWidth o) * (maskOfWidth o w + 1#o)) ||| b.setWidth o := by
+  intro v a b hvw
+  have hv : v ≤ o := by lia
+  have ha : a.toNat * 2 ^ w < 2 ^ o := by
+    calc a.toNat * 2 ^ w < 2 ^ v * 2 ^ w :=
+          Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
+      _ = 2 ^ (v + w) := (Nat.pow_add 2 v w).symm
+      _ ≤ 2 ^ o := Nat.pow_le_pow_right (by lia) hvw
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_setWidth_of_le hvw, BitVec.toNat_or, BitVec.toNat_append,
+      BitVec.toNat_setWidth_of_le h, BitVec.toNat_mul, BitVec.toNat_add,
+      BitVec.toNat_setWidth_of_le hv, toNat_maskOfWidth h, BitVec.toNat_ofNat]
+  congr 1
+  have h2 : (2 ^ w - 1 + 1 % 2 ^ o) % 2 ^ o = 2 ^ w % 2 ^ o := by
+    rw [Nat.add_mod_mod]
+    congr 1
+    have := Nat.two_pow_pos w
+    lia
+  rw [h2, Nat.mul_mod_mod, Nat.shiftLeft_eq, Nat.mod_eq_of_lt ha]
 
 /-! ### The sign bit: a test against the mask's top bit -/
 

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -97,23 +97,14 @@ theorem setWidth_append_eq_or_mul_maskOfWidth_add_one {w o : Nat} (h : w ≤ o) 
       (a ++ b).setWidth o
         = ((a.setWidth o) * (maskOfWidth o w + 1#o)) ||| b.setWidth o := by
   intro v a b hvw
-  have hv : v ≤ o := by lia
-  have ha : a.toNat * 2 ^ w < 2 ^ o := by
-    calc a.toNat * 2 ^ w < 2 ^ v * 2 ^ w :=
-          Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
-      _ = 2 ^ (v + w) := (Nat.pow_add 2 v w).symm
-      _ ≤ 2 ^ o := Nat.pow_le_pow_right (by lia) hvw
   apply BitVec.eq_of_toNat_eq
-  rw [BitVec.toNat_setWidth_of_le hvw, BitVec.toNat_or, BitVec.toNat_append,
-      BitVec.toNat_setWidth_of_le h, BitVec.toNat_mul, BitVec.toNat_add,
-      BitVec.toNat_setWidth_of_le hv, toNat_maskOfWidth h, BitVec.toNat_ofNat]
+  simp only [BitVec.toNat_or, BitVec.toNat_setWidth_of_le, hvw, h,
+      BitVec.toNat_append, maskOfWidth_add_one_eq_twoPow h,
+      BitVec.mul_twoPow_eq_shiftLeft, BitVec.toNat_shiftLeft]
   congr 1
-  have h2 : (2 ^ w - 1 + 1 % 2 ^ o) % 2 ^ o = 2 ^ w % 2 ^ o := by
-    rw [Nat.add_mod_mod]
-    congr 1
-    have := Nat.two_pow_pos w
-    lia
-  rw [h2, Nat.mul_mod_mod, Nat.shiftLeft_eq, Nat.mod_eq_of_lt ha]
+  rw [Nat.shiftLeft_eq, Nat.shiftLeft_eq, BitVec.toNat_setWidth_of_le (by lia), Nat.mod_eq_of_lt]
+  have a_lt_vw := Nat.mul_lt_mul_of_lt_of_le a.isLt (Nat.le_refl _) (Nat.two_pow_pos w)
+  grind [Nat.pow_le_pow_right (n := 2) (by lia) hvw]
 
 /-! ### The sign bit: a test against the mask's top bit -/
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -150,7 +150,8 @@ structure WidthInfo where
   widthMaskHypFvar : FVarId
   /-- The hypothesis that the width variable is less than the bmc bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- The FVar of the bound hypothesis, necessary so 'simp' rewrites with it. -/
+  /-- The hypothesis that the width variable is less than the bmc bound.
+      (FVar necessary so 'simp' rewrites with it.) -/
   hypWidthLeBoundNote : FVarId
 
 meta def WidthInfo.name (this : WidthInfo) : Name :=
@@ -182,14 +183,14 @@ meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
   let some reified ← Tm.reifyWidth this.env reducedExpr | pure none
   return this.infos[reified.toName]?
 
-meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos : WidthInfos)
-  : MetaM (MVarId × WidthInfos) := g.withContext do
+meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Apply width_elim
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.term.toExpr infos.env, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.toExpr infos.env, ← g.getType]
       | throwError m!"{``width_elim} should generate a goal"
     -- Intros
-    let name := widthTm.term.toName
+    let name := widthTm.toName
     let maskName := Name.mkSimple s!"m_{name}"
     let (#[mask, maskHyp], g) ← g.withContext
       <| g.introN 2 [maskName, Name.mkSimple s!"h_{maskName}"]
@@ -199,7 +200,7 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
       mkFreshExprMVar (mkAppN (Expr.const ``LE.le [.zero])
         #[mkConst ``Nat,
           mkConst ``instLENat,
-          widthTm.term.toExpr infos.env,
+          widthTm.toExpr infos.env,
           mkNatLit maxBound])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_blast") hypWidthLeBound
@@ -210,13 +211,44 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : WidthTm) (infos
 
     let info : WidthInfo := {
       widthName := name,
-      widthTm := widthTm.term,
+      widthTm := widthTm,
       widthMaskFvar := mask,
       widthMaskHypFvar := maskHyp
       hypWidthLeBoundMVarId := hypWidthLeBound.mvarId!,
       hypWidthLeBoundNote
     }
-    return (g, infos.push info)
+    return (g, info, infos.push info)
+
+meta def WidthInfos.getOrCreateTm (this : WidthInfos) (g : MVarId) (term : Tm .width) (maxBound : Nat)
+  : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
+  if let some info := this.getFromTm? term then -- use reified.toExpr as a kind of "normal"/"canonical" form
+    return (g, info, this)
+  else
+    introMaskWidth maxBound g term this
+
+meta def introMaskRec (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+  : MetaM (MVarId × WidthInfo × WidthInfos) :=
+
+  match widthTm with
+  | .widthAtom _ => infos.getOrCreateTm g widthTm maxBound
+  | .widthAdd v w => do
+    let (g, vInfo, infos) ← introMaskRec maxBound g v infos
+    let (g, wInfo, infos) ← introMaskRec maxBound g w infos
+    let (g, thisInfo, infos) ← infos.getOrCreateTm g widthTm maxBound
+
+    -- Apply the thoerem to convert a sum of widths into a product of masks
+    let (_hyp, g) ← g.withContext do
+      g.note (Name.mkSimple s!"htest") <|
+      ← mkAppM ``maskOfWidth_add_eq_mul_of_maskOfWidth #[
+        .fvar vInfo.hypWidthLeBoundNote,
+        .fvar wInfo.hypWidthLeBoundNote,
+        .fvar thisInfo.hypWidthLeBoundNote,
+        .fvar vInfo.widthMaskHypFvar,
+        .fvar wInfo.widthMaskHypFvar,
+      ]
+
+    return (g, thisInfo, infos)
+
 
 /--
 Pair of local facts about the converted `BitVec` variables.
@@ -315,10 +347,11 @@ meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateC
   -- Compute max width
   let maxWidth := widthTms.getUniverseWidthUpperBound ctx
   -- Intro all the masks
-  widthTms.terms.foldM (init := (g, { env := widthTms.env })) (fun (g, widthInfos) _ widthTm =>
-    introMaskWidth maxWidth g widthTm widthInfos
-  )
-
+  widthTms.terms.foldM
+    (init := (g, { env := widthTms.env }))
+    fun (g, widthInfos) _ widthTm => do
+      let (g, _, infos) ← introMaskRec maxWidth g widthTm.term widthInfos
+      return (g, infos)
 /--
 Eliminate the bitvector variables to introduce the masked versions.
 -/

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -62,6 +62,7 @@ Inductive data structure to express the terms that this tactic reasons about.
 -/
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
+| widthAdd (v w : Tm .width) : Tm .width
 
 /--
 Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
@@ -73,7 +74,13 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
     -- An atom is an expression that is present in the Env.
     pure <| some (.widthAtom id)
   else
-    pure none
+    match_expr e with
+    | HAdd.hAdd ty _ _ _ ae be =>
+        let .true := Expr.isNat ty | pure none
+        let some a ← Tm.reifyWidth env ae | pure none
+        let some b ← Tm.reifyWidth env be | pure none
+        pure (some (.widthAdd a b))
+    | _ => pure none
 
 /--
 Convert a `Tm` into an `Expr` given an environment.
@@ -81,6 +88,7 @@ Convert a `Tm` into an `Expr` given an environment.
 meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
   match this with
   | .widthAtom id => env.width2expr[id]!
+  | .widthAdd v w => mkNatAdd (v.toExpr env) (w.toExpr env)
 
 /--
 Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
@@ -88,6 +96,16 @@ Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable
 meta def Tm.toName (tm: Tm .width) : Name :=
   match tm with
   | .widthAtom e => Name.mkSimple s!"w{e}"
+  | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
+
+/--
+Compute how many bits are needed to hold this width's value without overflowing.
+The maximum over all widths gives the blast width used for the whole goal.
+-/
+meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
+  match tm with
+  | .widthAtom _ => ctx.bmcBound
+  | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
 
 structure WidthTm where
   term : Tm .width
@@ -111,6 +129,12 @@ meta def WidthTms.getOrCreateTm (g : MVarId) (this : WidthTms) (wExpr : Expr)
   else
     let widthTm := { term := reified }
     return (g, widthTm, this.push widthTm)
+
+/-- Get the maximum width needed for blasting across all widths. -/
+meta def WidthTms.getUniverseWidthUpperBound (this : WidthTms)
+    (ctx : PbvTranslateContext) : Nat :=
+  this.terms.fold (fun val _e wTm =>
+    val.max (wTm.term.getUniverseWidthUpperBound ctx)) ctx.bmcBound
 
 /--
 Information about the width variable and associated hypotheses.
@@ -288,9 +312,11 @@ meta partial def visitExprRec (g : MVarId)
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
+  -- Compute max width
+  let maxWidth := widthTms.getUniverseWidthUpperBound ctx
   -- Intro all the masks
   widthTms.terms.foldM (init := (g, { env := widthTms.env })) (fun (g, widthInfos) _ widthTm =>
-    introMaskWidth ctx.bmcBound g widthTm widthInfos
+    introMaskWidth maxWidth g widthTm widthInfos
   )
 
 /--
@@ -305,12 +331,13 @@ These theorems require pre-filling the width bound in order to be used within
 the Simp set.
 -/
 meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
-  (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
+  (widthTms : WidthTms) (simp : SimpTheoremsArray) :
+    MetaM SimpTheoremsArray := g.withContext do
   let thms := #[``eq_iff]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name)
-      <| ← mkAppM name #[mkNatLit <| ctx.bmcBound]
+      <| ← mkAppM name #[mkNatLit <| widthTms.getUniverseWidthUpperBound ctx]
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -321,6 +348,7 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
       ``BitVec.setWidth_eq,
       ``setWidth_add,
       ``setWidth_setWidth,
+      ``setWidth_append_eq_or_mul_maskOfWidth_add_one,
   ]
 
   let mut simp := simp
@@ -371,7 +399,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Create simp set
-  let thms := ← addBoundRewrites g ctx
+  let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -99,7 +99,7 @@ meta def Tm.toName (tm: Tm .width) : Name :=
   | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
 
 /--
-Compute how many bits are needed to hold this width's value without overflowing.
+Compute an upper bound of the width of a width term.
 The maximum over all widths gives the blast width used for the whole goal.
 -/
 meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
@@ -126,13 +126,13 @@ meta def WidthTms.push (this : WidthTms) (width : WidthTm) : WidthTms :=
 { terms := this.terms.insert (width.term.toName) width, env := this.env }
 
 /--
-Either get existing width term, or try and reify one if it does not exist.
+Reify a width term, and either get and existing term, or create one.
 -/
 meta def WidthTms.getOrCreateTm (g : MVarId) (this : WidthTms) (wExpr : Expr)
   : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
   let some reified ← Tm.reifyWidth this.env wExpr
     | throwError m!"Failed to reify width expr: {wExpr}"
-  if let some info := this.terms[reified.toName]? then -- use reified.toExpr as a kind of "normal"/"canonical" form
+  if let some info := this.terms[reified.toName]? then
     return (g, info, this)
   else
     let widthTm := { term := reified }
@@ -150,16 +150,17 @@ Information about the width variable and associated hypotheses.
 structure WidthInfo where
   /-- The Name corresponding to this width. -/
   widthName : Name
-  /-- The Expr corresponding to this width. -/
+  /-- The `Tm` corresponding to this width. -/
   widthTm : Tm .width
   /-- The FVarId corresponding to the new mask variable for this width. -/
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
   widthMaskHypFvar : FVarId
-  /-- The hypothesis that the width variable is less than the blast bound. -/
+  /-- The proof obligation that the width variable is less than or equal to
+      the blast bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- The hypothesis that the width variable is less than the blast bound.
-      (FVar necessary so 'simp' rewrites with it.) -/
+  /-- The hypothesis that the width variable is less than or equal to the blast
+      bound. -/
   hypWidthLeBoundNote : FVarId
 
 meta def WidthInfo.name (this : WidthInfo) : Name :=
@@ -192,8 +193,8 @@ meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
   return this.infos[reified.toName]?
 
 /--
-Given a width term (`widthTm`), introduce the a `BitVec` variable correspoding
-to the mask of that width. Then introduce hypothesis bounding the width to the
+Given a width term (`widthTm`), introduce a `BitVec` variable corresponding
+to the mask of that width. Then introduce a hypothesis bounding the width to the
 provided `maxBound` and enforce it as a mask with `maskOfWidth_and_add_one_eq_zero`.
 -/
 meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
@@ -324,7 +325,7 @@ meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (
   else { bvs := this.bvs.insert fvar widthTm }
 
 /--
-Given an expression, if it is of `BitVec w` type then create a mask for the
+Given an expression, if it is of `BitVec w` type then create a term `Tm` for the
 width `w`. If it is also an FVar, then it means it's a variable hence it has to
 be added to the set of FVars to be reverted.
 -/
@@ -343,9 +344,8 @@ meta def visitExprNonrec (g : MVarId)
     return (g, widthTms, bvs)
 
 /--
-Visit an expression, collecting all widths and introducing mask variables.
-For bitvectors, collect the bitvectors that need to be eliminated,
-and then eliminate them all in the next step.
+Visit an expression, collecting all widths and all bitvectors `FVars` that
+correspond to individual bitvector variables.
 -/
 meta partial def visitExprRec (g : MVarId)
     (widthTms : WidthTms) (bvs : BitVecFVarsToRevert)
@@ -469,13 +469,12 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 
 /--
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
-parametric bitvector formula, containing a single-width parameter, into a
-concrete width formula.
+parametric bitvector formula into a concrete width formula.
 
 The tactic generates multiple goals:
 1. The desired concrete width formula that can be decided using `bv_decide`
 2. Multiple side-goals to prove that the width parameters are bounded by the
-provided bound, these should be solvable by grind.
+computed blast width, these should be solvable by grind.
 -/
 syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num) : tactic
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -156,9 +156,9 @@ structure WidthInfo where
   widthMaskFvar : FVarId
   /-- The FVarId of the pure-BV hypothesis that this width is a mask variable. -/
   widthMaskHypFvar : FVarId
-  /-- The hypothesis that the width variable is less than the bmc bound. -/
+  /-- The hypothesis that the width variable is less than the blast bound. -/
   hypWidthLeBoundMVarId : MVarId
-  /-- The hypothesis that the width variable is less than the bmc bound.
+  /-- The hypothesis that the width variable is less than the blast bound.
       (FVar necessary so 'simp' rewrites with it.) -/
   hypWidthLeBoundNote : FVarId
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -79,7 +79,7 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
         let .true := Expr.isNat ty | pure none
         let some a ← Tm.reifyWidth env ae | pure none
         let some b ← Tm.reifyWidth env be | pure none
-        pure (some (.widthAdd a b))
+        return some (widthAdd a b)
     | _ => pure none
 
 /--
@@ -107,11 +107,19 @@ meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateConte
   | .widthAtom _ => ctx.bmcBound
   | .widthAdd wa wb => wa.getUniverseWidthUpperBound ctx + wb.getUniverseWidthUpperBound ctx
 
+/--
+Structure to hold a width term.
+-/
 structure WidthTm where
   term : Tm .width
 
+/--
+Collect width terms into one data structure.
+-/
 structure WidthTms where
+  /-- The width environment mapping `.atoms` to `Expr` -/
   env : TmWidthEnv
+  /-- The HashMap mapping a Name to a `WidthTm`. -/
   terms: HashMap Name WidthTm := {}
 
 meta def WidthTms.push (this : WidthTms) (width : WidthTm) : WidthTms :=
@@ -183,6 +191,11 @@ meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
   let some reified ← Tm.reifyWidth this.env reducedExpr | pure none
   return this.infos[reified.toName]?
 
+/--
+Given a width term (`widthTm`), introduce the a `BitVec` variable correspoding
+to the mask of that width. Then introduce hypothesis bounding the width to the
+provided `maxBound` and enforce it as a mask with `maskOfWidth_and_add_one_eq_zero`.
+-/
 meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Apply width_elim
@@ -219,16 +232,23 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (inf
     }
     return (g, info, infos.push info)
 
+/--
+Get the mask corresponding to a `Tm` from the `WidthInfos` if it exists, else
+create it and return the updated `WidthInfos`.
+-/
 meta def WidthInfos.getOrCreateTm (this : WidthInfos) (g : MVarId) (term : Tm .width) (maxBound : Nat)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-  if let some info := this.getFromTm? term then -- use reified.toExpr as a kind of "normal"/"canonical" form
+  if let some info := this.getFromTm? term then
     return (g, info, this)
   else
     introMaskWidth maxBound g term this
 
+/--
+Recurse through a `.width Tm`, converting `Nat` term into a `BitVec` mask, and
+translating relations on the terms into relations on the `BitVec` (eg. add).
+-/
 meta def introMaskRec (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) :=
-
   match widthTm with
   | .widthAtom _ => infos.getOrCreateTm g widthTm maxBound
   | .widthAdd v w => do
@@ -341,6 +361,10 @@ meta partial def visitExprRec (g : MVarId)
   else
     return (g, widthTms, bvs)
 
+/--
+Given the width terms in the formula, translate all `Nat` widths into `BitVec`
+masks and introduce hypothesis to model the masks.
+-/
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
@@ -352,6 +376,7 @@ meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateC
     fun (g, widthInfos) _ widthTm => do
       let (g, _, infos) ← introMaskRec maxWidth g widthTm.term widthInfos
       return (g, infos)
+
 /--
 Eliminate the bitvector variables to introduce the masked versions.
 -/
@@ -359,6 +384,7 @@ meta def introMaskedBitvectors (bvs : BitVecFVarsToRevert) (g : MVarId)
     (widthInfos : WidthInfos) : MetaM (MVarId × BitVecInfos) := do
   bvs.bvs.foldM (init := (g, {})) fun (g, bvInfos) bvFvarId widthTm => do
     introBitvecFVarUnchecked widthInfos g bvInfos bvFvarId widthTm
+
 /--
 These theorems require pre-filling the width bound in order to be used within
 the Simp set.

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -11,8 +11,8 @@ namespace Veir.Data.PBV
 Read-only configuration for the tactic.
 -/
 meta structure PbvTranslateContext where
-  /-- The bound upto which we want to bitblast our widths. -/
-   bmcBound : Nat
+  /-- The bound up to which we want to bitblast our widths. -/
+  bmcBound : Nat
 
 meta def Expr.isNat (e : Expr) : Bool := e.isConstOf ``Nat
 
@@ -26,7 +26,7 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
   | _ => none
 
 /--
-An environment that maps width atoms in `Tm` into its `Expr`
+An environment that maps the width atoms of a `Tm` to their `Expr`s.
 -/
 meta structure TmWidthEnv where
   width2expr : Array Expr := #[]
@@ -40,7 +40,7 @@ expressions. These are either width `Expr`s coming from `BitVec w` or
 `Nat` variables in the local context.
 -/
 meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
-  (← getLCtx).foldrM (init := {}) fun ldecl (widthEnv : TmWidthEnv ) => do
+  (← getLCtx).foldrM (init := {}) fun ldecl (widthEnv : TmWidthEnv) => do
       if let some width := getBitvecType? ldecl.type then
         let some _ := widthEnv.width2expr.idxOf? width | pure <| widthEnv.push width
         pure widthEnv
@@ -52,7 +52,7 @@ meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
 
 /--
 Type to capture the expressions this tactic will handle.
-Only capture `width` at the moment.
+Only captures `width` at the moment.
 -/
 inductive TmKind
 | width
@@ -65,7 +65,7 @@ inductive Tm : TmKind → Type
 | widthAdd (v w : Tm .width) : Tm .width
 
 /--
-Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
+Function to reify an `Expr` into a `Tm`. This function constructs the tree holding
 the width term. The environment holds the 'atom' `Expr`s which are the building
 blocks of the terms.
 -/
@@ -93,13 +93,14 @@ meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
 /--
 Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
 -/
-meta def Tm.toName (tm: Tm .width) : Name :=
+meta def Tm.toName (tm : Tm .width) : Name :=
   match tm with
   | .widthAtom e => Name.mkSimple s!"w{e}"
   | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
 
 /--
-Compute an upper bound of the width of a width term.
+Compute an upper bound on the value of this width term: an atom is bounded by
+the bmc bound, and a sum by the sum of the bounds of its parts.
 The maximum over all widths gives the blast width used for the whole goal.
 -/
 meta def Tm.getUniverseWidthUpperBound (tm : Tm .width) (ctx : PbvTranslateContext) : Nat :=
@@ -117,16 +118,17 @@ structure WidthTm where
 Collect width terms into one data structure.
 -/
 structure WidthTms where
-  /-- The width environment mapping `.atoms` to `Expr` -/
+  /-- The width environment mapping `.atoms` to `Expr`. -/
   env : TmWidthEnv
   /-- The HashMap mapping a Name to a `WidthTm`. -/
-  terms: HashMap Name WidthTm := {}
+  terms : HashMap Name WidthTm := {}
 
 meta def WidthTms.push (this : WidthTms) (width : WidthTm) : WidthTms :=
 { terms := this.terms.insert (width.term.toName) width, env := this.env }
 
 /--
-Reify a width term, and either get and existing term, or create one.
+Reify the width `Expr`, then either return the term already stored under that
+name, or create and store a new one.
 -/
 meta def WidthTms.getOrCreateTm (g : MVarId) (this : WidthTms) (wExpr : Expr)
   : MetaM (MVarId × WidthTm × WidthTms) := g.withContext do
@@ -169,8 +171,8 @@ meta def WidthInfo.name (this : WidthInfo) : Name :=
 structure WidthInfos where
   /-- One WidthInfo per width -/
   infos : HashMap Name WidthInfo := {}
-  /-- Width Environemnt -/
-  env: TmWidthEnv
+  /-- Width environment. -/
+  env : TmWidthEnv
 
 meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
   { infos := this.infos.insert (info.widthTm.toName) info, env := this.env }
@@ -184,7 +186,7 @@ meta def WidthInfos.getFromTm? (this : WidthInfos) (wTm : Tm .width) : Option Wi
 /--
 Get WidthInfo from an Expr.
 -/
-meta def WidthInfos.getFromExpr? (this: WidthInfos) (wExpr : Expr)
+meta def WidthInfos.getFromExpr? (this : WidthInfos) (wExpr : Expr)
     : MetaM (Option WidthInfo) := do
   -- Reduce the expression (allows for cases such as (w + 0) to be reduced to w).
   let reducedExpr ← whnf wExpr
@@ -257,9 +259,9 @@ meta def introMaskRec (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos
     let (g, wInfo, infos) ← introMaskRec maxBound g w infos
     let (g, thisInfo, infos) ← infos.getOrCreateTm g widthTm maxBound
 
-    -- Apply the thoerem to convert a sum of widths into a product of masks
+    -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
     let (_hyp, g) ← g.withContext do
-      g.note (Name.mkSimple s!"htest") <|
+      g.note (Name.mkSimple s!"h_{widthTm.toName}_mask_mul") <|
       ← mkAppM ``maskOfWidth_add_eq_mul_of_maskOfWidth #[
         .fvar vInfo.hypWidthLeBoundNote,
         .fvar wInfo.hypWidthLeBoundNote,
@@ -272,7 +274,8 @@ meta def introMaskRec (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos
 
 
 /--
-Pair of local facts about the converted `BitVec` variables.
+The `BitVec` variable that a parametric-width variable was converted into,
+together with the hypothesis constraining it.
 -/
 meta structure BitVecInfo where
   /-- The FVarId corresponding to the new concrete-width variable. -/
@@ -291,19 +294,20 @@ meta def BitVecInfos.push (this : BitVecInfos) (val : BitVecInfo) : BitVecInfos 
   { this with infos := this.infos.push val }
 
 /--
-Analyze a single bitvector FVarId, and try to introduce it as a `BitVec`
-variable in our larger universe.
+Analyze a single bitvector FVarId, and introduce it as a `BitVec` variable in
+our larger universe. `Unchecked` because `widthTm` is trusted to be the width of
+`bvFVarId`; it is not re-derived from the local context.
 -/
 meta def introBitvecFVarUnchecked (widthInfos : WidthInfos) (g : MVarId)
       (bvInfos : BitVecInfos) (bvFVarId : FVarId) (widthTm : WidthTm) :
       MetaM (MVarId × BitVecInfos) := g.withContext do
   -- Revert to expose forall with the BitVec.
   let (#[oldVar], g) ← g.revert #[bvFVarId]
-    | throwError m!"Reverting {g} shuold produce a var."
+    | throwError m!"Reverting {g} should produce a var."
   let wExpr := widthTm.term.toExpr widthInfos.env
   -- Apply ``var_elim.
   let some infos := widthInfos.getFromTm? widthTm.term
-    | throwError m!"{wExpr} Shuold have be defined in widthInfos."
+    | throwError m!"{wExpr} should have been defined in widthInfos."
   let [g] ← g.withContext <| g.apply <| ← mkAppM ``var_elim #[.fvar infos.hypWidthLeBoundNote]
     | throwError m!"{``var_elim} should generate a single goal. Produced {g}"
 
@@ -315,19 +319,19 @@ meta def introBitvecFVarUnchecked (widthInfos : WidthInfos) (g : MVarId)
   return (g, bvInfos.push { bvVar, bvHyp })
 
 /--
-This creates a plan of bitvector fvars to be reverted, and their corresponding widths.
+A plan of the bitvector fvars to be reverted, and their corresponding widths.
 -/
 structure BitVecFVarsToRevert where
   bvs : HashMap FVarId WidthTm := {}
 
 meta def BitVecFVarsToRevert.push (this : BitVecFVarsToRevert) (fvar : FVarId) (widthTm : WidthTm) : BitVecFVarsToRevert :=
-  if this.bvs.contains fvar then  this
+  if this.bvs.contains fvar then this
   else { bvs := this.bvs.insert fvar widthTm }
 
 /--
 Given an expression, if it is of `BitVec w` type then create a term `Tm` for the
-width `w`. If it is also an FVar, then it means it's a variable hence it has to
-be added to the set of FVars to be reverted.
+width `w`. If it is also an FVar then it is a variable, and hence has to be
+added to the set of FVars to be reverted.
 -/
 meta def visitExprNonrec (g : MVarId)
     (widthTms : WidthTms) (bvs : BitVecFVarsToRevert)
@@ -363,7 +367,7 @@ meta partial def visitExprRec (g : MVarId)
 
 /--
 Given the width terms in the formula, translate all `Nat` widths into `BitVec`
-masks and introduce hypothesis to model the masks.
+masks and introduce the hypotheses that model the masks.
 -/
 meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
   : MetaM (MVarId × WidthInfos)
@@ -386,8 +390,8 @@ meta def introMaskedBitvectors (bvs : BitVecFVarsToRevert) (g : MVarId)
     introBitvecFVarUnchecked widthInfos g bvInfos bvFvarId widthTm
 
 /--
-These theorems require pre-filling the width bound in order to be used within
-the Simp set.
+Add the theorems that need the blast width pre-filled before they can be used
+within the Simp set (currently just `eq_iff`).
 -/
 meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
   (widthTms : WidthTms) (simp : SimpTheoremsArray) :
@@ -416,9 +420,9 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context. Simplify the final formula
-to remove redundant masking operations, not strictly necessary for `bv_decide`
-to decide the resulting formula.
+Add the mask hypotheses of the translated `BitVec`s to the Simp theorem context.
+These simplify the final formula by removing redundant masking operations; they
+are not strictly necessary for `bv_decide` to decide the resulting formula.
 -/
 meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -428,7 +432,7 @@ meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   return simp
 
 /--
-Add theorems bounding each width to the provided bound to the simp set.
+Add the hypotheses bounding each width by the blast width to the simp set.
 -/
 meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -440,6 +444,7 @@ meta def addWidthInfosSimpLemmas (g : MVarId) (widthInfos : WidthInfos)
 
 /--
 Run simp on an MVarId given a set of simp theorems.
+Throws if `simp` closes the goal outright.
 -/
 meta def applySimp (g : MVarId) (simp : SimpTheoremsArray) : MetaM MVarId := g.withContext do
   let simpCtx ← Simp.mkContext (simpTheorems := simp)


### PR DESCRIPTION
- Introduce support for `BitVec.append`. 
  - For this to work, we introduce some theorems to convert conditions on width variables into conditions on the corresponding `BitVec` masks. 
  - We also need to extend the `Tm .width` to capture additions on widths. The bitblasting bound is now computed by recursing over all width terms and adding the provided width for each `atom`, e.g. a `w+w` with a provided `w <= 8` will make the concrete bound be `16`. 
  - This also requires a theorem `maskOfWidth_add_eq_mul_of_maskOfWidth` to relate an addition on `Nat` width variables to a constraint on masks.
- Add `append` to both the `Examples.lean` and the unit testing.