### PR TITLE
feat(LLVM): parse fneg, fmuladd, fabs, fcmp, and the float casts

### DIFF
--- a/Test/LLVM/fcmp.mlir
+++ b/Test/LLVM/fcmp.mlir
@@ -1,0 +1,45 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i1 (f64, f64)>, linkage = #llvm.linkage<external>, sym_name = "compare"}> ({
+  ^bb0(%a: f64, %b: f64):
+    %_false = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 0 : i64}> : (f64, f64) -> i1
+    %oeq = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 1 : i64}> : (f64, f64) -> i1
+    %ogt = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 2 : i64}> : (f64, f64) -> i1
+    %oge = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 3 : i64}> : (f64, f64) -> i1
+    %olt = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 4 : i64}> : (f64, f64) -> i1
+    %ole = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 5 : i64}> : (f64, f64) -> i1
+    %one = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 6 : i64}> : (f64, f64) -> i1
+    %ord = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 7 : i64}> : (f64, f64) -> i1
+    %ueq = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 8 : i64}> : (f64, f64) -> i1
+    %ugt = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 9 : i64}> : (f64, f64) -> i1
+    %uge = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 10 : i64}> : (f64, f64) -> i1
+    %ult = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 11 : i64}> : (f64, f64) -> i1
+    %ule = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 12 : i64}> : (f64, f64) -> i1
+    %une = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 13 : i64}> : (f64, f64) -> i1
+    %uno = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 14 : i64}> : (f64, f64) -> i1
+    %_true = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 15 : i64}> : (f64, f64) -> i1
+    // Also check the fastmath flags.
+    %fast = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<nnan>, predicate = 1 : i64}> : (f64, f64) -> i1
+    "llvm.return"(%oeq) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 0 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 1 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 2 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 3 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 4 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 5 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 6 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 7 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 8 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 9 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 10 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 11 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 12 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 13 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 14 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "predicate" = 15 : i64}> : (f64, f64) -> i1
+// CHECK: "llvm.fcmp"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<nnan>, "predicate" = 1 : i64}> : (f64, f64) -> i1

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -80,6 +80,8 @@
       %fp2si = "llvm.fptosi"(%fcst) : (f64) -> i32
       %fabs = "llvm.intr.fabs"(%fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64) -> f64
       %fp2ui = "llvm.fptoui"(%fcst) : (f64) -> i32
+      %f32 = "llvm.mlir.constant"() <{value = 1.000000e+00 : f32}> : () -> f32
+      %fpext = "llvm.fpext"(%f32) : (f32) -> f64
       %60 = "llvm.freeze"(%5) : (i32) -> i32
       %61 = "llvm.mlir.poison"() : () -> i64
       %62 = "llvm.bitcast"(%5) : (i32) -> !llvm.byte<32>
@@ -170,6 +172,8 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.fptosi"(%arg7_0) : (f64) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.intr.fabs"(%arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fptoui"(%arg7_0) : (f64) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.mlir.constant"() <{"value" = 0x3f800000 : f32}> : () -> f32
+// CHECK-NEXT:       %{{.*}} = "llvm.fpext"(%{{.*}}) : (f32) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.freeze"(%{{.*}}) : (i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.poison"() : () -> i64
 // CHECK-NEXT:       %{{.*}} = "llvm.bitcast"(%{{.*}}) : (i32) -> !llvm.byte<32>

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -77,6 +77,7 @@
       %fma = "llvm.intr.fmuladd"(%fcst, %fcst, %fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, f64, f64) -> f64
       %si2fp = "llvm.sitofp"(%5) : (i32) -> f64
       %ui2fp = "llvm.uitofp"(%5) : (i32) -> f64
+      %uitofp_nn = "llvm.uitofp"(%5) <{nonNeg}> : (i32) -> f64
       %fp2si = "llvm.fptosi"(%fcst) : (f64) -> i32
       %fabs = "llvm.intr.fabs"(%fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64) -> f64
       %fp2ui = "llvm.fptoui"(%fcst) : (f64) -> i32
@@ -169,6 +170,7 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.intr.fmuladd"(%arg7_0, %arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.sitofp"(%{{.*}}) : (i32) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.uitofp"(%{{.*}}) : (i32) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.uitofp"(%{{.*}}) <{nonNeg}> : (i32) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fptosi"(%arg7_0) : (f64) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.intr.fabs"(%arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.fptoui"(%arg7_0) : (f64) -> i32

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -73,6 +73,13 @@
       %57 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
       %58 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
       %59 = "llvm.frem"(%fcst, %fcst) <{fastmathFlags = #llvm.fastmath<nsz, nnan, ninf>}> : (f64, f64) -> f64
+      %fneg = "llvm.fneg"(%fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64) -> f64
+      %fma = "llvm.intr.fmuladd"(%fcst, %fcst, %fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, f64, f64) -> f64
+      %si2fp = "llvm.sitofp"(%5) : (i32) -> f64
+      %ui2fp = "llvm.uitofp"(%5) : (i32) -> f64
+      %fp2si = "llvm.fptosi"(%fcst) : (f64) -> i32
+      %fabs = "llvm.intr.fabs"(%fcst) <{fastmathFlags = #llvm.fastmath<none>}> : (f64) -> f64
+      %fp2ui = "llvm.fptoui"(%fcst) : (f64) -> i32
       %60 = "llvm.freeze"(%5) : (i32) -> i32
       %61 = "llvm.mlir.poison"() : () -> i64
       %62 = "llvm.bitcast"(%5) : (i32) -> !llvm.byte<32>
@@ -156,6 +163,13 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<ninf>}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<nsz>}> : (f64, f64) -> f64
 // CHECK-NEXT:       %{{.*}} = "llvm.frem"(%arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<fast>}> : (f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fneg"(%arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.intr.fmuladd"(%arg7_0, %arg7_0, %arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64, f64, f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.sitofp"(%{{.*}}) : (i32) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.uitofp"(%{{.*}}) : (i32) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fptosi"(%arg7_0) : (f64) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.intr.fabs"(%arg7_0) <{"fastmathFlags" = #llvm.fastmath<none>}> : (f64) -> f64
+// CHECK-NEXT:       %{{.*}} = "llvm.fptoui"(%arg7_0) : (f64) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.freeze"(%{{.*}}) : (i32) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.mlir.poison"() : () -> i64
 // CHECK-NEXT:       %{{.*}} = "llvm.bitcast"(%{{.*}}) : (i32) -> !llvm.byte<32>

--- a/Test/Verifier/llvm_fcmp_integer_operands.mlir
+++ b/Test/Verifier/llvm_fcmp_integer_operands.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32, i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32, %i: i32):
+    %r = "llvm.fcmp"(%i, %i) <{fastmathFlags = #llvm.fastmath<none>, predicate = 1 : i64}> : (i32, i32) -> i1
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fcmp: Expected operand 0 to have floating point type

--- a/Test/Verifier/llvm_fcmp_invalid_predicate.mlir
+++ b/Test/Verifier/llvm_fcmp_invalid_predicate.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i1 (f64, f64)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%a: f64, %b: f64):
+    %r = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 16 : i64}> : (f64, f64) -> i1
+    "llvm.return"(%r) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fcmp: invalid predicate 16

--- a/Test/Verifier/llvm_fcmp_non_i1_result.mlir
+++ b/Test/Verifier/llvm_fcmp_non_i1_result.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i32 (f64, f64)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%a: f64, %b: f64):
+    %r = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 1 : i64}> : (f64, f64) -> i32
+    "llvm.return"(%r) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fcmp: Expected an i1 result

--- a/Test/Verifier/llvm_fcmp_non_i1_result.mlir
+++ b/Test/Verifier/llvm_fcmp_non_i1_result.mlir
@@ -9,4 +9,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.fcmp: Expected an i1 result
+// CHECK: llvm.fcmp: Expected i1 result

--- a/Test/Verifier/llvm_fcmp_non_i64_predicate.mlir
+++ b/Test/Verifier/llvm_fcmp_non_i64_predicate.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i1 (f64, f64)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%a: f64, %b: f64):
+    %r = "llvm.fcmp"(%a, %b) <{fastmathFlags = #llvm.fastmath<none>, predicate = 2 : i32}> : (f64, f64) -> i1
+    "llvm.return"(%r) : (i1) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fcmp: expected predicate to be an i64 integer attribute, but got 2 : i32

--- a/Test/Verifier/llvm_fmuladd_mixed_widths.mlir
+++ b/Test/Verifier/llvm_fmuladd_mixed_widths.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32, i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32, %i: i32):
+    %r = "llvm.intr.fmuladd"(%d, %s, %d) <{fastmathFlags = #llvm.fastmath<none>}> : (f64, f32, f64) -> f64
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.intr.fmuladd: Expected operands to have the same type

--- a/Test/Verifier/llvm_fneg_integer_operand.mlir
+++ b/Test/Verifier/llvm_fneg_integer_operand.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32, i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32, %i: i32):
+    %r = "llvm.fneg"(%i) <{fastmathFlags = #llvm.fastmath<none>}> : (i32) -> i32
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fneg: Expected operand 0 to have floating point type

--- a/Test/Verifier/llvm_fpext_integer_operand.mlir
+++ b/Test/Verifier/llvm_fpext_integer_operand.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32, i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32, %i: i32):
+    %r = "llvm.fpext"(%i) : (i32) -> f64
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fpext: Expected operand 0 to have floating point type

--- a/Test/Verifier/llvm_fptosi_integer_operand.mlir
+++ b/Test/Verifier/llvm_fptosi_integer_operand.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32, i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32, %i: i32):
+    %r = "llvm.fptosi"(%i) : (i32) -> i32
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fptosi: Expected operand 0 to have floating point type

--- a/Test/Verifier/llvm_sitofp_float_operand.mlir
+++ b/Test/Verifier/llvm_sitofp_float_operand.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32, i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32, %i: i32):
+    %r = "llvm.sitofp"(%d) : (f64) -> f64
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.sitofp: Expected operand 0 to have integer type

--- a/Veir/Data/LLVM.lean
+++ b/Veir/Data/LLVM.lean
@@ -2,3 +2,4 @@ module
 
 public import Veir.Data.LLVM.Int
 public import Veir.Data.LLVM.Byte
+public import Veir.Data.LLVM.FloatPred

--- a/Veir/Data/LLVM/FloatPred.lean
+++ b/Veir/Data/LLVM/FloatPred.lean
@@ -1,0 +1,69 @@
+module
+
+namespace Veir.Data.LLVM
+
+public section
+
+/--
+The predicate of an `llvm.fcmp`.
+-/
+inductive FloatPred where
+  | _false
+  | oeq
+  | ogt
+  | oge
+  | olt
+  | ole
+  | one
+  | ord
+  | ueq
+  | ugt
+  | uge
+  | ult
+  | ule
+  | une
+  | uno
+  | _true
+deriving DecidableEq, Inhabited, Repr, Hashable
+
+def FloatPred.fromNat (s : Nat) : Option FloatPred :=
+  match s with
+  | 0 => some ._false
+  | 1 => some .oeq
+  | 2 => some .ogt
+  | 3 => some .oge
+  | 4 => some .olt
+  | 5 => some .ole
+  | 6 => some .one
+  | 7 => some .ord
+  | 8 => some .ueq
+  | 9 => some .ugt
+  | 10 => some .uge
+  | 11 => some .ult
+  | 12 => some .ule
+  | 13 => some .une
+  | 14 => some .uno
+  | 15 => some ._true
+  | _ => none
+
+def FloatPred.toNat : FloatPred → Nat
+  | ._false => 0
+  | .oeq => 1
+  | .ogt => 2
+  | .oge => 3
+  | .olt => 4
+  | .ole => 5
+  | .one => 6
+  | .ord => 7
+  | .ueq => 8
+  | .ugt => 9
+  | .uge => 10
+  | .ult => 11
+  | .ule => 12
+  | .une => 13
+  | .uno => 14
+  | ._true => 15
+
+end
+
+end Veir.Data.LLVM

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -74,6 +74,7 @@ inductive Llvm where
 | uitofp
 | fptosi
 | fptoui
+| fpext
 | intr__fmuladd
 | intr__fabs
 | freeze
@@ -387,7 +388,7 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
   | .intr__sshl__sat, _ | .intr__ushl__sat, _
   | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _
   | .fneg, _ | .fcmp, _ | .sitofp, _ | .uitofp, _ | .fptosi, _ | .fptoui, _
-  | .intr__fmuladd, _ | .intr__fabs, _ => .none
+  | .fpext, _ | .intr__fmuladd, _ | .intr__fabs, _ => .none
   -- For everything else: be conservative!
   | _, _ => .unknown
 
@@ -426,7 +427,7 @@ def Llvm.propagatesPoison : Llvm → Bool
   -- `RuntimeValue` represents a poisoned float yet, so listing them here would
   -- claim a fold that cannot be materialized.
   | .fadd | .fsub | .fmul | .fdiv | .frem
-  | .fneg | .fcmp | .sitofp | .uitofp | .fptosi | .fptoui
+  | .fneg | .fcmp | .sitofp | .uitofp | .fptosi | .fptoui | .fpext
   | .intr__fmuladd | .intr__fabs
   | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__global
   | .mlir__addressof
@@ -870,7 +871,7 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 2 1
     ((op.getResult 0).get! ctx.raw).type.verifyI1 "llvm.fcmp: Expected an i1 result"
-  | .sitofp | .uitofp | .fptosi | .fptoui => do
+  | .sitofp | .uitofp | .fptosi | .fptoui | .fpext => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 1 1
     pure ()

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -861,20 +861,22 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     op.verifyFloatBinop ctx opIn
   | .fneg | .intr__fabs => do
     op.checkIsNonNullIntegerType ctx opIn
-    op.verifyPlainOpCounts ctx opIn 1 1
-    pure ()
+    op.verifyFloatUnop ctx opIn
   | .intr__fmuladd => do
     op.checkIsNonNullIntegerType ctx opIn
-    op.verifyPlainOpCounts ctx opIn 3 1
-    pure ()
+    op.verifyFloatTernop ctx opIn
   | .fcmp => do
     op.checkIsNonNullIntegerType ctx opIn
-    op.verifyPlainOpCounts ctx opIn 2 1
-    ((op.getResult 0).get! ctx.raw).type.verifyI1 "llvm.fcmp: Expected an i1 result"
-  | .sitofp | .uitofp | .fptosi | .fptoui | .fpext => do
+    op.verifyFCmp ctx opIn
+  | .sitofp | .uitofp => do
     op.checkIsNonNullIntegerType ctx opIn
-    op.verifyPlainOpCounts ctx opIn 1 1
-    pure ()
+    op.verifyIntToFloatTypes ctx opIn
+  | .fptosi | .fptoui => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyFloatToIntTypes ctx opIn
+  | .fpext => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyFloatExtTypes ctx opIn
   | .module_flags => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 0 0

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -68,6 +68,14 @@ inductive Llvm where
 | fmul
 | fdiv
 | frem
+| fneg
+| fcmp
+| sitofp
+| uitofp
+| fptosi
+| fptoui
+| intr__fmuladd
+| intr__fabs
 | freeze
 | bitcast
 | inttoptr
@@ -114,7 +122,9 @@ match op with
 | .load => LoadProperties
 | .store => StoreProperties
 | .getelementptr => GetelementptrProperties
-| .fadd | .fsub | .fmul | .fdiv | .frem => FastMathFlagsProperties
+| .fadd | .fsub | .fmul | .fdiv | .frem | .fneg | .intr__fmuladd | .intr__fabs =>
+  FastMathFlagsProperties
+| .fcmp => FcmpProperties
 | .call => LLVMCallProperties
 | .func => LLVMFuncProperties
 | .module_flags => LLVMModuleFlagsProperties
@@ -153,8 +163,9 @@ def Llvm.fromAttrDict
   case load => exact LoadProperties.fromAttrDict attrDict
   case store => exact StoreProperties.fromAttrDict attrDict
   case getelementptr => exact GetelementptrProperties.fromAttrDict attrDict
-  case fadd | fsub | fmul | fdiv | frem =>
+  case fadd | fsub | fmul | fdiv | frem | fneg | intr__fmuladd | intr__fabs =>
     exact FastMathFlagsProperties.fromAttrDict attrDict
+  case fcmp => exact FcmpProperties.fromAttrDict attrDict
   case func => exact LLVMFuncProperties.fromAttrDict attrDict
   case module_flags => exact LLVMModuleFlagsProperties.fromAttrDict attrDict
   case call => exact LLVMCallProperties.fromAttrDict attrDict
@@ -206,9 +217,15 @@ def Llvm.toAttrDict
       let attr := IntegerAttr.mk (Int.ofNat val) (IntegerType.mk 32)
       dict := dict.insert "overflowFlags".toUTF8 (Attribute.integerAttr attr)
     dict
-  | .fadd | .fsub | .fmul | .fdiv | .frem =>
+  | .fadd | .fsub | .fmul | .fdiv | .frem | .fneg | .intr__fmuladd | .intr__fabs =>
     (Std.HashMap.emptyWithCapacity 1).insert
       "fastmathFlags".toUTF8 (Attribute.fastMathFlagsAttr props.attr)
+  | .fcmp => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "fastmathFlags".toUTF8 (Attribute.fastMathFlagsAttr props.fastmathFlags)
+    let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
+    dict := dict.insert "predicate".toUTF8 (Attribute.integerAttr value)
+    dict
   | .icmp =>
     let value := IntegerAttr.mk (Int.ofNat props.predicate.toNat) (IntegerType.mk 64)
     (Std.HashMap.emptyWithCapacity 1).insert
@@ -368,7 +385,9 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
   | .intr__sadd__sat, _ | .intr__uadd__sat, _
   | .intr__ssub__sat, _ | .intr__usub__sat, _
   | .intr__sshl__sat, _ | .intr__ushl__sat, _
-  | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _ => .none
+  | .fadd, _ | .fsub, _ | .fmul, _ | .fdiv, _ | .frem, _
+  | .fneg, _ | .fcmp, _ | .sitofp, _ | .uitofp, _ | .fptosi, _ | .fptoui, _
+  | .intr__fmuladd, _ | .intr__fabs, _ => .none
   -- For everything else: be conservative!
   | _, _ => .unknown
 
@@ -407,6 +426,8 @@ def Llvm.propagatesPoison : Llvm → Bool
   -- `RuntimeValue` represents a poisoned float yet, so listing them here would
   -- claim a fold that cannot be materialized.
   | .fadd | .fsub | .fmul | .fdiv | .frem
+  | .fneg | .fcmp | .sitofp | .uitofp | .fptosi | .fptoui
+  | .intr__fmuladd | .intr__fabs
   | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__global
   | .mlir__addressof
   | .select | .br | .cond_br | .switch | .unreachable | .alloca | .load | .store
@@ -837,6 +858,22 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
   | .fadd | .fsub | .fmul | .fdiv | .frem => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyFloatBinop ctx opIn
+  | .fneg | .intr__fabs => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyPlainOpCounts ctx opIn 1 1
+    pure ()
+  | .intr__fmuladd => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyPlainOpCounts ctx opIn 3 1
+    pure ()
+  | .fcmp => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyPlainOpCounts ctx opIn 2 1
+    ((op.getResult 0).get! ctx.raw).type.verifyI1 "llvm.fcmp: Expected an i1 result"
+  | .sitofp | .uitofp | .fptosi | .fptoui => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyPlainOpCounts ctx opIn 1 1
+    pure ()
   | .module_flags => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 0 0

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -113,7 +113,7 @@ match op with
 | .intr__assume => LLVMAssumeProperties
 | .or => DisjointProperties
 | .trunc => NswNuwProperties
-| .zext => NnegProperties
+| .zext | .uitofp => NnegProperties
 | .icmp => IcmpProperties
 | .br => LLVMBrProperties
 | .cond_br => LLVMCondBrProperties
@@ -149,7 +149,7 @@ def Llvm.fromAttrDict
   case intr__abs => exact IntMinPoisonProperties.fromAttrDict attrDict
   case intr__assume => exact LLVMAssumeProperties.fromAttrDict attrDict
   case or => exact DisjointProperties.fromAttrDict attrDict
-  case zext => exact NnegProperties.fromAttrDict attrDict
+  case zext | uitofp => exact NnegProperties.fromAttrDict attrDict
   case icmp => exact IcmpProperties.fromAttrDict attrDict
   case br => exact LLVMBrProperties.fromAttrDict attrDict
   case cond_br => exact LLVMCondBrProperties.fromAttrDict attrDict
@@ -279,7 +279,7 @@ def Llvm.toAttrDict
     if props.disjoint then
       dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
-  | .zext => props.toAttrDict
+  | .zext | .uitofp => props.toAttrDict
   | .intr__ctlz | .intr__cttz =>
     let value := if props.is_zero_poison then 1 else 0
     let attr := IntegerAttr.mk value (IntegerType.mk 1)

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -1,6 +1,7 @@
 module
 
 public import Veir.Data.LLVM.Int.Basic
+public import Veir.Data.LLVM.FloatPred
 public import Std.Data.HashMap
 public import Veir.IR.Attribute
 
@@ -323,6 +324,34 @@ def IcmpProperties.fromAttrDictFor (opName : String) (attrDict : Std.HashMap Byt
 def IcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String IcmpProperties :=
   IcmpProperties.fromAttrDictFor "llvm.icmp" attrDict
+
+/-- Properties of `llvm.fcmp`. -/
+structure FcmpProperties where
+  predicate : Data.LLVM.FloatPred
+  fastmathFlags : FastMathFlagsAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def FcmpProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String FcmpProperties := do
+  if let some (key, _) := attrDict.toArray.find? (fun (k, _) =>
+      k ≠ "predicate".toUTF8 && k ≠ "fastmathFlags".toUTF8) then
+    throw s!"llvm.fcmp: unexpected property '{String.fromUTF8! key}'"
+  let some attr := attrDict["predicate".toUTF8]?
+    | throw "llvm.fcmp: missing predicate"
+  let .integerAttr intAttr := attr
+    | throw s!"llvm.fcmp: expected predicate to be an integer attribute, but got {attr}"
+  if intAttr.type.bitwidth ≠ 64 then
+    throw s!"llvm.fcmp: expected predicate to be an i64 integer attribute, but got {attr}"
+  if intAttr.value < 0 then
+    throw s!"llvm.fcmp: invalid predicate {intAttr.value}"
+  let some predicate := Data.LLVM.FloatPred.fromNat intAttr.value.toNat
+    | throw s!"llvm.fcmp: invalid predicate {intAttr.value}"
+  let flags ← match attrDict["fastmathFlags".toUTF8]? with
+    | some (.fastMathFlagsAttr flags) => .ok flags
+    | some attr =>
+      throw s!"llvm.fcmp: expected 'fastmathFlags' to be a fast math flags attribute, but got {attr}"
+    | none => .ok { nnan := false, ninf := false, nsz := false }
+  return { predicate, fastmathFlags := flags }
 
 /--
   Properties of LLVM memory operations.

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -261,6 +261,43 @@ def OperationPtr.verifyFloatBinop (op : OperationPtr)
   op.verifyResultTypeMatches ctx operandType
     s!"{instrName}: Expected result type to match operand type"
 
+def OperationPtr.verifyFloatUnop (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 1 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+  operandType.verifyFloatType s!"{instrName}: Expected operand 0 to have floating point type"
+  op.verifyResultTypeMatches ctx operandType
+    s!"{instrName}: Expected result type to match operand type"
+
+def OperationPtr.verifyFloatTernop (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 3 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  for i in [0:3] do
+    ((op.getOperand! ctx.raw i).getType! ctx.raw).verifyFloatType
+      s!"{instrName}: Expected operand {i} to have floating point type"
+  let operandType ← op.verifyOperandTypesMatch ctx 0 1
+    s!"{instrName}: Expected operands to have the same type"
+  let _ ← op.verifyOperandTypesMatch ctx 1 2
+    s!"{instrName}: Expected operands to have the same type"
+  op.verifyResultTypeMatches ctx operandType
+    s!"{instrName}: Expected result type to match operand type"
+
+def OperationPtr.verifyFCmp (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 2 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyFloatType
+    s!"{instrName}: Expected operand 0 to have floating point type"
+  ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyFloatType
+    s!"{instrName}: Expected operand 1 to have floating point type"
+  let _ ← op.verifyOperandTypesMatch ctx 0 1
+    s!"{instrName}: Expected operands to have the same type"
+  ((op.getResult 0).get! ctx.raw).type.verifyI1 s!"{instrName}: Expected i1 result"
+
 def OperationPtr.verifyIntegerTernop (op : OperationPtr)
     (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
@@ -332,6 +369,40 @@ def OperationPtr.verifyTruncTypes (op : OperationPtr)
     else
       pure ()
   | _, _, _ => throw s!"{instrName}: Expected 1 integer operand and 1 integer result"
+
+def OperationPtr.verifyIntToFloatTypes (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 1 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyIntegerType
+    s!"{instrName}: Expected operand 0 to have integer type"
+  ((op.getResult 0).get! ctx.raw).type.verifyFloatType
+    s!"{instrName}: Expected floating point result type"
+
+def OperationPtr.verifyFloatToIntTypes (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 1 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyFloatType
+    s!"{instrName}: Expected operand 0 to have floating point type"
+  ((op.getResult 0).get! ctx.raw).type.verifyIntegerType
+    s!"{instrName}: Expected integer result type"
+
+/--
+  A conversion between floating point types. MLIR does not check that
+  `llvm.fpext` widens, so neither does this.
+-/
+def OperationPtr.verifyFloatExtTypes (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 1 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyFloatType
+    s!"{instrName}: Expected operand 0 to have floating point type"
+  ((op.getResult 0).get! ctx.raw).type.verifyFloatType
+    s!"{instrName}: Expected floating point result type"
 
 def OperationPtr.verifyIntegerExtTypes (op : OperationPtr)
     (ctx : WfIRContext OpInfo)


### PR DESCRIPTION
`fpext`, `sitofp`, `uitofp`, `fptosi` and `fptoui` carry no properties; `fneg`, `llvm.intr.fmuladd` and `llvm.intr.fabs` reuse `FastMathFlagsProperties`; `fcmp` uses the newly introduced `FcmpProperties`, which again use the new `FloatPred`, which relates floating point comparison predicates to natural numbers.

This PR completes the floating operations needed for sqlite.