### PR TITLE
fix(parser): accept shorthand LLVM parameterless types

### DIFF
--- a/Test/LLVM/pretty_llvm_types.mlir
+++ b/Test/LLVM/pretty_llvm_types.mlir
@@ -1,0 +1,30 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<2 x x86_amx>)>, linkage = #llvm.linkage<external>, sym_name = "use_x86_amx"}> ({
+  ^bb0(%arg0: !llvm.array<2 x !llvm.x86_amx>):
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<4 x ppc_fp128>)>, linkage = #llvm.linkage<external>, sym_name = "use_ppc_fp128"}> ({
+  ^bb0(%arg0: !llvm.array<4 x !llvm.ppc_fp128>):
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<1 x metadata>)>, linkage = #llvm.linkage<external>, sym_name = "use_metadata"}> ({
+  ^bb0(%arg0: !llvm.array<1 x !llvm.metadata>):
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<1 x label>)>, linkage = #llvm.linkage<external>, sym_name = "use_label"}> ({
+  ^bb0(%arg0: !llvm.array<1 x !llvm.label>):
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.x86_amx)>, linkage = #llvm.linkage<external>, sym_name = "use_full_prefix"}> ({
+  ^bb0(%arg0: !llvm.x86_amx):
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: !llvm.array<2 x !llvm.x86_amx>
+// CHECK: !llvm.array<4 x !llvm.ppc_fp128>
+// CHECK: !llvm.array<1 x !llvm.metadata>
+// CHECK: !llvm.array<1 x !llvm.label>
+// CHECK: !llvm.x86_amx

--- a/Test/LLVM/pretty_llvm_types.mlir
+++ b/Test/LLVM/pretty_llvm_types.mlir
@@ -14,9 +14,9 @@
   ^bb0(%arg0: !llvm.array<1 x !llvm.target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>):
     "llvm.return"() : () -> ()
   }) : () -> ()
-  // `metadata`, `label` and `token` are invalid as array elements.
-  "llvm.func"() <{function_type = !llvm.func<void (metadata, label, token)>, linkage = #llvm.linkage<external>, sym_name = "use_metadata_label_token"}> ({
-  ^bb0(%arg0: !llvm.metadata, %arg1: !llvm.label, %arg2: !llvm.token):
+  // `metadata` and `label` are invalid as array elements.
+  "llvm.func"() <{function_type = !llvm.func<void (metadata, label)>, linkage = #llvm.linkage<external>, sym_name = "use_metadata_and_label"}> ({
+  ^bb0(%arg0: !llvm.metadata, %arg1: !llvm.label):
     "llvm.return"() : () -> ()
   }) : () -> ()
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.x86_amx, !llvm.target<"aarch64.svcount">)>, linkage = #llvm.linkage<external>, sym_name = "use_full_prefix"}> ({
@@ -31,7 +31,7 @@
 // CHECK: (%arg{{[0-9_]+}} : !llvm.array<4 x !llvm.ppc_fp128>):
 // CHECK: !llvm.func<void (!llvm.array<1 x !llvm.target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>)>
 // CHECK: (%arg{{[0-9_]+}} : !llvm.array<1 x !llvm.target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>):
-// CHECK: !llvm.func<void (!llvm.metadata, !llvm.label, !llvm.token)>
-// CHECK: (%arg{{[0-9_]+}} : !llvm.metadata, %arg{{[0-9_]+}} : !llvm.label, %arg{{[0-9_]+}} : !llvm.token):
+// CHECK: !llvm.func<void (!llvm.metadata, !llvm.label)>
+// CHECK: (%arg{{[0-9_]+}} : !llvm.metadata, %arg{{[0-9_]+}} : !llvm.label):
 // CHECK: !llvm.func<void (!llvm.x86_amx, !llvm.target<"aarch64.svcount">)>
 // CHECK: (%arg{{[0-9_]+}} : !llvm.x86_amx, %arg{{[0-9_]+}} : !llvm.target<"aarch64.svcount">):

--- a/Test/LLVM/pretty_llvm_types.mlir
+++ b/Test/LLVM/pretty_llvm_types.mlir
@@ -1,4 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
 
 "builtin.module"() ({
   "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<2 x x86_amx>)>, linkage = #llvm.linkage<external>, sym_name = "use_x86_amx"}> ({
@@ -9,22 +10,28 @@
   ^bb0(%arg0: !llvm.array<4 x !llvm.ppc_fp128>):
     "llvm.return"() : () -> ()
   }) : () -> ()
-  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<1 x metadata>)>, linkage = #llvm.linkage<external>, sym_name = "use_metadata"}> ({
-  ^bb0(%arg0: !llvm.array<1 x !llvm.metadata>):
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<1 x target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>)>, linkage = #llvm.linkage<external>, sym_name = "use_target"}> ({
+  ^bb0(%arg0: !llvm.array<1 x !llvm.target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>):
     "llvm.return"() : () -> ()
   }) : () -> ()
-  "llvm.func"() <{function_type = !llvm.func<void (!llvm.array<1 x label>)>, linkage = #llvm.linkage<external>, sym_name = "use_label"}> ({
-  ^bb0(%arg0: !llvm.array<1 x !llvm.label>):
+  // `metadata`, `label` and `token` are invalid as array elements.
+  "llvm.func"() <{function_type = !llvm.func<void (metadata, label, token)>, linkage = #llvm.linkage<external>, sym_name = "use_metadata_label_token"}> ({
+  ^bb0(%arg0: !llvm.metadata, %arg1: !llvm.label, %arg2: !llvm.token):
     "llvm.return"() : () -> ()
   }) : () -> ()
-  "llvm.func"() <{function_type = !llvm.func<void (!llvm.x86_amx)>, linkage = #llvm.linkage<external>, sym_name = "use_full_prefix"}> ({
-  ^bb0(%arg0: !llvm.x86_amx):
+  "llvm.func"() <{function_type = !llvm.func<void (!llvm.x86_amx, !llvm.target<"aarch64.svcount">)>, linkage = #llvm.linkage<external>, sym_name = "use_full_prefix"}> ({
+  ^bb0(%arg0: !llvm.x86_amx, %arg1: !llvm.target<"aarch64.svcount">):
     "llvm.return"() : () -> ()
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: !llvm.array<2 x !llvm.x86_amx>
-// CHECK: !llvm.array<4 x !llvm.ppc_fp128>
-// CHECK: !llvm.array<1 x !llvm.metadata>
-// CHECK: !llvm.array<1 x !llvm.label>
-// CHECK: !llvm.x86_amx
+// CHECK: !llvm.func<void (!llvm.array<2 x !llvm.x86_amx>)>
+// CHECK: (%arg{{[0-9_]+}} : !llvm.array<2 x !llvm.x86_amx>):
+// CHECK: !llvm.func<void (!llvm.array<4 x !llvm.ppc_fp128>)>
+// CHECK: (%arg{{[0-9_]+}} : !llvm.array<4 x !llvm.ppc_fp128>):
+// CHECK: !llvm.func<void (!llvm.array<1 x !llvm.target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>)>
+// CHECK: (%arg{{[0-9_]+}} : !llvm.array<1 x !llvm.target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>):
+// CHECK: !llvm.func<void (!llvm.metadata, !llvm.label, !llvm.token)>
+// CHECK: (%arg{{[0-9_]+}} : !llvm.metadata, %arg{{[0-9_]+}} : !llvm.label, %arg{{[0-9_]+}} : !llvm.token):
+// CHECK: !llvm.func<void (!llvm.x86_amx, !llvm.target<"aarch64.svcount">)>
+// CHECK: (%arg{{[0-9_]+}} : !llvm.x86_amx, %arg{{[0-9_]+}} : !llvm.target<"aarch64.svcount">):

--- a/UnitTest/AttrParser.lean
+++ b/UnitTest/AttrParser.lean
@@ -560,6 +560,33 @@ macro "#assert " e:term : command =>
 #assert expectSuccessType "!llvm.array<4 x struct<packed (i8, i32)>>"
   (LLVM.ArrayType.mk 4 (UnregisteredAttr.mk "!llvm.struct<packed (i8, i32)>" true none : Attribute)) true
 
+
+/-! ## LLVM parameterless types -/
+#assert expectSuccessType "!llvm.x86_amx"
+  ⟨UnregisteredAttr.mk "!llvm.x86_amx" true none, by grind⟩
+#assert expectSuccessType "!llvm.token"
+  ⟨UnregisteredAttr.mk "!llvm.token" true none, by grind⟩
+#assert expectSuccessType "!llvm.array<2 x x86_amx>"
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.x86_amx" true none : Attribute))
+#assert expectSuccessType "!llvm.array<2 x !llvm.x86_amx>"
+  (LLVM.ArrayType.mk 2 (UnregisteredAttr.mk "!llvm.x86_amx" true none : Attribute))
+#assert expectSuccessType "!llvm.array<4 x ppc_fp128>"
+  (LLVM.ArrayType.mk 4 (UnregisteredAttr.mk "!llvm.ppc_fp128" true none : Attribute))
+#assert expectSuccessType "!llvm.array<1 x metadata>"
+  (LLVM.ArrayType.mk 1 (UnregisteredAttr.mk "!llvm.metadata" true none : Attribute))
+#assert expectSuccessType "!llvm.array<1 x label>"
+  (LLVM.ArrayType.mk 1 (UnregisteredAttr.mk "!llvm.label" true none : Attribute))
+#assert expectSuccessType "!llvm.array<1 x token>"
+  (LLVM.ArrayType.mk 1 (UnregisteredAttr.mk "!llvm.token" true none : Attribute))
+-- The bare form only works nested inside another LLVM type.
+#assert expectMissingType "x86_amx"
+-- The target body is kept as written.
+#assert expectSuccessType "!llvm.target<\"aarch64.svcount\">"
+  ⟨UnregisteredAttr.mk "!llvm.target<\"aarch64.svcount\">" true none, by grind⟩
+#assert expectSuccessType "!llvm.array<1 x target<\"spirv.Image\", i32, 0>>"
+  (LLVM.ArrayType.mk 1
+    (UnregisteredAttr.mk "!llvm.target<\"spirv.Image\", i32, 0>" true none : Attribute))
+
 /-! ## LLVM Function type -/
 #assert expectSuccessType "!llvm.func<i32 (i32)>"
   ⟨.llvmFunctionType (FunctionType.mk

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -509,6 +509,54 @@ partial def parseOptionalDialectType : AttrParserM (Option TypeAttr) := do
     return some (⟨UnregisteredAttr.mk ("!" ++ String.fromUTF8! dialectName) true none, by grind⟩)
 
 /--
+  Consume the type name `!name`, or (exclusively) `name` without the dialect prefix when
+  `short`. Consumes nothing if the name is not there.
+-/
+private def parseOptionalTypeName (name : String) (short : Bool) : AttrParserM Bool := do
+  if short then
+    let mnemonic := match name.splitOn "." with
+      | _dialect :: mnemonic@(_ :: _) => ".".intercalate mnemonic
+      | _ => name
+    return ← parseOptionalKeyword mnemonic.toByteArray
+  let token ← peekToken
+  let .exclamationIdent := token.kind | return false
+  let input := (← getThe ParserState).input
+  let typeName := { token.slice with start := token.slice.start + 1 }.of input
+  if typeName ≠ name.toByteArray then return false
+  let _ ← consumeToken
+  return true
+
+/--
+  The LLVM types that take no parameters. `void` and `ptr` have their own parsers.
+-/
+private def llvmParameterlessTypes : List String :=
+  ["llvm.x86_amx", "llvm.ppc_fp128", "llvm.label", "llvm.metadata", "llvm.token"]
+
+/--
+  Parse the parameterless type `!name`, or (exclusively) `name` without the dialect prefix
+  when `short`.
+-/
+def parseOptionalUnregisteredSingletonType (name : String) (short := false) :
+    AttrParserM (Option TypeAttr) := do
+  if !(← parseOptionalTypeName name short) then return none
+  return some ⟨UnregisteredAttr.mk ("!" ++ name) true none, by grind⟩
+
+/--
+  Parse the type `!name<...>`, or (exclusively) `name<...>` without the dialect prefix when
+  `short`. The body is kept as written, so both spellings print as `!name<...>`.
+-/
+def parseOptionalUnregisteredType (name : String) (short := false) :
+    AttrParserM (Option TypeAttr) := do
+  if !(← parseOptionalTypeName name short) then return none
+  let startPos ← getPos
+  parsePunctuation "<"
+  let _ ← parseUnregisteredAttrBody
+  let endPos := (← peekToken).slice.stop
+  parsePunctuation ">"
+  let body := (Slice.mk startPos endPos).of (← getThe ParserState).input
+  return some ⟨UnregisteredAttr.mk ("!" ++ name ++ String.fromUTF8! body) true none, by grind⟩
+
+/--
   Attributes VeIR registers but does not interpret: everything between `<` and
   `>` is kept verbatim and printed back unchanged.
 -/
@@ -972,15 +1020,7 @@ partial def parseOptionalVectorType : AttrParserM (Option TypeAttr) := do
   or (exclusively) the shorter form `array<size x type>` if the corresponding argument is set.
 -/
 partial def parseOptionalLLVMArrayType (short := false) : AttrParserM (Option TypeAttr) := do
-  if short then
-    let .true ← parseOptionalKeyword "array".toByteArray | return none
-  else
-    let token ← peekToken
-    let .exclamationIdent := token.kind | return none
-    let input := (← getThe ParserState).input
-    let typeName := { token.slice with start := token.slice.start + 1 }.of input
-    if typeName ≠ "llvm.array".toByteArray then return none
-    let _ ← consumeToken
+  if !(← parseOptionalTypeName "llvm.array" short) then return none
   parsePunctuation "<"
   let size ← parseInteger false false
   parseKeyword "x".toByteArray
@@ -1034,15 +1074,7 @@ partial def parseOptionalFunctionType : AttrParserM (Option FunctionType) := do
   which is all that is currently required.
 -/
 partial def parseOptionalLLVMStructType (short := false) : AttrParserM (Option TypeAttr) := do
-  if short then
-    let .true ← parseOptionalKeyword "struct".toByteArray | return none
-  else
-    let token ← peekToken
-    let .exclamationIdent := token.kind | return none
-    let input := (← getThe ParserState).input
-    let typeName := { token.slice with start := token.slice.start + 1 }.of input
-    if typeName ≠ "llvm.struct".toByteArray then return none
-    let _ ← consumeToken
+  if !(← parseOptionalTypeName "llvm.struct" short) then return none
   -- Capture the `struct<...>` body opaquely and normalize to the full
   -- `!llvm.struct<...>` spelling, so both forms produce identical output.
   let startPos ← getPos
@@ -1055,8 +1087,9 @@ partial def parseOptionalLLVMStructType (short := false) : AttrParserM (Option T
 
 /--
   Parse a type within an LLVM-dialect type body, accepting the LLVM "pretty-print"
-  sugar keywords `void`, `ptr`, and the bare nested forms `array<...>`,
-  `struct<...>`, and `func<...>` in addition to the regular MLIR type forms.
+  sugar keywords `void`, `ptr`, `x86_amx`, `ppc_fp128`, `label`, `metadata`, `token`, and
+  the bare nested forms `array<...>`, `struct<...>`, `func<...>`, and `target<...>` in
+  addition to the regular MLIR type forms.
 
   The bare nested form exists because the LLVM dialect has a custom directive
   `PrettyLLVMType`, which allows types from the LLVM dialect to be written
@@ -1086,17 +1119,11 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
     return type
   if let some type ← parseOptionalLLVMFunctionType true then
     return type
-  for kw in #["x86_amx", "ppc_fp128", "label", "metadata"] do
-    if ← parseOptionalKeyword kw.toByteArray then
-      return ⟨UnregisteredAttr.mk s!"!llvm.{kw}" true none, by grind⟩
-  if ← parseOptionalKeyword "target".toByteArray then
-    let startPos ← getPos
-    parsePunctuation "<"
-    let _ ← parseUnregisteredAttrBody
-    let endPos := (← peekToken).slice.stop
-    parsePunctuation ">"
-    let body := (Slice.mk startPos endPos).of (← getThe ParserState).input
-    return ⟨UnregisteredAttr.mk ("!llvm.target" ++ String.fromUTF8! body) true none, by grind⟩
+  for name in llvmParameterlessTypes do
+    if let some type ← parseOptionalUnregisteredSingletonType name true then
+      return type
+  if let some type ← parseOptionalUnregisteredType "llvm.target" true then
+    return type
   parseType errorMsg
 
 /--
@@ -1105,15 +1132,7 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
   in any position other than the last.
 -/
 partial def parseOptionalLLVMFunctionType (short := false) : AttrParserM (Option TypeAttr) := do
-  if short then
-    let .true ← parseOptionalKeyword "func".toByteArray | return none
-  else
-    let token ← peekToken
-    let .exclamationIdent := token.kind | return none
-    let input := (← getThe ParserState).input
-    let typeName := { token.slice with start := token.slice.start + 1 }.of input
-    if typeName ≠ "llvm.func".toByteArray then return none
-    let _ ← consumeToken
+  if !(← parseOptionalTypeName "llvm.func" short) then return none
   parsePunctuation "<"
   let result ← parseLLVMType "llvm.func result type expected"
   let params ← parseDelimitedList .paren do
@@ -1220,23 +1239,11 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some llvmStructType
   if let some llvmFunctionType ← parseOptionalLLVMFunctionType then
     return some llvmFunctionType
-  if let .exclamationIdent := (← peekToken).kind then
-    let input := (← getThe ParserState).input
-    let token ← peekToken
-    let typeName := { token.slice with start := token.slice.start + 1 }.of input
-    for kw in #["x86_amx", "ppc_fp128", "label", "metadata"] do
-      if typeName == s!"llvm.{kw}".toByteArray then
-        let _ ← consumeToken
-        return some ⟨UnregisteredAttr.mk s!"!llvm.{kw}" true none, by grind⟩
-    if typeName == "llvm.target".toByteArray then
-      let _ ← consumeToken
-      let startPos ← getPos
-      parsePunctuation "<"
-      let _ ← parseUnregisteredAttrBody
-      let endPos := (← peekToken).slice.stop
-      parsePunctuation ">"
-      let body := (Slice.mk startPos endPos).of input
-      return some ⟨UnregisteredAttr.mk ("!llvm.target" ++ String.fromUTF8! body) true none, by grind⟩
+  for name in llvmParameterlessTypes do
+    if let some llvmParameterlessType ← parseOptionalUnregisteredSingletonType name then
+      return some llvmParameterlessType
+  if let some llvmTargetType ← parseOptionalUnregisteredType "llvm.target" then
+    return some llvmTargetType
   if let some cudaTilePointerType := ← parseOptionalCudaTilePointerType then
     return some cudaTilePointerType
   if let some ioAddressType := ← parseOptionalIoAddressType then

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -1086,6 +1086,17 @@ partial def parseLLVMType (errorMsg : String := "type expected") : AttrParserM T
     return type
   if let some type ← parseOptionalLLVMFunctionType true then
     return type
+  for kw in #["x86_amx", "ppc_fp128", "label", "metadata"] do
+    if ← parseOptionalKeyword kw.toByteArray then
+      return ⟨UnregisteredAttr.mk s!"!llvm.{kw}" true none, by grind⟩
+  if ← parseOptionalKeyword "target".toByteArray then
+    let startPos ← getPos
+    parsePunctuation "<"
+    let _ ← parseUnregisteredAttrBody
+    let endPos := (← peekToken).slice.stop
+    parsePunctuation ">"
+    let body := (Slice.mk startPos endPos).of (← getThe ParserState).input
+    return ⟨UnregisteredAttr.mk ("!llvm.target" ++ String.fromUTF8! body) true none, by grind⟩
   parseType errorMsg
 
 /--
@@ -1209,6 +1220,23 @@ partial def parseOptionalType : AttrParserM (Option TypeAttr) := do
     return some llvmStructType
   if let some llvmFunctionType ← parseOptionalLLVMFunctionType then
     return some llvmFunctionType
+  if let .exclamationIdent := (← peekToken).kind then
+    let input := (← getThe ParserState).input
+    let token ← peekToken
+    let typeName := { token.slice with start := token.slice.start + 1 }.of input
+    for kw in #["x86_amx", "ppc_fp128", "label", "metadata"] do
+      if typeName == s!"llvm.{kw}".toByteArray then
+        let _ ← consumeToken
+        return some ⟨UnregisteredAttr.mk s!"!llvm.{kw}" true none, by grind⟩
+    if typeName == "llvm.target".toByteArray then
+      let _ ← consumeToken
+      let startPos ← getPos
+      parsePunctuation "<"
+      let _ ← parseUnregisteredAttrBody
+      let endPos := (← peekToken).slice.stop
+      parsePunctuation ">"
+      let body := (Slice.mk startPos endPos).of input
+      return some ⟨UnregisteredAttr.mk ("!llvm.target" ++ String.fromUTF8! body) true none, by grind⟩
   if let some cudaTilePointerType := ← parseOptionalCudaTilePointerType then
     return some cudaTilePointerType
   if let some ioAddressType := ← parseOptionalIoAddressType then


### PR DESCRIPTION
Part of #952.

Adds shorthand parsing for the remaining LLVM parameterless types: `x86_amx`, `ppc_fp128`, `metadata`, `label`, `token`, and `target<...>`.

```mlir
!llvm.array<2 x x86_amx>
!llvm.array<4 x ppc_fp128>
!llvm.array<1 x target<"spirv.Image", i32, 0, 0, 0, 0, 0, 0>>
!llvm.func<void (metadata, label, token)>
```

The printer emits the full `!llvm.` prefix, so a second parse site in `parseOptionalType` accepts that form for round-trip correctness.

Both spellings are handled by `parseOptionalUnregisteredSingletonType` and `parseOptionalUnregisteredType`, which take the type name as a parameter, and the names themselves live in a single `llvmParameterlessTypes` list used by both parse sites. The shared name matching replaces the hand-rolled prologue in the array, struct and function type parsers as well.

Tested by `Test/LLVM/pretty_llvm_types.mlir`, which runs `VEIR_ROUNDTRIP` and `MLIR_ROUNDTRIP`, and by unit tests in `UnitTest/AttrParser.lean`.

Two pre-existing limitations that this PR extends to the new types rather than fixing:

- A `target<...>` body is stored as text, like `!llvm.struct<...>`. Type aliases inside a body are not resolved, and two spellings of the same type are not equal.
- VeIR accepts `!llvm.array<N x metadata|label|token>` where `mlir-opt` rejects it, so the round-trip test uses parameter position for those three.
