### PR TITLE
feat(puddle): add native metadata guards and rewrites

### DIFF
--- a/UnitTest/Puddle.lean
+++ b/UnitTest/Puddle.lean
@@ -53,6 +53,50 @@ theorem mulTwo_valid : Pattern.Valid mulTwo := by
   simp only [mulTwo, matchConstant]
   provePuddleValid
 
+/-- Rewrite `x + 0` to `x`, matching the zero with a native metadata predicate. -/
+private def nativeMatch : Pattern OpCode :=
+  Pattern.Builder
+    (do
+      let returnType ← MatchProg.type (Attr := IntegerType)
+      let x ← MatchProg.value returnType
+      let cst ← MatchProg.operation (.arith .constant) #[] #[returnType]
+      MatchProg.matchNative (returnType, cst.properties)
+        (fun (type, properties) =>
+          type = IntegerType.mk 32 && properties.value.value = 0)
+      let _ ← MatchProg.root (.arith .addi) #[x, cst.res[0]!] #[returnType]
+      return x)
+    pure
+    (fun x => x)
+
+/-- Rewrite `x * 2` to `x + 3`, creating the constant metadata with a native function. -/
+private def nativeApply : Pattern OpCode :=
+  Pattern.Builder
+    (do
+      let returnType ← MatchProg.type (Attr := IntegerType)
+      let x ← MatchProg.value returnType
+      let cst ← MatchProg.operation (.arith .constant) #[] #[returnType]
+        (fun properties => properties.value.value = 2)
+      let _ ← MatchProg.root (.arith .muli) #[x, cst.res[0]!] #[returnType]
+      return (returnType, x, cst.properties))
+    (fun (returnType, x, properties) => do
+      let (newType, newProperties) ← CreateProg.applyNative (returnType, properties)
+        (fun (type, properties) =>
+          some (type, { properties with
+            value := { properties.value with value := properties.value.value + 1 } }))
+      let constant ← CreateProg.operation (.arith .constant) #[] #[newType] newProperties
+      let addProperties ← CreateProg.property (.arith .addi) default
+      let add ← CreateProg.operation (.arith .addi) #[x, constant.res[0]!] #[newType] addProperties
+      return add)
+    (fun result => result)
+
+theorem nativeMatch_valid : Pattern.Valid nativeMatch := by
+  simp only [nativeMatch]
+  provePuddleValid
+
+theorem nativeApply_valid : Pattern.Valid nativeApply := by
+  simp only [nativeApply]
+  provePuddleValid
+
 /- ## Test matcher builder validation -/
 
 /-- A matcher that is missing a root declaration. -/
@@ -125,3 +169,25 @@ info: "builtin.module"() ({
 -/
 #guard_msgs in
 #eval! rewriteAndPrint mulTwoProgram mulTwo
+
+/--
+info: "builtin.module"() ({
+  ^4():
+    %5 = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
+    "test.test"(%5) : (i32) -> ()
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! rewriteAndPrint addZeroProgram nativeMatch
+
+/--
+info: "builtin.module"() ({
+  ^4():
+    %5 = "arith.constant"() <{"value" = 42 : i32}> : () -> i32
+    %10 = "arith.constant"() <{"value" = 3 : i32}> : () -> i32
+    %11 = "arith.addi"(%5, %10) : (i32, i32) -> i32
+    "test.test"(%11) : (i32) -> ()
+}) : () -> ()
+-/
+#guard_msgs in
+#eval! rewriteAndPrint mulTwoProgram nativeApply

--- a/Veir/PatternRewriter/Puddle/Builders.lean
+++ b/Veir/PatternRewriter/Puddle/Builders.lean
@@ -109,25 +109,40 @@ def MatchProg.value (type : Handle OpCode .type) : MatchProg.Builder (Handle OpC
 
 /--
 Match a non-root operation given its opcode, operands, result types, and properties. The operation
-is assumed to have no block arguments or regions, but can have any attribute dictionary. Returns
-a bundle of handles that contains the operation handle, an array of handles for its SSA results,
-and a handle for its concrete properties.
+is assumed to have no block arguments or regions, but can have any attribute dictionary. Returns a
+bundle containing the operation, its SSA results, and its concrete properties.
 -/
 @[expose, inline]
 def MatchProg.operation (opCode : OpCode) (operands : Array (Handle OpCode .value))
-    (returnTypes : Array (Handle OpCode .type))
+    (resultTypes : Array (Handle OpCode .type))
     (property : PropertyMatcher opCode := fun _ => true) :
     MatchProg.Builder (OpHandle opCode) :=
   ⟨fun state =>
     let op := Handle.mk (OpInfo := OpCode) state.nextId
-    let res := (Array.range returnTypes.size).map fun index =>
+    let res := (Array.range resultTypes.size).map fun index =>
       Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
-    let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
-    have hresults : res.size = returnTypes.size := by grind
+    let properties := Handle.mk (OpInfo := OpCode) (state.nextId + resultTypes.size + 1)
+    have hresults : res.size = resultTypes.size := by grind
     (⟨op, res, properties⟩, { state with
-      nextId := state.nextId + returnTypes.size + 2
-      decls := .operation opCode operands returnTypes property properties op res hresults ::
+      nextId := state.nextId + resultTypes.size + 2
+      decls := .operation opCode operands resultTypes property properties op res hresults ::
         state.decls
+    })⟩
+
+/--
+Match with a predicate over matched type/property metadata. Returns `true` if the match was
+successful, and `false` otherwise.
+-/
+@[expose, inline]
+protected def MatchProg.matchNative {Inputs : Type} [IsMetadataTuple OpCode Inputs]
+    (inputs : Inputs) (predicate : MetadataValues OpCode Inputs → Bool) :
+    MatchProg.Builder Unit :=
+  ⟨fun state =>
+    ((), {
+      state with
+      /- Match declarations normally execute in reverse authoring order. A guard consumes handles
+         declared before it, so place it after the declarations already accumulated. -/
+      decls := state.decls ++ [.applyNative inputs predicate]
     })⟩
 
 /--
@@ -139,20 +154,20 @@ root through already-bound handles.
 -/
 @[expose, inline]
 def MatchProg.root (opCode : OpCode) (operands : Array (Handle OpCode .value))
-    (returnTypes : Array (Handle OpCode .type))
+    (resultTypes : Array (Handle OpCode .type))
     (property : PropertyMatcher opCode := fun _ => true) :
     MatchProg.Builder (RootHandle opCode) :=
   ⟨fun state =>
     let op := Handle.mk (OpInfo := OpCode) state.nextId
-    let results := (Array.range returnTypes.size).map fun index =>
+    let results := (Array.range resultTypes.size).map fun index =>
       Handle.mk (OpInfo := OpCode) (state.nextId + index + 1)
-    let properties := Handle.mk (OpInfo := OpCode) (state.nextId + returnTypes.size + 1)
-    have hresults : results.size = returnTypes.size := by grind
+    let properties := Handle.mk (OpInfo := OpCode) (state.nextId + resultTypes.size + 1)
+    have hresults : results.size = resultTypes.size := by grind
     (⟨op, properties⟩, { state with
-      nextId := state.nextId + returnTypes.size + 2
+      nextId := state.nextId + resultTypes.size + 2
       root? := some op
       rootConstraints :=
-        .operation opCode operands returnTypes property properties op results hresults ::
+        .operation opCode operands resultTypes property properties op results hresults ::
           state.rootConstraints
       numRoots := state.numRoots + 1
     })⟩
@@ -179,6 +194,39 @@ def MatchProg.build (builder : MatchProg.Builder α) : MatchProg OpCode α :=
 `CreateProg` builder functions appends a logical step and returns fresh handles that later steps may
 consume.
 -/
+
+namespace MetadataTuple.Atom
+
+/-- Allocate the handle denoted by a metadata atom. -/
+@[expose]
+def fresh {Handle : Type} : MetadataTuple.Atom OpCode Handle → Nat → Handle × Nat
+| .type, nextId => (⟨nextId⟩, nextId + 1)
+| .property _, nextId => (⟨nextId⟩, nextId + 1)
+
+end MetadataTuple.Atom
+
+namespace MetadataTuple.Shape
+
+/-- Allocate every handle in a metadata-tuple shape. -/
+@[expose]
+def fresh : (shape : MetadataTuple.Shape OpCode Handles) → Nat → Handles × Nat
+| .unit, nextId => ((), nextId)
+| .atom metadataAtom, nextId => metadataAtom.fresh nextId
+| .cons head tail, nextId =>
+    let (headHandle, nextId) := head.fresh nextId
+    let (tailHandles, nextId) := tail.fresh nextId
+    ((headHandle, tailHandles), nextId)
+
+end MetadataTuple.Shape
+
+namespace MetadataTuple
+
+/-- Allocate all handles in a metadata tuple. -/
+@[expose]
+def fresh {Handles : Type} [self : IsMetadataTuple OpCode Handles] (nextId : Nat) : Handles × Nat :=
+  self.shape.fresh nextId
+
+end MetadataTuple
 
 /-- The operation and SSA-result handles introduced by a creation declaration. -/
 structure CreatedOpHandle where
@@ -249,6 +297,26 @@ def CreateProg.operation (opCode : OpCode) (operands : Array (Handle OpCode .val
     (⟨op, res⟩, {
       nextId := state.nextId + resultTypes.size + 1
       decls := .operation opCode operands resultTypes properties op res :: state.decls
+    })⟩
+
+/--
+Apply an inline native metadata function to a tuple of type/property handles.
+
+Both `Inputs` and `Outputs` are tuple of type and property handles, and `rewrite` is a function that
+takes the values of those handles and returns a new tuple of type/property values. Returning `none`
+from `rewrite` rejects creation and invalidates the entire IR.
+-/
+@[expose, inline]
+def CreateProg.applyNative {Inputs Outputs : Type}
+    [IsMetadataTuple OpCode Inputs] [IsMetadataTuple OpCode Outputs]
+    (inputs : Inputs)
+    (rewrite : MetadataValues OpCode Inputs → Option (MetadataValues OpCode Outputs)) :
+    CreateProg.Builder Outputs :=
+  ⟨fun state =>
+    let (outputs, nextId) := MetadataTuple.fresh (Handles := Outputs) state.nextId
+    (outputs, {
+      nextId
+      decls := .applyNative inputs rewrite outputs :: state.decls
     })⟩
 
 /-- Build a creation program using the matcher's exports and continuing its handle numbering. -/

--- a/Veir/PatternRewriter/Puddle/Definitions.lean
+++ b/Veir/PatternRewriter/Puddle/Definitions.lean
@@ -69,6 +69,101 @@ structure Handle (OpInfo : Type) [HasOpInfo OpInfo] (handleType : HandleType OpI
 deriving Repr, DecidableEq, Inhabited
 
 /-!
+## Metadata tuples
+
+In the Puddle DSL, metadata is a generic term for types and operation properties. Both
+`MatchDecl.applyNative` and `CreateDecl.applyNative` need to translate between the concrete metadata
+values and the handles that denote them. We thus need to define a translation between the two
+representation types.
+
+`MetadataTuple.Atom` describes a single type or property handle, and `MetadataTuple.Shape`
+describes flat, right-associated tuples of those atoms. `IsMetadataTuple` witnesses that a type is
+a valid metadata tuple, and `MetadataTuple.Shape.Values` gives the corresponding concrete metadata
+type used during execution.
+-/
+
+/--
+An atom of a metadata tuple, which is either a type handle or a property handle.
+Its type parameter represents the kind of handle it denotes.
+-/
+inductive MetadataTuple.Atom (OpInfo : Type) [HasOpInfo OpInfo] : Type → Type 1 where
+/-- A type handle. -/
+| type : MetadataTuple.Atom OpInfo (Handle OpInfo .type)
+/-- A property handle for an operation with opcode `opCode`. -/
+| property (opCode : OpInfo) : MetadataTuple.Atom OpInfo (Handle OpInfo (.prop opCode))
+
+/-- The concrete metadata type denoted by an atom's handle. -/
+@[expose, reducible]
+def MetadataTuple.Atom.Value {Handle : Type} : MetadataTuple.Atom OpInfo Handle → Type
+| .type => TypeAttr
+| .property opCode => propertiesOf opCode
+
+/--
+A flat right-associated tuple of type and property handles.
+Its type parameter represents the tuple type it denotes.
+
+It includes `unit` for empty tuples and `atom` to avoid a trailing `a × Unit` at the leaves.
+-/
+inductive MetadataTuple.Shape (OpInfo : Type) [HasOpInfo OpInfo] : Type → Type 1 where
+/-- The shape of an empty metadata tuple. -/
+| unit : MetadataTuple.Shape OpInfo Unit
+/-- The shape of a single metadata handle. -/
+| atom {Handle : Type} :
+    MetadataTuple.Atom OpInfo Handle → MetadataTuple.Shape OpInfo Handle
+/-- Prepend a metadata atom to an existing tuple shape. -/
+| cons {Head Tail : Type} :
+    MetadataTuple.Atom OpInfo Head → MetadataTuple.Shape OpInfo Tail →
+      MetadataTuple.Shape OpInfo (Head × Tail)
+
+/-- The concrete metadata type corresponding to a tuple shape. -/
+@[expose, reducible]
+def MetadataTuple.Shape.Values : MetadataTuple.Shape OpInfo Handles → Type
+| .unit => Unit
+| .atom metadataAtom => metadataAtom.Value
+| .cons head tail => head.Value × tail.Values
+
+/--
+Witness that `Handles` is a tuple of property and type handle types.
+
+The class only contains a `MetadataTuple.Shape` witness of the tuple type, which is used to
+translate a tuple of handles into its tuple of concrete metadata values.
+
+For example, `Handle OpInfo .type × Handle OpInfo (.prop opCode)` receives the shape
+`.cons .type (.atom (.property opCode))` automatically.
+-/
+class IsMetadataTuple (OpInfo : Type) [HasOpInfo OpInfo] (Handles : Type) where
+  shape : MetadataTuple.Shape OpInfo Handles
+
+/--
+The concrete metadata type denoted by a tuple of type and property handles.
+For example, `Handle OpInfo .type × Handle OpInfo (.prop opCode)` denotes
+`TypeAttr × propertiesOf opCode`.
+-/
+abbrev MetadataValues (OpInfo : Type) [HasOpInfo OpInfo] (Handles : Type)
+    [self : IsMetadataTuple OpInfo Handles] : Type := self.shape.Values
+
+/-!
+The following instances synthesize `IsMetadataTuple` recursively for tuples of type and property
+handles.
+-/
+
+instance : IsMetadataTuple OpInfo Unit := ⟨.unit⟩
+
+instance : IsMetadataTuple OpInfo (Handle OpInfo .type) :=
+  ⟨.atom .type⟩
+
+instance (opCode : OpInfo) : IsMetadataTuple OpInfo (Handle OpInfo (.prop opCode)) :=
+  ⟨.atom (.property opCode)⟩
+
+instance [tail : IsMetadataTuple OpInfo Tail] :
+    IsMetadataTuple OpInfo (Handle OpInfo .type × Tail) :=
+  ⟨.cons .type tail.shape⟩
+
+instance (opCode : OpInfo) [tail : IsMetadataTuple OpInfo Tail] :
+    IsMetadataTuple OpInfo (Handle OpInfo (.prop opCode) × Tail) :=
+  ⟨.cons (.property opCode) tail.shape⟩
+
+/-!
 ## Matcher phase
 
 `MatchDecl` is the internal declarative representation of a pattern constraint. Users should use
@@ -100,6 +195,9 @@ inductive MatchDecl (OpInfo : Type) [HasOpInfo OpInfo] where
 | value (type : Handle OpInfo .type) (result : Handle OpInfo .value)
 /-- Require the type bound to `result` to be accepted by `matcher`. -/
 | type (matcher : TypeMatcher) (result : Handle OpInfo .type)
+/-- Require the concrete metadata denoted by `inputs` to satisfy `predicate`. -/
+| applyNative {Inputs : Type} [IsMetadataTuple OpInfo Inputs]
+    (inputs : Inputs) (predicate : MetadataValues OpInfo Inputs → Bool)
 /-- Identify an operation from the already-bound `result` or `results` handle, check every result
 handle against that operation, require the given opcode, operands, result types, and properties,
 and bind the discovered entities to their corresponding handles. -/
@@ -153,6 +251,14 @@ created operation and SSA results to `result` and `results`.
     (properties : Handle OpInfo (.prop opCode))
     (result : Handle OpInfo .op)
     (results : Array (Handle OpInfo .value))
+/-- Run a pure metadata transformation and bind its output values to `outputs`. Returning `none`
+rejects the creation phase and invalidates the entire IR context. -/
+| applyNative {Inputs Outputs : Type}
+    [IsMetadataTuple OpInfo Inputs]
+    [IsMetadataTuple OpInfo Outputs]
+    (inputs : Inputs)
+    (rewrite : MetadataValues OpInfo Inputs → Option (MetadataValues OpInfo Outputs))
+    (outputs : Outputs)
 
 /--
 The ordered creation phase of a Puddle rule.

--- a/Veir/PatternRewriter/Puddle/Execution.lean
+++ b/Veir/PatternRewriter/Puddle/Execution.lean
@@ -212,6 +212,125 @@ def findOp (assignment : Assignment OpInfo) (opHandle : Handle OpInfo .op)
 
 end Assignment
 
+namespace MetadataTuple.Atom
+
+/-- Resolve a metadata atom's handle against a concrete assignment. -/
+@[expose]
+def resolve (metadataAtom : MetadataTuple.Atom OpInfo T) (assignment : Assignment OpInfo)
+    (handle : T) : Option metadataAtom.Value :=
+  match metadataAtom with
+  | .type => assignment.getType handle
+  | .property _ => assignment.getProperty handle
+
+/-- Bind a metadata atom's handle in a concrete assignment. -/
+@[expose]
+def bind (metadataAtom : MetadataTuple.Atom OpInfo T) (assignment : Assignment OpInfo)
+    (handle : T) (value : metadataAtom.Value) : Option (Assignment OpInfo) :=
+  match metadataAtom with
+  | .type => assignment.bindType handle value
+  | .property _ => assignment.bindProperty handle value
+
+end MetadataTuple.Atom
+
+namespace MetadataTuple.Shape
+
+/-- Resolve every handle in a metadata-tuple shape against a concrete assignment. -/
+@[expose]
+def resolve (shape : MetadataTuple.Shape OpInfo Handles) (assignment : Assignment OpInfo)
+  (handles : Handles) : Option shape.Values :=
+match shape with
+| .unit => some ()
+| .atom metadataAtom => metadataAtom.resolve assignment handles
+| .cons head tail => do
+    let headValue ← head.resolve assignment handles.1
+    let tailValues ← tail.resolve assignment handles.2
+    return (headValue, tailValues)
+
+/-- Bind every handle in a metadata-tuple shape in a concrete assignment. -/
+@[expose]
+def bind (shape : MetadataTuple.Shape OpInfo Handles) (assignment : Assignment OpInfo)
+    (handles : Handles) (values : shape.Values) : Option (Assignment OpInfo) :=
+match shape with
+| .unit => some assignment
+| .atom metadataAtom => metadataAtom.bind assignment handles values
+| .cons head tail => do
+    let assignment ← head.bind assignment handles.1 values.1
+    tail.bind assignment handles.2 values.2
+
+end MetadataTuple.Shape
+
+namespace MetadataTuple
+
+/-- Resolve all handles in a metadata tuple against a concrete assignment. -/
+@[expose]
+def resolve {Handles : Type} [self : IsMetadataTuple OpInfo Handles]
+    (assignment : Assignment OpInfo) (handles : Handles) : Option (MetadataValues OpInfo Handles) :=
+  self.shape.resolve assignment handles
+
+/-- Bind all handles in a metadata tuple in a concrete assignment. -/
+@[expose]
+def bind {Handles : Type} [self : IsMetadataTuple OpInfo Handles]
+    (assignment : Assignment OpInfo) (handles : Handles) (values : MetadataValues OpInfo Handles) :
+    Option (Assignment OpInfo) :=
+  self.shape.bind assignment handles values
+
+
+/-! Canonical tuple equations used when reducing inline native declarations in proofs. -/
+
+@[simp]
+theorem resolve_unit (assignment : Assignment OpInfo) (handles : Unit) :
+    resolve assignment handles = some () := by
+  rfl
+
+@[simp]
+theorem resolve_type (assignment : Assignment OpInfo) (handle : Handle OpInfo .type) :
+    resolve assignment handle = assignment.getType handle := by
+  rfl
+
+@[simp]
+theorem resolve_property (assignment : Assignment OpInfo) {opCode : OpInfo}
+    (handle : Handle OpInfo (.prop opCode)) :
+    resolve assignment handle = assignment.getProperty handle := by
+  rfl
+
+@[simp]
+theorem resolve_type_cons {Tail : Type} [IsMetadataTuple OpInfo Tail]
+    (assignment : Assignment OpInfo) (handles : Handle OpInfo .type × Tail) :
+    resolve assignment handles = do
+      let headValue ← assignment.getType handles.1
+      let tailValues ← resolve assignment handles.2
+      return (headValue, tailValues) := by
+  rfl
+
+@[simp]
+theorem resolve_property_cons {Tail : Type} [IsMetadataTuple OpInfo Tail]
+    (assignment : Assignment OpInfo) {opCode : OpInfo}
+    (handles : Handle OpInfo (.prop opCode) × Tail) :
+    resolve assignment handles = do
+      let headValue ← assignment.getProperty handles.1
+      let tailValues ← resolve assignment handles.2
+      return (headValue, tailValues) := by
+  rfl
+
+@[simp]
+theorem bind_unit (assignment : Assignment OpInfo) (handles values : Unit) :
+    bind assignment handles values = some assignment := by
+  rfl
+
+@[simp]
+theorem bind_type (assignment : Assignment OpInfo) (handle : Handle OpInfo .type)
+    (value : TypeAttr) :
+    bind assignment handle value = assignment.bindType handle value := by
+  rfl
+
+@[simp]
+theorem bind_property (assignment : Assignment OpInfo) {opCode : OpInfo}
+    (handle : Handle OpInfo (.prop opCode)) (value : propertiesOf opCode) :
+    bind assignment handle value = assignment.bindProperty handle value := by
+  rfl
+
+end MetadataTuple
+
 /--
 Interpret a single declarative match instruction, returning `none` if the match fails, or an updated
 assignment if it succeeds.
@@ -253,6 +372,10 @@ def MatchDecl.run (decl : MatchDecl OpInfo) (ctx : IRContext OpInfo)
     -/
     let actual ← Assignment.getType assignment typeHandle
     guard (matcher actual)
+    return assignment
+  | @MatchDecl.applyNative _ _ _Inputs inputBundle inputs predicate =>
+    let values ← MetadataTuple.resolve (self := inputBundle) assignment inputs
+    guard (predicate values)
     return assignment
 
 /--
@@ -315,6 +438,11 @@ def CreateDecl.run (decl : CreateDecl OpInfo) (assignment : Assignment OpInfo)
       none
   | .type value result =>
     let assignment ← Assignment.bindType assignment result value
+    return (ctx, #[], assignment)
+  | @CreateDecl.applyNative _ _ _ _ inputBundle outputBundle inputs rewrite outputs =>
+    let values ← MetadataTuple.resolve (self := inputBundle) assignment inputs
+    let outputValues ← rewrite values
+    let assignment ← MetadataTuple.bind (self := outputBundle) assignment outputs outputValues
     return (ctx, #[], assignment)
 
 /--

--- a/Veir/PatternRewriter/Puddle/Validity.lean
+++ b/Veir/PatternRewriter/Puddle/Validity.lean
@@ -176,6 +176,36 @@ def forbidMany (ctx : HandleContext) (handles : List (Handle OpCode kind)) : Han
 
 end HandleContext
 
+namespace MetadataTuple.Shape
+
+/-- Require every handle described by a metadata tuple shape to be available. -/
+@[expose]
+def requireBindings (shape : MetadataTuple.Shape OpCode Handles) (ctx : HandleContext)
+    (handles : Handles) : Bool :=
+  match shape with
+  | .unit => true
+  | .atom .type => ctx.require handles
+  | .atom (.property _) => ctx.require handles
+  | .cons .type tail => ctx.require handles.1 && tail.requireBindings ctx handles.2
+  | .cons (.property _) tail => ctx.require handles.1 && tail.requireBindings ctx handles.2
+
+/-- Insert every handle described by a metadata tuple shape, requiring each one to be fresh. -/
+@[expose]
+def insertFreshBindings (shape : MetadataTuple.Shape OpCode Handles) (ctx : HandleContext)
+    (handles : Handles) : Option HandleContext :=
+  match shape with
+  | .unit => some ctx
+  | .atom .type => ctx.insertFresh handles
+  | .atom (.property _) => ctx.insertFresh handles
+  | .cons .type tail => do
+      let ctx ← ctx.insertFresh handles.1
+      tail.insertFreshBindings ctx handles.2
+  | .cons (.property _) tail => do
+      let ctx ← ctx.insertFresh handles.1
+      tail.insertFreshBindings ctx handles.2
+
+end MetadataTuple.Shape
+
 /-- Collect the handles that a matcher declaration binds during a successful match. -/
 @[expose]
 def MatchDecl.collectBindings (decl : MatchDecl OpCode)
@@ -191,6 +221,9 @@ def MatchDecl.collectBindings (decl : MatchDecl OpCode)
       defined.insert typeHandle
   | .type _ _ =>
       some defined
+  | @MatchDecl.applyNative _ _ _ inputBundle inputs _ => do
+      guard (inputBundle.shape.requireBindings defined inputs)
+      return defined
 
 /--
 Collect all the handles that a list of matcher declarations bind during a successful match.
@@ -236,6 +269,9 @@ def CreateDecl.checkBindings (ctx : HandleContext) (decl : CreateDecl OpCode)
       guard (resultHandles.size = resultTypes.size)
       let defined ← ctx.insertFresh opHandle
       defined.insertManyFresh resultHandles.toList
+  | @CreateDecl.applyNative _ _ _ _ inputBundle outputBundle inputs _ outputs => do
+      guard (inputBundle.shape.requireBindings ctx inputs)
+      outputBundle.shape.insertFreshBindings ctx outputs
 
 /-- Validate a creation program from a matcher-defined handle context. -/
 @[expose]
@@ -305,10 +341,11 @@ macro "unfoldPuddleBuilder" : tactic =>
   `(tactic| (
     /- Unfold the builder functions -/
     simp only [Pattern.Builder, MatchProg.build, CreateProg.build, bind, pure,
-      MatchProg.value, MatchProg.type, MatchProg.root, MatchProg.operation, CreateProg.operation,
-      CreateProg.property];
-    /- Simplify the resulting expressions with standard simplifications -/
-    simp only [Nat.zero_add, Nat.reduceAdd, List.size_toArray, List.length_cons, List.length_nil,
+      MatchProg.value, MatchProg.type, MatchProg.root, MatchProg.operation, MatchProg.matchNative,
+      CreateProg.operation, CreateProg.property, CreateProg.applyNative, MetadataTuple.fresh,
+      MetadataTuple.Shape.fresh, MetadataTuple.Atom.fresh,
+      /- Simplify the resulting expressions with standard simplifications -/
+      Nat.zero_add, Nat.reduceAdd, List.size_toArray, List.length_cons, List.length_nil,
       Array.size_map, Array.size_range, Nat.lt_add_one, getElem!_pos, Array.getElem_map,
       Array.getElem_range, Nat.add_zero, List.cons_append, List.nil_append, List.reverse_nil,
       List.reverse_cons, List.reverse_nil, List.nil_append, List.cons_append]))


### PR DESCRIPTION
Puddle previously matched and created properties and types only through individual declarations. Some conditions and rewrites need to consume or produce combinations of type and property metadata.

This change adds MatchProg.matchNative and CreateProg.applyNative over metadata tuples. Tuple handle shapes are inferred through IsMetadataTuple, while resolution and binding operate directly on the concrete runtime Assignment.