### PR TITLE
feat(LLVM): add llvm.mlir.undef syntax

### DIFF
--- a/Test/LLVM/mlir_undef.mlir
+++ b/Test/LLVM/mlir_undef.mlir
@@ -1,0 +1,26 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+//
+// `llvm.mlir.undef` produces a value of any LLVM type with no operands and no
+// attributes, exactly as `llvm.mlir.poison` does. clang reaches for it when a
+// global is only partly initialized, which is why every use of it in the
+// sqlite3 corpus is a struct inside an `llvm.mlir.global` body.
+
+"builtin.module"() ({
+  // A partly initialized global: the aggregate starts undefined and is filled
+  // in by `insertvalue` in the general case.
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = !llvm.struct<(i16, i8)>, linkage = #llvm.linkage<external>, sym_name = "partly"}> ({
+    %u = "llvm.mlir.undef"() : () -> !llvm.struct<(i16, i8)>
+    "llvm.return"(%u) : (!llvm.struct<(i16, i8)>) -> ()
+  }) : () -> ()
+  // The scalar and pointer forms, for contrast with the aggregate one.
+  "llvm.func"() <{function_type = !llvm.func<i32 ()>, linkage = #llvm.linkage<external>, sym_name = "scalar"}> ({
+    %x = "llvm.mlir.undef"() : () -> i32
+    %p = "llvm.mlir.undef"() : () -> !llvm.ptr
+    "llvm.return"(%x) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.mlir.undef"() : () -> !llvm.struct<(i16, i8)>
+// CHECK: "llvm.mlir.undef"() : () -> i32
+// CHECK: "llvm.mlir.undef"() : () -> !llvm.ptr

--- a/Test/Verifier/llvm_mlir_undef_with_operand.mlir
+++ b/Test/Verifier/llvm_mlir_undef_with_operand.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// `llvm.mlir.undef` takes nothing: it is a source of value, not a cast.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i32 (i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%x: i32):
+    %u = "llvm.mlir.undef"(%x) : (i32) -> i32
+    "llvm.return"(%u) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.undef: Expected 0 operand(s)

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -16,6 +16,7 @@ public section
 inductive Llvm where
 | mlir__constant
 | mlir__poison
+| mlir__undef
 | mlir__zero
 | mlir__global
 | mlir__addressof
@@ -317,7 +318,8 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
   | .alloca, _ => .allocate
   | .load, props => if props.volatile_ then .readWrite else .read
   | .store, props => if props.volatile_ then .readWrite else .write
-  | .mlir__constant, _ | .mlir__poison, _ | .mlir__zero, _ | .mlir__addressof, _
+  | .mlir__constant, _ | .mlir__poison, _ | .mlir__undef, _ | .mlir__zero, _
+  | .mlir__addressof, _
   | .and, _ | .or, _ | .xor, _
   | .add, _ | .sub, _ | .mul, _
   | .sdiv, _ | .udiv, _ | .srem, _ | .urem, _
@@ -341,7 +343,7 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
 
 def Llvm.isConstantLike (op : Llvm) : Bool :=
   match op with
-  | .mlir__constant | .mlir__poison | .mlir__zero | .mlir__addressof => true
+  | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__addressof => true
   | _ => false
 
 def Llvm.isIsolatedFromAbove (op : Llvm) : Bool :=
@@ -373,7 +375,8 @@ def Llvm.propagatesPoison : Llvm → Bool
   -- `RuntimeValue` represents a poisoned float yet, so listing them here would
   -- claim a fold that cannot be materialized.
   | .fadd | .fsub | .fmul | .fdiv | .frem
-  | .mlir__constant | .mlir__poison | .mlir__zero | .mlir__global | .mlir__addressof
+  | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__global
+  | .mlir__addressof
   | .select | .br | .cond_br | .switch | .unreachable | .alloca | .load | .store
   | .intr__lifetime__start | .intr__lifetime__end
   | .getelementptr | .call | .return | .func | .module_flags | .freeze => false
@@ -525,7 +528,7 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
           throw s!"llvm.mlir.constant: string length {stringAttr.value.size} does not match declared array size {arrType.size}"
       | _ => throw "llvm.mlir.constant: Expected array result type for a string constant"
       pure ()
-  | .mlir__poison => do
+  | .mlir__poison | .mlir__undef => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 0 1
     pure ()


### PR DESCRIPTION
This adds syntax support for `llvm.mlir.undef`.

When adding interpreter support, we need to be careful to ensure we only add as much undef support as LLVM actually needs. Undef is deprecated with the exception of memory loads.