### PR TITLE
feat(LLVM): add llvm.intr.assume

### DIFF
--- a/Test/LLVM/assume.mlir
+++ b/Test/LLVM/assume.mlir
@@ -1,0 +1,23 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+//
+// `llvm.intr.assume` takes an `i1` condition followed by the operands of its
+// operand bundles: `op_bundle_sizes` gives the operand count of each bundle
+// and `op_bundle_tags` its name, and is omitted when there are no bundles.
+// LLVM only allows bundles on a constant `true` condition.
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1, !llvm.ptr)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1, %p: !llvm.ptr):
+    %true = "llvm.mlir.constant"() <{value = 1 : i1}> : () -> i1
+    %four = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+    "llvm.intr.assume"(%c) <{op_bundle_sizes = array<i32>}> : (i1) -> ()
+    "llvm.intr.assume"(%true, %p, %four) <{op_bundle_sizes = array<i32: 2>, op_bundle_tags = ["align"]}> : (i1, !llvm.ptr, i64) -> ()
+    "llvm.intr.assume"(%true, %p, %four, %p) <{op_bundle_sizes = array<i32: 2, 1>, op_bundle_tags = ["align", "nonnull"]}> : (i1, !llvm.ptr, i64, !llvm.ptr) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK:      "llvm.intr.assume"(%{{.*}}) <{"op_bundle_sizes" = array<i32>}> : (i1) -> ()
+// CHECK-NEXT: "llvm.intr.assume"(%{{.*}}, %{{.*}}, %{{.*}}) <{"op_bundle_sizes" = array<i32: 2>, "op_bundle_tags" = ["align"]}> : (i1, !llvm.ptr, i64) -> ()
+// CHECK-NEXT: "llvm.intr.assume"(%{{.*}}, %{{.*}}, %{{.*}}, %{{.*}}) <{"op_bundle_sizes" = array<i32: 2, 1>, "op_bundle_tags" = ["align", "nonnull"]}> : (i1, !llvm.ptr, i64, !llvm.ptr) -> ()

--- a/Test/Verifier/llvm_assume_bundle_operand_count_mismatch.mlir
+++ b/Test/Verifier/llvm_assume_bundle_operand_count_mismatch.mlir
@@ -1,0 +1,14 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// Every operand after the condition belongs to a bundle, so an extra pointer
+// with no bundle to hold it is an error.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1, !llvm.ptr)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1, %p: !llvm.ptr):
+    "llvm.intr.assume"(%c, %p) <{op_bundle_sizes = array<i32>}> : (i1, !llvm.ptr) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: Expected 1 condition and 0 operand bundle operand(s) per 'op_bundle_sizes', but got 2 operand(s)

--- a/Test/Verifier/llvm_assume_bundle_tag_count_mismatch.mlir
+++ b/Test/Verifier/llvm_assume_bundle_tag_count_mismatch.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// Each bundle is named by a tag, so one bundle needs exactly one tag.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1, !llvm.ptr)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1, %p: !llvm.ptr):
+    "llvm.intr.assume"(%c, %p) <{op_bundle_sizes = array<i32: 1>}> : (i1, !llvm.ptr) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: Expected 1 operand bundle tag(s), but got 0

--- a/Test/Verifier/llvm_assume_missing_bundle_sizes.mlir
+++ b/Test/Verifier/llvm_assume_missing_bundle_sizes.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// `op_bundle_sizes` is required even when there are no bundles.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1):
+    "llvm.intr.assume"(%c) : (i1) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: missing 'op_bundle_sizes' property

--- a/Test/Verifier/llvm_assume_negative_bundle_size.mlir
+++ b/Test/Verifier/llvm_assume_negative_bundle_size.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A bundle cannot take a negative number of operands.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1):
+    "llvm.intr.assume"(%c) <{op_bundle_sizes = array<i32: -1>, op_bundle_tags = ["align"]}> : (i1) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: op_bundle_sizes contains a negative size

--- a/Test/Verifier/llvm_assume_non_i1_condition.mlir
+++ b/Test/Verifier/llvm_assume_non_i1_condition.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The condition of `llvm.intr.assume` is a single bit; an i32 is not one.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%x: i32):
+    "llvm.intr.assume"(%x) <{op_bundle_sizes = array<i32>}> : (i32) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: Expected i1 condition

--- a/Test/Verifier/llvm_assume_non_i32_bundle_sizes.mlir
+++ b/Test/Verifier/llvm_assume_non_i32_bundle_sizes.mlir
@@ -1,0 +1,14 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// `op_bundle_sizes` is an i32 dense array in MLIR; other element types are
+// rejected rather than widened.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1):
+    "llvm.intr.assume"(%c) <{op_bundle_sizes = array<i64>}> : (i1) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: Expected 'op_bundle_sizes' to be an i32 dense array attribute

--- a/Test/Verifier/llvm_assume_non_string_bundle_tag.mlir
+++ b/Test/Verifier/llvm_assume_non_string_bundle_tag.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// Bundle tags are the bundle names, so they have to be strings.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i1, !llvm.ptr)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%c: i1, %p: !llvm.ptr):
+    "llvm.intr.assume"(%c, %p) <{op_bundle_sizes = array<i32: 1>, op_bundle_tags = [1 : i32]}> : (i1, !llvm.ptr) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.assume: Expected operand bundle tags to be string attributes

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -36,6 +36,7 @@ inductive Llvm where
 | intr__bitreverse
 | intr__fshl
 | intr__fshr
+| intr__assume
 | mul
 | sdiv
 | udiv
@@ -94,6 +95,7 @@ match op with
 | .ashr => ExactProperties
 | .intr__ctlz | .intr__cttz => ZeroPoisonProperties
 | .intr__abs => IntMinPoisonProperties
+| .intr__assume => LLVMAssumeProperties
 | .or => DisjointProperties
 | .trunc => NswNuwProperties
 | .zext => NnegProperties
@@ -127,6 +129,7 @@ def Llvm.fromAttrDict
   case intr__cttz =>
     exact ZeroPoisonProperties.fromAttrDictFor "llvm.intr.cttz" attrDict
   case intr__abs => exact IntMinPoisonProperties.fromAttrDict attrDict
+  case intr__assume => exact LLVMAssumeProperties.fromAttrDict attrDict
   case or => exact DisjointProperties.fromAttrDict attrDict
   case zext => exact NnegProperties.fromAttrDict attrDict
   case icmp => exact IcmpProperties.fromAttrDict attrDict
@@ -247,6 +250,12 @@ def Llvm.toAttrDict
     let attr := IntegerAttr.mk value (IntegerType.mk 1)
     (Std.HashMap.emptyWithCapacity 1).insert
       "is_int_min_poison".toUTF8 (Attribute.integerAttr attr)
+  | .intr__assume => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "op_bundle_sizes".toUTF8 (Attribute.denseArrayAttr props.op_bundle_sizes)
+    if let some tags := props.op_bundle_tags then
+      dict := dict.insert "op_bundle_tags".toUTF8 (.arrayAttr tags)
+    dict
   | .alloca => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 3
     dict := dict.insert "alignment".toUTF8 (Attribute.integerAttr props.alignment)
@@ -375,7 +384,7 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .fadd | .fsub | .fmul | .fdiv | .frem
   | .mlir__constant | .mlir__poison | .mlir__zero | .mlir__global | .mlir__addressof
   | .select | .br | .cond_br | .switch | .unreachable | .alloca | .load | .store
-  | .intr__lifetime__start | .intr__lifetime__end
+  | .intr__lifetime__start | .intr__lifetime__end | .intr__assume
   | .getelementptr | .call | .return | .func | .module_flags | .freeze => false
 
 instance : IsOpCode Llvm where
@@ -567,6 +576,28 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     let .llvmPointerType _ := operandType.val
       | throw "Expected operand 0 to have !llvm.ptr type"
     pure ()
+  | .intr__assume => do
+    op.checkIsNonNullIntegerType ctx opIn
+    let props := op.getProperties! ctx.raw Llvm.intr__assume
+    let sizes := props.op_bundle_sizes
+    if sizes.elementType.bitwidth ≠ 32 then
+      throw "llvm.intr.assume: Expected 'op_bundle_sizes' to be an i32 dense array attribute"
+    if sizes.values.any (· < 0) then
+      throw "llvm.intr.assume: op_bundle_sizes contains a negative size"
+    let bundleOperands := (sizes.values.foldl (· + ·) 0).toNat
+    let numOperands := op.getNumOperands ctx.raw opIn
+    if numOperands ≠ 1 + bundleOperands then
+      throw s!"llvm.intr.assume: Expected 1 condition and {bundleOperands} operand bundle \
+        operand(s) per 'op_bundle_sizes', but got {numOperands} operand(s)"
+    op.verifyPlainOpCounts ctx opIn numOperands 0
+    ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyI1 "llvm.intr.assume: Expected i1 condition"
+    let tags := (props.op_bundle_tags.map (·.value)).getD #[]
+    if tags.size ≠ sizes.values.size then
+      throw s!"llvm.intr.assume: Expected {sizes.values.size} operand bundle tag(s), \
+        but got {tags.size}"
+    for tag in tags do
+      let .stringAttr _ := tag
+        | throw "llvm.intr.assume: Expected operand bundle tags to be string attributes"
   | .mlir__addressof => do
     op.verifyPlainOpCounts ctx opIn 0 1
     let resultType := ((op.getResult 0).get! ctx.raw).type

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -125,6 +125,35 @@ def IntMinPoisonProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attrib
   else
     throw s!"llvm.intr.abs: expected 'is_int_min_poison' to be 0 or 1, but got {intAttr.value}"
 
+/--
+  Properties of the `llvm.intr.assume` intrinsic. The condition is followed by
+  the operands of its operand bundles: `op_bundle_sizes` gives the operand
+  count of each bundle and `op_bundle_tags` its name. MLIR omits
+  `op_bundle_tags` when there are no bundles.
+-/
+structure LLVMAssumeProperties where
+  op_bundle_sizes : DenseArrayAttr
+  op_bundle_tags : Option ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMAssumeProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMAssumeProperties := do
+  if let some (key, _) := attrDict.toArray.find? (fun (k, _) =>
+      k ≠ "op_bundle_sizes".toUTF8 && k ≠ "op_bundle_tags".toUTF8) then
+    throw s!"llvm.intr.assume: unexpected property '{String.fromUTF8! key}'"
+  let sizes ← match attrDict["op_bundle_sizes".toUTF8]? with
+    | some (.denseArrayAttr sizes) => pure sizes
+    | some attr =>
+      throw s!"llvm.intr.assume: expected 'op_bundle_sizes' to be a dense array attribute, \
+        but got {attr}"
+    | none => throw "llvm.intr.assume: missing 'op_bundle_sizes' property"
+  let tags ← match attrDict["op_bundle_tags".toUTF8]? with
+    | some (.arrayAttr tags) => pure (some tags)
+    | some attr =>
+      throw s!"llvm.intr.assume: expected 'op_bundle_tags' to be an array attribute, but got {attr}"
+    | none => pure none
+  return { op_bundle_sizes := sizes, op_bundle_tags := tags }
+
 structure FastMathFlagsProperties where
   attr : FastMathFlagsAttr
 deriving Inhabited, Repr, Hashable, DecidableEq


### PR DESCRIPTION
Part of #947.

The condition is followed by the operands of the op's operand bundles, so the properties model `op_bundle_sizes` and the optional `op_bundle_tags` explicitly instead of an `extra` dictionary, and the verifier checks what MLIR's does: an i1 condition, non-negative i32 sizes that account for every operand after the condition, and one string tag per bundle.

@tobiasgrosser 