### PR TITLE
feat(Verif): Add support for label attr

### DIFF
--- a/Test/Verif/label.mlir
+++ b/Test/Verif/label.mlir
@@ -1,0 +1,20 @@
+// RUN: VEIR_ROUNDTRIP
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT: ^{{.*}}():
+// CHECK-NEXT: "hw.module"() <{{.*}}"sym_name" = "top"{{.*}}> ({
+// CHECK-NEXT: ^{{.*}}(%[[A:[^ ]+]] : i1):
+// CHECK-NEXT: "verif.assume"(%[[A]]) <{"label" = "assumption"}> : (i1) -> ()
+// CHECK-NEXT: "verif.assert"(%[[A]]) <{"label" = "assertion"}> : (i1) -> ()
+// CHECK-NEXT:    "hw.output"() : () -> ()
+// CHECK-NEXT:    }) : () -> ()
+// CHECK-NEXT:  }) : () -> ()
+
+"builtin.module"() ({
+  "hw.module"() <{comment = "", module_type = !hw.modty<input a : i1>, parameters = [], per_port_attrs = [], result_locs = [], sym_name = "top"}> ({
+  ^bb0(%arg0: i1):
+    "verif.assume"(%arg0) <{label = "assumption"}> : (i1) -> ()
+    "verif.assert"(%arg0) <{label = "assertion"}> : (i1) -> ()
+    "hw.output"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Veir/Dialects/Verif/OpInfo.lean
+++ b/Veir/Dialects/Verif/OpInfo.lean
@@ -18,9 +18,9 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[expose, properties_of]
 def Verif.propertiesOf (op : Verif) : Type :=
-match op with
-| .assume => VerifAssumeAssertProperties
-| .assert => VerifAssumeAssertProperties
+  match op with
+  | .assume => VerifAssumeAssertProperties
+  | .assert => VerifAssumeAssertProperties
 
 def Verif.fromAttrDict
     (op : Verif) (attrDict : Std.HashMap ByteArray Attribute) :

--- a/Veir/Dialects/Verif/OpInfo.lean
+++ b/Veir/Dialects/Verif/OpInfo.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.IR.Simp
 public import Veir.IR.OpInfo
+public import Veir.Dialects.Verif.Properties
 public import Veir.Verifier.Basic
 meta import Veir.Meta.OpCode
 
@@ -16,19 +17,27 @@ inductive Verif where
 deriving Inhabited, Repr, Hashable, DecidableEq
 
 @[expose, properties_of]
-def Verif.propertiesOf (_op : Verif) : Type :=
-  Unit
+def Verif.propertiesOf (op : Verif) : Type :=
+match op with
+| .assume => VerifAssumeAssertProperties
+| .assert => VerifAssumeAssertProperties
 
 def Verif.fromAttrDict
-    (op : Verif) (_attrDict : Std.HashMap ByteArray Attribute) :
+    (op : Verif) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String (Verif.propertiesOf op) := by
   cases op
+  case assume => exact VerifAssumeAssertProperties.fromAttrDict attrDict
+  case assert => exact VerifAssumeAssertProperties.fromAttrDict attrDict
   all_goals exact .ok ()
 
 def Verif.toAttrDict
-    (op : Verif) (_props : Verif.propertiesOf op) :
+    (op : Verif) (props : Verif.propertiesOf op) :
     Std.HashMap ByteArray Attribute :=
-  Std.HashMap.emptyWithCapacity 0
+  match op with
+  | .assume | .assert => Id.run do
+    match props.label with
+    | some label => (Std.HashMap.emptyWithCapacity 1).insert "label".toUTF8 (.stringAttr label)
+    | none => Std.HashMap.emptyWithCapacity 0
 
 @[get_effects]
 def Verif.getEffects

--- a/Veir/Dialects/Verif/Properties.lean
+++ b/Veir/Dialects/Verif/Properties.lean
@@ -1,0 +1,29 @@
+module
+
+public import Veir.IR.Attribute
+public import Std.Data.HashMap
+
+namespace Veir
+
+public section
+
+/--
+  Properties of the `verif.assume`and `verif.assert` operations.
+-/
+structure VerifAssumeAssertProperties where
+  label : Option StringAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def VerifAssumeAssertProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+  Except String VerifAssumeAssertProperties := do
+  let label : Option StringAttr ←
+  match attrDict["label".toUTF8]? with
+    | none => pure none
+    | some (.stringAttr l) => pure (some l)
+    | some other => throw s!"verif: expected 'label' to be a string attribute, but got {other}"
+
+  return { label }
+
+end
+
+end Veir


### PR DESCRIPTION
This patch adds support for the `label` attribute from `verif.assume` and `verif.assert`.