### PR TITLE
feat(io): Tweaks I/O Dialect

### DIFF
--- a/Test/IO/recv_non_address_result.mlir
+++ b/Test/IO/recv_non_address_result.mlir
@@ -3,8 +3,9 @@
 "builtin.module"() ({
   "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
     %len = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
-    %n, %from = "io.recv"(%len, %len) : (i64, i64) -> (i64, !io.address)
-    // CHECK: io.recv: Expected operand 0 to have !llvm.ptr type
+    %buf = "llvm.alloca"(%len) <{elem_type = i8}> : (i64) -> !llvm.ptr
+    %n, %from = "io.recv"(%buf, %len) : (!llvm.ptr, i64) -> (i64, i32)
+    // CHECK: io.recv: Expected result 1 to have !io.address type
     "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/IO/recv_non_i64_result.mlir
+++ b/Test/IO/recv_non_i64_result.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    %len = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+    %buf = "llvm.alloca"(%len) <{elem_type = i8}> : (i64) -> !llvm.ptr
+    %n, %from = "io.recv"(%buf, %len) : (!llvm.ptr, i64) -> (i32, !io.address)
+    // CHECK: io.recv: Expected result 0 to have i64 type
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/IO/roundtrip.mlir
+++ b/Test/IO/roundtrip.mlir
@@ -6,8 +6,8 @@
   "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
     // CHECK-NEXT:     "func.func"() <{"function_type" = () -> (), "sym_name" = "main"}> ({
     // CHECK-NEXT:       ^{{.*}}():
-    %peer = "test.test"() : () -> !io.address
-    // CHECK-NEXT:         %[[peer:.*]] = "test.test"() : () -> !io.address
+    %peer = "io.self"() : () -> !io.address
+    // CHECK-NEXT:         %[[peer:.*]] = "io.self"() : () -> !io.address
     %len = "llvm.mlir.constant"() <{value = 32 : i64}> : () -> i64
     // CHECK-NEXT:         %[[len:.*]] = "llvm.mlir.constant"() <{"value" = 32 : i64}> : () -> i64
     %buf = "llvm.alloca"(%len) <{elem_type = i8}> : (i64) -> !llvm.ptr

--- a/Test/IO/roundtrip.mlir
+++ b/Test/IO/roundtrip.mlir
@@ -16,8 +16,8 @@
     // CHECK-NEXT:         %{{.*}} = "io.rand"(%[[buf]], %[[len]]) : (!llvm.ptr, i64) -> i64
     %n1 = "io.send"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
     // CHECK-NEXT:         %{{.*}} = "io.send"(%[[peer]], %[[buf]], %[[len]]) : (!io.address, !llvm.ptr, i64) -> i64
-    %n2 = "io.recv"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
-    // CHECK-NEXT:         %{{.*}} = "io.recv"(%[[peer]], %[[buf]], %[[len]]) : (!io.address, !llvm.ptr, i64) -> i64
+    %n2, %from = "io.recv"(%buf, %len) : (!llvm.ptr, i64) -> (i64, !io.address)
+    // CHECK-NEXT:         %{{.*}}:2 = "io.recv"(%[[buf]], %[[len]]) : (!llvm.ptr, i64) -> (i64, !io.address)
     "func.return"() : () -> ()
     // CHECK-NEXT:         "func.return"() : () -> ()
   }) : () -> ()

--- a/Test/IO/self_non_address_result.mlir
+++ b/Test/IO/self_non_address_result.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> ()}> ({
+    %a = "io.self"() : () -> i32
+    // CHECK: io.self: Expected result 0 to have !io.address type
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()

--- a/Test/Passes/CSE/memory.mlir
+++ b/Test/Passes/CSE/memory.mlir
@@ -19,8 +19,8 @@
   ^bb0(%peer : !io.address, %buf : !llvm.ptr, %len : i64):
     %rand0 = "io.rand"(%buf, %len) : (!llvm.ptr, i64) -> i64
     %rand1 = "io.rand"(%buf, %len) : (!llvm.ptr, i64) -> i64
-    %recv0 = "io.recv"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
-    %recv1 = "io.recv"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
+    %recv0, %from0 = "io.recv"(%buf, %len) : (!llvm.ptr, i64) -> (i64, !io.address)
+    %recv1, %from1 = "io.recv"(%buf, %len) : (!llvm.ptr, i64) -> (i64, !io.address)
     %send0 = "io.send"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
     %send1 = "io.send"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
     "test.test"(%rand0, %rand1, %recv0, %recv1, %send0, %send1) : (i64, i64, i64, i64, i64, i64) -> ()
@@ -28,11 +28,11 @@
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : !io.address, %{{.*}} : !llvm.ptr, %{{.*}} : i64):
     // CHECK-NEXT: %[[RAND0:.*]] = "io.rand"(%{{.*}}, %{{.*}}) : (!llvm.ptr, i64) -> i64
     // CHECK-NEXT: %[[RAND1:.*]] = "io.rand"(%{{.*}}, %{{.*}}) : (!llvm.ptr, i64) -> i64
-    // CHECK-NEXT: %[[RECV0:.*]] = "io.recv"(%{{.*}}, %{{.*}}, %{{.*}}) : (!io.address, !llvm.ptr, i64) -> i64
-    // CHECK-NEXT: %[[RECV1:.*]] = "io.recv"(%{{.*}}, %{{.*}}, %{{.*}}) : (!io.address, !llvm.ptr, i64) -> i64
+    // CHECK-NEXT: %[[RECV0:.*]]:2 = "io.recv"(%{{.*}}, %{{.*}}) : (!llvm.ptr, i64) -> (i64, !io.address)
+    // CHECK-NEXT: %[[RECV1:.*]]:2 = "io.recv"(%{{.*}}, %{{.*}}) : (!llvm.ptr, i64) -> (i64, !io.address)
     // CHECK-NEXT: %[[SEND0:.*]] = "io.send"(%{{.*}}, %{{.*}}, %{{.*}}) : (!io.address, !llvm.ptr, i64) -> i64
     // CHECK-NEXT: %[[SEND1:.*]] = "io.send"(%{{.*}}, %{{.*}}, %{{.*}}) : (!io.address, !llvm.ptr, i64) -> i64
-    // CHECK-NEXT: "test.test"(%[[RAND0]], %[[RAND1]], %[[RECV0]], %[[RECV1]], %[[SEND0]], %[[SEND1]]) : (i64, i64, i64, i64, i64, i64) -> ()
+    // CHECK-NEXT: "test.test"(%[[RAND0]], %[[RAND1]], %[[RECV0]]#0, %[[RECV1]]#0, %[[SEND0]], %[[SEND1]]) : (i64, i64, i64, i64, i64, i64) -> ()
     "func.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/DCE/basic.mlir
+++ b/Test/Passes/DCE/basic.mlir
@@ -54,13 +54,13 @@
     "func.func"()  <{function_type = (!io.address, !llvm.ptr, i64) -> (), sym_name = "io"}> ({
       ^6(%peer : !io.address, %buf : !llvm.ptr, %len : i64):
         %1 = "io.rand"(%buf, %len) : (!llvm.ptr, i64) -> i64
-        %2 = "io.recv"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
+        %2, %from = "io.recv"(%buf, %len) : (!llvm.ptr, i64) -> (i64, !io.address)
         %3 = "io.send"(%peer, %buf, %len) : (!io.address, !llvm.ptr, i64) -> i64
         // The unused statuses do not make the operations dead.
         // CHECK:      "func.func"() <{"function_type" = (!io.address, !llvm.ptr, i64) -> (), "sym_name" = "io"}> ({
         // CHECK-NEXT: ^{{.*}}(%{{.*}} : !io.address, %{{.*}} : !llvm.ptr, %{{.*}} : i64):
         // CHECK-NEXT: %{{.*}} = "io.rand"(%{{.*}}, %{{.*}}) : (!llvm.ptr, i64) -> i64
-        // CHECK-NEXT: %{{.*}} = "io.recv"(%{{.*}}, %{{.*}}, %{{.*}}) : (!io.address, !llvm.ptr, i64) -> i64
+        // CHECK-NEXT: %{{.*}}:2 = "io.recv"(%{{.*}}, %{{.*}}) : (!llvm.ptr, i64) -> (i64, !io.address)
         // CHECK-NEXT: %{{.*}} = "io.send"(%{{.*}}, %{{.*}}, %{{.*}}) : (!io.address, !llvm.ptr, i64) -> i64
         // CHECK-NEXT: "func.return"() : () -> ()
         "func.return"() : () -> ()

--- a/Veir/Dialects/IO/OpInfo.lean
+++ b/Veir/Dialects/IO/OpInfo.lean
@@ -10,15 +10,19 @@ public section
 
 /--
 Byte exchange with the environment. Buffers are `(ptr : !llvm.ptr, len : integer)`
-and peers are `!io.address` values. Every operation returns an `i64` status:
-non-negative is the number of bytes transferred, which may be below `len`;
-negative is an `Io.Error` code.
+and peers are `!io.address` values. Result 0 of every operation is an `i64`
+status: non-negative is the number of bytes transferred, which may be below
+`len`; negative is an `Io.Error` code.
 -/
 @[opcodes]
 inductive Io where
 /-- `(dest : !io.address, ptr : !llvm.ptr, len : integer) -> i64`: send `len` bytes at `ptr` to `dest`. -/
 | send
-/-- `(src : !io.address, ptr : !llvm.ptr, len : integer) -> i64`: receive up to `len` bytes from `src` into `ptr`. -/
+/--
+`(ptr : !llvm.ptr, len : integer) -> (i64, !io.address)`: receive the next message
+addressed to this program into `ptr`. Result 1 is the sender; it is unspecified
+when the status is negative.
+-/
 | recv
 /-- `(ptr : !llvm.ptr, len : integer) -> i64`: fill up to `len` bytes at `ptr` with random bytes. -/
 | rand
@@ -32,6 +36,9 @@ def closed : Int := -1
 
 /-- No input or entropy left. -/
 def exhausted : Int := -2
+
+/-- The next message exceeds the buffer; it stays in flight. -/
+def messageTooLong : Int := -3
 
 end Io.Error
 
@@ -93,8 +100,8 @@ def Io.verifyBufferOperands {OpInfo : Type} [IsOpCode OpInfo]
     s!"{instrName}: Expected operand {base + 1} to have integer type"
 
 /--
-Verify an `io` operation: `send` and `recv` take `(address, ptr, len)`, `rand`
-takes `(ptr, len)`; all return one `i64`.
+Verify an `io` operation: `send` takes `(address, ptr, len)`, `recv` and `rand`
+take `(ptr, len)`; result 0 is always `i64`, and `recv` adds an `!io.address`.
 -/
 @[expose]
 def Io.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInfo Io]
@@ -103,11 +110,16 @@ def Io.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInf
   let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   op.checkIsNonNullIntegerType ctx opIn
   match opType with
-  | .send | .recv =>
+  | .send =>
     op.verifyPlainOpCounts ctx opIn 3 1
     ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIoAddressType
       s!"{instrName}: Expected operand 0 to have !io.address type"
     Io.verifyBufferOperands op ctx 1 instrName
+  | .recv =>
+    op.verifyPlainOpCounts ctx opIn 2 2
+    Io.verifyBufferOperands op ctx 0 instrName
+    ((op.getResult 1).get! ctx.raw).type.verifyIoAddressType
+      s!"{instrName}: Expected result 1 to have !io.address type"
   | .rand =>
     op.verifyPlainOpCounts ctx opIn 2 1
     Io.verifyBufferOperands op ctx 0 instrName

--- a/Veir/Dialects/IO/OpInfo.lean
+++ b/Veir/Dialects/IO/OpInfo.lean
@@ -10,12 +10,14 @@ public section
 
 /--
 Byte exchange with the environment. Buffers are `(ptr : !llvm.ptr, len : integer)`
-and peers are `!io.address` values. Result 0 of every operation is an `i64`
-status: non-negative is the number of bytes transferred, which may be below
-`len`; negative is an `Io.Error` code.
+and peers are `!io.address` values. `self` yields the program's own address;
+result 0 of every other operation is an `i64` status: non-negative is the number of bytes
+transferred, which may be below `len`; negative is an `Io.Error` code.
 -/
 @[opcodes]
 inductive Io where
+/-- `() -> !io.address`: the address of the running program, fixed by the environment. -/
+| self
 /-- `(dest : !io.address, ptr : !llvm.ptr, len : integer) -> i64`: send `len` bytes at `ptr` to `dest`. -/
 | send
 /--
@@ -59,15 +61,18 @@ def Io.toAttrDict
   | _ => Std.HashMap.emptyWithCapacity 0
 
 /--
-All `io` operations access their buffer and have observable effects, so they
-are `readWrite`: never dead, and never reordered with each other or with memory
-accesses.
+`self` only reads the environment. Every other `io` operation accesses its buffer
+and has observable effects, so it is `readWrite`: never dead, and never
+reordered with each other or with memory accesses.
 -/
 @[get_effects]
 def Io.getEffects
-    (_op : Io) (_props : Io.propertiesOf _op) : MemoryEffects :=
-  .readWrite
+    (op : Io) (_props : Io.propertiesOf op) : MemoryEffects :=
+  match op with
+  | .self => .none
+  | _ => .readWrite
 
+/-- `self` is fixed by the environment, not by the operation, so it is not a literal. -/
 def Io.isConstantLike (_op : Io) : Bool :=
   false
 
@@ -99,9 +104,17 @@ def Io.verifyBufferOperands {OpInfo : Type} [IsOpCode OpInfo]
   ((op.getOperand! ctx.raw (base + 1)).getType! ctx.raw).verifyIntegerType
     s!"{instrName}: Expected operand {base + 1} to have integer type"
 
+/-- Result 0 must be the `i64` status. -/
+def Io.verifyStatusResult {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo) (instrName : String) :
+    Except String PUnit :=
+  ((op.getResult 0).get! ctx.raw).type.verifyI64
+    s!"{instrName}: Expected result 0 to have i64 type"
+
 /--
-Verify an `io` operation: `send` takes `(address, ptr, len)`, `recv` and `rand`
-take `(ptr, len)`; result 0 is always `i64`, and `recv` adds an `!io.address`.
+Verify an `io` operation: `self` takes nothing and returns an `!io.address`;
+`send` takes `(address, ptr, len)`, `recv` and `rand` take `(ptr, len)`, and
+their result 0 is an `i64` status, with `recv` adding an `!io.address`.
 -/
 @[expose]
 def Io.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInfo Io]
@@ -110,21 +123,26 @@ def Io.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo] [HasDialect OpInf
   let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
   op.checkIsNonNullIntegerType ctx opIn
   match opType with
+  | .self =>
+    op.verifyPlainOpCounts ctx opIn 0 1
+    ((op.getResult 0).get! ctx.raw).type.verifyIoAddressType
+      s!"{instrName}: Expected result 0 to have !io.address type"
   | .send =>
     op.verifyPlainOpCounts ctx opIn 3 1
     ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIoAddressType
       s!"{instrName}: Expected operand 0 to have !io.address type"
     Io.verifyBufferOperands op ctx 1 instrName
+    Io.verifyStatusResult op ctx instrName
   | .recv =>
     op.verifyPlainOpCounts ctx opIn 2 2
     Io.verifyBufferOperands op ctx 0 instrName
+    Io.verifyStatusResult op ctx instrName
     ((op.getResult 1).get! ctx.raw).type.verifyIoAddressType
       s!"{instrName}: Expected result 1 to have !io.address type"
   | .rand =>
     op.verifyPlainOpCounts ctx opIn 2 1
     Io.verifyBufferOperands op ctx 0 instrName
-  ((op.getResult 0).get! ctx.raw).type.verifyI64
-    s!"{instrName}: Expected result 0 to have i64 type"
+    Io.verifyStatusResult op ctx instrName
 
 instance : HasOpInfo Io where
   verifyLocalInvariants := Io.verifyLocalInvariants


### PR DESCRIPTION
Adapts `recv` to return the sender's address and adds `self` to refer to one's address