### PR TITLE
feat(cir): tolerate unmodelled constants, comparisons and lowerings

### DIFF
--- a/Test/Cir/invalid_const_other_type.mlir
+++ b/Test/Cir/invalid_const_other_type.mlir
@@ -1,0 +1,7 @@
+// RUN: not veir-opt --allow-unregistered-dialect %s 2>&1 | filecheck %s
+
+// An unmodelled constant value still has to agree with the result type when it carries one.
+// CHECK: cir.const: Expected result type to match the constant's type
+"builtin.module"() ({
+  %0 = "cir.const"() <{value = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>}> : () -> !cir.int<s, 32>
+}) : () -> ()

--- a/Test/Cir/unmodelled.mlir
+++ b/Test/Cir/unmodelled.mlir
@@ -1,0 +1,25 @@
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+
+// ClangIR pieces VeIR does not model. A registered `cir` operation in an unmodelled
+// variant (a pointer or float constant, a pointer comparison, a float select) is accepted
+// and printed back verbatim; an unknown operation falls back to `builtin.unregistered`.
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.ptr<!cir.int<s, 32>>) -> !cir.bool>, sym_name = "unmodelled"}> ({
+  ^bb0(%p : !cir.ptr<!cir.int<s, 32>>):
+    %null = "cir.const"() <{value = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>}> : () -> !cir.ptr<!cir.int<s, 32>>
+    %f = "cir.const"() <{value = #cir.fp<1.500000e+00> : !cir.double}> : () -> !cir.double
+    %eq = "cir.cmp"(%p, %null) <{kind = 4 : i32}> : (!cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.int<s, 32>>) -> !cir.bool
+    %sel = "cir.select"(%eq, %f, %f) : (!cir.bool, !cir.double, !cir.double) -> !cir.double
+    %g = "cir.get_global"() <{name = @counter}> : () -> !cir.ptr<!cir.int<s, 32>>
+    "cir.return"(%eq) : (!cir.bool) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "cir.func"() <{"function_type" = !cir.func<(!cir.ptr<!cir.int<s, 32>>) -> !cir.bool>, "sym_name" = "unmodelled"}> ({
+// CHECK-NEXT: ^{{.*}}(%{{.*}} : !cir.ptr<!cir.int<s, 32>>):
+// CHECK-NEXT: %{{.*}} = "cir.const"() <{"value" = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>}> : () -> !cir.ptr<!cir.int<s, 32>>
+// CHECK-NEXT: %{{.*}} = "cir.const"() <{"value" = #cir.fp<1.500000e+00> : !cir.double}> : () -> !cir.double
+// CHECK-NEXT: %{{.*}} = "cir.cmp"(%{{.*}}, %{{.*}}) <{"kind" = 4 : i32}> : (!cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.int<s, 32>>) -> !cir.bool
+// CHECK-NEXT: %{{.*}} = "cir.select"(%{{.*}}, %{{.*}}, %{{.*}}) : (!cir.bool, !cir.double, !cir.double) -> !cir.double
+// CHECK-NEXT: %{{.*}} = "cir.get_global"() <{"name" = @counter}> : () -> !cir.ptr<!cir.int<s, 32>>
+// CHECK-NEXT: "cir.return"(%{{.*}}) : (!cir.bool) -> ()

--- a/Test/Passes/CirToStd/partial.mlir
+++ b/Test/Passes/CirToStd/partial.mlir
@@ -1,0 +1,28 @@
+// RUN: veir-opt %s --allow-unregistered-dialect -p=cir-to-std{strict=false},reconcile-cast | filecheck %s
+// RUN: not veir-opt %s --allow-unregistered-dialect -p=cir-to-std 2>&1 | filecheck %s --check-prefix=STRICT
+
+// With `strict=false`, cir-to-std lowers what it can and leaves the rest in place: the null
+// pointer constant, the pointer comparison and the unknown `cir.call` survive, while the
+// integer arithmetic around them is lowered and bridged with casts. The default strict mode
+// rejects the same input.
+// STRICT: cir-to-std: operation '{{.*}}' was not lowered
+
+"builtin.module"() ({
+  "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>, !cir.ptr<!cir.int<s, 32>>) -> !cir.int<s, 32>>, sym_name = "f"}> ({
+  ^bb0(%a : !cir.int<s, 32>, %p : !cir.ptr<!cir.int<s, 32>>):
+    %null = "cir.const"() <{value = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>}> : () -> !cir.ptr<!cir.int<s, 32>>
+    %isnull = "cir.cmp"(%p, %null) <{kind = 4 : i32}> : (!cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.int<s, 32>>) -> !cir.bool
+    %g = "cir.call"(%a) <{callee = @g}> : (!cir.int<s, 32>) -> !cir.int<s, 32>
+    %s = "cir.add"(%a, %g) <{no_signed_wrap = false, no_unsigned_wrap = false, saturated = false}> : (!cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    %r = "cir.select"(%isnull, %s, %a) : (!cir.bool, !cir.int<s, 32>, !cir.int<s, 32>) -> !cir.int<s, 32>
+    "cir.return"(%r) : (!cir.int<s, 32>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "cir.const"() <{"value" = #cir.ptr<null> : !cir.ptr<!cir.int<s, 32>>}> : () -> !cir.ptr<!cir.int<s, 32>>
+// CHECK-NEXT: [[ISNULL:%.*]] = "cir.cmp"(%{{.*}}, %{{.*}}) <{"kind" = 4 : i32}> : (!cir.ptr<!cir.int<s, 32>>, !cir.ptr<!cir.int<s, 32>>) -> !cir.bool
+// CHECK-NEXT: [[G:%.*]] = "cir.call"(%{{.*}}) <{"callee" = @g}> : (!cir.int<s, 32>) -> !cir.int<s, 32>
+// CHECK:      [[G0:%.*]] = "builtin.unrealized_conversion_cast"([[G]]) : (!cir.int<s, 32>) -> i32
+// CHECK-NEXT: [[SUM:%.*]] = "arith.addi"(%{{.*}}, [[G0]]) : (i32, i32) -> i32
+// CHECK-NEXT: [[COND:%.*]] = "builtin.unrealized_conversion_cast"([[ISNULL]]) : (!cir.bool) -> i1
+// CHECK:      "arith.select"([[COND]], [[SUM]], %{{.*}}) : (i1, i32, i32) -> i32

--- a/Test/Passes/CirToStd/unsupported_cast.mlir
+++ b/Test/Passes/CirToStd/unsupported_cast.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s -p=cir-to-std 2>&1 | filecheck %s
 
-// A bitcast (kind 1) round-trips but has no lowering.
-// CHECK: Error while applying cir-to-std lowering
+// A bitcast (kind 1) round-trips but has no lowering; strict mode reports it.
+// CHECK: cir-to-std: operation 'cir.cast' was not lowered
 "builtin.module"() ({
   "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<u, 32>>, sym_name = "f"}> ({
   ^bb0(%a : !cir.int<s, 32>):

--- a/Test/Passes/CirToStd/unsupported_saturated.mlir
+++ b/Test/Passes/CirToStd/unsupported_saturated.mlir
@@ -1,7 +1,7 @@
 // RUN: not veir-opt %s -p=cir-to-std 2>&1 | filecheck %s
 
-// Saturating arithmetic has no arith counterpart.
-// CHECK: Error while applying cir-to-std lowering
+// Saturating arithmetic has no arith counterpart; strict mode reports it.
+// CHECK: cir-to-std: operation 'cir.add' was not lowered
 
 "builtin.module"() ({
   "cir.func"() <{function_type = !cir.func<(!cir.int<s, 32>) -> !cir.int<s, 32>>, sym_name = "f"}> ({

--- a/Veir/Dialects/Cir/OpInfo.lean
+++ b/Veir/Dialects/Cir/OpInfo.lean
@@ -146,6 +146,15 @@ def TypeAttr.verifyCirIntOrBoolType (ty : TypeAttr) (msg : String) : Except Stri
   | .cirIntType _ | .cirBoolType _ => pure ()
   | type => throw s!"{msg}, but found {type} instead"
 
+/--
+  Verify that a type can be compared by `cir.cmp`: a ClangIR integer or boolean type, or a
+  type VeIR does not model (ClangIR also compares pointers and floats).
+-/
+def TypeAttr.verifyCirComparableType (ty : TypeAttr) (msg : String) : Except String PUnit :=
+  match ty.val with
+  | .cirIntType _ | .cirBoolType _ | .unregisteredAttr _ => pure ()
+  | type => throw s!"{msg}, but found {type} instead"
+
 /-- Verify a binary integer operation: two operands of one `!cir.int` type and a like result. -/
 def OperationPtr.verifyCirBinOp {OpInfo : Type} [IsOpCode OpInfo]
     (op : OperationPtr) (ctx : WfIRContext OpInfo)
@@ -195,8 +204,8 @@ def OperationPtr.verifyCirCmpOp {OpInfo : Type} [IsOpCode OpInfo]
   let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let operandType ← op.verifyOperandTypesMatch ctx 0 1
     s!"{instrName}: Expected operands to have the same type"
-  operandType.verifyCirIntOrBoolType
-    s!"{instrName}: Expected operands to have !cir.int or !cir.bool type"
+  operandType.verifyCirComparableType
+    s!"{instrName}: Expected operands to have a comparable type"
   ((op.getResult 0).get! ctx.raw).type.verifyCirBoolType
     s!"{instrName}: Expected result to have !cir.bool type"
 
@@ -248,8 +257,9 @@ def OperationPtr.verifyCirConstOp {OpInfo : Type} [IsOpCode OpInfo]
   let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   let props := op.getProperties! ctx.raw Cir.const
   let resultType := ((op.getResult 0).get! ctx.raw).type
-  if props.value.type ≠ resultType.val then
-    throw s!"{instrName}: Expected result type to match the constant's type"
+  if let some type := props.value.type then
+    if type ≠ resultType.val then
+      throw s!"{instrName}: Expected result type to match the constant's type"
   if let .int attr := props.value then
     let width := attr.type.width
     let (lo, hi) : Int × Int :=

--- a/Veir/Dialects/Cir/Properties.lean
+++ b/Veir/Dialects/Cir/Properties.lean
@@ -63,20 +63,30 @@ def CirCastKind.toNat : CirCastKind → Nat
   | .bool_to_int => 38
   | .other code => code
 
-/-- The value of a `cir.const`: a typed integer or boolean constant. -/
+/--
+  The value of a `cir.const`: a typed integer or boolean constant, or any other attribute
+  (a null pointer, a float, an aggregate) kept verbatim so that the operation round-trips.
+-/
 inductive CirConstValue where
   | int (attr : CirIntAttr)
   | bool (attr : CirBoolAttr)
+  | other (attr : Attribute)
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 def CirConstValue.toAttribute : CirConstValue → Attribute
   | .int attr => .cirIntAttr attr
   | .bool attr => .cirBoolAttr attr
+  | .other attr => attr
 
-/-- The type a constant value carries, which its result must match. -/
-def CirConstValue.type : CirConstValue → Attribute
-  | .int attr => .cirIntType attr.type
-  | .bool _ => .cirBoolType {}
+/--
+  The type a constant value carries, which its result must match. An unmodelled value only
+  has a type when it was written with a trailing `: type`.
+-/
+def CirConstValue.type : CirConstValue → Option Attribute
+  | .int attr => some (.cirIntType attr.type)
+  | .bool _ => some (.cirBoolType {})
+  | .other (.unregisteredAttr attr) => attr.type
+  | .other _ => none
 
 /-! ## Helpers -/
 
@@ -148,7 +158,7 @@ def CirConstProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute)
   match attr with
   | .cirIntAttr intAttr => return { value := .int intAttr }
   | .cirBoolAttr boolAttr => return { value := .bool boolAttr }
-  | attr => throw s!"cir.const: expected 'value' to be a #cir.int or #cir.bool attribute, but got {attr}"
+  | attr => return { value := .other attr }
 
 /--
   Properties of `cir.add`, `cir.sub` and `cir.minus`. ClangIR always prints their

--- a/Veir/Passes/CirToStd.lean
+++ b/Veir/Passes/CirToStd.lean
@@ -21,6 +21,11 @@ namespace Veir
   successor's argument types. The function boundary is left to
   `coerce-cir-function-boundaries` and the cast round trips to `reconcile-cast`; the `cir`
   pass group chains them.
+
+  Operations the pass cannot lower (unmodelled types, constant values or cast kinds,
+  saturating arithmetic) are left in place. By default the pass then fails, since the `cir`
+  pipeline expects a complete lowering; with `cir-to-std{strict=false}` they survive alongside
+  the lowered operations, which is how ClangIR output with unmodelled pieces is explored.
 -/
 
 /-! ## Types -/
@@ -99,19 +104,23 @@ abbrev StdBuilder :=
 /--
   Lower a single-result `cir` operation `cirOp` with `numOperands` operands: cast the operands
   to builtin types, run `build`, cast the result back to the operation's `cir` result type,
-  and erase the operation. `build` may inspect the properties; returning `none` from it aborts
-  the pass, which is how unsupported flags are reported.
+  and erase the operation. The operation is left in place when `supported` rejects its
+  properties or when one of its types has no builtin counterpart; the pass reports such
+  leftovers in strict mode. `build` returning `none` is an internal failure that aborts the
+  pass.
 -/
-def lowerValueOp (cirOp : Cir) (numOperands : Nat)
-    (build : Cir.propertiesOf cirOp → StdBuilder)
+def lowerValueOpIf (cirOp : Cir) (numOperands : Nat)
+    (supported : Cir.propertiesOf cirOp → Bool) (build : Cir.propertiesOf cirOp → StdBuilder)
     (rewriter : PatternRewriter OpCode) (op : OperationPtr)
     (_opInBounds : op.InBounds rewriter.ctx.raw) : Option (PatternRewriter OpCode) := do
   let some (operands, props) := matchOp op rewriter.ctx.raw cirOp numOperands
     | return rewriter
+  if !supported props then return rewriter
   let ip := InsertPoint.before op
   let cirResultType := (op.getResult 0 : ValuePtr).getType! rewriter.ctx.raw
-  let some stdResultType := cirTypeToStd cirResultType | none
+  let some stdResultType := cirTypeToStd cirResultType | return rewriter
   let cirOperandTypes := operands.map (·.getType! rewriter.ctx.raw)
+  if cirOperandTypes.any (fun t => (cirTypeToStd t).isNone) then return rewriter
   let mut rw := rewriter
   let mut stdOperands : Array ValuePtr := #[]
   for v in operands do
@@ -123,21 +132,27 @@ def lowerValueOp (cirOp : Cir) (numOperands : Nat)
   let rewriter := rewriter.replaceValue! (op.getResult 0) back
   return rewriter.eraseOp! op
 
-/-- `cir.const` → `arith.constant`. -/
-def lowerConst := lowerValueOp .const 0 fun props rewriter _ _ resultType ip => do
+/-- `lowerValueOpIf` for operations whose every property variant is supported. -/
+def lowerValueOp (cirOp : Cir) (numOperands : Nat) (build : Cir.propertiesOf cirOp → StdBuilder) :=
+  lowerValueOpIf cirOp numOperands (fun _ => true) build
+
+/-- `cir.const` → `arith.constant`; unmodelled constant values are left in place. -/
+def lowerConst := lowerValueOpIf .const 0 (fun props => props.value matches .int _ | .bool _)
+    fun props rewriter _ _ resultType ip => do
   let .integerType rt := resultType.val | none
   match props.value with
   | .int attr => emitStdConstant rewriter attr.value rt.bitwidth ip
   | .bool attr => emitStdConstant rewriter (if attr.value then 1 else 0) rt.bitwidth ip
+  | .other _ => none
 
-/-- `cir.add` → `arith.addi`; the saturating form is rejected. -/
-def lowerAdd := lowerValueOp .add 2 fun props rewriter operands _ resultType ip => do
-  if props.flagSet "saturated" then none
+/-- `cir.add` → `arith.addi`; the saturating form is left in place. -/
+def lowerAdd := lowerValueOpIf .add 2 (fun props => !props.flagSet "saturated")
+    fun _ rewriter operands _ resultType ip =>
   emitArith rewriter .addi noOverflow resultType operands ip
 
-/-- `cir.sub` → `arith.subi`; the saturating form is rejected. -/
-def lowerSub := lowerValueOp .sub 2 fun props rewriter operands _ resultType ip => do
-  if props.flagSet "saturated" then none
+/-- `cir.sub` → `arith.subi`; the saturating form is left in place. -/
+def lowerSub := lowerValueOpIf .sub 2 (fun props => !props.flagSet "saturated")
+    fun _ rewriter operands _ resultType ip =>
   emitArith rewriter .subi noOverflow resultType operands ip
 
 /-- A binary operation whose `arith` counterpart does not depend on signedness. -/
@@ -211,8 +226,10 @@ def lowerCmp := lowerValueOp .cmp 2 fun props rewriter operands cirTypes resultT
 def lowerSelect := lowerValueOp .select 3 fun _ rewriter operands _ resultType ip =>
   emitArith rewriter .select () resultType operands ip
 
-/-- `cir.cast` for the integral, int_to_bool and bool_to_int kinds. -/
-def lowerCast := lowerValueOp .cast 1 fun props rewriter operands cirTypes resultType ip => do
+/-- `cir.cast` for the integral, int_to_bool and bool_to_int kinds; other kinds are left in place. -/
+def lowerCast := lowerValueOpIf .cast 1
+    (fun props => props.kind matches .integral | .int_to_bool | .bool_to_int)
+    fun props rewriter operands cirTypes resultType ip => do
   let src := operands[0]!
   let .integerType st := (src.getType! rewriter.ctx.raw).val | none
   let .integerType rt := resultType.val | none
@@ -312,7 +329,7 @@ def convertCirBlock (ctx : WfIRContext OpCode) (block : BlockPtr) : WfIRContext 
 
 /-! ## Pass implementation -/
 
-def CirToStdPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
+def CirToStdPass.impl (strict : Bool) (ctx : WfIRContext OpCode) (op : OperationPtr)
     (_ : op.InBounds ctx.raw) : ExceptT String IO (WfIRContext OpCode) := do
   let lowering := RewritePattern.GreedyRewritePattern #[
     lowerConst, lowerAdd, lowerSub, lowerMul, lowerDiv, lowerRem,
@@ -321,21 +338,25 @@ def CirToStdPass.impl (ctx : WfIRContext OpCode) (op : OperationPtr)
     lowerBr, lowerBrCond, lowerUnreachable
   ]
   let some lowered := RewritePattern.applyInContext lowering ctx
-    | throw "Error while applying cir-to-std lowering (unsupported operation or flag)"
+    | throw "cir-to-std: internal rewriter failure"
   -- The lowered branches still forward `cir` values: retype the blocks they target.
   let mut converted := lowered
   for block in converted.raw.blocks.keys do
     converted := convertCirBlock converted block
-  -- Nothing but the function shell may remain.
-  for o in converted.raw.operations.keys do
-    if let .cir cirOp := o.getOpType! converted.raw then
-      if cirOp ≠ .func && cirOp ≠ .return then
-        throw s!"cir-to-std: operation '{String.fromUTF8! (IsOpCode.name cirOp)}' was not lowered"
+  -- In strict mode, nothing but the function shell may remain.
+  if strict then
+    for o in converted.raw.operations.keys do
+      if let .cir cirOp := o.getOpType! converted.raw then
+        if cirOp ≠ .func && cirOp ≠ .return then
+          throw s!"cir-to-std: operation '{String.fromUTF8! (IsOpCode.name cirOp)}' was not lowered"
   return converted
 
 public def CirToStdPass : Pass OpCode :=
   { name := "cir-to-std"
     description := "Lower the cir dialect's integer core to the arith, cf and llvm dialects."
-    run := fun _ => CirToStdPass.impl }
+    options := .ofList [
+      ("strict", { description := "Fail if a cir operation other than cir.func/cir.return remains.",
+                   defaultValue := true })]
+    run := fun options => CirToStdPass.impl ((options.get? "strict").getD true) }
 
 end Veir


### PR DESCRIPTION
ClangIR output mixes the modelled integer core with pieces VeIR does not model. Unknown ops and types already fall back to builtin.unregistered under `--allow-unregistered-dialect`; this makes the registered cir ops tolerate their unmodelled variants as well:

- cir.const keeps any value attribute verbatim (CirConstValue.other) and only checks the result type against a trailing `: type`.
- cir.cmp accepts operands of an unregistered type, since ClangIR compares pointers and floats.
- cir-to-std patterns leave operations they cannot lower in place instead of aborting the pass. The new `strict` option (default true) keeps the completeness check, so `-p=cir` behaves as before, while `cir-to-std{strict=false}` lowers what it can around the leftovers.