### PR TITLE
feat(PBV): Handle sign and zero extend operations 

### DIFF
--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -34,3 +34,32 @@ example {w t v: Nat} (a b : BitVec w)
   := by
   pbv_decide 16
   · bv_decide
+
+/-- Zero extending a zero extension -/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+
+/-- Sign extending a zero extensions -/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (hqr : q < r)
+  (hpq : p < q) :
+  (x.zeroExtend q).signExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+
+/-- Double zero extending with composite width. -/
+example (p q : Nat) (x : BitVec p)
+  (hr : q ≤ 8)
+  (hpq : q > p) :
+  (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
+  := by
+  pbv_decide 8
+  · bv_decide

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -35,17 +35,7 @@ example {w t v: Nat} (a b : BitVec w)
   pbv_decide 16
   · bv_decide
 
-/-- Zero extending a zero extension -/
-example (p q r : Nat) (x : BitVec p)
-  (hr : r ≤ 8)
-  (hqr : q < r)
-  (hpq : p < q) :
-  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
-  := by
-  pbv_decide 8
-  · bv_decide
-
-/-- Sign extending a zero extensions -/
+/-- Sign extending a zero extension -/
 example (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)
   (hqr : q < r)
@@ -55,10 +45,10 @@ example (p q r : Nat) (x : BitVec p)
   pbv_decide 8
   · bv_decide
 
-/-- Double zero extending with composite width. -/
+/-- Double zero extending with composite width -/
 example (p q : Nat) (x : BitVec p)
-  (hr : q ≤ 8)
-  (hpq : q > p) :
+  (hq : q ≤ 8)
+  (hqp : q > p) :
   (x.zeroExtend q).zeroExtend (q + q) = x.zeroExtend (q + q)
   := by
   pbv_decide 8

--- a/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
+++ b/UnitTest/BoundedBitblasting/BoundedBitblasting.lean
@@ -35,6 +35,15 @@ example {w t v: Nat} (a b : BitVec w)
   pbv_decide 16
   · bv_decide
 
+/-- Double zero extend with conjunction condition -/
+example (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (h : q < r ∧ p < q)
+  : (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+  pbv_decide 8
+  · bv_decide
+
 /-- Sign extending a zero extension -/
 example (p q r : Nat) (x : BitVec p)
   (hr : r ≤ 8)

--- a/Veir/Data/PBV.lean
+++ b/Veir/Data/PBV.lean
@@ -50,7 +50,9 @@ which we wish to prove it, the tactic performs the following steps:
 * `Veir.Data.PBV.Lemmas` — `Nat` and `BitVec` lemmas used by the translation.
 * `Veir.Data.PBV.Elim` — steps 3 and 4: `width_elim` and `var_elim`.
 * `Veir.Data.PBV.Mask` — step 5: `maskOfWidth`, the mask constraint.
-* `Veir.Data.PBV.Push` — step 6: pushing `setWidth` from the root to its leaves.
+* `Veir.Data.PBV.Push` — step 5: translating width relations and width
+  arithmetic into mask relations; step 6: pushing `setWidth` from the root to
+  its leaves.
 * `Veir.Data.PBV.Examples` — a manual trace of the whole pipeline.
 
 -/

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -31,7 +31,7 @@ theorem trace_add_comm_manual (w : Nat) (x y : BitVec w) (hw : w ≤ 4) :
   apply var_elim w_le_bw
   intro y h_ymw
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
+  have mw_mask := and_add_one_eq_zero_of_maskOfWidth h_mw
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
       eq_iff (o := 4),             -- Introduce `setWidth` to goal
@@ -70,13 +70,13 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
   apply var_elim p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
-  have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
-  have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
+  have mr_mask := and_add_one_eq_zero_of_maskOfWidth h_mr
+  have mq_mask := and_add_one_eq_zero_of_maskOfWidth h_mq
+  have mp_mask := and_add_one_eq_zero_of_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq h_pq
-  have bv_q_lt_r := lt_eq_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr h_qr
+  have bv_p_lt_q := lt_of_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq h_pq
+  have bv_q_lt_r := lt_of_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr h_qr
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
@@ -85,8 +85,8 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
     BitVec.setWidth_eq,
     p_le_bw,
     r_le_bw,
-    q_le_bw,                       -- Lets simp discharge the `v ≤ o` side condition of
-                                   -- `setWidth_signExtend_eq_and_maskOfWidth`
+    q_le_bw,                       -- Lets simp discharge the `w ≤ o` side condition of
+                                   -- `setWidth_setWidth`
   ] at h_xmp ⊢
 -- Step 8: BitBlast!
   bv_decide
@@ -117,12 +117,12 @@ theorem trace_zero_sign_extend (p q r : Nat) (x : BitVec p)
   apply var_elim p_le_bw
   intro x h_xmp
 -- Step 5: Convert width hypothesis to mask hypothesis
-  have mr_mask := maskOfWidth_and_add_one_eq_zero h_mr
-  have mq_mask := maskOfWidth_and_add_one_eq_zero h_mq
-  have mp_mask := maskOfWidth_and_add_one_eq_zero h_mp
+  have mr_mask := and_add_one_eq_zero_of_maskOfWidth h_mr
+  have mq_mask := and_add_one_eq_zero_of_maskOfWidth h_mq
+  have mp_mask := and_add_one_eq_zero_of_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_p_lt_q := lt_eq_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq hpq
+  have bv_p_lt_q := lt_of_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq hpq
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
@@ -149,9 +149,11 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
 --         8, because every append here has width `w + w`.
   have w_le_bw : w ≤ 16 := by grind
   have w_add_w_le_bw : w + w ≤ 16 := by grind
--- Step 2-3: Introduce mask to replace `w` Nat var.
+-- Step 2-3: Introduce masks to replace the `w` and `w + w` Nat widths.
   apply width_elim 16 w
   intro mw h_mw
+  apply width_elim 16 (w + w)
+  intro mw_add_w h_mw_add_w
 -- Step 4: Eliminate the parametric bv vars of width `w`
 --         enforcing width constraint with mask.
   revert a
@@ -161,8 +163,8 @@ theorem trace_append (w : Nat) (a b : BitVec w) (hw : w ≤ 8) :
   apply var_elim w_le_bw
   intro b h_bmw
 -- Step 5: Convert width hypothesis to mask hypothesis.
-  have mw_mask := maskOfWidth_and_add_one_eq_zero h_mw
-  have w_add_w_mask := maskOfWidth_add_eq_mul_of_maskOfWidth w_le_bw w_le_bw w_add_w_le_bw h_mw h_mw
+  have mw_mask := and_add_one_eq_zero_of_maskOfWidth h_mw
+  have w_add_w_mask := add_eq_mul_of_maskOfWidth w_le_bw w_le_bw w_add_w_le_bw h_mw h_mw h_mw_add_w
 -- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down.
   simp only [
     eq_iff (o := 16),

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -120,11 +120,11 @@ theorem trace_zero_zero_extend_conj (p q r : Nat) (x : BitVec p)
   have mp_mask := and_add_one_eq_zero_of_maskOfWidth h_mp
 -- Step 5B: Translate the condition on the natural number width
 --          into a fact about the bitvector masks
-  have bv_h := by
+  have bv_h : mq < mr ∧ mp < mq := by
     apply And.intro
     · apply lt_of_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr (And.left h)
     · apply lt_of_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq (And.right h)
-
+-- Step 6: Remove natural numbers from goal and hyps, by pushing setWidths down
   simp only [
     eq_iff (o := 8),
     setWidth_setWidth,

--- a/Veir/Data/PBV/Examples.lean
+++ b/Veir/Data/PBV/Examples.lean
@@ -91,6 +91,53 @@ theorem trace_zero_zero_extend (p q r : Nat) (x : BitVec p)
 -- Step 8: BitBlast!
   bv_decide
 
+/-- Manual trace of a double zero extension where the width condition is encoded
+    as a conjunction of two inequalities. Only step 5B differs from the above. -/
+theorem trace_zero_zero_extend_conj (p q r : Nat) (x : BitVec p)
+  (hr : r ≤ 8)
+  (h : q < r ∧ p < q) :
+  (x.zeroExtend q).zeroExtend r = x.zeroExtend r
+  := by
+-- Step 1: Bound widths to the provided blast width
+  have r_le_bw : r ≤ 8 := by grind
+  have q_le_bw : q ≤ 8 := by grind
+  have p_le_bw : p ≤ 8 := by grind
+-- Step 2-3: Introduce mask to replace `w` Nat var
+  apply width_elim 8 r
+  intro mr h_mr
+  apply width_elim 8 q
+  intro mq h_mq
+  apply width_elim 8 p
+  intro mp h_mp
+-- Step 4: Eliminate the parametric bv var of width `w`
+--         enforcing width constraint with mask
+  revert x
+  apply var_elim p_le_bw
+  intro x h_xmp
+-- Step 5: Convert width hypothesis to mask hypothesis
+  have mr_mask := and_add_one_eq_zero_of_maskOfWidth h_mr
+  have mq_mask := and_add_one_eq_zero_of_maskOfWidth h_mq
+  have mp_mask := and_add_one_eq_zero_of_maskOfWidth h_mp
+-- Step 5B: Translate the condition on the natural number width
+--          into a fact about the bitvector masks
+  have bv_h := by
+    apply And.intro
+    · apply lt_of_lt_of_eq_maskOfWidth q_le_bw r_le_bw h_mq h_mr (And.left h)
+    · apply lt_of_lt_of_eq_maskOfWidth p_le_bw q_le_bw h_mp h_mq (And.right h)
+
+  simp only [
+    eq_iff (o := 8),
+    setWidth_setWidth,
+    BitVec.zeroExtend_eq_setWidth,
+    BitVec.setWidth_eq,
+    p_le_bw,
+    r_le_bw,
+    q_le_bw,                       -- Lets simp discharge the `w ≤ o` side condition of
+                                   -- `setWidth_setWidth`
+  ] at h_xmp ⊢
+-- Step 8: BitBlast!
+  bv_decide
+
 /-- Manual trace of a zero extension to `q` followed by a sign extension to `r`,
     which is a single zero extension to `r`, since `p < q` leaves the sign bit
     of the intermediate value clear -/

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -34,20 +34,6 @@ theorem maskOfWidth_and_add_one_eq_zero {o w : Nat} {m : BitVec o}
     Nat.sub_add_cancel Nat.one_le_two_pow, Nat.and_comm (2 ^ w - 1),
     Nat.and_two_pow_sub_one_eq_mod]
 
-/-- `maskOfWidth` is monotone with respect to unsigned bitvec comparison. -/
-theorem maskOfWidth_lt_maskOfWidth {o w₁ w₂ : Nat} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (h : w₁ < w₂) : maskOfWidth o w₁ < maskOfWidth o w₂ := by
-  rw [BitVec.lt_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂]
-  have hlt : 2 ^ w₁ < 2 ^ w₂ := Nat.pow_lt_pow_right (by lia) (by lia)
-  have : 0 < 2 ^ w₁ := by grind
-  lia
-
-/-- Strict width order becomes strict mask order. -/
-theorem mask_lt_mask {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw : w₁ < w₂) : m₁ < m₂ := by
-  grind only [maskOfWidth_lt_maskOfWidth]
-
 /-- ANDing with `maskOfWidth o w` keeps exactly the low `w` bits. -/
 theorem toNat_and_maskOfWidth {o w : Nat} (h : w ≤ o) (x : BitVec o) :
     (x &&& maskOfWidth o w).toNat = x.toNat % 2 ^ w := by

--- a/Veir/Data/PBV/Mask.lean
+++ b/Veir/Data/PBV/Mask.lean
@@ -6,8 +6,8 @@ public import Veir.Data.PBV.Lemmas
 
 A width `w` is represented by the mask `2^w - 1` of the blast width, and it is
 encoded as a bitvector constraint `m &&& (m + 1) = 0` which the bitblaster
-can reason about. Other relations between bitwidths are encoded as bitvector
-inequalities and equalities.
+can reason about. Relations between bitwidths are encoded as bitvector
+inequalities and equalities in `Veir.Data.PBV.Push`.
 -/
 
 namespace Veir.Data.PBV
@@ -27,7 +27,7 @@ theorem toNat_maskOfWidth {o w : Nat} (h : w ≤ o) :
 /-- The mask constraint: the only fact about `m` surviving abstraction. This
 encodes `m = 2^k - 1` for some `k : Nat` in terms of bitvector operations
 removing the dependency on `k` and allowing it to be bitblasted. -/
-theorem maskOfWidth_and_add_one_eq_zero {o w : Nat} {m : BitVec o}
+theorem and_add_one_eq_zero_of_maskOfWidth {o w : Nat} {m : BitVec o}
     (hm : m = maskOfWidth o w) : m &&& (m + 1#o) = 0#o := by
   subst hm
   simp [maskOfWidth, BitVec.ofNat_add_ofNat, ← BitVec.ofNat_and,

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -27,8 +27,16 @@ theorem eq_iff (o : Nat) {w : Nat} (h : w ≤ o) :
 
 /-! ## Translating `Nat` width relations and arithmetic into mask operations -/
 
-/-- `<` on the widths translates to `<` on the masks. -/
-theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+/-- Equality on the widths translates to equality on the masks.
+    (Redundant hypotheses needed to match the shape of other width-to-bv theorems.) -/
+theorem eq_of_eq_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (_h₁ : w₁ ≤ o) (_h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ = w₂) : (m₁ = m₂) := by
+  subst m₁ m₂
+  congr
+
+/-- LT on the widths translates to LT on the masks. -/
+theorem lt_of_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
     (hw₁w₂ : w₁ < w₂) : (m₁ < m₂) := by
   subst m₁ m₂
@@ -37,7 +45,7 @@ theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h
   exact hw₁w₂
 
 /-- LE on the widths translates to the masks. -/
-theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+theorem le_of_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
     (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by
   subst m₁ m₂
@@ -45,24 +53,14 @@ theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h
       Nat.sub_le_sub_iff_right (by grind), Nat.pow_le_pow_iff_right (by grind)]
   exact hw₁w₂
 
-/-- LE on the widths translates to the masks. -/
-theorem ge_eq_ge_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ ≥ w₂) : (m₁ ≥ m₂) := by
-  grind [le_eq_le_of_eq_maskOfWidth]
-
-/-- LE on the widths translates to the masks. -/
-theorem gt_eq_gt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
-    (hw₁w₂ : w₁ > w₂) : (m₁ > m₂) := by
-  grind [lt_eq_lt_of_eq_maskOfWidth]
-
-/-- Adding widths becomes multiplying masks: `2^(w₁ + w₂) - 1` is
+/-- Adding widths becomes multiplying masks: the mask `m₃` of `w₁ + w₂` is
 `2^w₁ * 2^w₂ - 1`, written in terms of the masks `m₁` and `m₂`. -/
-theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o}
+theorem add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ m₃ : BitVec o}
     (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o) (h₁₂ : w₁ + w₂ ≤ o)
-    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂) :
-    maskOfWidth o (w₁ + w₂) = (m₁ + 1#o) * (m₂ + 1#o) - 1#o := by
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hm₃ : m₃ = maskOfWidth o (w₁ + w₂)) :
+    m₃ = (m₁ + 1#o) * (m₂ + 1#o) - 1#o := by
+  subst m₃
   cases o
   · simp [hm₁, hm₂, maskOfWidth_zero_eq_zero]
   · rw [hm₁, maskOfWidth_add_one_eq_twoPow h₁, hm₂, maskOfWidth_add_one_eq_twoPow h₂,

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -44,7 +44,7 @@ theorem lt_of_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h
       Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
   exact hw₁w₂
 
-/-- LE on the widths translates to the masks. -/
+/-- LE on the widths translates to LE on the masks. -/
 theorem le_of_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
     (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
     (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by

--- a/Veir/Data/PBV/Push.lean
+++ b/Veir/Data/PBV/Push.lean
@@ -36,6 +36,27 @@ theorem lt_eq_lt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h
       Nat.sub_lt_sub_iff_right (by grind), Nat.pow_lt_pow_iff_right (by grind)]
   exact hw₁w₂
 
+/-- LE on the widths translates to the masks. -/
+theorem le_eq_le_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ ≤ w₂) : (m₁ ≤ m₂) := by
+  subst m₁ m₂
+  rw [BitVec.le_def, toNat_maskOfWidth h₁, toNat_maskOfWidth h₂,
+      Nat.sub_le_sub_iff_right (by grind), Nat.pow_le_pow_iff_right (by grind)]
+  exact hw₁w₂
+
+/-- LE on the widths translates to the masks. -/
+theorem ge_eq_ge_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ ≥ w₂) : (m₁ ≥ m₂) := by
+  grind [le_eq_le_of_eq_maskOfWidth]
+
+/-- LE on the widths translates to the masks. -/
+theorem gt_eq_gt_of_eq_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o} (h₁ : w₁ ≤ o) (h₂ : w₂ ≤ o)
+    (hm₁ : m₁ = maskOfWidth o w₁) (hm₂ : m₂ = maskOfWidth o w₂)
+    (hw₁w₂ : w₁ > w₂) : (m₁ > m₂) := by
+  grind [lt_eq_lt_of_eq_maskOfWidth]
+
 /-- Adding widths becomes multiplying masks: `2^(w₁ + w₂) - 1` is
 `2^w₁ * 2^w₂ - 1`, written in terms of the masks `m₁` and `m₂`. -/
 theorem maskOfWidth_add_eq_mul_of_maskOfWidth {o w₁ w₂ : Nat} {m₁ m₂ : BitVec o}

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -125,10 +125,13 @@ meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
 /--
 Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
 -/
-meta def Tm.toName (tm : Tm .width) : Name :=
+meta def Tm.toName {k : TmKind} (tm : Tm k) : Name :=
   match tm with
-  | .widthAtom e => Name.mkSimple s!"w{e}"
+  | .widthAtom e  => Name.mkSimple s!"w{e}"
   | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
+  | .widthLT  v w => Name.mkSimple s!"{v.toName}_lt_{w.toName}"
+  | .widthLE  v w => Name.mkSimple s!"{v.toName}_le_{w.toName}"
+  | .widthEQ  v w => Name.mkSimple s!"{v.toName}_eq_{w.toName}"
 
 /--
 Compute an upper bound on the value of this width term: an atom is bounded by
@@ -268,47 +271,37 @@ meta def introMaskWidth (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (i
     return (g, info, infos.push info)
 
 /--
-Get the mask corresponding to a `Tm` from the `WidthInfos` if it exists, else
-create it and return the updated `WidthInfos`.
--/
-meta def WidthInfos.getOrCreateTm (this : WidthInfos) (g : MVarId)
-  (term : Tm .width) (blastWidth : Nat)
-  : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
-  if let some info := this.getFromTm? term then
-    return (g, info, this)
-  else
-    introMaskWidth blastWidth g term this
-
-/--
 Recurse through a `.width Tm`, converting `Nat` term into a `BitVec` mask, and
 translating relations on the terms into relations on the `BitVec` (eg. add).
 -/
 meta def introMaskRec (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
-  : MetaM (MVarId × WidthInfo × WidthInfos) :=
+  : MetaM (MVarId × WidthInfo × WidthInfos) := do
+  -- Check if this width term is already in widthInfos
+  if let some info := infos.getFromTm? widthTm then
+    return (g, info, infos)
+  -- Otherwise, recurse through the term to create it
   match widthTm with
-  | .widthAtom _ => infos.getOrCreateTm g widthTm blastWidth
+  | .widthAtom _ => introMaskWidth blastWidth g widthTm infos
   | .widthAdd v w => do
-    let (g, vInfo, infos) ← introMaskRec blastWidth g v infos
-    let (g, wInfo, infos) ← introMaskRec blastWidth g w infos
-    if let some info := infos.getFromTm? widthTm then
-      -- If the add term has already been declared, skip restating the hypothesis
-        return (g, info, infos)
-    else
-      let (g, thisInfo, infos) ← introMaskWidth blastWidth g widthTm infos
-      -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
-      let (_hyp, g) ← g.withContext do
-        g.note (Name.mkSimple s!"h_{widthTm.toName}_mask_mul")
-        <| ← mkAppM ``add_eq_mul_of_maskOfWidth
-        <| #[
-          vInfo.hypWidthLeBoundNote,
-          wInfo.hypWidthLeBoundNote,
-          thisInfo.hypWidthLeBoundNote,
-          vInfo.widthMaskHypFvar,
-          wInfo.widthMaskHypFvar,
-          thisInfo.widthMaskHypFvar
-        ].map mkFVar
+    -- Get or create masks of the children
+    let (g, vInfo, infos)    ← introMaskRec blastWidth g v infos
+    let (g, wInfo, infos)    ← introMaskRec blastWidth g w infos
+    -- Intro the mask for this term
+    let (g, thisInfo, infos) ← introMaskWidth blastWidth g widthTm infos
+    -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
+    let (_hyp, g) ← g.withContext do
+      g.note (Name.mkSimple s!"bv_{widthTm.toName}")
+      <| ← mkAppM ``add_eq_mul_of_maskOfWidth
+      <| #[
+        vInfo.hypWidthLeBoundNote,
+        wInfo.hypWidthLeBoundNote,
+        thisInfo.hypWidthLeBoundNote,
+        vInfo.widthMaskHypFvar,
+        wInfo.widthMaskHypFvar,
+        thisInfo.widthMaskHypFvar
+      ].map mkFVar
 
-      return (g, thisInfo, infos)
+    return (g, thisInfo, infos)
 
 /--
 The `BitVec` variable that a parametric-width variable was converted into,
@@ -405,11 +398,11 @@ meta partial def visitExprRec (g : MVarId)
 /--
 Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
 -/
-meta def getThmFromProp (term : Tm .prop) : Name × Tm .width × Tm .width × String :=
+meta def getThmFromProp (term : Tm .prop) : Name × Tm .width × Tm .width :=
   match term with
-  | .widthLT v w => (``lt_of_lt_of_eq_maskOfWidth, v, w, "lt")
-  | .widthLE v w => (``le_of_le_of_eq_maskOfWidth, v, w, "le")
-  | .widthEQ v w => (``eq_of_eq_of_eq_maskOfWidth, v, w, "eq")
+  | .widthLT v w => (``lt_of_lt_of_eq_maskOfWidth, v, w)
+  | .widthLE v w => (``le_of_le_of_eq_maskOfWidth, v, w)
+  | .widthEQ v w => (``eq_of_eq_of_eq_maskOfWidth, v, w)
 
 /--
 If a statament in the local context that can be reified as a prop is found, then
@@ -421,13 +414,13 @@ meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos)
   -- If the hypothesis cannot be reified, skip it
   let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return (g, widthInfos)
   -- Get the theorem matching the prop
-  let (thm, v, w, str) := getThmFromProp prop
+  let (thm, v, w) := getThmFromProp prop
   -- Get or create the masks for the width terms
   let (g, vInfo, widthInfos) ← introMaskRec blastWidth g v widthInfos
   let (g, wInfo, widthInfos) ← introMaskRec blastWidth g w widthInfos
   -- Apply the theorem to convert the width condition into a `BitVec` condition.
   let (_, g) ← g.withContext
-    <| g.note (Name.mkSimple s!"bv_{v.toName}_{str}_{w.toName}")
+    <| g.note (Name.mkSimple s!"bv_{prop.toName}")
     <| ← g.withContext <| mkAppM thm <| #[
         vInfo.hypWidthLeBoundNote,
         wInfo.hypWidthLeBoundNote,

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -52,26 +52,30 @@ meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
 
 /--
 Type to capture the expressions this tactic will handle.
-Only captures `width` at the moment.
 -/
 inductive TmKind
 | width
+| prop
 
 /--
-Inductive data structure to express the terms that this tactic reasons about.
+Inductive data structure to express the Terms that this tactic reasons about.
 -/
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
 | widthAdd (v w : Tm .width) : Tm .width
+| widthLT (v m : Tm .width) : Tm .prop
+| widthLE (v m : Tm .width) : Tm .prop
+| widthGT (v m : Tm .width) : Tm .prop
+| widthGE (v m : Tm .width) : Tm .prop
 
 /--
-Function to reify an `Expr` into a `Tm`. This function constructs the tree holding
+Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
 the width term. The environment holds the 'atom' `Expr`s which are the building
 blocks of the terms.
 -/
 meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .width)) := do
   if let some id := env.width2expr.idxOf? e then
-    -- An atom is an expression that is present in the Env.
+    -- An atom is an expression is present in the Env
     pure <| some (.widthAtom id)
   else
     match_expr e with
@@ -79,8 +83,28 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
         let .true := Expr.isNat ty | pure none
         let some a ← Tm.reifyWidth env ae | pure none
         let some b ← Tm.reifyWidth env be | pure none
-        return some (widthAdd a b)
+        pure (some (.widthAdd a b))
     | _ => pure none
+
+/--
+Match width relation.
+-/
+meta def matchWidthRel (e : Expr) :
+    Option ((Tm TmKind.width → Tm TmKind.width → Tm TmKind.prop) × Expr × Expr) :=
+  match_expr e with
+  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLT, ea, eb) else none
+  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLE, ea, eb) else none
+  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGT, ea, eb) else none
+  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGE, ea, eb) else none
+  | _ => none
+
+meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
+  if let some (rel, ea, eb) := matchWidthRel e then
+    let some wa ← Tm.reifyWidth env ea | pure none
+    let some wb ← Tm.reifyWidth env eb | pure none
+    pure <| some (rel wa wb)
+  else
+    pure none
 
 /--
 Convert a `Tm` into an `Expr` given an environment.
@@ -366,6 +390,49 @@ meta partial def visitExprRec (g : MVarId)
     return (g, widthTms, bvs)
 
 /--
+Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
+-/
+meta def getThmFromTm (term : Tm .prop) : Option (Name × Tm .width × Tm .width) :=
+  match term with
+  | .widthLT v w => (``lt_eq_lt_of_eq_maskOfWidth, v, w)
+  | .widthLE v w => (``le_eq_le_of_eq_maskOfWidth, v, w)
+  | .widthGT v w => (``gt_eq_gt_of_eq_maskOfWidth, v, w)
+  | .widthGE v w => (``ge_eq_ge_of_eq_maskOfWidth, v, w)
+  | _ => none
+
+/--
+If a condition on the width hypothesis is found, and the widths are contained
+within the `WidthInfos` set, then convert into a statement about the width masks.
+-/
+meta def translateWidthPrecond (widthInfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+    : MetaM (MVarId) := g.withContext do
+  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return g
+  let some (thm, v, w) := getThmFromTm prop | return g
+  let some vInfo := widthInfos.getFromTm? v |
+    logInfo m!"Skipping width condition transformation, term {v.toExpr widthInfos.env} is not a mask."
+    return g
+  let some wInfo := widthInfos.getFromTm? w |
+    logInfo m!"Skipping width condition transformation, term {w.toExpr widthInfos.env} is not a mask."
+    return g
+  let (_, g) ← g.withContext
+    <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
+    <| ← mkAppM thm <| #[
+        vInfo.hypWidthLeBoundNote,
+        wInfo.hypWidthLeBoundNote,
+        vInfo.widthMaskHypFvar,
+        wInfo.widthMaskHypFvar,
+        ldecl.fvarId,
+        ].map mkFVar
+  return g
+
+/--
+Traverse the local context and add any width pre-conditions to the goal.
+-/
+meta def translateWidthPreconds (winfos: WidthInfos)
+    (g : MVarId) : MetaM MVarId := g.withContext do
+  (← getLCtx).foldlM (translateWidthPrecond winfos) g
+
+/--
 Given the width terms in the formula, translate all `Nat` widths into `BitVec`
 masks and introduce the hypotheses that model the masks.
 -/
@@ -391,12 +458,15 @@ meta def introMaskedBitvectors (bvs : BitVecFVarsToRevert) (g : MVarId)
 
 /--
 Add the theorems that need the blast width pre-filled before they can be used
-within the Simp set (currently just `eq_iff`).
+within the Simp set.
 -/
 meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
   (widthTms : WidthTms) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
-  let thms := #[``eq_iff]
+  let thms := #[
+        ``eq_iff,
+        ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
+  ]
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name)
@@ -412,6 +482,8 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
       ``setWidth_add,
       ``setWidth_setWidth,
       ``setWidth_append_eq_or_mul_maskOfWidth_add_one,
+      ``signBitOfMask_eq,
+        ``setWidth_signExtend_eq_and_maskOfWidth,
   ]
 
   let mut simp := simp
@@ -420,9 +492,9 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
   return simp
 
 /--
-Add the mask hypotheses of the translated `BitVec`s to the Simp theorem context.
-These simplify the final formula by removing redundant masking operations; they
-are not strictly necessary for `bv_decide` to decide the resulting formula.
+Add BitVecInfos theorems to the Simp theorem context. Simplify the final formula
+to remove redundant masking operations, not strictly necessary for `bv_decide`
+to decide the resulting formula.
 -/
 meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -475,6 +547,8 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, widthInfos) ← introMaskWidths widthTms g ctx
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
+  -- Find and translate conditions on the width vars
+  let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -296,7 +296,6 @@ meta def introMaskRec (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos
 
     return (g, thisInfo, infos)
 
-
 /--
 The `BitVec` variable that a parametric-width variable was converted into,
 together with the hypothesis constraining it.
@@ -392,60 +391,61 @@ meta partial def visitExprRec (g : MVarId)
 /--
 Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
 -/
-meta def getThmFromTm (term : Tm .prop) : Option (Name × Tm .width × Tm .width) :=
+meta def getThmFromProp (term : Tm .prop) : Name × Tm .width × Tm .width :=
   match term with
   | .widthLT v w => (``lt_eq_lt_of_eq_maskOfWidth, v, w)
   | .widthLE v w => (``le_eq_le_of_eq_maskOfWidth, v, w)
   | .widthGT v w => (``gt_eq_gt_of_eq_maskOfWidth, v, w)
   | .widthGE v w => (``ge_eq_ge_of_eq_maskOfWidth, v, w)
-  | _ => none
 
 /--
 If a condition on the width hypothesis is found, and the widths are contained
 within the `WidthInfos` set, then convert into a statement about the width masks.
 -/
-meta def translateWidthPrecond (widthInfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
-    : MetaM (MVarId) := g.withContext do
-  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return g
-  let some (thm, v, w) := getThmFromTm prop | return g
-  let some vInfo := widthInfos.getFromTm? v |
-    logInfo m!"Skipping width condition transformation, term {v.toExpr widthInfos.env} is not a mask."
-    return g
-  let some wInfo := widthInfos.getFromTm? w |
-    logInfo m!"Skipping width condition transformation, term {w.toExpr widthInfos.env} is not a mask."
-    return g
+meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+    : MetaM (MVarId × WidthInfos) := g.withContext do
+  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) |
+    -- logWarning m!"{ldecl.toExpr} : {ldecl.type} could not be reified into a `Tm .prop`, it will not be used as a `BitVec` hypothesis."
+    return (g, widthInfos)
+  logInfo m!"Managed to reify {ldecl.type}"
+  -- Get the theorem matching the prop
+  let (thm, v, w) := getThmFromProp prop
+  -- Get or create the masks for the width terms
+  let (g, vInfo, widthInfos) ← introMaskRec blastWidth g v widthInfos
+  let (g, wInfo, widthInfos) ← introMaskRec blastWidth g w widthInfos
+  -- Apply the theorem to convert the width condition into a `BitVec` condition.
   let (_, g) ← g.withContext
     <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
-    <| ← mkAppM thm <| #[
+    <| ← g.withContext <| mkAppM thm <| #[
         vInfo.hypWidthLeBoundNote,
         wInfo.hypWidthLeBoundNote,
         vInfo.widthMaskHypFvar,
         wInfo.widthMaskHypFvar,
         ldecl.fvarId,
-        ].map mkFVar
-  return g
+      ].map mkFVar
+
+  return (g, widthInfos)
 
 /--
 Traverse the local context and add any width pre-conditions to the goal.
 -/
-meta def translateWidthPreconds (winfos: WidthInfos)
-    (g : MVarId) : MetaM MVarId := g.withContext do
-  (← getLCtx).foldlM (translateWidthPrecond winfos) g
+meta def translateWidthPreconds (blastWidth : Nat) (winfos: WidthInfos)
+    (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
+  (← getLCtx).foldlM (init := (g, winfos)) fun (g, widthInfos) ldecl =>
+    translateWidthPrecond blastWidth widthInfos g ldecl
 
 /--
 Given the width terms in the formula, translate all `Nat` widths into `BitVec`
 masks and introduce the hypotheses that model the masks.
 -/
-meta def introMaskWidths (widthTms : WidthTms) (g : MVarId) (ctx : PbvTranslateContext)
+meta def introMaskWidths (blastWidth : Nat) (widthTms : WidthTms) (g : MVarId)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
-  -- Compute max width
-  let maxWidth := widthTms.getUniverseWidthUpperBound ctx
   -- Intro all the masks
   widthTms.terms.foldM
     (init := (g, { env := widthTms.env }))
     fun (g, widthInfos) _ widthTm => do
-      let (g, _, infos) ← introMaskRec maxWidth g widthTm.term widthInfos
+      let (g, _, infos) ← introMaskRec blastWidth g widthTm.term widthInfos
       return (g, infos)
 
 /--
@@ -543,12 +543,14 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let widthEnv ← createWidthEnv g
   -- Find `BitVec`s and intro their widths
   let (g, widthTms, bvsToRevert) ← visitExprRec g { env := widthEnv } {} (← g.getType)
+  -- Compute the blast width
+  let blastWidth := widthTms.getUniverseWidthUpperBound ctx
   -- Introduce the width masks, bounded by the max width
-  let (g, widthInfos) ← introMaskWidths widthTms g ctx
+  let (g, widthInfos) ← introMaskWidths blastWidth widthTms g
+  -- Find and translate conditions on the width vars
+  let (g, widthInfos) ← translateWidthPreconds blastWidth widthInfos g
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
-  -- Find and translate conditions on the width vars
-  let g ← translateWidthPreconds widthInfos g
   -- Create simp set
   let thms := ← addBoundRewrites g ctx widthTms
            <| ← addPushTheorems g

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -51,31 +51,31 @@ meta def createWidthEnv (g : MVarId) : MetaM TmWidthEnv := g.withContext do
           pure widthEnv
 
 /--
-Type to capture the expressions this tactic will handle.
+Type to capture the expressions this tactic handles: `Nat` width terms and
+the propositions relating them.
 -/
 inductive TmKind
 | width
 | prop
 
 /--
-Inductive data structure to express the Terms that this tactic reasons about.
+Inductive data structure to express the terms that this tactic reasons about.
 -/
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
 | widthAdd (v w : Tm .width) : Tm .width
-| widthLT (v m : Tm .width) : Tm .prop
-| widthLE (v m : Tm .width) : Tm .prop
-| widthGT (v m : Tm .width) : Tm .prop
-| widthGE (v m : Tm .width) : Tm .prop
+| widthLT (v w : Tm .width) : Tm .prop
+| widthLE (v w : Tm .width) : Tm .prop
+| widthEQ (v w : Tm .width) : Tm .prop
 
 /--
-Function to Reify an `Expr` into a `Tm`. This function constructs the tree holding
+Function to reify an `Expr` into a `Tm`. This function constructs the tree holding
 the width term. The environment holds the 'atom' `Expr`s which are the building
 blocks of the terms.
 -/
 meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .width)) := do
   if let some id := env.width2expr.idxOf? e then
-    -- An atom is an expression is present in the Env
+    -- An atom is an expression that is present in the Env.
     pure <| some (.widthAtom id)
   else
     match_expr e with
@@ -83,28 +83,36 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
         let .true := Expr.isNat ty | pure none
         let some a ← Tm.reifyWidth env ae | pure none
         let some b ← Tm.reifyWidth env be | pure none
-        pure (some (.widthAdd a b))
+        return some (widthAdd a b)
     | _ => pure none
 
 /--
-Match width relation.
+Match a width relation over `Nat`, returning the `Tm .prop` constructor for it
+together with the `Expr`s on either side. `>` and `≥` are normalised into
+`widthLT` and `widthLE` by swapping the two sides. Returns `none` for anything
+else, including the same relations at a type other than `Nat`.
 -/
 meta def matchWidthRel (e : Expr) :
     Option ((Tm TmKind.width → Tm TmKind.width → Tm TmKind.prop) × Expr × Expr) :=
   match_expr e with
-  | LT.lt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLT, ea, eb) else none
-  | LE.le ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthLE, ea, eb) else none
-  | GT.gt ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGT, ea, eb) else none
-  | GE.ge ty _inst ea eb => if (ty.isConstOf ``Nat) then some (.widthGE, ea, eb) else none
+  | LT.lt ty _inst ea eb => if Expr.isNat ty then some (.widthLT, ea, eb) else none
+  | LE.le ty _inst ea eb => if Expr.isNat ty then some (.widthLE, ea, eb) else none
+  | GT.gt ty _inst ea eb => if Expr.isNat ty then some (.widthLT, eb, ea) else none
+  | GE.ge ty _inst ea eb => if Expr.isNat ty then some (.widthLE, eb, ea) else none
+  | Eq ty ea eb          => if Expr.isNat ty then some (.widthEQ, ea, eb) else none
   | _ => none
 
-meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
+/--
+Reify an `Expr` into a `Tm .prop`. Returns `none` if the expression is not a
+width relation, or if either side of the relation fails to reify as a width.
+-/
+meta def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
   if let some (rel, ea, eb) := matchWidthRel e then
-    let some wa ← Tm.reifyWidth env ea | pure none
-    let some wb ← Tm.reifyWidth env eb | pure none
-    pure <| some (rel wa wb)
+    let some wa ← Tm.reifyWidth env ea | return none
+    let some wb ← Tm.reifyWidth env eb | return none
+    return some (rel wa wb)
   else
-    pure none
+    return none
 
 /--
 Convert a `Tm` into an `Expr` given an environment.
@@ -221,13 +229,13 @@ meta def WidthInfos.getFromExpr? (this : WidthInfos) (wExpr : Expr)
 /--
 Given a width term (`widthTm`), introduce a `BitVec` variable corresponding
 to the mask of that width. Then introduce a hypothesis bounding the width to the
-provided `maxBound` and enforce it as a mask with `maskOfWidth_and_add_one_eq_zero`.
+provided `blastWidth` and enforce it as a mask with `and_add_one_eq_zero_of_maskOfWidth`.
 -/
-meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+meta def introMaskWidth (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Apply width_elim
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit maxBound, widthTm.toExpr infos.env, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit blastWidth, widthTm.toExpr infos.env, ← g.getType]
       | throwError m!"{``width_elim} should generate a goal"
     -- Intros
     let name := widthTm.toName
@@ -241,12 +249,12 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (inf
         #[mkConst ``Nat,
           mkConst ``instLENat,
           widthTm.toExpr infos.env,
-          mkNatLit maxBound])
+          mkNatLit blastWidth])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_blast") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
     -- Assert the BitVec mask constraint.
-    let hypExpr ← g.withContext do mkAppM ``maskOfWidth_and_add_one_eq_zero #[mkFVar maskHyp]
+    let hypExpr ← g.withContext do mkAppM ``and_add_one_eq_zero_of_maskOfWidth #[mkFVar maskHyp]
     let (_, g) ← g.withContext do g.note (Name.mkSimple s!"h_{maskName}_bv_mask") hypExpr
 
     let info : WidthInfo := {
@@ -263,38 +271,44 @@ meta def introMaskWidth (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (inf
 Get the mask corresponding to a `Tm` from the `WidthInfos` if it exists, else
 create it and return the updated `WidthInfos`.
 -/
-meta def WidthInfos.getOrCreateTm (this : WidthInfos) (g : MVarId) (term : Tm .width) (maxBound : Nat)
+meta def WidthInfos.getOrCreateTm (this : WidthInfos) (g : MVarId)
+  (term : Tm .width) (blastWidth : Nat)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
   if let some info := this.getFromTm? term then
     return (g, info, this)
   else
-    introMaskWidth maxBound g term this
+    introMaskWidth blastWidth g term this
 
 /--
 Recurse through a `.width Tm`, converting `Nat` term into a `BitVec` mask, and
 translating relations on the terms into relations on the `BitVec` (eg. add).
 -/
-meta def introMaskRec (maxBound : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+meta def introMaskRec (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) :=
   match widthTm with
-  | .widthAtom _ => infos.getOrCreateTm g widthTm maxBound
+  | .widthAtom _ => infos.getOrCreateTm g widthTm blastWidth
   | .widthAdd v w => do
-    let (g, vInfo, infos) ← introMaskRec maxBound g v infos
-    let (g, wInfo, infos) ← introMaskRec maxBound g w infos
-    let (g, thisInfo, infos) ← infos.getOrCreateTm g widthTm maxBound
+    let (g, vInfo, infos) ← introMaskRec blastWidth g v infos
+    let (g, wInfo, infos) ← introMaskRec blastWidth g w infos
+    if let some info := infos.getFromTm? widthTm then
+      -- If the add term has already been declared, skip restating the hypothesis
+        return (g, info, infos)
+    else
+      let (g, thisInfo, infos) ← introMaskWidth blastWidth g widthTm infos
+      -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
+      let (_hyp, g) ← g.withContext do
+        g.note (Name.mkSimple s!"h_{widthTm.toName}_mask_mul")
+        <| ← mkAppM ``add_eq_mul_of_maskOfWidth
+        <| #[
+          vInfo.hypWidthLeBoundNote,
+          wInfo.hypWidthLeBoundNote,
+          thisInfo.hypWidthLeBoundNote,
+          vInfo.widthMaskHypFvar,
+          wInfo.widthMaskHypFvar,
+          thisInfo.widthMaskHypFvar
+        ].map mkFVar
 
-    -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
-    let (_hyp, g) ← g.withContext do
-      g.note (Name.mkSimple s!"h_{widthTm.toName}_mask_mul") <|
-      ← mkAppM ``maskOfWidth_add_eq_mul_of_maskOfWidth #[
-        .fvar vInfo.hypWidthLeBoundNote,
-        .fvar wInfo.hypWidthLeBoundNote,
-        .fvar thisInfo.hypWidthLeBoundNote,
-        .fvar vInfo.widthMaskHypFvar,
-        .fvar wInfo.widthMaskHypFvar,
-      ]
-
-    return (g, thisInfo, infos)
+      return (g, thisInfo, infos)
 
 /--
 The `BitVec` variable that a parametric-width variable was converted into,
@@ -391,31 +405,29 @@ meta partial def visitExprRec (g : MVarId)
 /--
 Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
 -/
-meta def getThmFromProp (term : Tm .prop) : Name × Tm .width × Tm .width :=
+meta def getThmFromProp (term : Tm .prop) : Name × Tm .width × Tm .width × String :=
   match term with
-  | .widthLT v w => (``lt_eq_lt_of_eq_maskOfWidth, v, w)
-  | .widthLE v w => (``le_eq_le_of_eq_maskOfWidth, v, w)
-  | .widthGT v w => (``gt_eq_gt_of_eq_maskOfWidth, v, w)
-  | .widthGE v w => (``ge_eq_ge_of_eq_maskOfWidth, v, w)
+  | .widthLT v w => (``lt_of_lt_of_eq_maskOfWidth, v, w, "lt")
+  | .widthLE v w => (``le_of_le_of_eq_maskOfWidth, v, w, "le")
+  | .widthEQ v w => (``eq_of_eq_of_eq_maskOfWidth, v, w, "eq")
 
 /--
-If a condition on the width hypothesis is found, and the widths are contained
-within the `WidthInfos` set, then convert into a statement about the width masks.
+If a statament in the local context that can be reified as a prop is found, then
+convert into a statement about the width masks, instantiating new masks if needed.
 -/
-meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos) (g : MVarId) (ldecl : LocalDecl)
+meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos)
+    (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId × WidthInfos) := g.withContext do
-  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) |
-    -- logWarning m!"{ldecl.toExpr} : {ldecl.type} could not be reified into a `Tm .prop`, it will not be used as a `BitVec` hypothesis."
-    return (g, widthInfos)
-  logInfo m!"Managed to reify {ldecl.type}"
+  -- If the hypothesis cannot be reified, skip it
+  let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return (g, widthInfos)
   -- Get the theorem matching the prop
-  let (thm, v, w) := getThmFromProp prop
+  let (thm, v, w, str) := getThmFromProp prop
   -- Get or create the masks for the width terms
   let (g, vInfo, widthInfos) ← introMaskRec blastWidth g v widthInfos
   let (g, wInfo, widthInfos) ← introMaskRec blastWidth g w widthInfos
   -- Apply the theorem to convert the width condition into a `BitVec` condition.
   let (_, g) ← g.withContext
-    <| g.note (Name.mkSimple s!"bv_{v.toName}_lt_{w.toName}")
+    <| g.note (Name.mkSimple s!"bv_{v.toName}_{str}_{w.toName}")
     <| ← g.withContext <| mkAppM thm <| #[
         vInfo.hypWidthLeBoundNote,
         wInfo.hypWidthLeBoundNote,
@@ -429,10 +441,12 @@ meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos) (g :
 /--
 Traverse the local context and add any width pre-conditions to the goal.
 -/
-meta def translateWidthPreconds (blastWidth : Nat) (winfos: WidthInfos)
+meta def translateWidthPreconds (blastWidth : Nat) (winfos : WidthInfos)
     (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
-  (← getLCtx).foldlM (init := (g, winfos)) fun (g, widthInfos) ldecl =>
-    translateWidthPrecond blastWidth widthInfos g ldecl
+  (← getLCtx).foldlM (
+    init := (g, winfos))
+    fun (g, widthInfos) ldecl =>
+      translateWidthPrecond blastWidth widthInfos g ldecl
 
 /--
 Given the width terms in the formula, translate all `Nat` widths into `BitVec`
@@ -460,8 +474,7 @@ meta def introMaskedBitvectors (bvs : BitVecFVarsToRevert) (g : MVarId)
 Add the theorems that need the blast width pre-filled before they can be used
 within the Simp set.
 -/
-meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
-  (widthTms : WidthTms) (simp : SimpTheoremsArray) :
+meta def addBoundRewrites (g : MVarId) (blastWidth : Nat) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
         ``eq_iff,
@@ -470,7 +483,7 @@ meta def addBoundRewrites (g : MVarId) (ctx : PbvTranslateContext)
 
   thms.foldlM (init := simp) fun simps name =>
     return ← simps.addTheorem (.other name)
-      <| ← mkAppM name #[mkNatLit <| widthTms.getUniverseWidthUpperBound ctx]
+      <| ← mkAppM name #[mkNatLit blastWidth]
 
 /--
 Add theorems to the Simp theorem context that push the `setWidth`s in.
@@ -483,7 +496,7 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
       ``setWidth_setWidth,
       ``setWidth_append_eq_or_mul_maskOfWidth_add_one,
       ``signBitOfMask_eq,
-        ``setWidth_signExtend_eq_and_maskOfWidth,
+      ``setWidth_signExtend_eq_and_maskOfWidth,
   ]
 
   let mut simp := simp
@@ -492,9 +505,9 @@ meta def addPushTheorems (g : MVarId) (simp : SimpTheoremsArray) :
   return simp
 
 /--
-Add BitVecInfos theorems to the Simp theorem context. Simplify the final formula
-to remove redundant masking operations, not strictly necessary for `bv_decide`
-to decide the resulting formula.
+Add the mask hypotheses of the translated `BitVec`s to the Simp theorem context.
+These simplify the final formula by removing redundant masking operations; they
+are not strictly necessary for `bv_decide` to decide the resulting formula.
 -/
 meta def addBvInfos (g : MVarId) (bvInfos : BitVecInfos)
   (simp : SimpTheoremsArray) : MetaM SimpTheoremsArray := g.withContext do
@@ -552,7 +565,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Create simp set
-  let thms := ← addBoundRewrites g ctx widthTms
+  let thms := ← addBoundRewrites g blastWidth
            <| ← addPushTheorems g
            <| ← addBvInfos g bvInfos -- This step is not strictly necessary.
            <| ← addWidthInfosSimpLemmas g widthInfos #[]
@@ -567,10 +580,14 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula into a concrete width formula.
 
+Widths built out of width variables and `+` are supported, as are the width
+relations `<`, `≤`, `>`, `≥` and `=` occurring as hypotheses, which are
+translated into the corresponding relations on the width masks.
+
 The tactic generates multiple goals:
-1. The desired concrete width formula that can be decided using `bv_decide`
+1. The desired concrete width formula that can be decided using `bv_decide`.
 2. Multiple side-goals to prove that the width parameters are bounded by the
-computed blast width, these should be solvable by grind.
+computed blast width. These should be solvable by `grind`.
 -/
 syntax (name := pbvDecide) "pbv_decide" (ppSpace colGt num) : tactic
 

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -274,7 +274,7 @@ meta def introMaskWidth (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (i
 Recurse through a `.width Tm`, converting `Nat` term into a `BitVec` mask, and
 translating relations on the terms into relations on the `BitVec` (eg. add).
 -/
-meta def introMaskRec (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+meta def getOrCreateWidthMask (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := do
   -- Check if this width term is already in widthInfos
   if let some info := infos.getFromTm? widthTm then
@@ -284,8 +284,8 @@ meta def introMaskRec (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (inf
   | .widthAtom _ => introMaskWidth blastWidth g widthTm infos
   | .widthAdd v w => do
     -- Get or create masks of the children
-    let (g, vInfo, infos)    ← introMaskRec blastWidth g v infos
-    let (g, wInfo, infos)    ← introMaskRec blastWidth g w infos
+    let (g, vInfo, infos) ← getOrCreateWidthMask blastWidth g v infos
+    let (g, wInfo, infos) ← getOrCreateWidthMask blastWidth g w infos
     -- Intro the mask for this term
     let (g, thisInfo, infos) ← introMaskWidth blastWidth g widthTm infos
     -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
@@ -293,15 +293,16 @@ meta def introMaskRec (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (inf
       g.note (Name.mkSimple s!"bv_{widthTm.toName}")
       <| ← mkAppM ``add_eq_mul_of_maskOfWidth
       <| #[
-        vInfo.hypWidthLeBoundNote,
-        wInfo.hypWidthLeBoundNote,
-        thisInfo.hypWidthLeBoundNote,
-        vInfo.widthMaskHypFvar,
-        wInfo.widthMaskHypFvar,
-        thisInfo.widthMaskHypFvar
-      ].map mkFVar
+        .fvar vInfo.hypWidthLeBoundNote,
+        .fvar wInfo.hypWidthLeBoundNote,
+        .fvar thisInfo.hypWidthLeBoundNote,
+        .fvar vInfo.widthMaskHypFvar,
+        .fvar wInfo.widthMaskHypFvar,
+        .fvar thisInfo.widthMaskHypFvar
+      ]
 
     return (g, thisInfo, infos)
+
 
 /--
 The `BitVec` variable that a parametric-width variable was converted into,
@@ -416,18 +417,18 @@ meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos)
   -- Get the theorem matching the prop
   let (thm, v, w) := getThmFromProp prop
   -- Get or create the masks for the width terms
-  let (g, vInfo, widthInfos) ← introMaskRec blastWidth g v widthInfos
-  let (g, wInfo, widthInfos) ← introMaskRec blastWidth g w widthInfos
+  let (g, vInfo, widthInfos) ← getOrCreateWidthMask blastWidth g v widthInfos
+  let (g, wInfo, widthInfos) ← getOrCreateWidthMask blastWidth g w widthInfos
   -- Apply the theorem to convert the width condition into a `BitVec` condition.
   let (_, g) ← g.withContext
     <| g.note (Name.mkSimple s!"bv_{prop.toName}")
     <| ← g.withContext <| mkAppM thm <| #[
-        vInfo.hypWidthLeBoundNote,
-        wInfo.hypWidthLeBoundNote,
-        vInfo.widthMaskHypFvar,
-        wInfo.widthMaskHypFvar,
-        ldecl.fvarId,
-      ].map mkFVar
+        .fvar vInfo.hypWidthLeBoundNote,
+        .fvar wInfo.hypWidthLeBoundNote,
+        .fvar vInfo.widthMaskHypFvar,
+        .fvar wInfo.widthMaskHypFvar,
+        .fvar ldecl.fvarId,
+      ]
 
   return (g, widthInfos)
 
@@ -452,7 +453,7 @@ meta def introMaskWidths (blastWidth : Nat) (widthTms : WidthTms) (g : MVarId)
   widthTms.terms.foldM
     (init := (g, { env := widthTms.env }))
     fun (g, widthInfos) _ widthTm => do
-      let (g, _, infos) ← introMaskRec blastWidth g widthTm.term widthInfos
+      let (g, _, infos) ← getOrCreateWidthMask blastWidth g widthTm.term widthInfos
       return (g, infos)
 
 /--

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -111,7 +111,7 @@ meta def matchWidthRel (e : Expr) :
 
 /--
 Reify an `Expr` into a `Tm .prop`. Returns `none` if the expression is not a
-width relation, or if either side of the relation fails to reify as a width.
+supported prop, or if the subterms fails to reify as `Tm .width`s.
 -/
 meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
   if let some (rel, ea, eb) := matchWidthRel e then
@@ -225,9 +225,11 @@ structure WidthInfos where
   infos : HashMap Name WidthInfo := {}
   /-- Width environment. -/
   env : TmWidthEnv
+  /-- Width at which the bit-blasting occurs. -/
+  blastWidth : Nat
 
 meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-  { infos := this.infos.insert (info.widthTm.toName) info, env := this.env }
+  { infos := this.infos.insert (info.widthTm.toName) info, env := this.env, blastWidth := this.blastWidth }
 
 /--
 Get WidthInfo from a Term.
@@ -251,11 +253,11 @@ Given a width term (`widthTm`), introduce a `BitVec` variable corresponding
 to the mask of that width. Then introduce a hypothesis bounding the width to the
 provided `blastWidth` and enforce it as a mask with `and_add_one_eq_zero_of_maskOfWidth`.
 -/
-meta def introMaskWidth (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+meta def introMaskWidth (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Apply width_elim
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit blastWidth, widthTm.toExpr infos.env, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim #[mkNatLit infos.blastWidth, widthTm.toExpr infos.env, ← g.getType]
       | throwError m!"{``width_elim} should generate a goal"
     -- Intros
     let name := widthTm.toName
@@ -269,7 +271,7 @@ meta def introMaskWidth (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (i
         #[mkConst ``Nat,
           mkConst ``instLENat,
           widthTm.toExpr infos.env,
-          mkNatLit blastWidth])
+          mkNatLit infos.blastWidth])
     g.withContext <| check hypWidthLeBound
     let (hypWidthLeBoundNote, g) ← g.withContext do g.note (Name.mkSimple s!"h_{name}_le_blast") hypWidthLeBound
     g.withContext <| check (mkFVar hypWidthLeBoundNote)
@@ -291,20 +293,20 @@ meta def introMaskWidth (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (i
 Recurse through a `.width Tm`, converting `Nat` term into a `BitVec` mask, and
 translating relations on the terms into relations on the `BitVec` (eg. add).
 -/
-meta def getOrCreateWidthMask (blastWidth : Nat) (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
+meta def getOrCreateWidthMask (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := do
   -- Check if this width term is already in widthInfos
   if let some info := infos.getFromTm? widthTm then
     return (g, info, infos)
   -- Otherwise, recurse through the term to create it
   match widthTm with
-  | .widthAtom _ => introMaskWidth blastWidth g widthTm infos
+  | .widthAtom _ => introMaskWidth g widthTm infos
   | .widthAdd v w => do
     -- Get or create masks of the children
-    let (g, vInfo, infos) ← getOrCreateWidthMask blastWidth g v infos
-    let (g, wInfo, infos) ← getOrCreateWidthMask blastWidth g w infos
+    let (g, vInfo, infos) ← getOrCreateWidthMask g v infos
+    let (g, wInfo, infos) ← getOrCreateWidthMask g w infos
     -- Intro the mask for this term
-    let (g, thisInfo, infos) ← introMaskWidth blastWidth g widthTm infos
+    let (g, thisInfo, infos) ← introMaskWidth g widthTm infos
     -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
     let (_hyp, g) ← g.withContext do
       g.note (Name.mkSimple s!"bv_{widthTm.toName}")
@@ -417,12 +419,12 @@ meta partial def visitExprRec (g : MVarId)
 Given a `Tm .prop` and the `Expr` is was reified from, construct the expr that
 corresponds to the `Prop` expressed in terms of the masks.
 -/
-meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (blastWidth : Nat) (g : MVarId)
+meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (g : MVarId)
     (wInfos: WidthInfos) : MetaM (MVarId × WidthInfos × Expr) := g.withContext do
   -- Helper to apply a theorem for a binary operation on widths.
   let applyPropBinop (thm : Name) (v w : Tm .width) : MetaM (MVarId × WidthInfos × Expr) := do
-    let (g, vInfo, wInfos) ← getOrCreateWidthMask blastWidth g v wInfos
-    let (g, wInfo, wInfos) ← getOrCreateWidthMask blastWidth g w wInfos
+    let (g, vInfo, wInfos) ← getOrCreateWidthMask g v wInfos
+    let (g, wInfo, wInfos) ← getOrCreateWidthMask g w wInfos
     let expr ← g.withContext <| mkAppM thm <| #[
           .fvar vInfo.hypWidthLeBoundNote,
           .fvar wInfo.hypWidthLeBoundNote,
@@ -437,8 +439,8 @@ meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (blastWidth : Nat) (g
   | .widthLE v w => applyPropBinop ``le_of_le_of_eq_maskOfWidth v w
   | .widthEQ v w => applyPropBinop ``eq_of_eq_of_eq_maskOfWidth v w
   | .AND a b => do
-    let (g, wInfos, aExpr) ← getExprFromProp a (← mkAppM ``And.left  #[prop]) blastWidth g wInfos
-    let (g, wInfos, bExpr) ← getExprFromProp b (← mkAppM ``And.right #[prop]) blastWidth g wInfos
+    let (g, wInfos, aExpr) ← getExprFromProp a (← mkAppM ``And.left  #[prop]) g wInfos
+    let (g, wInfos, bExpr) ← getExprFromProp b (← mkAppM ``And.right #[prop]) g wInfos
     let expr ← g.withContext <| mkAppM ``And.intro <| #[aExpr, bExpr]
     return (g, wInfos, expr)
 
@@ -446,13 +448,13 @@ meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (blastWidth : Nat) (g
 If a statament in the local context that can be reified as a prop is found, then
 convert into a statement about the width masks, creatingg new masks if needed.
 -/
-meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos)
+meta def translateWidthPrecond (widthInfos : WidthInfos)
     (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId × WidthInfos) := g.withContext do
   -- If the hypothesis cannot be reified, skip it.
   let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return (g, widthInfos)
   -- Obtain the `Expr` of the prop in terms of the mask.
-  let (g, wInfos, expr) ← getExprFromProp prop (ldecl.toExpr) blastWidth g widthInfos
+  let (g, wInfos, expr) ← getExprFromProp prop (ldecl.toExpr) g widthInfos
   -- State the mask version of the prop
   let (_, g) ← g.note (Name.mkSimple s!"bv_{prop.toName}") expr
   return (g, wInfos)
@@ -460,12 +462,12 @@ meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos)
 /--
 Traverse the local context and add any width pre-conditions to the goal.
 -/
-meta def translateWidthPreconds (blastWidth : Nat) (winfos : WidthInfos)
+meta def translateWidthPreconds (winfos : WidthInfos)
     (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
   (← getLCtx).foldlM (
     init := (g, winfos))
     fun (g, widthInfos) ldecl =>
-      translateWidthPrecond blastWidth widthInfos g ldecl
+      translateWidthPrecond widthInfos g ldecl
 
 /--
 Given the width terms in the formula, translate all `Nat` widths into `BitVec`
@@ -476,9 +478,9 @@ meta def introMaskWidths (blastWidth : Nat) (widthTms : WidthTms) (g : MVarId)
   := g.withContext do
   -- Intro all the masks
   widthTms.terms.foldM
-    (init := (g, { env := widthTms.env }))
+    (init := (g, { env := widthTms.env, blastWidth }))
     fun (g, widthInfos) _ widthTm => do
-      let (g, _, infos) ← getOrCreateWidthMask blastWidth g widthTm.term widthInfos
+      let (g, _, infos) ← getOrCreateWidthMask g widthTm.term widthInfos
       return (g, infos)
 
 /--
@@ -580,7 +582,7 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   -- Introduce the width masks, bounded by the max width
   let (g, widthInfos) ← introMaskWidths blastWidth widthTms g
   -- Find and translate conditions on the width vars
-  let (g, widthInfos) ← translateWidthPreconds blastWidth widthInfos g
+  let (g, widthInfos) ← translateWidthPreconds widthInfos g
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Create simp set

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -419,8 +419,11 @@ meta partial def visitExprRec (g : MVarId)
 Given a `Tm .prop` and the `Expr` is was reified from, construct the expr that
 corresponds to the `Prop` expressed in terms of the masks.
 -/
-meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (g : MVarId)
+meta def getMaskedExprFromProp (prop : Tm .prop) (proof : Expr) (g : MVarId)
     (wInfos: WidthInfos) : MetaM (MVarId × WidthInfos × Expr) := g.withContext do
+  -- Ensure the proof and prop match.
+  unless ← isDefEq (← inferType proof) (prop.toExpr wInfos.env)
+    do throwError m!"Prop : {prop.toExpr wInfos.env} doesn't match the proof : {← inferType proof}"
   -- Helper to apply a theorem for a binary operation on widths.
   let applyPropBinop (thm : Name) (v w : Tm .width) : MetaM (MVarId × WidthInfos × Expr) := do
     let (g, vInfo, wInfos) ← getOrCreateWidthMask g v wInfos
@@ -430,17 +433,17 @@ meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (g : MVarId)
           .fvar wInfo.hypWidthLeBoundNote,
           .fvar vInfo.widthMaskHypFvar,
           .fvar wInfo.widthMaskHypFvar,
-          prop,
+          proof,
         ]
     return (g, wInfos, expr)
   -- Recurse over the prop structure
-  match propTm with
+  match prop with
   | .widthLT v w => applyPropBinop ``lt_of_lt_of_eq_maskOfWidth v w
   | .widthLE v w => applyPropBinop ``le_of_le_of_eq_maskOfWidth v w
   | .widthEQ v w => applyPropBinop ``eq_of_eq_of_eq_maskOfWidth v w
   | .AND a b => do
-    let (g, wInfos, aExpr) ← getExprFromProp a (← mkAppM ``And.left  #[prop]) g wInfos
-    let (g, wInfos, bExpr) ← getExprFromProp b (← mkAppM ``And.right #[prop]) g wInfos
+    let (g, wInfos, aExpr) ← getMaskedExprFromProp a (← mkAppM ``And.left  #[proof]) g wInfos
+    let (g, wInfos, bExpr) ← getMaskedExprFromProp b (← mkAppM ``And.right #[proof]) g wInfos
     let expr ← g.withContext <| mkAppM ``And.intro <| #[aExpr, bExpr]
     return (g, wInfos, expr)
 
@@ -454,7 +457,7 @@ meta def translateWidthPrecond (widthInfos : WidthInfos)
   -- If the hypothesis cannot be reified, skip it.
   let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return (g, widthInfos)
   -- Obtain the `Expr` of the prop in terms of the mask.
-  let (g, wInfos, expr) ← getExprFromProp prop (ldecl.toExpr) g widthInfos
+  let (g, wInfos, expr) ← getMaskedExprFromProp prop (ldecl.toExpr) g widthInfos
   -- State the mask version of the prop
   let (_, g) ← g.note (Name.mkSimple s!"bv_{prop.toName}") expr
   return (g, wInfos)

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -5,15 +5,8 @@ public meta import Std
 public import Veir.Data.PBV
 
 open Lean Elab Tactic Meta Simp Std
-namespace Veir.Data.PBV
 
-/--
-Read-only configuration for the tactic.
--/
-meta structure PbvTranslateContext where
-  /-- The bound up to which we want to bitblast our widths. -/
-  bmcBound : Nat
-
+/-- Check if an `Expr` is a `Nat`. -/
 meta def Expr.isNat (e : Expr) : Bool := e.isConstOf ``Nat
 
 /--
@@ -24,6 +17,19 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
   match_expr e with
   | BitVec w => some w
   | _ => none
+
+/-- Given `a b : Nat`, return `a < b` -/
+meta def mkNatLT (a b : Expr) : Expr :=
+  mkApp2 (mkApp2 (mkConst ``LT.lt [0]) Nat.mkType Nat.mkInstLT) a b
+
+namespace Veir.Data.PBV
+
+/--
+Read-only configuration for the tactic.
+-/
+meta structure PbvTranslateContext where
+  /-- The bound up to which we want to bitblast our widths. -/
+  bmcBound : Nat
 
 /--
 An environment that maps the width atoms of a `Tm` to their `Expr`s.
@@ -67,6 +73,7 @@ inductive Tm : TmKind → Type
 | widthLT (v w : Tm .width) : Tm .prop
 | widthLE (v w : Tm .width) : Tm .prop
 | widthEQ (v w : Tm .width) : Tm .prop
+| AND (v w : Tm .prop) : Tm .prop
 
 /--
 Function to reify an `Expr` into a `Tm`. This function constructs the tree holding
@@ -106,21 +113,30 @@ meta def matchWidthRel (e : Expr) :
 Reify an `Expr` into a `Tm .prop`. Returns `none` if the expression is not a
 width relation, or if either side of the relation fails to reify as a width.
 -/
-meta def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
+meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
   if let some (rel, ea, eb) := matchWidthRel e then
     let some wa ← Tm.reifyWidth env ea | return none
     let some wb ← Tm.reifyWidth env eb | return none
     return some (rel wa wb)
   else
-    return none
+    match_expr e with
+    | And ea eb => do
+      let some pa ← Tm.reifyProp env ea | return none
+      let some pb ← Tm.reifyProp env eb | return none
+      return some (.AND pa pb)
+    | _ => return none
 
 /--
 Convert a `Tm` into an `Expr` given an environment.
 -/
-meta def Tm.toExpr (this : Tm .width) (env : TmWidthEnv) : Expr :=
+meta def Tm.toExpr {k : TmKind} (this : Tm k) (env : TmWidthEnv) : Expr :=
   match this with
   | .widthAtom id => env.width2expr[id]!
   | .widthAdd v w => mkNatAdd (v.toExpr env) (w.toExpr env)
+  | .widthLT  v w => mkNatLT (v.toExpr env) (w.toExpr env)
+  | .widthLE  v w => mkNatLE (v.toExpr env) (w.toExpr env)
+  | .widthEQ  v w => mkNatEq (v.toExpr env) (w.toExpr env)
+  | .AND a b => mkAnd (a.toExpr env) (b.toExpr env)
 
 /--
 Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
@@ -132,6 +148,7 @@ meta def Tm.toName {k : TmKind} (tm : Tm k) : Name :=
   | .widthLT  v w => Name.mkSimple s!"{v.toName}_lt_{w.toName}"
   | .widthLE  v w => Name.mkSimple s!"{v.toName}_le_{w.toName}"
   | .widthEQ  v w => Name.mkSimple s!"{v.toName}_eq_{w.toName}"
+  | .AND a b => Name.mkSimple s!"{a.toName}_and_{a.toName}"
 
 /--
 Compute an upper bound on the value of this width term: an atom is bounded by
@@ -397,40 +414,48 @@ meta partial def visitExprRec (g : MVarId)
     return (g, widthTms, bvs)
 
 /--
-Extract `Tm .width`s and corresponding theorem from `Tm .prop`.
+Given a `Tm .prop` and the `Expr` is was reified from, construct the expr that
+corresponds to the `Prop` expressed in terms of the masks.
 -/
-meta def getThmFromProp (term : Tm .prop) : Name × Tm .width × Tm .width :=
-  match term with
-  | .widthLT v w => (``lt_of_lt_of_eq_maskOfWidth, v, w)
-  | .widthLE v w => (``le_of_le_of_eq_maskOfWidth, v, w)
-  | .widthEQ v w => (``eq_of_eq_of_eq_maskOfWidth, v, w)
+meta def getExprFromProp (propTm : Tm .prop) (prop : Expr) (blastWidth : Nat) (g : MVarId)
+    (wInfos: WidthInfos) : MetaM (MVarId × WidthInfos × Expr) := g.withContext do
+  -- Helper to apply a theorem for a binary operation on widths.
+  let applyPropBinop (thm : Name) (v w : Tm .width) : MetaM (MVarId × WidthInfos × Expr) := do
+    let (g, vInfo, wInfos) ← getOrCreateWidthMask blastWidth g v wInfos
+    let (g, wInfo, wInfos) ← getOrCreateWidthMask blastWidth g w wInfos
+    let expr ← g.withContext <| mkAppM thm <| #[
+          .fvar vInfo.hypWidthLeBoundNote,
+          .fvar wInfo.hypWidthLeBoundNote,
+          .fvar vInfo.widthMaskHypFvar,
+          .fvar wInfo.widthMaskHypFvar,
+          prop,
+        ]
+    return (g, wInfos, expr)
+  -- Recurse over the prop structure
+  match propTm with
+  | .widthLT v w => applyPropBinop ``lt_of_lt_of_eq_maskOfWidth v w
+  | .widthLE v w => applyPropBinop ``le_of_le_of_eq_maskOfWidth v w
+  | .widthEQ v w => applyPropBinop ``eq_of_eq_of_eq_maskOfWidth v w
+  | .AND a b => do
+    let (g, wInfos, aExpr) ← getExprFromProp a (← mkAppM ``And.left  #[prop]) blastWidth g wInfos
+    let (g, wInfos, bExpr) ← getExprFromProp b (← mkAppM ``And.right #[prop]) blastWidth g wInfos
+    let expr ← g.withContext <| mkAppM ``And.intro <| #[aExpr, bExpr]
+    return (g, wInfos, expr)
 
 /--
 If a statament in the local context that can be reified as a prop is found, then
-convert into a statement about the width masks, instantiating new masks if needed.
+convert into a statement about the width masks, creatingg new masks if needed.
 -/
 meta def translateWidthPrecond (blastWidth : Nat) (widthInfos : WidthInfos)
     (g : MVarId) (ldecl : LocalDecl)
     : MetaM (MVarId × WidthInfos) := g.withContext do
-  -- If the hypothesis cannot be reified, skip it
+  -- If the hypothesis cannot be reified, skip it.
   let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return (g, widthInfos)
-  -- Get the theorem matching the prop
-  let (thm, v, w) := getThmFromProp prop
-  -- Get or create the masks for the width terms
-  let (g, vInfo, widthInfos) ← getOrCreateWidthMask blastWidth g v widthInfos
-  let (g, wInfo, widthInfos) ← getOrCreateWidthMask blastWidth g w widthInfos
-  -- Apply the theorem to convert the width condition into a `BitVec` condition.
-  let (_, g) ← g.withContext
-    <| g.note (Name.mkSimple s!"bv_{prop.toName}")
-    <| ← g.withContext <| mkAppM thm <| #[
-        .fvar vInfo.hypWidthLeBoundNote,
-        .fvar wInfo.hypWidthLeBoundNote,
-        .fvar vInfo.widthMaskHypFvar,
-        .fvar wInfo.widthMaskHypFvar,
-        .fvar ldecl.fvarId,
-      ]
-
-  return (g, widthInfos)
+  -- Obtain the `Expr` of the prop in terms of the mask.
+  let (g, wInfos, expr) ← getExprFromProp prop (ldecl.toExpr) blastWidth g widthInfos
+  -- State the mask version of the prop
+  let (_, g) ← g.note (Name.mkSimple s!"bv_{prop.toName}") expr
+  return (g, wInfos)
 
 /--
 Traverse the local context and add any width pre-conditions to the goal.

--- a/Veir/Meta/PBVDecide.lean
+++ b/Veir/Meta/PBVDecide.lean
@@ -18,7 +18,7 @@ meta def getBitvecType? (e : Expr) : Option Expr :=
   | BitVec w => some w
   | _ => none
 
-/-- Given `a b : Nat`, return `a < b` -/
+/-- Given `a b : Nat`, return `a < b`. -/
 meta def mkNatLT (a b : Expr) : Expr :=
   mkApp2 (mkApp2 (mkConst ``LT.lt [0]) Nat.mkType Nat.mkInstLT) a b
 
@@ -70,10 +70,10 @@ Inductive data structure to express the terms that this tactic reasons about.
 inductive Tm : TmKind → Type
 | widthAtom (id : Nat) : Tm .width
 | widthAdd (v w : Tm .width) : Tm .width
-| widthLT (v w : Tm .width) : Tm .prop
-| widthLE (v w : Tm .width) : Tm .prop
-| widthEQ (v w : Tm .width) : Tm .prop
-| AND (v w : Tm .prop) : Tm .prop
+| widthLt (v w : Tm .width) : Tm .prop
+| widthLe (v w : Tm .width) : Tm .prop
+| widthEq (v w : Tm .width) : Tm .prop
+| and (v w : Tm .prop) : Tm .prop
 
 /--
 Function to reify an `Expr` into a `Tm`. This function constructs the tree holding
@@ -95,23 +95,23 @@ meta partial def Tm.reifyWidth (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm
 
 /--
 Match a width relation over `Nat`, returning the `Tm .prop` constructor for it
-together with the `Expr`s on either side. `>` and `≥` are normalised into
-`widthLT` and `widthLE` by swapping the two sides. Returns `none` for anything
+together with the `Expr`s on either side. `>` and `≥` are normalized into
+`widthLt` and `widthLe` by swapping the two sides. Returns `none` for anything
 else, including the same relations at a type other than `Nat`.
 -/
 meta def matchWidthRel (e : Expr) :
     Option ((Tm TmKind.width → Tm TmKind.width → Tm TmKind.prop) × Expr × Expr) :=
   match_expr e with
-  | LT.lt ty _inst ea eb => if Expr.isNat ty then some (.widthLT, ea, eb) else none
-  | LE.le ty _inst ea eb => if Expr.isNat ty then some (.widthLE, ea, eb) else none
-  | GT.gt ty _inst ea eb => if Expr.isNat ty then some (.widthLT, eb, ea) else none
-  | GE.ge ty _inst ea eb => if Expr.isNat ty then some (.widthLE, eb, ea) else none
-  | Eq ty ea eb          => if Expr.isNat ty then some (.widthEQ, ea, eb) else none
+  | LT.lt ty _inst ea eb => if Expr.isNat ty then some (.widthLt, ea, eb) else none
+  | LE.le ty _inst ea eb => if Expr.isNat ty then some (.widthLe, ea, eb) else none
+  | GT.gt ty _inst ea eb => if Expr.isNat ty then some (.widthLt, eb, ea) else none
+  | GE.ge ty _inst ea eb => if Expr.isNat ty then some (.widthLe, eb, ea) else none
+  | Eq ty ea eb          => if Expr.isNat ty then some (.widthEq, ea, eb) else none
   | _ => none
 
 /--
 Reify an `Expr` into a `Tm .prop`. Returns `none` if the expression is not a
-supported prop, or if the subterms fails to reify as `Tm .width`s.
+supported prop, or if the subterms fail to reify as `Tm .width`s.
 -/
 meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm .prop)) := do
   if let some (rel, ea, eb) := matchWidthRel e then
@@ -123,7 +123,7 @@ meta partial def Tm.reifyProp (env : TmWidthEnv) (e : Expr) : MetaM (Option (Tm 
     | And ea eb => do
       let some pa ← Tm.reifyProp env ea | return none
       let some pb ← Tm.reifyProp env eb | return none
-      return some (.AND pa pb)
+      return some (.and pa pb)
     | _ => return none
 
 /--
@@ -133,10 +133,10 @@ meta def Tm.toExpr {k : TmKind} (this : Tm k) (env : TmWidthEnv) : Expr :=
   match this with
   | .widthAtom id => env.width2expr[id]!
   | .widthAdd v w => mkNatAdd (v.toExpr env) (w.toExpr env)
-  | .widthLT  v w => mkNatLT (v.toExpr env) (w.toExpr env)
-  | .widthLE  v w => mkNatLE (v.toExpr env) (w.toExpr env)
-  | .widthEQ  v w => mkNatEq (v.toExpr env) (w.toExpr env)
-  | .AND a b => mkAnd (a.toExpr env) (b.toExpr env)
+  | .widthLt  v w => mkNatLT (v.toExpr env) (w.toExpr env)
+  | .widthLe  v w => mkNatLE (v.toExpr env) (w.toExpr env)
+  | .widthEq  v w => mkNatEq (v.toExpr env) (w.toExpr env)
+  | .and      a b => mkAnd (a.toExpr env) (b.toExpr env)
 
 /--
 Generate a `Name` from a `Tm`. Uses the index of the atoms as the basic variable name.
@@ -145,10 +145,10 @@ meta def Tm.toName {k : TmKind} (tm : Tm k) : Name :=
   match tm with
   | .widthAtom e  => Name.mkSimple s!"w{e}"
   | .widthAdd v w => Name.mkSimple s!"{v.toName}_add_{w.toName}"
-  | .widthLT  v w => Name.mkSimple s!"{v.toName}_lt_{w.toName}"
-  | .widthLE  v w => Name.mkSimple s!"{v.toName}_le_{w.toName}"
-  | .widthEQ  v w => Name.mkSimple s!"{v.toName}_eq_{w.toName}"
-  | .AND a b => Name.mkSimple s!"{a.toName}_and_{a.toName}"
+  | .widthLt  v w => Name.mkSimple s!"{v.toName}_lt_{w.toName}"
+  | .widthLe  v w => Name.mkSimple s!"{v.toName}_le_{w.toName}"
+  | .widthEq  v w => Name.mkSimple s!"{v.toName}_eq_{w.toName}"
+  | .and      a b => Name.mkSimple s!"{a.toName}_and_{b.toName}"
 
 /--
 Compute an upper bound on the value of this width term: an atom is bounded by
@@ -229,7 +229,7 @@ structure WidthInfos where
   blastWidth : Nat
 
 meta def WidthInfos.push (this : WidthInfos) (info : WidthInfo) : WidthInfos :=
-  { infos := this.infos.insert (info.widthTm.toName) info, env := this.env, blastWidth := this.blastWidth }
+  { this with infos := this.infos.insert (info.widthTm.toName) info }
 
 /--
 Get WidthInfo from a Term.
@@ -257,7 +257,8 @@ meta def introMaskWidth (g : MVarId) (widthTm : Tm .width) (infos : WidthInfos)
   : MetaM (MVarId × WidthInfo × WidthInfos) := g.withContext do
     -- Apply width_elim
     let [g] ← g.withContext do
-      g.apply <| ← mkAppM ``width_elim #[mkNatLit infos.blastWidth, widthTm.toExpr infos.env, ← g.getType]
+      g.apply <| ← mkAppM ``width_elim
+        #[mkNatLit infos.blastWidth, widthTm.toExpr infos.env, ← g.getType]
       | throwError m!"{``width_elim} should generate a goal"
     -- Intros
     let name := widthTm.toName
@@ -309,9 +310,7 @@ meta def getOrCreateWidthMask (g : MVarId) (widthTm : Tm .width) (infos : WidthI
     let (g, thisInfo, infos) ← introMaskWidth g widthTm infos
     -- Rewrite the mask of a sum of widths into a product of the masks (+ 1).
     let (_hyp, g) ← g.withContext do
-      g.note (Name.mkSimple s!"bv_{widthTm.toName}")
-      <| ← mkAppM ``add_eq_mul_of_maskOfWidth
-      <| #[
+      g.note (Name.mkSimple s!"bv_{widthTm.toName}") <| ← mkAppM ``add_eq_mul_of_maskOfWidth #[
         .fvar vInfo.hypWidthLeBoundNote,
         .fvar wInfo.hypWidthLeBoundNote,
         .fvar thisInfo.hypWidthLeBoundNote,
@@ -416,67 +415,66 @@ meta partial def visitExprRec (g : MVarId)
     return (g, widthTms, bvs)
 
 /--
-Given a `Tm .prop` and the `Expr` is was reified from, construct the expr that
+Given a `Tm .prop` and the `Expr` it was reified from, construct the expr that
 corresponds to the `Prop` expressed in terms of the masks.
 -/
-meta def getMaskedExprFromProp (prop : Tm .prop) (proof : Expr) (g : MVarId)
-    (wInfos: WidthInfos) : MetaM (MVarId × WidthInfos × Expr) := g.withContext do
+meta def getMaskedExprFromProp (g : MVarId) (prop : Tm .prop) (proof : Expr)
+    (widthInfos : WidthInfos) : MetaM (MVarId × WidthInfos × Expr) := g.withContext do
   -- Ensure the proof and prop match.
-  unless ← isDefEq (← inferType proof) (prop.toExpr wInfos.env)
-    do throwError m!"Prop : {prop.toExpr wInfos.env} doesn't match the proof : {← inferType proof}"
+  unless ← isDefEq (← inferType proof) (prop.toExpr widthInfos.env)
+    do throwError m!"Prop : {prop.toExpr widthInfos.env} doesn't match the proof : {← inferType proof}"
   -- Helper to apply a theorem for a binary operation on widths.
   let applyPropBinop (thm : Name) (v w : Tm .width) : MetaM (MVarId × WidthInfos × Expr) := do
-    let (g, vInfo, wInfos) ← getOrCreateWidthMask g v wInfos
-    let (g, wInfo, wInfos) ← getOrCreateWidthMask g w wInfos
-    let expr ← g.withContext <| mkAppM thm <| #[
+    let (g, vInfo, widthInfos) ← getOrCreateWidthMask g v widthInfos
+    let (g, wInfo, widthInfos) ← getOrCreateWidthMask g w widthInfos
+    let expr ← g.withContext <| mkAppM thm #[
           .fvar vInfo.hypWidthLeBoundNote,
           .fvar wInfo.hypWidthLeBoundNote,
           .fvar vInfo.widthMaskHypFvar,
           .fvar wInfo.widthMaskHypFvar,
           proof,
         ]
-    return (g, wInfos, expr)
+    return (g, widthInfos, expr)
   -- Recurse over the prop structure
   match prop with
-  | .widthLT v w => applyPropBinop ``lt_of_lt_of_eq_maskOfWidth v w
-  | .widthLE v w => applyPropBinop ``le_of_le_of_eq_maskOfWidth v w
-  | .widthEQ v w => applyPropBinop ``eq_of_eq_of_eq_maskOfWidth v w
-  | .AND a b => do
-    let (g, wInfos, aExpr) ← getMaskedExprFromProp a (← mkAppM ``And.left  #[proof]) g wInfos
-    let (g, wInfos, bExpr) ← getMaskedExprFromProp b (← mkAppM ``And.right #[proof]) g wInfos
-    let expr ← g.withContext <| mkAppM ``And.intro <| #[aExpr, bExpr]
-    return (g, wInfos, expr)
+  | .widthLt v w => applyPropBinop ``lt_of_lt_of_eq_maskOfWidth v w
+  | .widthLe v w => applyPropBinop ``le_of_le_of_eq_maskOfWidth v w
+  | .widthEq v w => applyPropBinop ``eq_of_eq_of_eq_maskOfWidth v w
+  | .and a b => do
+    let (g, widthInfos, aExpr) ←
+      getMaskedExprFromProp g a (← mkAppM ``And.left  #[proof]) widthInfos
+    let (g, widthInfos, bExpr) ←
+      getMaskedExprFromProp g b (← mkAppM ``And.right #[proof]) widthInfos
+    let expr ← g.withContext <| mkAppM ``And.intro #[aExpr, bExpr]
+    return (g, widthInfos, expr)
 
 /--
-If a statament in the local context that can be reified as a prop is found, then
-convert into a statement about the width masks, creatingg new masks if needed.
+If the given hypothesis can be reified as a width prop, convert it into a
+statement about the width masks, creating new masks if needed.
 -/
-meta def translateWidthPrecond (widthInfos : WidthInfos)
-    (g : MVarId) (ldecl : LocalDecl)
+meta def translateWidthPrecond (g : MVarId) (ldecl : LocalDecl) (widthInfos : WidthInfos)
     : MetaM (MVarId × WidthInfos) := g.withContext do
   -- If the hypothesis cannot be reified, skip it.
   let some prop ← Tm.reifyProp widthInfos.env (ldecl.type) | return (g, widthInfos)
   -- Obtain the `Expr` of the prop in terms of the mask.
-  let (g, wInfos, expr) ← getMaskedExprFromProp prop (ldecl.toExpr) g widthInfos
+  let (g, widthInfos, expr) ← getMaskedExprFromProp g prop (ldecl.toExpr) widthInfos
   -- State the mask version of the prop
   let (_, g) ← g.note (Name.mkSimple s!"bv_{prop.toName}") expr
-  return (g, wInfos)
+  return (g, widthInfos)
 
 /--
 Traverse the local context and add any width pre-conditions to the goal.
 -/
-meta def translateWidthPreconds (winfos : WidthInfos)
-    (g : MVarId) : MetaM (MVarId × WidthInfos) := g.withContext do
-  (← getLCtx).foldlM (
-    init := (g, winfos))
-    fun (g, widthInfos) ldecl =>
-      translateWidthPrecond widthInfos g ldecl
+meta def translateWidthPreconds (g : MVarId) (widthInfos : WidthInfos)
+    : MetaM (MVarId × WidthInfos) := g.withContext do
+  (← getLCtx).foldlM (init := (g, widthInfos)) fun (g, widthInfos) ldecl =>
+    translateWidthPrecond g ldecl widthInfos
 
 /--
 Given the width terms in the formula, translate all `Nat` widths into `BitVec`
 masks and introduce the hypotheses that model the masks.
 -/
-meta def introMaskWidths (blastWidth : Nat) (widthTms : WidthTms) (g : MVarId)
+meta def introMaskWidths (g : MVarId) (widthTms : WidthTms) (blastWidth : Nat)
   : MetaM (MVarId × WidthInfos)
   := g.withContext do
   -- Intro all the masks
@@ -501,8 +499,8 @@ within the Simp set.
 meta def addBoundRewrites (g : MVarId) (blastWidth : Nat) (simp : SimpTheoremsArray) :
     MetaM SimpTheoremsArray := g.withContext do
   let thms := #[
-        ``eq_iff,
-        ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero
+      ``eq_iff,
+      ``msb_eq_and_signBitOfMask_maskOfWidth_ne_zero,
   ]
 
   thms.foldlM (init := simp) fun simps name =>
@@ -582,10 +580,10 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
   let (g, widthTms, bvsToRevert) ← visitExprRec g { env := widthEnv } {} (← g.getType)
   -- Compute the blast width
   let blastWidth := widthTms.getUniverseWidthUpperBound ctx
-  -- Introduce the width masks, bounded by the max width
-  let (g, widthInfos) ← introMaskWidths blastWidth widthTms g
+  -- Introduce the width masks, bounded by the blast width
+  let (g, widthInfos) ← introMaskWidths g widthTms blastWidth
   -- Find and translate conditions on the width vars
-  let (g, widthInfos) ← translateWidthPreconds widthInfos g
+  let (g, widthInfos) ← translateWidthPreconds g widthInfos
   -- Intro the `BitVec`s
   let (g, bvInfos) ← introMaskedBitvectors bvsToRevert g widthInfos
   -- Create simp set
@@ -604,9 +602,10 @@ meta def pbvTranslate (g : MVarId) (ctx : PbvTranslateContext) : MetaM (List MVa
 `pbv_decide` takes a `Nat` bound as input argument and uses it to translate a
 parametric bitvector formula into a concrete width formula.
 
-Widths built out of width variables and `+` are supported, as are the width
-relations `<`, `≤`, `>`, `≥` and `=` occurring as hypotheses, which are
-translated into the corresponding relations on the width masks.
+Widths built out of width variables and `+` are supported. So are the width
+relations `<`, `≤`, `>`, `≥` and `=`, and conjunctions (`∧`) of them, when they
+occur as hypotheses: each is translated into the corresponding relation on the
+width masks.
 
 The tactic generates multiple goals:
 1. The desired concrete width formula that can be decided using `bv_decide`.


### PR DESCRIPTION
Introduce support for sign and zero extend operations:
- Expand the `Tm` type to express props on width terms to parse width conditions. By prop we mean:
  - Equality and inequalities on width terms (`>` and `≥` are encoded as flipped `<` and `≤` respectively)
  - `and`s on the props
- Translate conditions on the widths into conditions on the corresponding masks.
- Define new theorems to relate widths and masks.
- Add test cases to `UnitTest`.
- Add an example that uses the `and` of two width conditions.
- (minor) Rename some theorems to match the lean convention.
