### PR TITLE
feat: support namespace-qualified dialect declarations

### DIFF
--- a/Veir/Meta/OpCode.lean
+++ b/Veir/Meta/OpCode.lean
@@ -10,18 +10,18 @@ open Lean Elab Command Meta
 namespace Veir
 
 meta structure Dialect where
-  leanName : String
+  leanName : Name
   mnemonic : String
   operations : Array String
   deriving Inhabited, Repr
 
-meta def mkDialect (env : Environment) (n : Name) (info : InductiveVal) : Dialect := Id.run do
+meta def mkDialect
+    (env : Environment) (currNamespace n : Name) (info : InductiveVal) : Dialect := Id.run do
   let mut ops := #[]
   for ctor in info.ctors do
     ops := ops.push ctor.getString!
-  let leanName := n.getString!
-  let mnemonic := (dialectNameAttr.getParam? env n).getD leanName.toLower
-  pure ⟨leanName, mnemonic, ops⟩
+  let mnemonic := (dialectNameAttr.getParam? env n).getD n.getString!.toLower
+  pure ⟨n.replacePrefix currNamespace .anonymous, mnemonic, ops⟩
 
 meta def mkCtor (n : Name) : TermElabM (TSyntax `Lean.Parser.Command.ctor) :=
   `(Lean.Parser.Command.ctor | | $(mkIdent n):ident)
@@ -44,7 +44,7 @@ meta def mkDialectCode (d : Dialect) : Name :=
 The dialect name as a Lean `Name`.
 -/
 meta def mkDialectCodeSimple (d : Dialect) : Name :=
-  .mkSimple <| d.leanName
+  d.leanName
 
 /--
 The name of an operation as a `String`. Used for `fromByteArray` and `fromName`.
@@ -81,10 +81,10 @@ meta def emitDialectFromName (d : Dialect) : TermElabM Command := do
   for op in d.operations do
     res ←
       `(if name = $(Syntax.mkStrLit (d.mkOpName op)).toByteArray then
-          some $(mkIdent (.mkStr2 d.leanName op))
+          some $(mkIdent (.str d.leanName op))
         else
           $res)
-  `(def $(mkIdent (.mkStr2 d.leanName "fromName"))
+  `(def $(mkIdent (.str d.leanName "fromName"))
       (name : $(mkIdent ``ByteArray)) : Option $(mkIdent d.mkDialectCodeSimple) := $res)
 
 /--
@@ -96,8 +96,8 @@ meta def emitDialectName (d : Dialect) : TermElabM Command := do
   for op in d.operations do
     alts := alts.push <| ←
       `(Lean.Parser.Term.matchAltExpr |
-         | $(mkIdent (.mkStr2 d.leanName op)) => $(Syntax.mkStrLit (d.mkOpName op)).toByteArray)
-  `(def $(mkIdent (.mkStr2 d.leanName "name"))
+         | $(mkIdent (.str d.leanName op)) => $(Syntax.mkStrLit (d.mkOpName op)).toByteArray)
+  `(def $(mkIdent (.str d.leanName "name"))
       (op : $(mkIdent d.mkDialectCodeSimple)) : ByteArray := match op with $alts:matchAlt* )
 
 /-- Generate `OpCode.fromName : ByteArray → Option OpCode` from a given array of dialects. -/
@@ -105,7 +105,7 @@ meta def emitGlobalFromName (ds : Array Dialect) : TermElabM Command := do
   let mut res : TSyntax `term ← `(none)
   for d in ds do
     res ←
-      `(match ($(mkIdent (.mkStr2 d.leanName "fromName")) name) with
+      `(match ($(mkIdent (.str d.leanName "fromName")) name) with
         | some op => some ($(mkIdent d.mkDialectCode) op)
         | none => $res)
   `(def $(mkIdent `OpCode.fromName)
@@ -117,7 +117,7 @@ meta def emitGlobalName (ds : Array Dialect) : TermElabM Command := do
   for d in ds do
     alts := alts.push <| ←
       `(Lean.Parser.Term.matchAltExpr |
-         | $(mkIdent d.mkDialectCode) op => $(mkIdent (.mkStr2 d.leanName "name")) op)
+         | $(mkIdent d.mkDialectCode) op => $(mkIdent (.str d.leanName "name")) op)
   `(def $(mkIdent `OpCode.name)
       (op : $(mkIdent `OpCode)) : ByteArray := match op with $alts:matchAlt* )
 
@@ -128,9 +128,10 @@ For now, this only include generating `Dialect.fromName` and `Dialect.name`.
 elab "#generate_dialect" dialect:ident : command => do
   let dialectName ← resolveGlobalConstNoOverload dialect
   let env ← getEnv
+  let currNamespace ← getCurrNamespace
   let some (.inductInfo info) := env.find? dialectName
     | throwError m!"Type {dialectName} is not defined or not an inductive."
-  let d := mkDialect env dialectName info
+  let d := mkDialect env currNamespace dialectName info
   elabCommand <| ← Command.liftTermElabM <| emitDialectFromName d
   elabCommand <| ← Command.liftTermElabM <| emitDialectName d
 
@@ -180,6 +181,7 @@ Dialect types declared in imported modules are included automatically.
 -/
 elab "#generate_op_codes" : command => do
   let env ← getEnv
+  let currNamespace ← getCurrNamespace
   let mut ts := #[]
   /- Gather opcodes defined in imported modules. -/
   for moduleIdx in [:env.allImportedModuleNames.size] do
@@ -191,7 +193,7 @@ elab "#generate_op_codes" : command => do
   for t in ts do
     let some (.inductInfo info) := env.find? t
       | throwError m!"Type {t} is not defined or not an inductive."
-    dialects := dialects.push <| mkDialect env t info
+    dialects := dialects.push <| mkDialect env currNamespace t info
 
   elabCommand <| ← Command.liftTermElabM <| mkOpCodeInductive dialects
   elabCommand <| ← Command.liftTermElabM <| emitGlobalFromName dialects


### PR DESCRIPTION
Preserve namespace-qualified Lean names when generating dialect helpers and global opcodes. This lets dialects such as Veir.LLZK.Function use natural Lean names while keeping their MLIR mnemonics independent.