### PR TITLE
ci: build and test against MLIR 23

### DIFF
--- a/.github/docker/namespace-base-image.Dockerfile
+++ b/.github/docker/namespace-base-image.Dockerfile
@@ -27,14 +27,14 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \
  && curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
       -o /etc/apt/trusted.gpg.d/llvm-snapshot.asc \
- && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-22 main" \
+ && echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-23 main" \
       > /etc/apt/sources.list.d/llvm.list \
  && apt-get update \
  && apt-get install -y --no-install-recommends \
-      mlir-22-tools \
+      mlir-23-tools \
       # leanc links through the system toolchain.
       build-essential \
- && ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt \
+ && ln -s /usr/bin/mlir-opt-23 /usr/bin/mlir-opt \
  && rm -rf /var/lib/apt/lists/*
 
 # `uv` provides both the Python interpreter and the test dependencies, so no

--- a/.github/workflows/lean_action_ci.yml
+++ b/.github/workflows/lean_action_ci.yml
@@ -54,16 +54,16 @@ jobs:
           uri: http://apt.llvm.org/noble/ 
           key: https://apt.llvm.org/llvm-snapshot.gpg.key
           component: main
-          suite: llvm-toolchain-noble-22
+          suite: llvm-toolchain-noble-23
 
       - name: Install mlir-opt
         uses: gerlero/apt-install@c0fa73fe5c4a22deecf6d629565be92a15dd2026 # v1.3.12
         with:
-          packages: mlir-22-tools
+          packages: mlir-23-tools
 
       - name: Rename MLIR-opt
         run: |
-          sudo ln -s /usr/bin/mlir-opt-22 /usr/bin/mlir-opt
+          sudo ln -s /usr/bin/mlir-opt-23 /usr/bin/mlir-opt
 
       - name: Build the project
         uses: leanprover/lean-action@50fcf42d2e460296f1a34b402e990d1b24f8b596 # v1.6.0


### PR DESCRIPTION
Move CI and the Namespace base image from MLIR 22 to MLIR 23: the apt suite, the `mlir-23-tools` package, and the `mlir-opt` symlink. `Test/lit.cfg` already lists 23 as supported, so no test changes are needed; the suite passes unchanged under MLIR 23.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)