### PR TITLE
build(nix): expose Lean executable apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,10 @@ Common tasks are wrapped in the [`Makefile`](Makefile): `make build` to build an
 
 With Nix, `nix develop` enters a development shell containing Lean's toolchain
 manager and all native and Python dependencies needed by those Make targets.
-The targets can also be run directly as flake apps with `nix run .#build` and
-`nix run .#tests`; `nix run .` displays the Makefile help.
+Executable targets like `veir-opt` and `veir-interpret` can be run with `nix run
+.#veir-opt`, `nix run .#veir-interpret`, etc. For convenience, makefile targets
+are also exposed as flake apps with `nix run .#build` and `nix run .#tests`;
+`nix run .` displays the Makefile help. 
 
 Our testing framework is split into two parts: unit tests written in Lean and
 [FileCheck](https://llvm.org/docs/CommandGuide/FileCheck.html) tests for the

--- a/flake.nix
+++ b/flake.nix
@@ -46,6 +46,24 @@
             then "Show VeIR's Make targets"
             else "Run VeIR's make ${target} target";
         };
+
+      makeLeanApp = pkgs: target:
+        let
+          package = pkgs.writeShellApplication {
+            name = target;
+            runtimeInputs = developmentPackages pkgs;
+            text = ''
+              export LEAN_AR="${pkgs.llvmPackages.llvm}/bin/llvm-ar"
+              export LEAN_CC="${self}/ExArray/compiler"
+              exec lake exe ${target} "$@"
+            '';
+          };
+        in
+        {
+          type = "app";
+          program = "${package}/bin/${target}";
+          meta.description = "Run VeIR's ${target} executable";
+        };
     in
     {
       devShells = forAllSystems (system:
@@ -71,6 +89,10 @@
           default = makeApp pkgs null;
           build = makeApp pkgs "build";
           tests = makeApp pkgs "tests";
+          "veir-opt" = makeLeanApp pkgs "veir-opt";
+          "veir-interpret" = makeLeanApp pkgs "veir-interpret";
+          "veir2mir" = makeLeanApp pkgs "veir2mir";
+          "run-benchmarks" = makeLeanApp pkgs "run-benchmarks";
         });
     };
 }


### PR DESCRIPTION
Expose the `[[lean_exe]]` targets in Nix flake as well, such as `.#veir-opt` and `.#veir-interpret`. This way developers can run `nix run .#veir-opt` and `nix run .#veir-interpret` instead of `nix develop --command lake exe veir-opt`.