### PR TITLE
feat: add `VectorType` type

### DIFF
--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -123,6 +123,20 @@ macro "#assert " e:term : command =>
 
 #assert expectSuccessAttr "i32" (IntegerType.mk 32)
 
+/-! ## Vector types -/
+
+#assert expectSuccessType "vector<4xi32>" (VectorType.mk #[4] (IntegerType.mk 32))
+#assert expectSuccessType "vector<2x4xf64>" (VectorType.mk #[2, 4] (FloatType.mk 64))
+#assert expectSuccessType "vector<2 x 4 x i32>" (VectorType.mk #[2, 4] (IntegerType.mk 32))
+#assert expectSuccessType "vector<i32>" (VectorType.mk #[] (IntegerType.mk 32))
+#assert expectSuccessAttr "vector<4xi32>" (VectorType.mk #[4] (IntegerType.mk 32))
+#assert ToString.toString (VectorType.mk #[2, 4] (IntegerType.mk 32) : VectorType) ==
+  "vector<2x4xi32>"
+#assert ToString.toString (VectorType.mk #[] (IntegerType.mk 32) : VectorType) == "vector<i32>"
+#assert expectErrorType "vector<4x>" "vector element type expected" (some 9)
+#assert expectErrorType "vector<0xi32>" "0 is not a supported dimension" (some 7)
+#assert expectErrorType "vector<0x32xi32>" "0 is not a supported dimension" (some 7)
+
 /-! ## Integer attributes -/
 
 #assert expectErrorAttr "0 : 2" "integer type expected after ':' in integer attribute" (some 4)

--- a/UnitTest/MlirParser.lean
+++ b/UnitTest/MlirParser.lean
@@ -42,6 +42,11 @@ def testParseOp (s : String) : IO Unit :=
   %x = \"arith.muli\"() : () -> i32
 }, {}) : () -> ()"
 
+/--
+  info: %3 = "test.test"() : () -> vector<2x4xi32>
+-/
+#guard_msgs in
+#eval! testParseOp "%x = \"test.test\"() : () -> vector<2 x 4 x i32>"
 
 /--
   info: "arith.addi"() ({

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -364,6 +364,21 @@ end HW
 mutual
 
 /--
+  A builtin fixed-size vector type.
+
+  The shape contains one entry per dimension, and `elementType` is expected to
+  be a valid vector element type. For example, `vector<2x4xi32>` is represented
+  by shape `#[2, 4]` and element type `i32`.
+
+  The element-type invariant is not proof-enforced in VeIR; MLIR enforces it
+  through `VectorElementTypeInterface`.
+-/
+structure VectorType where
+  shape : Array Nat
+  elementType : Attribute
+deriving Repr, Hashable
+
+/--
   The signature of a function, consisting of an array of input attributes
   and an array of output attributes.
 -/
@@ -436,6 +451,8 @@ inductive Attribute
 | integerType (type : IntegerType)
 /-- Float type -/
 | floatType (type : FloatType)
+/-- Builtin fixed-size vector type -/
+| vectorType (type : VectorType)
 /-- Integer attribute -/
 | integerAttr (attr : IntegerAttr)
 /-- Float attribute -/
@@ -516,6 +533,9 @@ deriving Inhabited, Repr, Hashable
 
 end
 
+instance : Inhabited VectorType where
+  default := { shape := #[], elementType := .integerType (IntegerType.mk 0) }
+
 instance : Coe FunctionType LLVMFunctionType where
   coe := .mk
 
@@ -547,6 +567,10 @@ theorem FunctionType.sizeOf_elems_outputs {ft : FunctionType} (hx : x ∈ ft.out
     sizeOf x < sizeOf ft := by
   grind [Array.sizeOf_lt_of_mem hx, cases FunctionType]
 
+theorem VectorType.sizeOf_elementType {t : VectorType} :
+    sizeOf t.elementType < sizeOf t := by
+  grind [cases VectorType]
+
 theorem LLVMFunctionType.sizeOf_functionType {ft : LLVMFunctionType} :
     sizeOf ft.functionType < sizeOf ft := by
   grind [cases LLVMFunctionType]
@@ -572,6 +596,17 @@ theorem Match.OptionalType.sizeOf_innerType {t : Match.OptionalType} :
 -/
 
 mutual
+def VectorType.decEq (type1 type2 : VectorType) : Decidable (type1 = type2) :=
+  if hshape : type1.shape = type2.shape then
+    match Attribute.decEq type1.elementType type2.elementType with
+    | isTrue _ => isTrue (by grind [cases VectorType])
+    | isFalse _ => isFalse (by grind)
+  else
+    isFalse (by grind)
+termination_by sizeOf type1
+decreasing_by
+  apply VectorType.sizeOf_elementType
+
 def FunctionType.decEq (type1 type2 : FunctionType) : Decidable (type1 = type2) :=
   let inputs1 := type1.inputs
   let outputs1 := type1.outputs
@@ -663,6 +698,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
       | isFalse hEq => isFalse (by grind))
   case floatType.floatType type1 type2 =>
     exact (match decEq type1 type2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
+  case vectorType.vectorType type1 type2 =>
+    exact (match VectorType.decEq type1 type2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
   case byteType.byteType type1 type2 =>
@@ -810,6 +849,7 @@ termination_by sizeOf attr1
 end
 
 instance : DecidableEq Attribute := Attribute.decEq
+instance : DecidableEq VectorType := VectorType.decEq
 instance : DecidableEq FunctionType := FunctionType.decEq
 instance : DecidableEq LLVMFunctionType := LLVMFunctionType.decEq
 instance : DecidableEq ArrayAttr := ArrayAttr.decEq
@@ -986,6 +1026,14 @@ instance : ToString HW.ModuleType where
 
 mutual
 
+def VectorType.toString (type : VectorType) : String :=
+  let shape := String.intercalate "x" (type.shape.toList.map ToString.toString)
+  let shape := if shape.isEmpty then "" else shape ++ "x"
+  s!"vector<{shape}{Attribute.toString type.elementType}>"
+termination_by sizeOf type
+decreasing_by
+  apply VectorType.sizeOf_elementType
+
 def ArrayAttr.toString (attr : ArrayAttr) : String :=
   let elems := String.intercalate ", " (attr.value.toList.map Attribute.toString)
   s!"[{elems}]"
@@ -1076,6 +1124,7 @@ def Attribute.toString (attr : Attribute) : String :=
   match attr with
   | .integerType type => ToString.toString type
   | .floatType type => ToString.toString type
+  | .vectorType type => type.toString
   | .byteType type => ToString.toString type
   | .fastMathFlagsAttr attr => ToString.toString attr
   | .arithIntegerOverflowFlagsAttr attr => ToString.toString attr
@@ -1120,6 +1169,9 @@ end
 
 instance : ToString Attribute where
   toString := Attribute.toString
+
+instance : ToString VectorType where
+  toString := VectorType.toString
 
 instance : ToString FunctionType where
   toString := FunctionType.toString
@@ -1327,6 +1379,7 @@ def isType (attr : Attribute) : Bool :=
   match attr with
   | .integerType _ => true
   | .floatType _ => true
+  | .vectorType _ => true
   | .byteType _ => true
   | .fastMathFlagsAttr _ => false
   | .arithIntegerOverflowFlagsAttr _ => false
@@ -1372,6 +1425,9 @@ def isType (attr : Attribute) : Bool :=
 def bitwidthOfType (type : Attribute) : Option Nat :=
   match type with
   | .integerType { bitwidth } | .floatType { bitwidth } | .byteType { bitwidth } => some bitwidth
+  | .vectorType { shape, elementType } => do
+      let elementBitwidth ← bitwidthOfType elementType
+      some (shape.foldl (· * ·) elementBitwidth)
   | .llvmPointerType _ => some 64
   | _ => none
 
@@ -1381,6 +1437,9 @@ def bitwidthOfType (type : Attribute) : Option Nat :=
 def sizeOfType (type : Attribute) : Option Nat :=
   match type with
   | .integerType { bitwidth } | .floatType { bitwidth } | .byteType { bitwidth } => some ((bitwidth + 7) / 8)
+  | .vectorType { shape, elementType } => do
+      let elementSize ← sizeOfType elementType
+      some (shape.foldl (· * ·) elementSize)
   | .llvmPointerType _ => some 8
   | .llvmArrayType { size, type } => do
       let inner ← sizeOfType type
@@ -1391,6 +1450,8 @@ def sizeOfType (type : Attribute) : Option Nat :=
 theorem isType_integerType type : (integerType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_floatType type : (floatType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_vectorType type : (vectorType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_byteType type : (byteType type).isType = true := by rfl
 @[simp, grind =]
@@ -1594,6 +1655,10 @@ instance : IsTypeAttr IntegerType where
 
 instance : IsTypeAttr FloatType where
   coe type := Attribute.asType (.floatType type) (by rfl)
+  coe_eq_inject _ := by rfl
+
+instance : IsTypeAttr VectorType where
+  coe type := Attribute.asType (.vectorType type) (by rfl)
   coe_eq_inject _ := by rfl
 
 instance : IsTypeAttr LLVM.ByteType where

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -39,6 +39,45 @@ def AttrParserM.run' (self : AttrParserM α)
   | .error err => .error err
 
 /--
+  Parse the `x` separator in a shaped type.
+
+  The lexer treats canonical fragments such as `x4xi32` as one identifier. If
+  the current identifier starts with `x`, consume just that leading byte and
+  re-lex the suffix so the following dimension or element type can be parsed
+  normally.
+-/
+private def parseShapeSeparator : AttrParserM Unit := do
+  let token ← peekToken
+  let input := (← getThe ParserState).input
+  if token.kind != .bareIdent || input.getD token.slice.start.byteOffset 0 != 'x'.toUInt8 then
+    throwAtCurrentPos "expected keyword 'x'"
+  resetToken (token.slice.start + 1)
+
+/--
+Parse one decimal vector dimension, if present.
+
+Numbers in the form `0x...` are parsed as `0`, since `x` is the separator for the next vector
+dimension, rather than a hexadecimal prefix.
+-/
+private def parseOptionalVectorDimension : AttrParserM (Option Nat) := do
+  let token ← peekToken
+  let .intLit := token.kind | return none
+  let spelling := token.slice.of (← getThe ParserState).input
+  let mut decimalLength := 0
+  while h : decimalLength < spelling.size do
+    if spelling[decimalLength].isDigit then
+      decimalLength := decimalLength + 1
+    else
+      break
+  let decimalSpelling := spelling.extract 0 decimalLength
+  let some dimension := (String.fromUTF8? decimalSpelling).bind String.toNat?
+    | throwAtCurrentPos "vector dimension must be a decimal integer"
+  if dimension = 0 then
+    throwAt token.slice.start "0 is not a supported dimension"
+  resetToken (token.slice.start + decimalLength)
+  return some dimension
+
+/--
   Parse an optional integer type.
   An integer type is represented as `i` followed by a positive integer indicating its width, e.g., `i32`.
 -/
@@ -633,6 +672,23 @@ inductive LLVMFuncParam
 mutual
 
 /--
+  Parse a builtin fixed-size vector type, if present.
+  Its syntax is `vector<dimension-list x element-type>`, e.g. `vector<2x4xi32>`;
+  the dimension list may be empty, as in `vector<i32>`.
+-/
+partial def parseOptionalVectorType : AttrParserM (Option TypeAttr) := do
+  if !(← parseOptionalKeyword "vector".toByteArray) then
+    return none
+  parsePunctuation "<"
+  let mut shape := #[]
+  while let some dim ← parseOptionalVectorDimension do
+    shape := shape.push dim
+    parseShapeSeparator
+  let elementType ← parseType "vector element type expected"
+  parsePunctuation ">"
+  return some (VectorType.mk shape elementType)
+
+/--
   Parse an LLVM array type, if present.
   Its syntax is `!llvm.array<size x type>`,
   or (exclusively) the shorter form `array<size x type>` if the corresponding argument is set.
@@ -808,6 +864,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some integerType
   if let some floatType ← parseOptionalFloatType then
     return some floatType
+  if let some vectorType ← parseOptionalVectorType then
+    return some vectorType
   if let some byteType ← parseOptionalByteType then
     return some byteType
   if let some registerType ← parseOptionalRegisterType then

--- a/Veir/Parser/Lexer.lean
+++ b/Veir/Parser/Lexer.lean
@@ -564,6 +564,10 @@ partial def lex (state : LexerState) : Except ParserError (Token × LexerState) 
     else
       .error { msg := s!"Unexpected character '{Char.ofUInt8 c}' at position {state.pos.byteOffset}" }
 
+/-- Set the lexer position to a given location. -/
+def LexerState.resetPosition (state : LexerState) (pos : Location) : LexerState :=
+  { state with pos }
+
 end Lexer
 
 end Veir.Parser

--- a/Veir/Parser/Parser.lean
+++ b/Veir/Parser/Parser.lean
@@ -79,6 +79,13 @@ def consumeToken : M Token := do
   set { lexer := lexerState, currentToken := nextToken : ParserState }
   return token
 
+/-- Move the lexer position to `pos` current token. -/
+def resetToken (pos : Location) : M Unit := do
+  let parserState ← get
+  let lexer := parserState.lexer.resetPosition pos
+  let (currentToken, lexer) ← ofExcept <| lex lexer
+  set { lexer, currentToken : ParserState }
+
 /--
   If the current token is of the expected kind, consume it and return it.
   Otherwise, return none.


### PR DESCRIPTION
This PR adds the `VectorType` type, which contains a single element type and an array of positive dimensions. All element types are currently allowed, though an interface will be required in the future, like in MLIR. Similarly, it is not yet enforced that dimensions are non-null.

This change also add support for printing and parsing.