### PR TITLE
Add initial support for the seq dialect

### DIFF
--- a/Test/Seq/identity.mlir
+++ b/Test/Seq/identity.mlir
@@ -1,0 +1,20 @@
+// RUN: VEIR_ROUNDTRIP
+
+// CHECK: "builtin.module"() ({
+// CHECK-NEXT:  ^{{.*}}():
+// CHECK-NEXT: "hw.module"() <{{{.*}}"sym_name" = "top"{{.*}}> ({
+// CHECK-NEXT: ^{{.*}}(%[[CLK:[^ ]+]] : i1, %[[RST:[^ ]+]] : i1, %[[D:[^ ]+]] : i1):
+// CHECK-NEXT: %[[CLOCK:[^ ]+]] = "seq.to_clock"(%[[CLK]]) : (i1) -> !seq.clock
+// CHECK-NEXT: %[[Q:[^ ]+]] = "seq.firreg"(%[[D]], %[[CLOCK]]) <{{{.*}}"name" = "q"{{.*}}}> : (i1, !seq.clock) -> i1
+// CHECK-NEXT:    "hw.output"(%[[Q]]) : (i1) -> ()
+// CHECK-NEXT:    }) : () -> ()
+// CHECK-NEXT:  }) : () -> ()
+
+"builtin.module"() ({
+  "hw.module"() <{comment = "", module_type = !hw.modty<input clk : i1, input rst : i1, input d : i1, output q : i1>, parameters = [], per_port_attrs = [], result_locs = [loc(unknown)], sym_name = "top"}> ({
+  ^bb0(%arg0: i1, %arg1: i1, %arg2: i1):
+    %0 = "seq.to_clock"(%arg0) : (i1) -> !seq.clock
+    %1 = "seq.firreg"(%arg2, %0) <{name = "q"}> : (i1, !seq.clock) -> i1
+    "hw.output"(%1) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Veir/Dialects/Seq/OpInfo.lean
+++ b/Veir/Dialects/Seq/OpInfo.lean
@@ -1,0 +1,108 @@
+module
+
+public import Veir.IR.OpInfo
+public import Veir.Dialects.Seq.Properties
+public import Veir.Verifier.Basic
+meta import Veir.Meta.OpCode
+
+namespace Veir
+
+public section
+
+@[opcodes]
+inductive Seq where
+| to_clock
+| firreg
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+@[expose, properties_of]
+def Seq.propertiesOf (op : Seq) : Type :=
+match op with
+| .to_clock => Unit
+| .firreg => SeqFirRegProperties
+
+def Seq.fromAttrDict
+    (op : Seq) (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String (Seq.propertiesOf op) := by
+  cases op
+  case to_clock => exact .ok ()
+  case firreg => exact SeqFirRegProperties.fromAttrDict attrDict
+
+def Seq.toAttrDict
+    (op : Seq) (props : Seq.propertiesOf op) :
+    Std.HashMap ByteArray Attribute :=
+  match op with
+  | .to_clock => Std.HashMap.emptyWithCapacity 0
+  | .firreg => Id.run do
+    let dict : Std.HashMap ByteArray Attribute := Std.HashMap.emptyWithCapacity 3
+    let dict := dict.insert "name".toUTF8 (.stringAttr props.name)
+    let dict :=
+      if props.isAsync then dict.insert "isAsync".toUTF8 (.unitAttr .mk) else dict
+    let dict :=
+      match props.preset with
+      | some preset => dict.insert "preset".toUTF8 (.integerAttr preset)
+      | none => dict
+    dict
+
+def Seq.propagatesPoison (op : Seq) : Bool :=
+  match op with
+  | .to_clock | .firreg => true
+
+@[is_terminator]
+def Seq.isTerminator (_op : Seq) : Bool :=
+  false
+
+@[get_effects]
+def Seq.getEffects
+    (op : Seq) (_props : Seq.propertiesOf op) : MemoryEffects :=
+  match op with
+  | .to_clock | .firreg => .none
+
+def Seq.isConstantLike (_op : Seq) : Bool :=
+  false
+
+def Seq.hasSSADominance (_op : Seq) (_index : Nat) : Bool :=
+  true
+
+def Seq.isIsolatedFromAbove (_op : Seq) : Bool :=
+  false
+
+#generate_dialect Seq
+
+instance : IsOpCode Seq where
+  fromName := Seq.fromName
+  name := Seq.name
+  propertiesOf := Seq.propertiesOf
+  fromAttrDict := Seq.fromAttrDict
+  toAttrDict := Seq.toAttrDict
+
+/--
+Verify the local invariants of a `seq` operation in any operation-info type
+containing the `seq` dialect.
+-/
+def Seq.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
+    [HasDialect OpInfo Seq] (opType : Seq) (op : OperationPtr)
+    (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  match opType with
+  | .to_clock => do
+    op.verifyPlainOpCounts ctx opIn 1 1
+  | .firreg => do
+    let numOps := op.getNumOperands ctx.raw opIn
+    if ¬(numOps >= 2 ∧ numOps ≤ 4) then
+      throw "Expected 2, 3 or 4 operands"
+    if op.getNumResults ctx.raw opIn ≠ 1 then
+      throw "Expected 1 result"
+    if op.getNumRegions ctx.raw opIn ≠ 0 then
+      throw "Expected 0 regions"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+
+instance : HasOpInfo Seq where
+  verifyLocalInvariants := Seq.verifyLocalInvariants
+  getEffects := Seq.getEffects
+  isConstantLike := Seq.isConstantLike
+  hasSSADominance := Seq.hasSSADominance
+  isTerminator := Seq.isTerminator
+  isIsolatedFromAbove := Seq.isIsolatedFromAbove
+
+end

--- a/Veir/Dialects/Seq/Properties.lean
+++ b/Veir/Dialects/Seq/Properties.lean
@@ -1,0 +1,36 @@
+module
+
+public import Veir.IR.Attribute
+public import Std.Data.HashMap
+
+namespace Veir
+
+public section
+
+/--
+  Properties of the `seq.firreg` operation.
+-/
+structure SeqFirRegProperties where
+  name : StringAttr
+  isAsync : Bool
+  preset : Option IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def SeqFirRegProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String SeqFirRegProperties := do
+  let some name := attrDict["name".toUTF8]? | throw "seq.firreg: requires attribute 'name'"
+  let .stringAttr name := name
+    | throw s!"seq.firreg: expected 'name' to be a string attribute, but got {name}"
+
+  let isAsync := attrDict.contains "isAsync".toUTF8
+
+  let preset ← match attrDict["preset".toUTF8]? with
+    | none => pure none
+    | some (.integerAttr i) => pure (some i)
+    | some other => throw s!"seq.firreg: expected 'preset' to be an integer attribute, but got {other}"
+
+  return { name, isAsync, preset }
+
+end
+
+end Veir

--- a/Veir/GlobalOpInfo.lean
+++ b/Veir/GlobalOpInfo.lean
@@ -37,6 +37,7 @@ match opCode with
 | .cir op => Cir.propertiesOf op
 | .include op => LLZK.Include.propertiesOf op
 | .function op => LLZK.Function.propertiesOf op
+| .seq op => Seq.propertiesOf op
 
 /--
   What are the memory effects of an operation with this opcode and these
@@ -66,6 +67,7 @@ def OpCode.getEffects (opCode : OpCode) (props : _propertiesOf opCode) : MemoryE
   | .cir op, props => Cir.getEffects op props
   | .include op, props => LLZK.Include.getEffects op props
   | .function op, props => LLZK.Function.getEffects op props
+  | .seq op, props => Seq.getEffects op props
 
 /--
   Return the kind of the region with the given index inside this operation.
@@ -93,6 +95,7 @@ def OpCode.getRegionKind (opCode : OpCode) (index : Nat) : RegionKind :=
   | .cir op => HasOpInfo.getRegionKind op index
   | .include op => HasOpInfo.getRegionKind op index
   | .function op => HasOpInfo.getRegionKind op index
+  | .seq op => HasOpInfo.getRegionKind op index
 
 /--
   Whether definitions in the indexed region of this opcode must dominate
@@ -121,6 +124,7 @@ def OpCode.hasSSADominance (opCode : OpCode) (index : Nat) : Bool :=
   | .cir op => Cir.hasSSADominance op index
   | .include op => LLZK.Include.hasSSADominance op index
   | .function op => LLZK.Function.hasSSADominance op index
+  | .seq op => Seq.hasSSADominance op index
 
 /--
   Whether the indexed region of this opcode is exempt from the requirement
@@ -150,6 +154,7 @@ def OpCode.hasNoTerminator (opCode : OpCode) (index : Nat) : Bool :=
   | .cir op => HasOpInfo.hasNoTerminator op index
   | .include op => HasOpInfo.hasNoTerminator op index
   | .function op => HasOpInfo.hasNoTerminator op index
+  | .seq op => HasOpInfo.hasNoTerminator op index
 
 /-- Whether this opcode carries MLIR's `IsolatedFromAbove` trait. -/
 def OpCode.isIsolatedFromAbove (opCode : OpCode) : Bool :=
@@ -175,6 +180,7 @@ def OpCode.isIsolatedFromAbove (opCode : OpCode) : Bool :=
   | .cir op => HasOpInfo.isIsolatedFromAbove op
   | .include op => HasOpInfo.isIsolatedFromAbove op
   | .function op => HasOpInfo.isIsolatedFromAbove op
+  | .seq op => HasOpInfo.isIsolatedFromAbove op
 
 /--
   Does this OpCode count as an MLIR basic block terminator? Dialects that do
@@ -204,6 +210,7 @@ def OpCode.isTerminator (opCode : OpCode) : Bool :=
   | .cir op => HasOpInfo.isTerminator op
   | .include op => HasOpInfo.isTerminator op
   | .function op => HasOpInfo.isTerminator op
+  | .seq op => HasOpInfo.isTerminator op
 
 /--
   Does this `OpCode` materialize a literal constant value, i.e. an op
@@ -236,6 +243,7 @@ def OpCode.isConstantLike (opCode : OpCode) : Bool :=
   | .cir op => Cir.isConstantLike op
   | .include op => LLZK.Include.isConstantLike op
   | .function op => LLZK.Function.isConstantLike op
+  | .seq op => Seq.isConstantLike op
 
 /--
   Does an operation with this opcode produce a wholly poisoned result whenever
@@ -264,6 +272,7 @@ def OpCode.propagatesPoison (opCode : OpCode) : Bool :=
   | .cir op => HasOpInfo.propagatesPoison op
   | .include op => HasOpInfo.propagatesPoison op
   | .function op => HasOpInfo.propagatesPoison op
+  | .seq op => HasOpInfo.propagatesPoison op
 
 def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray Attribute) :
     Except String (_propertiesOf opCode) :=
@@ -289,6 +298,7 @@ def Properties.fromAttrDict (opCode : OpCode) (attrDict : Std.HashMap ByteArray 
   | .cir op => Cir.fromAttrDict op attrDict
   | .include op => LLZK.Include.fromAttrDict op attrDict
   | .function op => LLZK.Function.fromAttrDict op attrDict
+  | .seq op => Seq.fromAttrDict op attrDict
 
 /--
   Converts the properties of an operation into a dictionary of attributes.
@@ -318,6 +328,7 @@ def Properties.toAttrDict
   | .cir op, props => Cir.toAttrDict op props
   | .include op, props => LLZK.Include.toAttrDict op props
   | .function op, props => LLZK.Function.toAttrDict op props
+  | .seq op, props => Seq.toAttrDict op props
 
 instance : IsOpCode OpCode where
   fromName := OpCode.fromName
@@ -350,6 +361,7 @@ def OpCode.functionInterface? (opCode : OpCode) : Option (FunctionOpInterface (_
   | .cir op => HasOpInfo.functionInterface? op
   | .include op => HasOpInfo.functionInterface? op
   | .function op => HasOpInfo.functionInterface? op
+  | .seq op => HasOpInfo.functionInterface? op
 
 #generate_has_dialect_instances OpCode
 
@@ -378,6 +390,7 @@ def OpCode.verifyLocalInvariants (opCode : OpCode) (op : OperationPtr)
   | .io opType => Io.verifyLocalInvariants opType op ctx opIn
   | .include opType => LLZK.Include.verifyLocalInvariants opType op ctx opIn
   | .function opType => LLZK.Function.verifyLocalInvariants opType op ctx opIn
+  | .seq opType => Seq.verifyLocalInvariants opType op ctx opIn
 
 instance : HasOpInfo OpCode where
   verifyLocalInvariants := OpCode.verifyLocalInvariants
@@ -412,7 +425,7 @@ def OpCode.materializeConstant (opCode : OpCode) (value : RuntimeValue)
     | .riscv_cf _ | .riscv_stack _ | .rv64 _ | .cf _ | .builtin _
     | .verif _
     | .func _ | .datapath _ | .pdl _ | .test _ | .cir _ | .io _ | .include _
-    | .function _ => none
+    | .function _ | .seq _ => none
   guard materialized.fst.isConstantLike
   return materialized
 

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -416,6 +416,17 @@ deriving Inhabited, Repr, DecidableEq, Hashable
 
 end HW
 
+namespace Seq
+
+/--
+  The `!seq.clock` type from CIRCT's seq dialect.
+  This represents a clock.
+-/
+structure ClockType
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+end Seq
+
 mutual
 
 /--
@@ -610,6 +621,8 @@ inductive Attribute
 | pdlTypeType (type : PDL.TypeType)
 /-- Match optional handle type -/
 | matchOptionalType (type : Match.OptionalType)
+/-- CIRCT seq clock type -/
+| seqClockType (type : Seq.ClockType)
 deriving Inhabited, Repr, Hashable
 
 end
@@ -970,6 +983,8 @@ def Attribute.decEq (attr1 attr2 : Attribute) : Decidable (attr1 = attr2) := by
     exact (isTrue (by grind))
   case pdlTypeType.pdlTypeType type1 type2 =>
     exact (isTrue (by grind))
+  case seqClockType.seqClockType =>
+    exact (isTrue (by grind))
   all_goals exact isFalse (by grind)
 termination_by sizeOf attr1
 end
@@ -1177,6 +1192,10 @@ instance : ToString HW.ModuleType where
     let values := attr.ports.iter.map ToString.toString |>.intercalateString ", "
     s!"!hw.modty<{values}>"
 
+instance : ToString Seq.ClockType where
+  toString _ :=
+    s!"!seq.clock"
+
 mutual
 
 def ArrayAttr.toString (attr : ArrayAttr) : String :=
@@ -1349,6 +1368,7 @@ def Attribute.toString (attr : Attribute) : String :=
   | .pdlValueType type => ToString.toString type
   | .pdlTypeType type => ToString.toString type
   | .matchOptionalType type => type.toString
+  | .seqClockType type => ToString.toString type
 termination_by sizeOf attr
 
 end
@@ -1615,6 +1635,7 @@ def isType (attr : Attribute) : Bool :=
   | .pdlValueType _ => true
   | .pdlTypeType _ => true
   | .matchOptionalType _ => true
+  | .seqClockType _ => true
 
 /--
   Returns the size, in bits, that an LLVM type would use if stored to memory.
@@ -1708,6 +1729,8 @@ theorem isType_pdlOperationType type : (pdlOperationType type).isType = true := 
 theorem isType_pdlValueType type : (pdlValueType type).isType = true := by rfl
 @[simp, grind =]
 theorem isType_pdlTypeType type : (pdlTypeType type).isType = true := by rfl
+@[simp, grind =]
+theorem isType_seqClockType type : (seqClockType type).isType = true := by rfl
 
 end Attribute
 
@@ -1962,6 +1985,10 @@ instance : IsTypeAttr TypeAttr where
   project_eq_some_iff _ _ := by
     simp only [Option.dite_none_right_eq_some, Option.some.injEq, TypeAttr.inj]
     grind
+
+instance : IsTypeAttr Seq.ClockType where
+  coe type := Attribute.asType (.seqClockType type) (by rfl)
+  coe_eq_inject _ := by rfl
 
 end
 end Veir

--- a/Veir/OpCode.lean
+++ b/Veir/OpCode.lean
@@ -30,6 +30,7 @@ public import Veir.Dialects.LLZK.Felt.OpInfo
 public import Veir.Dialects.LLZK.Include.OpInfo
 public import Veir.Dialects.LLZK.Function.OpInfo
 public import Veir.Dialects.Cir.OpInfo
+public import Veir.Dialects.Seq.OpInfo
 
 open Std
 

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -847,6 +847,19 @@ def parseOptionalHWModuleType : AttrParserM (Option HW.ModuleType) := do
   let ports ← parseDelimitedList .angle parseHWModulePort
   return some { ports }
 
+/--
+  Parse CIRCT's `seq` dialect's `ClockType` type.
+  Its syntax is `!seq.clock` (no parameters).
+-/
+def parseOptionalSeqClockType : AttrParserM (Option Seq.ClockType) := do
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return none
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ "seq.clock".toByteArray then return none
+  let _ ← consumeToken
+  return some {}
+
 /-- A parsed entry in an LLVM function type's parameter list. -/
 inductive LLVMFuncParam
   | type (ty : TypeAttr)
@@ -1096,6 +1109,8 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some ioAddressType
   if let some hwModuleType ← parseOptionalHWModuleType then
     return some hwModuleType
+  if let some seqClockType ← parseOptionalSeqClockType then
+    return some seqClockType
   if let some pdlRangeType ← parseOptionalPDLRangeType then
     return some pdlRangeType
   if let some pdlAttributeType ← parseOptionalPDLAttributeType then


### PR DESCRIPTION
Supports the `to_clock` and `firreg` operations.

Related issue: #1317.