### PR TITLE
feat(LLVM): parse llvm.fence

### DIFF
--- a/Test/LLVM/fence.mlir
+++ b/Test/LLVM/fence.mlir
@@ -1,0 +1,26 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+//
+// A fence orders other accesses rather than performing one, so only the four
+// orderings that say something are allowed, and all four are here: 4 is
+// `acquire`, 5 `release`, 6 `acq_rel` and 7 `seq_cst`. The weaker orderings
+// -- 0 `not_atomic`, 1 `unordered`, 2 `monotonic` -- are rejected, as is 3,
+// which MLIR leaves unused. Each is refused by its own test in Test/Verifier.
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "barriers"}> ({
+    "llvm.fence"() <{ordering = 4 : i64}> : () -> ()
+    "llvm.fence"() <{ordering = 5 : i64}> : () -> ()
+    "llvm.fence"() <{ordering = 6 : i64}> : () -> ()
+    "llvm.fence"() <{ordering = 7 : i64}> : () -> ()
+    // Narrowed to a single thread.
+    "llvm.fence"() <{ordering = 7 : i64, syncscope = "singlethread"}> : () -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.fence"() <{"ordering" = 4 : i64}> : () -> ()
+// CHECK: "llvm.fence"() <{"ordering" = 5 : i64}> : () -> ()
+// CHECK: "llvm.fence"() <{"ordering" = 6 : i64}> : () -> ()
+// CHECK: "llvm.fence"() <{"ordering" = 7 : i64}> : () -> ()
+// CHECK: "llvm.fence"() <{"ordering" = 7 : i64, "syncscope" = "singlethread"}> : () -> ()

--- a/Test/Verifier/llvm_fence_non_i64_ordering.mlir
+++ b/Test/Verifier/llvm_fence_non_i64_ordering.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%i: i32):
+    "llvm.fence"() <{ordering = 7 : i32}> : () -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fence: expected 'ordering' to be an i64 integer attribute, but got 7 : i32

--- a/Test/Verifier/llvm_fence_not_atomic_ordering.mlir
+++ b/Test/Verifier/llvm_fence_not_atomic_ordering.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+    "llvm.fence"() <{ordering = 0 : i64}> : () -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fence: can be given only acquire, release, acq_rel and seq_cst orderings

--- a/Test/Verifier/llvm_fence_unordered_ordering.mlir
+++ b/Test/Verifier/llvm_fence_unordered_ordering.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+    "llvm.fence"() <{ordering = 1 : i64}> : () -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fence: can be given only acquire, release, acq_rel and seq_cst orderings

--- a/Test/Verifier/llvm_fence_unused_ordering.mlir
+++ b/Test/Verifier/llvm_fence_unused_ordering.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// 3 is not an ordering at all: MLIR leaves that number unused, so it is
+// refused before the question of which orderings a fence accepts arises.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+    "llvm.fence"() <{ordering = 3 : i64}> : () -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fence: invalid ordering 3

--- a/Test/Verifier/llvm_fence_weak_ordering.mlir
+++ b/Test/Verifier/llvm_fence_weak_ordering.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+    "llvm.fence"() <{ordering = 2 : i64}> : () -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fence: can be given only acquire, release, acq_rel and seq_cst orderings

--- a/Veir/Data/LLVM.lean
+++ b/Veir/Data/LLVM.lean
@@ -3,3 +3,4 @@ module
 public import Veir.Data.LLVM.Int
 public import Veir.Data.LLVM.Byte
 public import Veir.Data.LLVM.FloatPred
+public import Veir.Data.LLVM.AtomicOrdering

--- a/Veir/Data/LLVM/AtomicOrdering.lean
+++ b/Veir/Data/LLVM/AtomicOrdering.lean
@@ -1,0 +1,43 @@
+module
+
+namespace Veir.Data.LLVM
+
+public section
+
+/--
+The memory ordering of an atomic operation. Not every operation accepts every
+ordering: a fence, for instance, needs at least `acquire`.
+-/
+inductive AtomicOrdering where
+  | not_atomic
+  | unordered
+  | monotonic
+  | acquire
+  | release
+  | acq_rel
+  | seq_cst
+deriving DecidableEq, Inhabited, Repr, Hashable
+
+def AtomicOrdering.fromNat (s : Nat) : Option AtomicOrdering :=
+  match s with
+  | 0 => some .not_atomic
+  | 1 => some .unordered
+  | 2 => some .monotonic
+  | 4 => some .acquire
+  | 5 => some .release
+  | 6 => some .acq_rel
+  | 7 => some .seq_cst
+  | _ => none
+
+def AtomicOrdering.toNat : AtomicOrdering → Nat
+  | .not_atomic => 0
+  | .unordered => 1
+  | .monotonic => 2
+  | .acquire => 4
+  | .release => 5
+  | .acq_rel => 6
+  | .seq_cst => 7
+
+end
+
+end Veir.Data.LLVM

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -55,6 +55,7 @@ inductive Llvm where
 | cond_br
 | switch
 | unreachable
+| fence
 | alloca
 | load
 | store
@@ -126,6 +127,7 @@ match op with
 | .store => StoreProperties
 | .getelementptr => GetelementptrProperties
 | .insertvalue => LLVMInsertValueProperties
+| .fence => LLVMFenceProperties
 | .fadd | .fsub | .fmul | .fdiv | .frem | .fneg | .intr__fmuladd | .intr__fabs =>
   FastMathFlagsProperties
 | .fcmp => FcmpProperties
@@ -169,6 +171,7 @@ def Llvm.fromAttrDict
   case store => exact StoreProperties.fromAttrDict attrDict
   case getelementptr => exact GetelementptrProperties.fromAttrDict attrDict
   case insertvalue => exact LLVMInsertValueProperties.fromAttrDict attrDict
+  case fence => exact LLVMFenceProperties.fromAttrDict attrDict
   case fadd | fsub | fmul | fdiv | frem | fneg | intr__fmuladd | intr__fabs =>
     exact FastMathFlagsProperties.fromAttrDict attrDict
   case fcmp => exact FcmpProperties.fromAttrDict attrDict
@@ -346,6 +349,13 @@ def Llvm.toAttrDict
   | .insertvalue =>
     (Std.HashMap.emptyWithCapacity 1).insert
       "position".toUTF8 (Attribute.denseArrayAttr props.position)
+  | .fence => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    let ordering := IntegerAttr.mk (Int.ofNat props.ordering.toNat) (IntegerType.mk 64)
+    dict := dict.insert "ordering".toUTF8 (Attribute.integerAttr ordering)
+    if let some syncscope := props.syncscope then
+      dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
+    dict
   | .getelementptr => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 3
     dict := dict.insert
@@ -454,7 +464,7 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .intr__fmuladd | .intr__fabs
   | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__global
   | .mlir__addressof
-  | .select | .br | .cond_br | .switch | .unreachable | .alloca | .load | .store
+  | .select | .br | .cond_br | .switch | .unreachable | .fence | .alloca | .load | .store
   | .intr__lifetime__start | .intr__lifetime__end | .intr__assume
   | .intr__memset | .intr__memcpy | .intr__memmove
   | .getelementptr | .insertvalue | .call | .call_intrinsic | .return | .func
@@ -869,6 +879,13 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       current := arrType.type
     if current ≠ valueType.val then
       throw s!"Type mismatch: cannot insert {valueType} into {containerType}"
+  | .fence => do
+    op.verifyPlainOpCounts ctx opIn 0 0
+    /- A fence orders other accesses, so the weaker orderings say nothing. -/
+    let props := op.getProperties! ctx.raw Llvm.fence
+    match props.ordering with
+    | .acquire | .release | .acq_rel | .seq_cst => pure ()
+    | _ => throw "llvm.fence: can be given only acquire, release, acq_rel and seq_cst orderings"
   | .getelementptr => do
     op.checkIsNonNullIntegerType ctx opIn
     let props := op.getProperties! ctx.raw Llvm.getelementptr

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -2,6 +2,7 @@ module
 
 public import Veir.Data.LLVM.Int.Basic
 public import Veir.Data.LLVM.FloatPred
+public import Veir.Data.LLVM.AtomicOrdering
 public import Std.Data.HashMap
 public import Veir.IR.Attribute
 
@@ -767,6 +768,34 @@ def LLVMInsertValueProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Att
   let .denseArrayAttr position := position
     | throw s!"llvm.insertvalue: expected 'position' to be a dense array attribute, but got {position}"
   return { position }
+
+/-- Properties of `llvm.fence`: how strongly it orders, and over what scope. -/
+structure LLVMFenceProperties where
+  ordering : Data.LLVM.AtomicOrdering
+  syncscope : Option StringAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMFenceProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMFenceProperties := do
+  if let some (key, _) := attrDict.toArray.find? (fun (k, _) =>
+      k ≠ "ordering".toUTF8 && k ≠ "syncscope".toUTF8) then
+    throw s!"llvm.fence: unexpected property '{String.fromUTF8! key}'"
+  let some attr := attrDict["ordering".toUTF8]?
+    | throw "llvm.fence: missing 'ordering' property"
+  let .integerAttr intAttr := attr
+    | throw s!"llvm.fence: expected 'ordering' to be an integer attribute, but got {attr}"
+  if intAttr.type.bitwidth ≠ 64 then
+    throw s!"llvm.fence: expected 'ordering' to be an i64 integer attribute, but got {attr}"
+  if intAttr.value < 0 then
+    throw s!"llvm.fence: invalid ordering {intAttr.value}"
+  let some ordering := Data.LLVM.AtomicOrdering.fromNat intAttr.value.toNat
+    | throw s!"llvm.fence: invalid ordering {intAttr.value}"
+  let syncscope ← match attrDict["syncscope".toUTF8]? with
+    | some (.stringAttr syncscope) => .ok (some syncscope)
+    | some attr =>
+      throw s!"llvm.fence: expected 'syncscope' to be a string attribute, but got {attr}"
+    | none => .ok none
+  return { ordering, syncscope }
 
 structure LLVMModuleFlagsProperties where
   flags : ArrayAttr


### PR DESCRIPTION
We introduce the property `ordering` using the new `Data.LLVM.AtomicOrdering`, which mirrors `IntPred` and `FloatPred`. Following MLIR, we leave 3 as an unused id. As a fence orders other accesses rather than performing one, its verifier allows only the four orderings that say something. A fence also carries `syncscope`, which is optional.