### PR TITLE
feat(LLVM): check the types of the floating point arithmetic

### DIFF
--- a/Test/Verifier/llvm_fadd_integer_operands.mlir
+++ b/Test/Verifier/llvm_fadd_integer_operands.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%i: i32):
+    %r = "llvm.fadd"(%i, %i) : (i32, i32) -> i32
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fadd: Expected operand 0 to have floating point type

--- a/Test/Verifier/llvm_fadd_mixed_widths.mlir
+++ b/Test/Verifier/llvm_fadd_mixed_widths.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64, f32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64, %s: f32):
+    %r = "llvm.fadd"(%d, %s) : (f64, f32) -> f64
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fadd: Expected operands to have the same type

--- a/Test/Verifier/llvm_fmul_integer_result.mlir
+++ b/Test/Verifier/llvm_fmul_integer_result.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (f64)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%d: f64):
+    %r = "llvm.fmul"(%d, %d) : (f64, f64) -> i32
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.fmul: Expected result type to match operand type

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -840,8 +840,7 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       throw "Expected 0 successors"
   | .fadd | .fsub | .fmul | .fdiv | .frem => do
     op.checkIsNonNullIntegerType ctx opIn
-    op.verifyPlainOpCounts ctx opIn 2 1
-    pure ()
+    op.verifyFloatBinop ctx opIn
   | .module_flags => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 0 0

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -158,6 +158,12 @@ def TypeAttr.verifyIntegerType
   | .integerType _ => pure ()
   | _ => throw errMsg
 
+def TypeAttr.verifyFloatType
+    (ty : TypeAttr) (errMsg : String) : Except String PUnit :=
+  match ty.val with
+  | .floatType _ => pure ()
+  | _ => throw errMsg
+
 def TypeAttr.verifyIntegerOrByteType
     (ty : TypeAttr) (errMsg : String) : Except String PUnit :=
   match ty.val with
@@ -236,6 +242,20 @@ def OperationPtr.verifyIntegerBinop (op : OperationPtr)
     s!"{instrName}: Expected operand 0 to have integer type"
   ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyIntegerType
     s!"{instrName}: Expected operand 1 to have integer type"
+  let operandType ← op.verifyOperandTypesMatch ctx 0 1
+    s!"{instrName}: Expected operands to have the same type"
+  op.verifyResultTypeMatches ctx operandType
+    s!"{instrName}: Expected result type to match operand type"
+
+def OperationPtr.verifyFloatBinop (op : OperationPtr)
+    (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  op.verifyPlainOpCounts ctx opIn 2 1
+  let instrName := String.fromUTF8! (IsOpCode.name (op.getOpType ctx.raw opIn))
+  ((op.getOperand! ctx.raw 0).getType! ctx.raw).verifyFloatType
+    s!"{instrName}: Expected operand 0 to have floating point type"
+  ((op.getOperand! ctx.raw 1).getType! ctx.raw).verifyFloatType
+    s!"{instrName}: Expected operand 1 to have floating point type"
   let operandType ← op.verifyOperandTypesMatch ctx 0 1
     s!"{instrName}: Expected operands to have the same type"
   op.verifyResultTypeMatches ctx operandType


### PR DESCRIPTION
Floating point operations expect scalar floating point types, all of uniform width.