### PR TITLE
feat(LLVM): parse llvm.call_intrinsic

### DIFF
--- a/Test/LLVM/call_intrinsic.mlir
+++ b/Test/LLVM/call_intrinsic.mlir
@@ -4,11 +4,8 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<i64 (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "sizes"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    // The shape clang emits: four arguments, no bundles.
     %r = "llvm.call_intrinsic"(%p, %b, %b, %b) <{fastmathFlags = #llvm.fastmath<none>, intrin = "llvm.objectsize.i64.p0", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 4, 0>}> : (!llvm.ptr, i1, i1, i1) -> i64
-    // No arguments and no result at all.
     "llvm.call_intrinsic"() <{intrin = "llvm.donothing", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>}> : () -> ()
-    // One bundle, whose single operand follows the argument.
     "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = ["align"], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
     "llvm.return"(%r) : (i64) -> ()
   }) : () -> ()

--- a/Test/LLVM/call_intrinsic.mlir
+++ b/Test/LLVM/call_intrinsic.mlir
@@ -1,0 +1,19 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<i64 (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "sizes"}> ({
+  ^bb0(%p: !llvm.ptr, %b: i1):
+    // The shape clang emits: four arguments, no bundles.
+    %r = "llvm.call_intrinsic"(%p, %b, %b, %b) <{fastmathFlags = #llvm.fastmath<none>, intrin = "llvm.objectsize.i64.p0", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 4, 0>}> : (!llvm.ptr, i1, i1, i1) -> i64
+    // No arguments and no result at all.
+    "llvm.call_intrinsic"() <{intrin = "llvm.donothing", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>}> : () -> ()
+    // One bundle, whose single operand follows the argument.
+    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = ["align"], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.return"(%r) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.call_intrinsic"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "intrin" = "llvm.objectsize.i64.p0", "op_bundle_sizes" = array<i32>, "operandSegmentSizes" = array<i32: 4, 0>}> : (!llvm.ptr, i1, i1, i1) -> i64
+// CHECK: "llvm.call_intrinsic"() <{"fastmathFlags" = #llvm.fastmath<none>, "intrin" = "llvm.donothing", "op_bundle_sizes" = array<i32>, "operandSegmentSizes" = array<i32: 0, 0>}> : () -> ()
+// CHECK: "llvm.call_intrinsic"({{.*}}) <{"fastmathFlags" = #llvm.fastmath<none>, "intrin" = "llvm.assume", "op_bundle_sizes" = array<i32: 1>, "op_bundle_tags" = ["align"], "operandSegmentSizes" = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()

--- a/Test/Verifier/llvm_call_intrinsic_bad_intrinsic_name.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_bad_intrinsic_name.mlir
@@ -4,9 +4,9 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.call_intrinsic"(%p) <{intrin = "assume", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.call_intrinsic: Expected 1 operand bundle tag(s), but got 0
+// CHECK: llvm.call_intrinsic: intrinsic name must start with 'llvm.'

--- a/Test/Verifier/llvm_call_intrinsic_bundle_size_mismatch.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_bundle_size_mismatch.mlir
@@ -1,9 +1,10 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
 
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr):
-    "llvm.call_intrinsic"(%p) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 2>, operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
+    "llvm.call_intrinsic"(%p) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 2>, op_bundle_tags = ["align"], operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Verifier/llvm_call_intrinsic_bundle_size_mismatch.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_bundle_size_mismatch.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%p: !llvm.ptr):
+    "llvm.call_intrinsic"(%p) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 2>, operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.call_intrinsic: op_bundle_sizes describes 2 operand(s), but operandSegmentSizes reserves 0

--- a/Test/Verifier/llvm_call_intrinsic_index_operand.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_index_operand.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (index) -> (), sym_name = "f"}> ({
+  ^bb0(%i: index):
+    "llvm.call_intrinsic"(%i) <{intrin = "llvm.assume", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (index) -> ()
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.call_intrinsic: operand 0 must be an LLVM dialect-compatible type, but got index

--- a/Test/Verifier/llvm_call_intrinsic_index_result.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_index_result.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+    %r = "llvm.call_intrinsic"() <{intrin = "llvm.readcyclecounter", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 0, 0>}> : () -> index
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.call_intrinsic: result 0 must be an LLVM dialect-compatible type, but got index

--- a/Test/Verifier/llvm_call_intrinsic_missing_bundle_tags.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_missing_bundle_tags.mlir
@@ -4,7 +4,7 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Verifier/llvm_call_intrinsic_non_i32_bundle_sizes.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_non_i32_bundle_sizes.mlir
@@ -4,9 +4,9 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i64: 1>, op_bundle_tags = ["align"], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.call_intrinsic: Expected 1 operand bundle tag(s), but got 0
+// CHECK: llvm.call_intrinsic: Expected 'op_bundle_sizes' to be an i32 dense array attribute

--- a/Test/Verifier/llvm_call_intrinsic_non_i32_segment_sizes.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_non_i32_segment_sizes.mlir
@@ -4,9 +4,9 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.call_intrinsic"(%p) <{intrin = "llvm.assume", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i64: 1, 0>}> : (!llvm.ptr) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.call_intrinsic: Expected 1 operand bundle tag(s), but got 0
+// CHECK: llvm.call_intrinsic: Expected 'operandSegmentSizes' to be an i32 dense array attribute

--- a/Test/Verifier/llvm_call_intrinsic_non_string_bundle_tag.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_non_string_bundle_tag.mlir
@@ -4,9 +4,9 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [1 : i32], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.call_intrinsic: Expected 1 operand bundle tag(s), but got 0
+// CHECK: llvm.call_intrinsic: Expected operand bundle tags to be string attributes

--- a/Test/Verifier/llvm_call_intrinsic_tag_count.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_tag_count.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%p: !llvm.ptr, %b: i1):
+    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.call_intrinsic: Expected 1 operand bundle tag(s), but got 0

--- a/Test/Verifier/llvm_call_intrinsic_with_region.mlir
+++ b/Test/Verifier/llvm_call_intrinsic_with_region.mlir
@@ -4,9 +4,9 @@
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.ptr, i1)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
   ^bb0(%p: !llvm.ptr, %b: i1):
-    "llvm.call_intrinsic"(%p, %b) <{intrin = "llvm.assume", op_bundle_sizes = array<i32: 1>, op_bundle_tags = [], operandSegmentSizes = array<i32: 1, 1>}> : (!llvm.ptr, i1) -> ()
+    "llvm.call_intrinsic"(%p) <{intrin = "llvm.assume", op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> ({ }) : (!llvm.ptr) -> ()
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.call_intrinsic: Expected 1 operand bundle tag(s), but got 0
+// CHECK: llvm.call_intrinsic: Expected 0 regions

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -827,6 +827,7 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     pure ()
   | .call_intrinsic => do
     op.checkIsNonNullIntegerType ctx opIn
+    op.verifyLLVMCompatibleTypes ctx opIn
     let props := op.getProperties! ctx.raw Llvm.call_intrinsic
     if !(String.fromUTF8? props.intrin.value).any (·.startsWith "llvm.") then
       throw "intrinsic name must start with 'llvm.'"

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -667,25 +667,13 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
   | .intr__assume => do
     op.checkIsNonNullIntegerType ctx opIn
     let props := op.getProperties! ctx.raw Llvm.intr__assume
-    let sizes := props.op_bundle_sizes
-    if sizes.elementType.bitwidth ≠ 32 then
-      throw "llvm.intr.assume: Expected 'op_bundle_sizes' to be an i32 dense array attribute"
-    if sizes.values.any (· < 0) then
-      throw "llvm.intr.assume: op_bundle_sizes contains a negative size"
-    let bundleOperands := (sizes.values.foldl (· + ·) 0).toNat
+    let bundleOperands ← verifyOperandBundles props.op_bundle_sizes props.op_bundle_tags
     let numOperands := op.getNumOperands ctx.raw opIn
     if numOperands ≠ 1 + bundleOperands then
-      throw s!"llvm.intr.assume: Expected 1 condition and {bundleOperands} operand bundle \
+      throw s!"Expected 1 condition and {bundleOperands} operand bundle \
         operand(s) per 'op_bundle_sizes', but got {numOperands} operand(s)"
     op.verifyPlainOpCounts ctx opIn numOperands 0
-    ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyI1 "llvm.intr.assume: Expected i1 condition"
-    let tags := (props.op_bundle_tags.map (·.value)).getD #[]
-    if tags.size ≠ sizes.values.size then
-      throw s!"llvm.intr.assume: Expected {sizes.values.size} operand bundle tag(s), \
-        but got {tags.size}"
-    for tag in tags do
-      let .stringAttr _ := tag
-        | throw "llvm.intr.assume: Expected operand bundle tags to be string attributes"
+    ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyI1 "Expected i1 condition"
   | .inttoptr | .ptrtoint => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 1 1
@@ -839,23 +827,19 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     pure ()
   | .call_intrinsic => do
     op.checkIsNonNullIntegerType ctx opIn
+    let props := op.getProperties! ctx.raw Llvm.call_intrinsic
+    if !(String.fromUTF8? props.intrin.value).any (·.startsWith "llvm.") then
+      throw "intrinsic name must start with 'llvm.'"
     if op.getNumResults ctx.raw opIn > 1 then
       throw "Expected at most 1 result"
-    let props := op.getProperties! ctx.raw Llvm.call_intrinsic
     let sizes ← op.verifyOperandSegmentSizes ctx opIn props.operandSegmentSizes 2
+    op.verifyPlainOpCounts ctx opIn (op.getNumOperands ctx.raw opIn) (op.getNumResults ctx.raw opIn)
     /- The second segment holds the operands of the bundles, which
        `op_bundle_sizes` splits again, one entry per bundle. -/
-    let bundleSizes := props.op_bundle_sizes.values
-    if bundleSizes.any (· < 0) then
-      throw "op_bundle_sizes contains a negative size"
-    let bundleOperands := (bundleSizes.foldl (· + ·) 0).toNat
+    let bundleOperands ← verifyOperandBundles props.op_bundle_sizes props.op_bundle_tags
     if bundleOperands ≠ sizes[1]! then
       throw s!"op_bundle_sizes describes {bundleOperands} operand(s), but \
         operandSegmentSizes reserves {sizes[1]!}"
-    if let some tags := props.op_bundle_tags then
-      if tags.value.size ≠ bundleSizes.size then
-        throw s!"Expected {bundleSizes.size} operand bundle tag(s), but got {tags.value.size}"
-    pure ()
   | .call => do
     op.checkIsNonNullIntegerType ctx opIn
     if op.getNumResults ctx.raw opIn > 1 then

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -60,6 +60,7 @@ inductive Llvm where
 | store
 | getelementptr
 | call
+| call_intrinsic
 | return
 | func
 | module_flags
@@ -116,6 +117,7 @@ match op with
 | .getelementptr => GetelementptrProperties
 | .fadd | .fsub | .fmul | .fdiv | .frem => FastMathFlagsProperties
 | .call => LLVMCallProperties
+| .call_intrinsic => LLVMCallIntrinsicProperties
 | .func => LLVMFuncProperties
 | .module_flags => LLVMModuleFlagsProperties
 | _ => Unit
@@ -158,6 +160,7 @@ def Llvm.fromAttrDict
   case func => exact LLVMFuncProperties.fromAttrDict attrDict
   case module_flags => exact LLVMModuleFlagsProperties.fromAttrDict attrDict
   case call => exact LLVMCallProperties.fromAttrDict attrDict
+  case call_intrinsic => exact LLVMCallIntrinsicProperties.fromAttrDict attrDict
   all_goals exact .ok ()
 
 def Llvm.toAttrDict
@@ -344,6 +347,20 @@ def Llvm.toAttrDict
     if let some callee := props.callee then
       dict := dict.insert "callee".toUTF8 (.flatSymbolRefAttr callee)
     dict
+  | .call_intrinsic => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 7
+    dict := dict.insert "intrin".toUTF8 (.stringAttr props.intrin)
+    dict := dict.insert "operandSegmentSizes".toUTF8
+      (Attribute.denseArrayAttr props.operandSegmentSizes)
+    dict := dict.insert "op_bundle_sizes".toUTF8
+      (Attribute.denseArrayAttr props.op_bundle_sizes)
+    dict := dict.insert "fastmathFlags".toUTF8 (Attribute.fastMathFlagsAttr props.fastmathFlags)
+    for (name, value) in [("op_bundle_tags", props.op_bundle_tags),
+                          ("arg_attrs", props.arg_attrs),
+                          ("res_attrs", props.res_attrs)] do
+      if let some value := value then
+        dict := dict.insert name.toUTF8 (.arrayAttr value)
+    dict
   | _ => Std.HashMap.emptyWithCapacity 0
 
 @[get_effects]
@@ -416,7 +433,8 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .select | .br | .cond_br | .switch | .unreachable | .alloca | .load | .store
   | .intr__lifetime__start | .intr__lifetime__end | .intr__assume
   | .intr__memset | .intr__memcpy | .intr__memmove
-  | .getelementptr | .call | .return | .func | .module_flags | .freeze => false
+  | .getelementptr | .call | .call_intrinsic | .return | .func | .module_flags
+  | .freeze => false
 
 instance : IsOpCode Llvm where
   fromName := Llvm.fromName
@@ -818,6 +836,25 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       throw "Expected 0 regions"
     if op.getNumSuccessors ctx.raw opIn ≠ 0 then
       throw "Expected 0 successors"
+    pure ()
+  | .call_intrinsic => do
+    op.checkIsNonNullIntegerType ctx opIn
+    if op.getNumResults ctx.raw opIn > 1 then
+      throw "Expected at most 1 result"
+    let props := op.getProperties! ctx.raw Llvm.call_intrinsic
+    let sizes ← op.verifyOperandSegmentSizes ctx opIn props.operandSegmentSizes 2
+    /- The second segment holds the operands of the bundles, which
+       `op_bundle_sizes` splits again, one entry per bundle. -/
+    let bundleSizes := props.op_bundle_sizes.values
+    if bundleSizes.any (· < 0) then
+      throw "op_bundle_sizes contains a negative size"
+    let bundleOperands := (bundleSizes.foldl (· + ·) 0).toNat
+    if bundleOperands ≠ sizes[1]! then
+      throw s!"op_bundle_sizes describes {bundleOperands} operand(s), but \
+        operandSegmentSizes reserves {sizes[1]!}"
+    if let some tags := props.op_bundle_tags then
+      if tags.value.size ≠ bundleSizes.size then
+        throw s!"Expected {bundleSizes.size} operand bundle tag(s), but got {tags.value.size}"
     pure ()
   | .call => do
     op.checkIsNonNullIntegerType ctx opIn

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -675,6 +675,51 @@ def LLVMMemIntrinsicProperties.fromAttrDict (attrDict : Std.HashMap ByteArray At
     Except String LLVMMemIntrinsicProperties :=
   LLVMMemIntrinsicProperties.fromAttrDictFor "llvm.intr.memset" attrDict
 
+/--
+  Properties of `llvm.call_intrinsic`.
+-/
+structure LLVMCallIntrinsicProperties where
+  intrin : StringAttr
+  operandSegmentSizes : DenseArrayAttr
+  op_bundle_sizes : DenseArrayAttr
+  op_bundle_tags : Option ArrayAttr
+  fastmathFlags : FastMathFlagsAttr
+  arg_attrs : Option ArrayAttr
+  res_attrs : Option ArrayAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMCallIntrinsicProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMCallIntrinsicProperties := do
+  if let some (key, _) := attrDict.toArray.find? (fun (k, _) =>
+      k ≠ "intrin".toUTF8 && k ≠ "operandSegmentSizes".toUTF8 && k ≠ "op_bundle_sizes".toUTF8
+        && k ≠ "op_bundle_tags".toUTF8 && k ≠ "fastmathFlags".toUTF8
+        && k ≠ "arg_attrs".toUTF8 && k ≠ "res_attrs".toUTF8) then
+    throw s!"llvm.call_intrinsic: unexpected property '{String.fromUTF8! key}'"
+  let some intrin := attrDict["intrin".toUTF8]?
+    | throw "llvm.call_intrinsic: missing 'intrin' property"
+  let .stringAttr intrin := intrin
+    | throw s!"llvm.call_intrinsic: expected 'intrin' to be a string attribute, but got {intrin}"
+  let some sizes := attrDict["operandSegmentSizes".toUTF8]?
+    | throw "llvm.call_intrinsic: missing 'operandSegmentSizes' property"
+  let .denseArrayAttr sizes := sizes
+    | throw s!"llvm.call_intrinsic: expected 'operandSegmentSizes' to be a dense array attribute, but got {sizes}"
+  let some bundleSizes := attrDict["op_bundle_sizes".toUTF8]?
+    | throw "llvm.call_intrinsic: missing 'op_bundle_sizes' property"
+  let .denseArrayAttr bundleSizes := bundleSizes
+    | throw s!"llvm.call_intrinsic: expected 'op_bundle_sizes' to be a dense array attribute, but got {bundleSizes}"
+  let tags ← optionalArrayAttr "llvm.call_intrinsic" "op_bundle_tags" attrDict
+  let argAttrs ← optionalDictArrayAttr "llvm.call_intrinsic" "arg_attrs" attrDict
+  let resAttrs ← optionalDictArrayAttr "llvm.call_intrinsic" "res_attrs" attrDict
+  /- MLIR materializes the default on parse, so it is always present. -/
+  let flags ← match attrDict["fastmathFlags".toUTF8]? with
+    | some (.fastMathFlagsAttr flags) => .ok flags
+    | some attr =>
+      throw s!"llvm.call_intrinsic: expected 'fastmathFlags' to be a fast math flags attribute, but got {attr}"
+    | none => .ok { nnan := false, ninf := false, nsz := false }
+  return { intrin, operandSegmentSizes := sizes, op_bundle_sizes := bundleSizes,
+           op_bundle_tags := tags, fastmathFlags := flags,
+           arg_attrs := argAttrs, res_attrs := resAttrs }
+
 structure LLVMModuleFlagsProperties where
   flags : ArrayAttr
 deriving Inhabited, Repr, Hashable, DecidableEq

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -710,12 +710,8 @@ def LLVMCallIntrinsicProperties.fromAttrDict (attrDict : Std.HashMap ByteArray A
   let tags ← optionalArrayAttr "llvm.call_intrinsic" "op_bundle_tags" attrDict
   let argAttrs ← optionalDictArrayAttr "llvm.call_intrinsic" "arg_attrs" attrDict
   let resAttrs ← optionalDictArrayAttr "llvm.call_intrinsic" "res_attrs" attrDict
-  /- MLIR materializes the default on parse, so it is always present. -/
-  let flags ← match attrDict["fastmathFlags".toUTF8]? with
-    | some (.fastMathFlagsAttr flags) => .ok flags
-    | some attr =>
-      throw s!"llvm.call_intrinsic: expected 'fastmathFlags' to be a fast math flags attribute, but got {attr}"
-    | none => .ok { nnan := false, ninf := false, nsz := false }
+  let ⟨flags⟩ ← (FastMathFlagsProperties.fromAttrDict attrDict).mapError
+    (s!"llvm.call_intrinsic: {·}")
   return { intrin, operandSegmentSizes := sizes, op_bundle_sizes := bundleSizes,
            op_bundle_tags := tags, fastmathFlags := flags,
            arg_attrs := argAttrs, res_attrs := resAttrs }

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -350,6 +350,32 @@ def OperationPtr.verifyIntegerExtTypes (op : OperationPtr)
     pure ()
 
 /--
+  Whether `type` is compatible with the LLVM dialect: integers, floats,
+  pointers, arrays and vectors of compatible types, void, and the `!llvm.*`
+  types VeIR keeps opaque, such as structs.
+-/
+partial def Attribute.isLLVMCompatibleType : Attribute → Bool
+  | .integerType _ | .floatType _ | .llvmPointerType _ | .llvmVoidType _ => true
+  | .llvmArrayType arrType => arrType.type.isLLVMCompatibleType
+  | .vectorType vecType => vecType.elementType.isLLVMCompatibleType
+  | .unregisteredAttr attr => attr.isType && attr.value.startsWith "!llvm."
+  | _ => false
+
+/-- Check that every operand and result has an LLVM dialect-compatible type. -/
+def OperationPtr.verifyLLVMCompatibleTypes (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  let opTypes := op.getOperandTypes! ctx.raw
+  for i in [0:opTypes.size] do
+    if !(opTypes[i]!).val.isLLVMCompatibleType then
+      throw s!"{instrName}: operand {i} must be an LLVM dialect-compatible type, but got {opTypes[i]!}"
+  for i in [0:op.getNumResults ctx.raw opIn] do
+    let type := ((op.getResult i).get! ctx.raw).type
+    if !type.val.isLLVMCompatibleType then
+      throw s!"{instrName}: result {i} must be an LLVM dialect-compatible type, but got {type}"
+
+/--
   Reject any operand or result whose type is a zero-width integer (`i0`).
   Whether `i0` is legal is a per-dialect policy, so callers must apply this
   check explicitly to operations that forbid it.

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -99,6 +99,8 @@ def OperationPtr.verifyOperandSegmentSizes
     (sizes : DenseArrayAttr) (expectedSegments : Nat) :
     Except String (Array Nat) := do
   let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  if sizes.elementType.bitwidth ≠ 32 then
+    throw s!"{instrName}: Expected 'operandSegmentSizes' to be an i32 dense array attribute"
   if sizes.values.size ≠ expectedSegments then
     throw s!"{instrName}: operandSegmentSizes expected {expectedSegments} entries, got {sizes.values.size}"
   let mut segmentSizes : Array Nat := #[]
@@ -110,6 +112,24 @@ def OperationPtr.verifyOperandSegmentSizes
   if segmentSum ≠ op.getNumOperands ctx.raw opIn then
     throw s!"{instrName}: operandSegmentSizes describes {segmentSum} operands, got {op.getNumOperands ctx.raw opIn}"
   return segmentSizes
+
+/--
+  Check the operand bundles described by `op_bundle_sizes` and `op_bundle_tags`
+  as MLIR's `verifyOperandBundles` does, and return the number of bundle operands.
+-/
+def verifyOperandBundles (sizes : DenseArrayAttr) (tags : Option ArrayAttr) :
+    Except String Nat := do
+  if sizes.elementType.bitwidth ≠ 32 then
+    throw "Expected 'op_bundle_sizes' to be an i32 dense array attribute"
+  if sizes.values.any (· < 0) then
+    throw "op_bundle_sizes contains a negative size"
+  let tags := (tags.map (·.value)).getD #[]
+  if tags.size ≠ sizes.values.size then
+    throw s!"Expected {sizes.values.size} operand bundle tag(s), but got {tags.size}"
+  for tag in tags do
+    let .stringAttr _ := tag
+      | throw "Expected operand bundle tags to be string attributes"
+  return (sizes.values.foldl (· + ·) 0).toNat
 
 def OperationPtr.verifyCondBranchOperandSegmentSizes
     (op : OperationPtr) (ctx : WfIRContext OpInfo) (opIn : op.InBounds ctx.raw)


### PR DESCRIPTION
Add `llvm.call_intrinsic`, the op MLIR uses for LLVM intrinsics without a dedicated op, with the properties clang emits: `intrin`, `operandSegmentSizes`, `op_bundle_sizes`, `op_bundle_tags`, `fastmathFlags`, `arg_attrs` and `res_attrs`. The verifier mirrors MLIR's: the name must start with `llvm.`, at most one result, no regions, `operandSegmentSizes` must be an i32 array matching the operands, and the bundle sizes and tags must be consistent. The bundle checks are shared with `llvm.intr.assume` through a new `verifyOperandBundles` helper, which also makes that op reject non-i32 sizes and missing or non-string tags the same way. Effects stay `.unknown`, since they depend on the intrinsic name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)