### PR TITLE
feat(LLVM): add constant range metadata

### DIFF
--- a/Test/LLVM/constant_range.mlir
+++ b/Test/LLVM/constant_range.mlir
@@ -1,0 +1,24 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+//
+// `#llvm.constant_range<iN, lo, hi>` is the half-open range a value is known
+// to lie in. It reaches VeIR as `llvm.range` inside the `arg_attrs` and
+// `res_attrs` dictionaries of `llvm.func` and `llvm.call`. The body is kept
+// verbatim, so the case that matters is the wrapping range: LLVM allows
+// `hi < lo`, and the bound prints back negative.
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i32 (i32)>, linkage = #llvm.linkage<external>, sym_name = "callee", arg_attrs = [{llvm.noundef, llvm.range = #llvm.constant_range<i32, 0, 20>}], res_attrs = [{llvm.noundef, llvm.range = #llvm.constant_range<i32, 0, 19>}]}> ({
+  ^bb0(%x: i32):
+    "llvm.return"(%x) : (i32) -> ()
+  }) : () -> ()
+  // A range that wraps: the upper bound reads as negative.
+  "llvm.func"() <{function_type = !llvm.func<i64 ()>, linkage = #llvm.linkage<external>, sym_name = "wrapping", res_attrs = [{llvm.range = #llvm.constant_range<i32, 0, -7>}]}> ({
+    %c = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
+    "llvm.return"(%c) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.range" = #llvm.constant_range<i32, 0, 20>
+// CHECK: "llvm.range" = #llvm.constant_range<i32, 0, 19>
+// CHECK: "llvm.range" = #llvm.constant_range<i32, 0, -7>

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -477,6 +477,13 @@ macro "#assert " e:term : command =>
 #assert expectSuccessAttr "#llvm.tailcallkind<none>" (TailCallKindAttr.mk "none")
 #assert expectSuccessAttr "#llvm.tailcallkind<musttail>" (TailCallKindAttr.mk "musttail")
 
+/-! ## LLVM constant ranges -/
+#assert expectSuccessAttr "#llvm.constant_range<i32, 0, 19>"
+  (ConstantRangeAttr.mk "i32, 0, 19")
+-- A wrapping range: LLVM allows `hi < lo`, and the bound reads back negative.
+#assert expectSuccessAttr "#llvm.constant_range<i32, 0, -7>"
+  (ConstantRangeAttr.mk "i32, 0, -7")
+
 /-! ## LLVM TBAA tags -/
 #assert expectSuccessAttr
   "#llvm.tbaa_tag<base_type = <id = \"int\">, access_type = <id = \"int\">, offset = 0>"

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -132,6 +132,17 @@ structure ModuleFlagAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  LLVM constant range attribute, e.g. `#llvm.constant_range<i32, 0, 19>`: the
+  half-open range `[0, 19)` a value is known to lie in. LLVM lets a range wrap,
+  so the upper bound may read as negative.
+
+  The body is kept as a string until VeIR uses it.
+-/
+structure ConstantRangeAttr where
+  value : String
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   LLVM TBAA tag attribute, e.g.
   `#llvm.tbaa_tag<base_type = <id = "int", members = {<#llvm.tbaa_root<id = "x">, 0>}>,
   access_type = <id = "int", members = {<#llvm.tbaa_root<id = "x">, 0>}>, offset = 0>`.
@@ -566,6 +577,8 @@ inductive Attribute
 | moduleFlagAttr (attr : ModuleFlagAttr)
 /-- LLVM TBAA tag attribute -/
 | tbaaTagAttr (attr : TbaaTagAttr)
+/-- LLVM constant range attribute -/
+| constantRangeAttr (attr : ConstantRangeAttr)
 /-- LLVM target features attribute -/
 | targetFeaturesAttr (attr : TargetFeaturesAttr)
 /-- DLTI data layout spec attribute -/
@@ -878,6 +891,10 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
       | isFalse hEq => isFalse (by grind))
+  case constantRangeAttr.constantRangeAttr attr1 attr2 =>
+    exact (match decEq attr1 attr2 with
+      | isTrue hEq => isTrue (by grind)
+      | isFalse hEq => isFalse (by grind))
   case tbaaTagAttr.tbaaTagAttr attr1 attr2 =>
     exact (match decEq attr1 attr2 with
       | isTrue hEq => isTrue (by grind)
@@ -1094,6 +1111,9 @@ instance : ToString TailCallKindAttr where
 
 instance : ToString ModuleFlagAttr where
   toString attr := s!"#llvm.mlir.module_flag<{attr.value}>"
+
+instance : ToString ConstantRangeAttr where
+  toString attr := s!"#llvm.constant_range<{attr.value}>"
 
 instance : ToString TbaaTagAttr where
   toString attr := s!"#llvm.tbaa_tag<{attr.value}>"
@@ -1381,6 +1401,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .tailCallKindAttr attr => ToString.toString attr
   | .moduleFlagAttr attr => ToString.toString attr
   | .tbaaTagAttr attr => ToString.toString attr
+  | .constantRangeAttr attr => ToString.toString attr
   | .targetFeaturesAttr attr => ToString.toString attr
   | .dlSpecAttr attr => ToString.toString attr
   | .integerAttr attr => ToString.toString attr
@@ -1652,6 +1673,7 @@ def isType (attr : Attribute) : Bool :=
   | .tailCallKindAttr _ => false
   | .moduleFlagAttr _ => false
   | .tbaaTagAttr _ => false
+  | .constantRangeAttr _ => false
   | .targetFeaturesAttr _ => false
   | .dlSpecAttr _ => false
   | .integerAttr _ => false
@@ -1742,6 +1764,8 @@ theorem isType_tailCallKind attr : (tailCallKindAttr attr).isType = false := by 
 theorem isType_moduleFlag attr : (moduleFlagAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_tbaaTag attr : (tbaaTagAttr attr).isType = false := by rfl
+@[simp, grind =]
+theorem isType_constantRange attr : (constantRangeAttr attr).isType = false := by rfl
 @[simp, grind =]
 theorem isType_targetFeatures attr : (targetFeaturesAttr attr).isType = false := by rfl
 @[simp, grind =]

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -444,6 +444,22 @@ partial def parseOptionalDialectType : AttrParserM (Option TypeAttr) := do
     return some (⟨UnregisteredAttr.mk ("!" ++ String.fromUTF8! dialectName) true none, by grind⟩)
 
 /--
+  Attributes VeIR registers but does not interpret: everything between `<` and
+  `>` is kept verbatim and printed back unchanged.
+-/
+private def verbatimBodyAttrs : List (ByteArray × (String → Attribute)) :=
+  [ ("llvm.cconv".toByteArray, fun body => (CConvAttr.mk body : Attribute)),
+    ("llvm.linkage".toByteArray, fun body => (LinkageAttr.mk body : Attribute)),
+    ("llvm.framePointerKind".toByteArray, fun body => (FramePointerKindAttr.mk body : Attribute)),
+    ("llvm.uwtableKind".toByteArray, fun body => (UwtableKindAttr.mk body : Attribute)),
+    ("llvm.tailcallkind".toByteArray, fun body => (TailCallKindAttr.mk body : Attribute)),
+    ("llvm.mlir.module_flag".toByteArray, fun body => (ModuleFlagAttr.mk body : Attribute)),
+    ("llvm.constant_range".toByteArray, fun body => (ConstantRangeAttr.mk body : Attribute)),
+    ("llvm.tbaa_tag".toByteArray, fun body => (TbaaTagAttr.mk body : Attribute)),
+    ("llvm.target_features".toByteArray, fun body => (TargetFeaturesAttr.mk body : Attribute)),
+    ("dlti.dl_spec".toByteArray, fun body => (DlSpecAttr.mk body : Attribute)) ]
+
+/--
   Parse a dialect attribute, if present.
   A dialect attribute has the form `#dialect.name` or `#dialect.name<body>`. Attributes VeIR
   understands are decoded; any other one is kept as an `UnregisteredAttr` when unregistered
@@ -462,59 +478,11 @@ partial def parseOptionalDialectAttr : AttrParserM (Option Attribute) := do
     let (nsw, nuw) ← parseIntegerOverflowFlags
     return some (ArithIntegerOverflowFlagsAttr.mk nsw nuw : Attribute)
 
-  if dialectName = "llvm.cconv".toByteArray then do
+  if let some (_, toAttr) := verbatimBodyAttrs.find? (fun (name, _) => dialectName == name) then
     parsePunctuation "<"
     let body ← parseUnregisteredAttrBody
     parsePunctuation ">"
-    return some (CConvAttr.mk body : Attribute)
-
-  if dialectName = "llvm.linkage".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (LinkageAttr.mk body : Attribute)
-
-  if dialectName = "llvm.framePointerKind".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (FramePointerKindAttr.mk body : Attribute)
-
-  if dialectName = "llvm.uwtableKind".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (UwtableKindAttr.mk body : Attribute)
-
-  if dialectName = "llvm.tailcallkind".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (TailCallKindAttr.mk body : Attribute)
-
-  if dialectName = "llvm.mlir.module_flag".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (ModuleFlagAttr.mk body : Attribute)
-
-  if dialectName = "llvm.tbaa_tag".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (TbaaTagAttr.mk body : Attribute)
-
-  if dialectName = "llvm.target_features".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (TargetFeaturesAttr.mk body : Attribute)
-
-  if dialectName = "dlti.dl_spec".toByteArray then do
-    parsePunctuation "<"
-    let body ← parseUnregisteredAttrBody
-    parsePunctuation ">"
-    return some (DlSpecAttr.mk body : Attribute)
+    return some (toAttr body)
 
   if !(← getThe AttrParserState).allowUnregisteredDialect then
     throwAt startPos s!"attribute '#{String.fromUTF8! dialectName}' is not registered. \


### PR DESCRIPTION
`#llvm.constant_range<iN, lo, hi>` is the half-open range a value is known to lie in. It reaches VeIR as `llvm.range` inside the `arg_attrs` and `res_attrs` dictionaries of `llvm.func` and `llvm.call`. Like the other LLVM metadata VeIR registers but store its body as an uninterpreted string.

Collapse the ten attributes that share this parse into a table. This cuts the build time from 45s to 6s, and makes the next such attribute a one-line entry.