### PR TITLE
fix: reject out-of-range integer attrs, fix mixed-width constant folding

### DIFF
--- a/Test/LLVM/constant_attr_width_normalization.mlir
+++ b/Test/LLVM/constant_attr_width_normalization.mlir
@@ -1,7 +1,5 @@
 // RUN: VEIR_ROUNDTRIP
 // RUN: MLIR_ROUNDTRIP
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
 // XFAIL: *
 
 // An MLIR `IntegerAttr` *is* an APInt of its declared width, so MLIR normalizes

--- a/Test/Parsing/integer-attr-out-of-range-i1-overflow.mlir
+++ b/Test/Parsing/integer-attr-out-of-range-i1-overflow.mlir
@@ -1,8 +1,5 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 // RUN: MLIR_INVALID
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
-// XFAIL: *
 
 // An MLIR `IntegerAttr` of width N is an APInt of width N, so the literal must
 // fit: mlir-opt accepts only [-2^(N-1), 2^N) and rejects everything else with

--- a/Test/Parsing/integer-attr-out-of-range-negative-overflow.mlir
+++ b/Test/Parsing/integer-attr-out-of-range-negative-overflow.mlir
@@ -1,8 +1,5 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 // RUN: MLIR_INVALID
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
-// XFAIL: *
 
 // An MLIR `IntegerAttr` of width N is an APInt of width N, so the literal must
 // fit: mlir-opt accepts only [-2^(N-1), 2^N) and rejects everything else with

--- a/Test/Parsing/integer-attr-out-of-range-unsigned-overflow.mlir
+++ b/Test/Parsing/integer-attr-out-of-range-unsigned-overflow.mlir
@@ -1,8 +1,5 @@
 // RUN: not veir-opt %s 2>&1 | filecheck %s
 // RUN: MLIR_INVALID
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
-// XFAIL: *
 
 // An MLIR `IntegerAttr` of width N is an APInt of width N, so the literal must
 // fit: mlir-opt accepts only [-2^(N-1), 2^N) and rejects everything else with

--- a/Test/Passes/RISCVCombines/constant_fold_attr_width_mismatch.mlir
+++ b/Test/Passes/RISCVCombines/constant_fold_attr_width_mismatch.mlir
@@ -1,8 +1,5 @@
 // RUN: veir-opt %s -p=riscv-combine | filecheck %s
 // RUN: %if mlir-min-22 %{ veir-opt %s -p=riscv-combine | mlir-opt --mlir-print-op-generic %}
-// Expected to fail until `llvm.mlir.constant` handles the value attribute's
-// integer width the way MLIR does; drop the XFAIL with the fix.
-// XFAIL: *
 
 // `matchConstantIntOp` (Veir/Passes/Matching/LLVM/Basic.lean) hands callers the
 // raw `IntegerAttr.value`, and `constant_fold_binop_local`

--- a/Test/Verifier/mod_arith_modulus_too_wide.mlir
+++ b/Test/Verifier/mod_arith_modulus_too_wide.mlir
@@ -9,5 +9,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: mod_arith.constant: Expected result to have ModArithType
-// CHECK-SAME: modulus 7 does not fit into the underlying storage type 'i2'
+// CHECK: integer constant out of range for attribute

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -104,6 +104,16 @@ structure IntegerAttr where
   type : IntegerType
 deriving Inhabited, Repr, DecidableEq, Hashable
 
+def IntegerAttr.normalize (value : Int) (bitwidth : Nat) : Int :=
+  if bitwidth == 0 then 0
+  else
+    let modulus : Int := 2 ^ bitwidth
+    let reduced := value % modulus
+    let unsigned := if reduced < 0 then reduced + modulus else reduced
+    if bitwidth == 1 then unsigned
+    else if unsigned ≥ modulus / 2 then unsigned - modulus
+    else unsigned
+
 /--
  Floating point fastmath flags attribute.
 -/

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -315,14 +315,28 @@ def parseOptionalNumericAttr : AttrParserM (Option Attribute) := do
 
   -- Determine the type after ':'.
   if let some integerType ← parseOptionalIntegerType then
-    return some (IntegerAttr.mk (← integerValue) integerType : Attribute)
+    let val ← integerValue
+    let n := integerType.bitwidth
+    if n > 0 then
+      let lo : Int := -(2 ^ (n - 1))
+      let hi : Int := 2 ^ n
+      if val < lo || val ≥ hi then
+        throwAt valueStartPos "integer constant out of range for attribute"
+    return some (IntegerAttr.mk val integerType : Attribute)
   else if let some floatType ← parseOptionalFloatType then
     return some (FloatAttr.mk floatType (← floatValue floatType) : Attribute)
   else if let some name ← parseOptionalPrefixedKeyword .exclamationIdent then
     let some typeAttr := (← resolveOptionalTypeAlias startPos name)
       | throwAt startPos "integer or float type expected after ':' in numeric attribute"
     if let some integerType := typeAttr.cast? IntegerType then
-      return some (IntegerAttr.mk (← integerValue) integerType : Attribute)
+      let val ← integerValue
+      let n := integerType.bitwidth
+      if n > 0 then
+        let lo : Int := -(2 ^ (n - 1))
+        let hi : Int := 2 ^ n
+        if val < lo || val ≥ hi then
+          throwAt valueStartPos "integer constant out of range for attribute"
+      return some (IntegerAttr.mk val integerType : Attribute)
     else if let some floatType := typeAttr.cast? FloatType then
       return some (FloatAttr.mk floatType (← floatValue floatType) : Attribute)
     else

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -1208,7 +1208,7 @@ def APlusC1MinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, ap) := matchAdd dAdd ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value - c2.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c1.value - c2.value) aty.bitwidth) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
@@ -1229,7 +1229,7 @@ def C2MinusAPlusC1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, _ap) := matchAdd dAdd ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2.value - c1.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c2.value - c1.value) aty.bitwidth) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
@@ -1250,7 +1250,7 @@ def AMinusC1MinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, _sp2) := matchSub dSub ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value + c2.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c1.value + c2.value) aty.bitwidth) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
@@ -1271,7 +1271,7 @@ def C1MinusAMinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (c1v, a, _sp2) := matchSub dSub ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value - c2.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c1.value - c2.value) aty.bitwidth) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
@@ -1292,7 +1292,7 @@ def AMinusC1PlusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, _sp) := matchSub dSub ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2.value - c1.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c2.value - c1.value) aty.bitwidth) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
@@ -2108,7 +2108,7 @@ def sub_to_add_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cval, _sp) := matchSub op ctx.raw | return (ctx, none)
   let some c := matchConstantIntVal cval ctx.raw | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
-  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c.value) xty))
+  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (-c.value) xty.bitwidth) xty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] negC none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (cn.getResult 0)]
@@ -2128,7 +2128,7 @@ def sub_of_mul_const_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cval, mp) := matchMul dMul ctx.raw | return (ctx, none)
   let some c := matchConstantIntVal cval ctx.raw | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
-  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c.value) xty))
+  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (-c.value) xty.bitwidth) xty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] negC none
   let (ctx, newMul) ← WfRewriter.createOp! ctx Llvm.mul #[x.getType! ctx.raw] #[x, (cn.getResult 0)]
@@ -2294,7 +2294,7 @@ def lshr_of_trunc_of_lshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, c1v, ip) := matchLshr dInner ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value + c2.value) xty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c1.value + c2.value) xty.bitwidth) xty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newLshr) ← WfRewriter.createOp! ctx Llvm.lshr #[x.getType! ctx.raw] #[x, (cf.getResult 0)]
@@ -2457,7 +2457,7 @@ def funnel_shift_overshift_l_local (ctx : WfIRContext OpCode) (op : OperationPtr
   let .integerType aty := (amt.getType! ctx.raw).val | return (ctx, none)
   let bw : Int := (aty.bitwidth : Int)
   if c.value < bw then return (ctx, none)
-  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c.value % bw) aty))
+  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c.value % bw) aty.bitwidth) aty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[amt.getType! ctx.raw] #[]
     #[] #[] newAmt none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__fshl #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
@@ -2475,7 +2475,7 @@ def funnel_shift_overshift_r_local (ctx : WfIRContext OpCode) (op : OperationPtr
   let .integerType aty := (amt.getType! ctx.raw).val | return (ctx, none)
   let bw : Int := (aty.bitwidth : Int)
   if c.value < bw then return (ctx, none)
-  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c.value % bw) aty))
+  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize (c.value % bw) aty.bitwidth) aty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[amt.getType! ctx.raw] #[]
     #[] #[] newAmt none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__fshr #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
@@ -2542,8 +2542,9 @@ def constant_fold_binop_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if operands.size ≠ 2 then return (ctx, none)
   let some c1 := matchConstantIntVal operands[0]! ctx.raw | return (ctx, none)
   let some c2 := matchConstantIntVal operands[1]! ctx.raw | return (ctx, none)
-  let a := c1.value
-  let b := c2.value
+  let .integerType rty := ((op.getResult 0 : ValuePtr).getType! ctx.raw).val | return (ctx, none)
+  let a := IntegerAttr.normalize (IntegerAttr.normalize c1.value c1.type.bitwidth) rty.bitwidth
+  let b := IntegerAttr.normalize (IntegerAttr.normalize c2.value c2.type.bitwidth) rty.bitwidth
   -- Only opcodes whose result is well-defined over unbounded `Int` (no fixed-width
   -- wrapping / signedness ambiguity) are folded. The bitwise ops (`and/or/xor`),
   -- the shifts, and the div/rem family need width-dependent semantics and are
@@ -2556,8 +2557,7 @@ def constant_fold_binop_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | .llvm .intr__smax => some (max a b)
     | _ => none
   let some result := folded | return (ctx, none)
-  let .integerType rty := ((op.getResult 0 : ValuePtr).getType! ctx.raw).val | return (ctx, none)
-  let foldedProps := LLVMConstantProperties.mk (.integer (IntegerAttr.mk result rty))
+  let foldedProps := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (IntegerAttr.normalize result rty.bitwidth) rty))
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[]
     #[] #[] foldedProps none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))


### PR DESCRIPTION
Part of #1298.

Parser rejects attrs outside `[-2^(N-1), 2^N)`:

```mlir
// now rejected, matching mlir-opt
%0 = "llvm.mlir.constant"() <{value = 256 : i8}> : () -> i8
```

Constant folder normalizes operands to their attribute bitwidth before folding. Without this, `200 : i8` folded as 200 instead of -56:

```mlir
%0 = "llvm.mlir.constant"() <{value = 200 : i8}> : () -> i32
```