### PR TITLE
feat(LLVM): add llvm.intr.vector.reduce.or

### DIFF
--- a/Test/LLVM/vector_reduce_or.mlir
+++ b/Test/LLVM/vector_reduce_or.mlir
@@ -1,0 +1,18 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+//
+// Reduce an integer vector to the bitwise OR of its elements. SQLite uses
+// vector<4xi8>; the element width and number of lanes may vary independently.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<4xi8>, vector<2xi32>, vector<8xi1>)>, linkage = #llvm.linkage<external>, sym_name = "reduce"}> ({
+  ^bb0(%bytes: vector<4xi8>, %words: vector<2xi32>, %bits: vector<8xi1>):
+    %a = "llvm.intr.vector.reduce.or"(%bytes) : (vector<4xi8>) -> i8
+    %b = "llvm.intr.vector.reduce.or"(%words) : (vector<2xi32>) -> i32
+    %c = "llvm.intr.vector.reduce.or"(%bits) : (vector<8xi1>) -> i1
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.intr.vector.reduce.or"(%{{[a-z0-9_]+}}) : (vector<4xi8>) -> i8
+// CHECK: "llvm.intr.vector.reduce.or"(%{{[a-z0-9_]+}}) : (vector<2xi32>) -> i32
+// CHECK: "llvm.intr.vector.reduce.or"(%{{[a-z0-9_]+}}) : (vector<8xi1>) -> i1

--- a/Test/Verifier/llvm_vector_reduce_or_multidimensional_vector.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_multidimensional_vector.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// LLVM vectors must be one-dimensional.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<2x2xi8>)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: vector<2x2xi8>):
+    %r = "llvm.intr.vector.reduce.or"(%v) : (vector<2x2xi8>) -> i8
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected a nonempty one-dimensional vector

--- a/Test/Verifier/llvm_vector_reduce_or_non_integer_element.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_non_integer_element.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// Bitwise OR reduction requires integer elements.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<4xf32>)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: vector<4xf32>):
+    %r = "llvm.intr.vector.reduce.or"(%v) : (vector<4xf32>) -> f32
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected vector elements to have integer type

--- a/Test/Verifier/llvm_vector_reduce_or_non_vector_operand.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_non_vector_operand.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The operand must be a vector.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i8)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: i8):
+    %r = "llvm.intr.vector.reduce.or"(%v) : (i8) -> i8
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected operand 0 to have vector type

--- a/Test/Verifier/llvm_vector_reduce_or_rank_zero_vector.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_rank_zero_vector.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// A rank-zero vector is not an LLVM vector.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<i8>)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: vector<i8>):
+    %r = "llvm.intr.vector.reduce.or"(%v) : (vector<i8>) -> i8
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected a nonempty one-dimensional vector

--- a/Test/Verifier/llvm_vector_reduce_or_result_type_mismatch.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_result_type_mismatch.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// The result type must match the vector element type.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<4xi8>)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: vector<4xi8>):
+    %r = "llvm.intr.vector.reduce.or"(%v) : (vector<4xi8>) -> i32
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected result type to match vector element type

--- a/Test/Verifier/llvm_vector_reduce_or_wrong_operand_count.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_wrong_operand_count.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// Reduction takes exactly one vector.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<4xi8>)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: vector<4xi8>):
+    %r = "llvm.intr.vector.reduce.or"(%v, %v) : (vector<4xi8>, vector<4xi8>) -> i8
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected 1 operand(s)

--- a/Test/Verifier/llvm_vector_reduce_or_wrong_result_count.mlir
+++ b/Test/Verifier/llvm_vector_reduce_or_wrong_result_count.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+// Reduction produces exactly one result.
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (vector<4xi8>)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%v: vector<4xi8>):
+    "llvm.intr.vector.reduce.or"(%v) : (vector<4xi8>) -> ()
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Expected 1 result(s)

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -44,6 +44,7 @@ inductive Llvm where
 | intr__fshl
 | intr__fshr
 | intr__assume
+| intr__vector__reduce__or
 | mul
 | sdiv
 | udiv
@@ -419,6 +420,7 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
   | .inttoptr, _ | .ptrtoint, _
   | .intr__smax, _ | .intr__smin, _ | .intr__umax, _ | .intr__umin, _
   | .intr__abs, _
+  | .intr__vector__reduce__or, _
   | .intr__sadd__sat, _ | .intr__uadd__sat, _
   | .intr__ssub__sat, _ | .intr__usub__sat, _
   | .intr__sshl__sat, _ | .intr__ushl__sat, _
@@ -457,6 +459,7 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .intr__ctlz | .intr__cttz | .intr__ctpop | .intr__bswap
   | .intr__bitreverse | .intr__fshl | .intr__fshr
   | .intr__smax | .intr__smin | .intr__umax | .intr__umin | .intr__abs
+  | .intr__vector__reduce__or
   | .intr__sadd__sat | .intr__uadd__sat | .intr__ssub__sat | .intr__usub__sat
   | .intr__sshl__sat | .intr__ushl__sat => true
   -- The floating-point arithmetic operations propagate poison too, but no
@@ -899,6 +902,20 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     match props.ordering with
     | .acquire | .release | .acq_rel | .seq_cst => pure ()
     | _ => throw "llvm.fence: can be given only acquire, release, acq_rel and seq_cst orderings"
+  | .intr__vector__reduce__or => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyPlainOpCounts ctx opIn 1 1
+    let operandType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+    let .vectorType vecType := operandType.val
+      | throw "Expected operand 0 to have vector type"
+    if vecType.shape.size ≠ 1 || vecType.shape[0]! = 0 then
+      throw "Expected a nonempty one-dimensional vector"
+    let .integerType _ := vecType.elementType
+      | throw "Expected vector elements to have integer type"
+    let resultType := ((op.getResult 0).get! ctx.raw).type
+    if resultType.val ≠ vecType.elementType then
+      throw "Expected result type to match vector element type"
+    pure ()
   | .getelementptr => do
     op.checkIsNonNullIntegerType ctx opIn
     let props := op.getProperties! ctx.raw Llvm.getelementptr


### PR DESCRIPTION
Part of #947.

Parse and verify `llvm.intr.vector.reduce.or` for fixed integer vectors, with a scalar result matching the element type. Includes VeIR/MLIR round-trip and rejection tests. SQLite function coverage increases from 1,435 to 1,437/1,598, accepting `incrVacuumStep` and `sqlite3BtreeOpen`.
