### PR TITLE
fix(LLVM,arith): use nonNeg instead of nneg

### DIFF
--- a/Test/Arith/extui_nonneg.mlir
+++ b/Test/Arith/extui_nonneg.mlir
@@ -1,0 +1,14 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: %if mlir-min-23 %{ MLIR_ROUNDTRIP %}
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i8) -> (), sym_name = "f"}> ({
+  ^bb0(%c: i8):
+    %a = "arith.extui"(%c) <{nonNeg}> : (i8) -> i32
+    %b = "arith.extui"(%c) : (i8) -> i32
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "arith.extui"(%{{[a-z0-9_]+}}) <{nonNeg}> : (i8) -> i32
+// CHECK: "arith.extui"(%{{[a-z0-9_]+}}) : (i8) -> i32

--- a/Test/Interpreter/Arith/extui_nneg.mlir
+++ b/Test/Interpreter/Arith/extui_nneg.mlir
@@ -4,8 +4,8 @@
   "func.func"() <{sym_name = "main", function_type = () -> (i32, i32)}> ({
     %cpos = "arith.constant"() <{ "value" = 42 : i8 }> : () -> i8
     %cneg = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
-    %a = "arith.extui"(%cpos) <{nneg}> : (i8) -> i32
-    %b = "arith.extui"(%cneg) <{nneg}> : (i8) -> i32
+    %a = "arith.extui"(%cpos) <{nonNeg}> : (i8) -> i32
+    %b = "arith.extui"(%cneg) <{nonNeg}> : (i8) -> i32
     "func.return"(%a, %b) : (i32, i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/zext_nneg.mlir
+++ b/Test/Interpreter/LLVM/zext_nneg.mlir
@@ -4,8 +4,8 @@
   "func.func"() <{sym_name = "main", function_type = () -> (i32, i32)}> ({
     %cpos = "llvm.mlir.constant"() <{ "value" = 42 : i8 }> : () -> i8
     %cneg = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
-    %a = "llvm.zext"(%cpos) <{nneg}> : (i8) -> i32
-    %b = "llvm.zext"(%cneg) <{nneg}> : (i8) -> i32
+    %a = "llvm.zext"(%cpos) <{nonNeg}> : (i8) -> i32
+    %b = "llvm.zext"(%cneg) <{nonNeg}> : (i8) -> i32
     "func.return"(%a, %b) : (i32, i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/LLVM/zext_nonneg.mlir
+++ b/Test/LLVM/zext_nonneg.mlir
@@ -1,0 +1,14 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i32)>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  ^bb0(%i: i32):
+    %a = "llvm.zext"(%i) <{nonNeg}> : (i32) -> i64
+    %b = "llvm.zext"(%i) : (i32) -> i64
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.zext"(%{{[a-z0-9_]+}}) <{nonNeg}> : (i32) -> i64
+// CHECK: "llvm.zext"(%{{[a-z0-9_]+}}) : (i32) -> i64

--- a/Test/Passes/CSE/arith.mlir
+++ b/Test/Passes/CSE/arith.mlir
@@ -113,7 +113,7 @@
     %c7_i8 = "arith.constant"() <{"value" = 7 : i8}> : () -> i8
     %zext_1 = "arith.extui"(%c7_i8) : (i8) -> i32
     %zext_2 = "arith.extui"(%c7_i8) : (i8) -> i32
-    %zext_nneg = "arith.extui"(%c7_i8) <{nneg}> : (i8) -> i32
+    %zext_nneg = "arith.extui"(%c7_i8) <{nonNeg}> : (i8) -> i32
     %sext = "arith.extsi"(%c7_i8) : (i8) -> i32
     %zext_i16 = "arith.extui"(%c7_i8) : (i8) -> i16
     %trunc_1 = "arith.trunci"(%a) : (i32) -> i8
@@ -127,7 +127,7 @@
     // CHECK-NEXT: %[[C8:.*]] = "arith.constant"() <{"value" = 8 : i32}> : () -> i32
     // CHECK-NEXT: %[[C7_I8:.*]] = "arith.constant"() <{"value" = 7 : i8}> : () -> i8
     // CHECK-NEXT: %[[ZEXT:.*]] = "arith.extui"(%[[C7_I8]]) : (i8) -> i32
-    // CHECK-NEXT: %[[ZEXT_NNEG:.*]] = "arith.extui"(%[[C7_I8]]) <{nneg}> : (i8) -> i32
+    // CHECK-NEXT: %[[ZEXT_NNEG:.*]] = "arith.extui"(%[[C7_I8]]) <{nonNeg}> : (i8) -> i32
     // CHECK-NEXT: %[[SEXT:.*]] = "arith.extsi"(%[[C7_I8]]) : (i8) -> i32
     // CHECK-NEXT: %[[ZEXT_I16:.*]] = "arith.extui"(%[[C7_I8]]) : (i8) -> i16
     // CHECK-NEXT: %[[TRUNC:.*]] = "arith.trunci"(%{{.*}}) : (i32) -> i8

--- a/Test/Passes/CSE/exact_and_misc_flags.mlir
+++ b/Test/Passes/CSE/exact_and_misc_flags.mlir
@@ -76,13 +76,13 @@
     %q_to_i8 = "llvm.trunc"(%q) : (i32) -> i8
     "llvm.br"(%q_to_i8) [^zext_nneg] : (i8) -> ()
 ^zext_nneg(%s : i8):
-    %zext_nneg_1 = "llvm.zext"(%s) <{nneg}> : (i8) -> i32
-    %zext_nneg_2 = "llvm.zext"(%s) <{nneg}> : (i8) -> i32
+    %zext_nneg_1 = "llvm.zext"(%s) <{nonNeg}> : (i8) -> i32
+    %zext_nneg_2 = "llvm.zext"(%s) <{nonNeg}> : (i8) -> i32
     %zext_plain  = "llvm.zext"(%s) : (i8) -> i32
     "test.test"(%zext_nneg_1, %zext_nneg_2, %zext_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i8):
-    // CHECK-NEXT: %[[ZEXT_NNEG:.*]] = "llvm.zext"(%{{.*}}) <{nneg}> : (i8) -> i32
+    // CHECK-NEXT: %[[ZEXT_NNEG:.*]] = "llvm.zext"(%{{.*}}) <{nonNeg}> : (i8) -> i32
     // CHECK-NEXT: %[[ZEXT_PLAIN:.*]] = "llvm.zext"(%{{.*}}) : (i8) -> i32
     // CHECK-NEXT: "test.test"(%[[ZEXT_NNEG]], %[[ZEXT_NNEG]], %[[ZEXT_PLAIN]])
     "llvm.return"() : () -> ()

--- a/Tools/veir2llvm
+++ b/Tools/veir2llvm
@@ -436,14 +436,14 @@ def flags_from_attrs(op: str, attr: str) -> list[str]:
         flags.append("exact")
     if op == "llvm.or" and "disjoint" in items:
         flags.append("disjoint")
-    if op == "llvm.zext" and "nneg" in items:
+    if op == "llvm.zext" and "nonNeg" in items:
         flags.append("nneg")
     unsupported = items - {
         "nuw",
         "nsw",
         "exact",
         "disjoint",
-        "nneg",
+        "nonNeg",
         "predicate",
         "operandSegmentSizes",
         "overflowFlags",

--- a/Tools/vsmith_generate.py
+++ b/Tools/vsmith_generate.py
@@ -391,7 +391,7 @@ class Generator:
                     if src_w >= 95:
                         continue
                     dst = f"i{self.rng.randint(src_w + 1, 95)}"
-                props = " <{nneg}>" if op == "llvm.zext" and self.rng.random() < 0.5 else ""
+                props = " <{nonNeg}>" if op == "llvm.zext" and self.rng.random() < 0.5 else ""
                 operand = self.random_dominating_value(src_w)
                 self.add_operation(op, [operand], [src], dst, props)
             elif choice < 0.82:

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -107,11 +107,7 @@ def Arith.toAttrDict
     if props.disjoint then
       dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
-  | .extui => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 1
-    if props.nneg then
-      dict := dict.insert "nneg".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    dict
+  | .extui => props.toAttrDict
   | _ => Std.HashMap.emptyWithCapacity 0
 
 @[get_effects]

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -261,11 +261,7 @@ def Llvm.toAttrDict
     if props.disjoint then
       dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
-  | .zext => Id.run do
-    let mut dict := Std.HashMap.emptyWithCapacity 1
-    if props.nneg then
-      dict := dict.insert "nneg".toUTF8 (Attribute.unitAttr UnitAttr.mk)
-    dict
+  | .zext => props.toAttrDict
   | .intr__ctlz | .intr__cttz =>
     let value := if props.is_zero_poison then 1 else 0
     let attr := IntegerAttr.mk value (IntegerType.mk 1)

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -66,8 +66,14 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 def NnegProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String NnegProperties := do
-  let nneg ← getUnitAttr "nneg" attrDict
+  let nneg ← getUnitAttr "nonNeg" attrDict
   return { nneg := nneg }
+
+def NnegProperties.toAttrDict (props : NnegProperties) : Std.HashMap ByteArray Attribute :=
+  if props.nneg then
+    (Std.HashMap.emptyWithCapacity 1).insert "nonNeg".toUTF8 (.unitAttr UnitAttr.mk)
+  else
+    Std.HashMap.emptyWithCapacity 0
 
 /--
   Properties of LLVM count-zero intrinsics. In LLVM IR, the second intrinsic


### PR DESCRIPTION
MLIR prints the non-negative flag as `nneg` in the pretty syntax but as `nonNeg` in the generic syntax that VeIR uses. Veir uses the generic syntax and consequently should use `nonNeg`. Rename the property on llvm.zext and arith.extui, teach veir2llvm and vsmith the new spelling, and print the flag from a shared NnegProperties.toAttrDict. The arith round trip is gated on mlir-min-23, which is the first release giving arith.extui the flag.