### PR TITLE
chore(IR): improve generated `IsAttr` proofs

### DIFF
--- a/UnitTest.lean
+++ b/UnitTest.lean
@@ -1,4 +1,5 @@
 import UnitTest.Lexer
+import UnitTest.Deriving
 import UnitTest.ParserError
 import UnitTest.Parser
 import UnitTest.AttrParser

--- a/UnitTest/Deriving.lean
+++ b/UnitTest/Deriving.lean
@@ -1,0 +1,46 @@
+import Veir.Meta.Deriving
+
+namespace DerivingTest
+
+mutual
+inductive Tree (α : Type) where
+  | leaf (value : α)
+  | branch (children : Forest α)
+
+structure Forest (α : Type) where
+  trees : Array (Tree α)
+end
+
+structure Label (α : Type) where
+  value : α
+
+/-! Positive test cases. -/
+
+derive_mutual_repr for Forest, Tree
+derive_mutual_hashable for Forest, Tree
+
+example : Repr (Tree Nat) := inferInstance
+example : Repr (Forest Nat) := inferInstance
+example : Hashable (Tree Nat) := inferInstance
+example : Hashable (Forest Nat) := inferInstance
+
+#guard reprStr (Tree.branch ⟨#[.leaf 7]⟩ : Tree Nat) ==
+  "DerivingTest.Tree.branch { trees := #[DerivingTest.Tree.leaf 7] }"
+
+/-! Types outside the mutual group are rejected. -/
+
+/-- error: DerivingTest.Label is not in the mutual group of DerivingTest.Forest -/
+#guard_msgs in
+derive_mutual_repr for Forest, Label, Tree
+
+/-- error: DerivingTest.Forest is not in the mutual group of DerivingTest.Label -/
+#guard_msgs in
+derive_mutual_repr for Label, Forest, Tree
+
+/-- error: DerivingTest.Label is not in the mutual group of DerivingTest.Forest -/
+#guard_msgs in
+derive_mutual_hashable for Forest, Label, Tree
+
+/-- error: DerivingTest.Forest is not in the mutual group of DerivingTest.Label -/
+#guard_msgs in
+derive_mutual_hashable for Label, Forest, Tree

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -1251,6 +1251,24 @@ class IsAttr (Attr : Type) extends ToString Attr, Inhabited Attr where
 
 attribute [grind unfold] IsAttr.inject
 
+/--
+Derive `project_eq_some_iff` from a projection that carries its correctness certificate.
+
+This is useful for efficiently deriving `IsAttr` instances for each attribute kind.
+-/
+theorem IsAttr.projectSubtype_eq_some_iff_of_projectSubtype
+    (inject : Attr → Attribute)
+    (projectSubtype : (attr : Attribute) → Option { specificAttr : Attr // inject specificAttr = attr })
+    (projectSubtype_inject : (specificAttr : Attr) →
+      projectSubtype (inject specificAttr) = some ⟨specificAttr, rfl⟩)
+    (attr : Attribute) (specificAttr : Attr) :
+    (projectSubtype attr).map Subtype.val = some specificAttr ↔ inject specificAttr = attr := by
+  constructor
+  · grind [Option.map_eq_some_iff]
+  · intro h
+    subst attr
+    simp [projectSubtype_inject]
+
 namespace Attribute
 
 /--
@@ -1358,16 +1376,21 @@ syntax "attribute_instance " term " => " ident : command
 macro_rules
   | `(attribute_instance $attrType:term => $ctor:ident) => do
     let attrName := Lean.Syntax.mkStrLit (toString attrType)
-    `(@[expose] instance : IsAttr $attrType where
-        toString := ToString.toString
-        default := Inhabited.default
-        name := $attrName
-        inject := $ctor
-        project
-          | $ctor value => some value
-          | _ => none
-        project_eq_some_iff attr _ := by
-          cases attr <;> simp_all [eq_comm])
+    `(@[expose] instance : IsAttr $attrType := by
+        let projectSubtype : (attr : Attribute) →
+            Option { specificAttr : $attrType // $ctor specificAttr = attr } :=
+          fun
+            | $ctor value => some ⟨value, rfl⟩
+            | _ => none
+        exact {
+          toString := ToString.toString
+          default := Inhabited.default
+          name := $attrName
+          inject := $ctor
+          project := fun attr => (projectSubtype attr).map Subtype.val
+          project_eq_some_iff := IsAttr.projectSubtype_eq_some_iff_of_projectSubtype
+            $ctor projectSubtype (fun _ => rfl)
+        })
 
 open Lean Elab Command Meta
 

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -5,6 +5,8 @@ public import Veir.Data.Float
 public import Lean.Elab.Command
 public import Std.Data.Iterators.Producers.Array
 
+meta import Veir.Meta.Deriving
+
 /-!
   # Attributes
 
@@ -513,7 +515,6 @@ mutual
 structure VectorType where
   shape : Array Nat
   elementType : Attribute
-deriving Repr, Hashable
 
 /--
   The signature of a function, consisting of an array of input attributes
@@ -523,7 +524,7 @@ structure FunctionType where
   inputs : Array Attribute
   outputs : Array Attribute
   isVarArg : Bool := false
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 /--
   The payload of an LLVM function type attribute.
@@ -533,7 +534,7 @@ deriving Inhabited, Repr, Hashable
 -/
 structure LLVMFunctionType where
   functionType : FunctionType
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 /--
   The payload of a ClangIR function type `!cir.func<(inputs) -> result>`.
@@ -541,14 +542,14 @@ deriving Inhabited, Repr, Hashable
 -/
 structure CirFuncType where
   functionType : FunctionType
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 /--
   An attribute that holds a sequence of attributes.
 -/
 structure ArrayAttr where
   value : Array Attribute
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 /--
   A dictionary attribute that maps byte array keys to attribute values.
@@ -563,7 +564,7 @@ structure DictionaryAttr where
   -/
   entries : Array (ByteArray × Attribute)
   /- TODO: figure out how to maintain a proof of sorted-ness and uniqueness. -/
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 /--
   An attribute representing a fixed-sized array type
@@ -571,7 +572,6 @@ deriving Inhabited, Repr, Hashable
 structure LLVM.ArrayType where
   size : Nat
   type : Attribute
-deriving Repr, Hashable
 
 /--
   The `!match.optional<...>` type, wrapping a PDL handle type whose value may
@@ -584,7 +584,6 @@ deriving Repr, Hashable
 -/
 structure Match.OptionalType where
   innerType : Attribute
-deriving Repr, Hashable
 
 /--
   An attribute from an unknown dialect, kept as its source text.
@@ -601,7 +600,7 @@ structure UnregisteredAttr where
   value : String
   isType : Bool
   type : Option Attribute := none
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 /--
   A data structure that represents compile-time information in the IR.
@@ -719,9 +718,19 @@ inductive Attribute
 | matchOptionalType (type : Match.OptionalType)
 /-- CIRCT seq clock type -/
 | seqClockType (type : Seq.ClockType)
-deriving Inhabited, Repr, Hashable
+deriving Inhabited
 
 end
+
+/- Derive Repr and Hashable instances for the mutual group. -/
+derive_mutual_repr for
+  VectorType, FunctionType, LLVMFunctionType, CirFuncType,
+  ArrayAttr, DictionaryAttr, LLVM.ArrayType, Match.OptionalType,
+  UnregisteredAttr, Attribute
+derive_mutual_hashable for
+  VectorType, FunctionType, LLVMFunctionType, CirFuncType,
+  ArrayAttr, DictionaryAttr, LLVM.ArrayType, Match.OptionalType,
+  UnregisteredAttr, Attribute
 
 instance : Inhabited VectorType where
   default := { shape := #[], elementType := .integerType (IntegerType.mk 0) }

--- a/Veir/Meta/Deriving.lean
+++ b/Veir/Meta/Deriving.lean
@@ -1,0 +1,64 @@
+module
+
+public meta import Lean.Elab.Deriving.Repr
+public meta import Lean.Elab.Deriving.Hashable
+
+/-!
+Commands for deriving instances while sharing helpers between mutually recursive types.
+
+Lean's standard Repr and Hashable handlers generate the whole mutual group's helpers
+again for each requested instance. These commands accept types from a single mutual
+group and generate its helpers once.
+-/
+
+namespace Veir
+
+open Lean Elab Command Deriving
+
+/--
+Derive a class instance for a mutual group of types, generating helpers only once.
+
+`className` is the name of the class to derive, `fnPrefix` is a prefix for the helper names (which
+is useful for debugging), `mkHelpers` is a function that generates the helpers in a mutual block,
+and `types` is the list of types to derive instances for.
+-/
+private meta def deriveSharedInstances (className : Name) (fnPrefix : String)
+    (mkHelpers : Deriving.Context → TermElabM Syntax) (types : Array Syntax) : CommandElabM Unit := do
+  /- Resolve the arguments as declaration names. -/
+  let typeNames ← types.mapM resolveGlobalConstNoOverload
+  let cmds ← liftTermElabM do
+    /- Get the mutual group by fetching it from the first type. -/
+    let ctx ← mkContext className fnPrefix typeNames[0]!
+    /- Generate a `mutual ... end` syntax tree containing the helper functions. -/
+    let helpers ← mkHelpers ctx
+    /- The list of commands to be executed. -/
+    let mut cmds : Array Lean.Command := #[⟨helpers⟩]
+
+    /- For each type in the group, generate an instance using the generated helper. -/
+    for typeName in typeNames do
+      /- Sanity check that the user only provided types from the same mutual group. -/
+      unless ctx.typeInfos.any (·.name == typeName) do
+        throwError "{typeName} is not in the mutual group of {typeNames[0]!}"
+      let instName ← mkInstName className typeName
+      cmds := cmds ++ (← mkInstanceCmds { ctx with instName } className #[typeName])
+    return cmds
+  cmds.forM elabCommand
+
+public section
+
+/--
+Derive Repr for distinct types from a single mutual group, generating helpers only once per type.
+-/
+elab "derive_mutual_repr " "for " types:ident,+ : command =>
+  deriveSharedInstances ``Repr "repr" Repr.mkMutualBlock types.getElems
+
+/--
+Derive Hashable for distinct types from a single mutual group, generating helpers only once per
+type.
+-/
+elab "derive_mutual_hashable " "for " types:ident,+ : command =>
+  deriveSharedInstances ``Hashable "hash" Hashable.mkHashFuncs types.getElems
+
+end
+
+end Veir


### PR DESCRIPTION
`attribute_instance` generates for each attribute kind a proof that is linear in the number of attribute kinds. This change makes this proof constant in the number of attribute kinds, making the entire process linear instead of quadratic.

This reduces the compilation of `Attribute.lean` from 7s to 4.7s locally.