### PR TITLE
feat: add make sqlite target for e2e SQLite3 parsing test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,3 +15,8 @@ tests: build ## run all tests
 	lake test
 	uv run lit Test/ -v
 	. ./.envrc && cd ExArray && lake exe test
+
+.PHONY: sqlite
+sqlite: build ## test sqlite3 parsing (expected to fail until fully supported)
+	test -f /tmp/sqlite3.c || (curl -sfL https://sqlite.org/2026/sqlite-amalgamation-3530300.zip -o /tmp/sqlite.zip && unzip -oqj /tmp/sqlite.zip '*/sqlite3.c' -d /tmp && rm /tmp/sqlite.zip)
+	Tools/vcc --emit-mlir /tmp/sqlite3.c -o /dev/null


### PR DESCRIPTION
Adds a `make sqlite` target

tracks progress toward the goal described in #947.

It will pass once veir supports every LLVM dialect op that sqlite's MLIR uses.

Example output today:

```
$ make sqlite

lake build
Build completed successfully (466 jobs).
test -f /tmp/sqlite3.c || (curl -sfL https://sqlite.org/2026/sqlite-amalgamation-3530300.zip -o /tmp/sqlite.zip && unzip -oqj /tmp/sqlite.zip '*/sqlite3.c' -d /tmp && rm /tmp/sqlite.zip)
Tools/vcc --emit-mlir /tmp/sqlite3.c -o /dev/null
vcc: lake failed:
sqlite3.mlir:3262:69: error: integer type expected after ':' in integer attribute
    %157209 = "llvm.mlir.constant"() <{value = 0x0000000000000000 : f64}> : () -> f64
                                                                    ^
```