### PR TITLE
fix(LLVM,arith): spell the flags isExact and isDisjoint, as MLIR does

### DIFF
--- a/Test/Interpreter/Arith/divsi_exact.mlir
+++ b/Test/Interpreter/Arith/divsi_exact.mlir
@@ -4,7 +4,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     %lhs = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %x = "arith.divsi"(%lhs, %rhs) <{exact}> : (i32, i32) -> i32
+    %x = "arith.divsi"(%lhs, %rhs) <{isExact}> : (i32, i32) -> i32
     "func.return"(%x) : (i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/divui_exact.mlir
+++ b/Test/Interpreter/Arith/divui_exact.mlir
@@ -4,7 +4,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     %lhs = "arith.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %rhs = "arith.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %x = "arith.divui"(%lhs, %rhs) <{exact}> : (i32, i32) -> i32
+    %x = "arith.divui"(%lhs, %rhs) <{isExact}> : (i32, i32) -> i32
     "func.return"(%x) : (i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/or_disjoint.mlir
+++ b/Test/Interpreter/Arith/or_disjoint.mlir
@@ -6,9 +6,9 @@
     %five = "arith.constant"() <{ "value" = 5 : i32 }> : () -> i32
     %eight = "arith.constant"() <{ "value" = 8 : i32 }> : () -> i32
     %negseven = "arith.constant"() <{ "value" = -7 : i32 }> : () -> i32
-    %x = "arith.ori"(%three, %five) <{disjoint}> : (i32, i32) -> i32
-    %y = "arith.ori"(%eight, %negseven) <{disjoint}> : (i32, i32) -> i32
-    %z = "arith.ori"(%three, %eight) <{disjoint}> : (i32, i32) -> i32
+    %x = "arith.ori"(%three, %five) <{isDisjoint}> : (i32, i32) -> i32
+    %y = "arith.ori"(%eight, %negseven) <{isDisjoint}> : (i32, i32) -> i32
+    %z = "arith.ori"(%three, %eight) <{isDisjoint}> : (i32, i32) -> i32
     "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shrsi_exact.mlir
+++ b/Test/Interpreter/Arith/shrsi_exact.mlir
@@ -6,9 +6,9 @@
     %negone = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
     %four = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %nine = "arith.constant"() <{ "value" = 9 : i8 }> : () -> i8
-    %x = "arith.shrsi"(%seven, %four) <{exact}> : (i8, i8) -> i8
-    %y = "arith.shrsi"(%negone, %four) <{exact}> : (i8, i8) -> i8
-    %z = "arith.shrsi"(%negone, %nine) <{exact}> : (i8, i8) -> i8
+    %x = "arith.shrsi"(%seven, %four) <{isExact}> : (i8, i8) -> i8
+    %y = "arith.shrsi"(%negone, %four) <{isExact}> : (i8, i8) -> i8
+    %z = "arith.shrsi"(%negone, %nine) <{isExact}> : (i8, i8) -> i8
     "func.return"(%x, %y, %z) : (i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/Arith/shrui_exact.mlir
+++ b/Test/Interpreter/Arith/shrui_exact.mlir
@@ -6,9 +6,9 @@
     %negone = "arith.constant"() <{ "value" = -1 : i8 }> : () -> i8
     %four = "arith.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %nine = "arith.constant"() <{ "value" = 9 : i8 }> : () -> i8
-    %x = "arith.shrui"(%seven, %four) <{exact}> : (i8, i8) -> i8
-    %y = "arith.shrui"(%negone, %four) <{exact}> : (i8, i8) -> i8
-    %z = "arith.shrui"(%negone, %nine) <{exact}> : (i8, i8) -> i8
+    %x = "arith.shrui"(%seven, %four) <{isExact}> : (i8, i8) -> i8
+    %y = "arith.shrui"(%negone, %four) <{isExact}> : (i8, i8) -> i8
+    %z = "arith.shrui"(%negone, %nine) <{isExact}> : (i8, i8) -> i8
     "func.return"(%x, %y, %z) : (i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/ashr_exact.mlir
+++ b/Test/Interpreter/LLVM/ashr_exact.mlir
@@ -6,9 +6,9 @@
     %negone = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
     %four = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %nine = "llvm.mlir.constant"() <{ "value" = 9 : i8 }> : () -> i8
-    %x = "llvm.ashr"(%seven, %four) <{exact}> : (i8, i8) -> i8
-    %y = "llvm.ashr"(%negone, %four) <{exact}> : (i8, i8) -> i8
-    %z = "llvm.ashr"(%negone, %nine) <{exact}> : (i8, i8) -> i8
+    %x = "llvm.ashr"(%seven, %four) <{isExact}> : (i8, i8) -> i8
+    %y = "llvm.ashr"(%negone, %four) <{isExact}> : (i8, i8) -> i8
+    %z = "llvm.ashr"(%negone, %nine) <{isExact}> : (i8, i8) -> i8
     "func.return"(%x, %y, %z) : (i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/lshr_exact.mlir
+++ b/Test/Interpreter/LLVM/lshr_exact.mlir
@@ -6,9 +6,9 @@
     %negone = "llvm.mlir.constant"() <{ "value" = -1 : i8 }> : () -> i8
     %four = "llvm.mlir.constant"() <{ "value" = 4 : i8 }> : () -> i8
     %nine = "llvm.mlir.constant"() <{ "value" = 9 : i8 }> : () -> i8
-    %x = "llvm.lshr"(%seven, %four) <{exact}> : (i8, i8) -> i8
-    %y = "llvm.lshr"(%negone, %four) <{exact}> : (i8, i8) -> i8
-    %z = "llvm.lshr"(%negone, %nine) <{exact}> : (i8, i8) -> i8
+    %x = "llvm.lshr"(%seven, %four) <{isExact}> : (i8, i8) -> i8
+    %y = "llvm.lshr"(%negone, %four) <{isExact}> : (i8, i8) -> i8
+    %z = "llvm.lshr"(%negone, %nine) <{isExact}> : (i8, i8) -> i8
     "func.return"(%x, %y, %z) : (i8, i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/or_disjoint.mlir
+++ b/Test/Interpreter/LLVM/or_disjoint.mlir
@@ -6,9 +6,9 @@
     %five = "llvm.mlir.constant"() <{ "value" = 5 : i32 }> : () -> i32
     %eight = "llvm.mlir.constant"() <{ "value" = 8 : i32 }> : () -> i32
     %negseven = "llvm.mlir.constant"() <{ "value" = -7 : i32 }> : () -> i32
-    %x = "llvm.or"(%three, %five) <{disjoint}> : (i32, i32) -> i32
-    %y = "llvm.or"(%eight, %negseven) <{disjoint}> : (i32, i32) -> i32
-    %z = "llvm.or"(%three, %eight) <{disjoint}> : (i32, i32) -> i32
+    %x = "llvm.or"(%three, %five) <{isDisjoint}> : (i32, i32) -> i32
+    %y = "llvm.or"(%eight, %negseven) <{isDisjoint}> : (i32, i32) -> i32
+    %z = "llvm.or"(%three, %eight) <{isDisjoint}> : (i32, i32) -> i32
     "func.return"(%x, %y, %z) : (i32, i32, i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/sdiv_exact.mlir
+++ b/Test/Interpreter/LLVM/sdiv_exact.mlir
@@ -4,7 +4,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %x = "llvm.sdiv"(%lhs, %rhs) <{exact}> : (i32, i32) -> i32
+    %x = "llvm.sdiv"(%lhs, %rhs) <{isExact}> : (i32, i32) -> i32
     "func.return"(%x) : (i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Interpreter/LLVM/udiv_exact.mlir
+++ b/Test/Interpreter/LLVM/udiv_exact.mlir
@@ -4,7 +4,7 @@
   "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
     %lhs = "llvm.mlir.constant"() <{ "value" = 7 : i32 }> : () -> i32
     %rhs = "llvm.mlir.constant"() <{ "value" = 2 : i32 }> : () -> i32
-    %x = "llvm.udiv"(%lhs, %rhs) <{exact}> : (i32, i32) -> i32
+    %x = "llvm.udiv"(%lhs, %rhs) <{isExact}> : (i32, i32) -> i32
     "func.return"(%x) : (i32) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/LLVM/exact_disjoint.mlir
+++ b/Test/LLVM/exact_disjoint.mlir
@@ -1,0 +1,24 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<void (i64)>, linkage = #llvm.linkage<external>, sym_name = "flags"}> ({
+  ^bb0(%a: i64):
+    %0 = "llvm.sdiv"(%a, %a) <{isExact}> : (i64, i64) -> i64
+    %1 = "llvm.udiv"(%a, %a) <{isExact}> : (i64, i64) -> i64
+    %2 = "llvm.lshr"(%a, %a) <{isExact}> : (i64, i64) -> i64
+    %3 = "llvm.ashr"(%a, %a) <{isExact}> : (i64, i64) -> i64
+    %4 = "llvm.or"(%a, %a) <{isDisjoint}> : (i64, i64) -> i64
+    %5 = "llvm.sdiv"(%a, %a) : (i64, i64) -> i64
+    %6 = "llvm.or"(%a, %a) : (i64, i64) -> i64
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.sdiv"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{isExact}> : (i64, i64) -> i64
+// CHECK: "llvm.udiv"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{isExact}> : (i64, i64) -> i64
+// CHECK: "llvm.lshr"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{isExact}> : (i64, i64) -> i64
+// CHECK: "llvm.ashr"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{isExact}> : (i64, i64) -> i64
+// CHECK: "llvm.or"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) <{isDisjoint}> : (i64, i64) -> i64
+// CHECK: "llvm.sdiv"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) : (i64, i64) -> i64
+// CHECK: "llvm.or"(%{{[a-z0-9_]+}}, %{{[a-z0-9_]+}}) : (i64, i64) -> i64

--- a/Test/Passes/ArithToLLVM/simple.mlir
+++ b/Test/Passes/ArithToLLVM/simple.mlir
@@ -12,7 +12,7 @@
     %wrapped = "arith.subi"(%c0, %c1) : (i8, i8) -> i8
     %difference = "arith.subi"(%c48, %c16)
       <{overflowFlags = #arith.overflow<nsw, nuw>}> : (i8, i8) -> i8
-    %combined = "arith.ori"(%difference, %c16) <{disjoint}> : (i8, i8) -> i8
+    %combined = "arith.ori"(%difference, %c16) <{isDisjoint}> : (i8, i8) -> i8
     "func.return"(%wrapped, %combined) : (i8, i8) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/CSE/arith.mlir
+++ b/Test/Passes/CSE/arith.mlir
@@ -50,11 +50,11 @@
     %add_nuw = "arith.addi"(%a, %b) <{"overflowFlags" = #arith.overflow<nuw>}> : (i32, i32) -> i32
     %add_both = "arith.addi"(%a, %b) <{"overflowFlags" = #arith.overflow<nsw, nuw>}> : (i32, i32) -> i32
     %or_plain = "arith.ori"(%a, %b) : (i32, i32) -> i32
-    %or_disjoint = "arith.ori"(%a, %b) <{disjoint}> : (i32, i32) -> i32
-    %or_disjoint_comm = "arith.ori"(%b, %a) <{disjoint}> : (i32, i32) -> i32
+    %or_disjoint = "arith.ori"(%a, %b) <{isDisjoint}> : (i32, i32) -> i32
+    %or_disjoint_comm = "arith.ori"(%b, %a) <{isDisjoint}> : (i32, i32) -> i32
     %div_plain = "arith.divsi"(%a, %b) : (i32, i32) -> i32
-    %div_exact_1 = "arith.divsi"(%a, %b) <{exact}> : (i32, i32) -> i32
-    %div_exact_2 = "arith.divsi"(%a, %b) <{exact}> : (i32, i32) -> i32
+    %div_exact_1 = "arith.divsi"(%a, %b) <{isExact}> : (i32, i32) -> i32
+    %div_exact_2 = "arith.divsi"(%a, %b) <{isExact}> : (i32, i32) -> i32
     "test.test"(%add_plain, %add_nsw, %add_nsw_comm, %add_nuw, %add_both, %or_plain, %or_disjoint, %or_disjoint_comm, %div_plain, %div_exact_1, %div_exact_2) : (i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32) -> ()
     "func.return"() : () -> ()
 
@@ -64,9 +64,9 @@
     // CHECK-NEXT: %[[ADD_NUW:.*]] = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nuw>}>
     // CHECK-NEXT: %[[ADD_BOTH:.*]] = "arith.addi"(%{{.*}}, %{{.*}}) <{"overflowFlags" = #arith.overflow<nsw, nuw>}>
     // CHECK-NEXT: %[[OR_PLAIN:.*]] = "arith.ori"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[OR_DISJOINT:.*]] = "arith.ori"(%{{.*}}, %{{.*}}) <{disjoint}>
+    // CHECK-NEXT: %[[OR_DISJOINT:.*]] = "arith.ori"(%{{.*}}, %{{.*}}) <{isDisjoint}>
     // CHECK-NEXT: %[[DIV_PLAIN:.*]] = "arith.divsi"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
-    // CHECK-NEXT: %[[DIV_EXACT:.*]] = "arith.divsi"(%{{.*}}, %{{.*}}) <{exact}>
+    // CHECK-NEXT: %[[DIV_EXACT:.*]] = "arith.divsi"(%{{.*}}, %{{.*}}) <{isExact}>
     // CHECK-NEXT: "test.test"(%[[ADD_PLAIN]], %[[ADD_NSW]], %[[ADD_NSW]], %[[ADD_NUW]], %[[ADD_BOTH]], %[[OR_PLAIN]], %[[OR_DISJOINT]], %[[OR_DISJOINT]], %[[DIV_PLAIN]], %[[DIV_EXACT]], %[[DIV_EXACT]])
   }) : () -> ()
 

--- a/Test/Passes/CSE/exact_and_misc_flags.mlir
+++ b/Test/Passes/CSE/exact_and_misc_flags.mlir
@@ -8,25 +8,25 @@
 
 // `lshr exact` is distinct from plain `lshr`.
 ^lshr_exact(%m : i32, %n : i32):
-    %lshr_exact_1 = "llvm.lshr"(%m, %n) <{exact}> : (i32, i32) -> i32
-    %lshr_exact_2 = "llvm.lshr"(%m, %n) <{exact}> : (i32, i32) -> i32
+    %lshr_exact_1 = "llvm.lshr"(%m, %n) <{isExact}> : (i32, i32) -> i32
+    %lshr_exact_2 = "llvm.lshr"(%m, %n) <{isExact}> : (i32, i32) -> i32
     %lshr_plain   = "llvm.lshr"(%m, %n) : (i32, i32) -> i32
     "test.test"(%lshr_exact_1, %lshr_exact_2, %lshr_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[LSHR_EXACT:.*]] = "llvm.lshr"(%{{.*}}, %{{.*}}) <{exact}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[LSHR_EXACT:.*]] = "llvm.lshr"(%{{.*}}, %{{.*}}) <{isExact}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[LSHR_PLAIN:.*]] = "llvm.lshr"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[LSHR_EXACT]], %[[LSHR_EXACT]], %[[LSHR_PLAIN]])
 
 // `ashr exact` is distinct from plain `ashr`.
     "llvm.br"(%m, %n) [^ashr_exact] : (i32, i32) -> ()
 ^ashr_exact(%o : i32, %p : i32):
-    %ashr_exact = "llvm.ashr"(%o, %p) <{exact}> : (i32, i32) -> i32
+    %ashr_exact = "llvm.ashr"(%o, %p) <{isExact}> : (i32, i32) -> i32
     %ashr_plain = "llvm.ashr"(%o, %p) : (i32, i32) -> i32
     "test.test"(%ashr_exact, %ashr_plain) : (i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[ASHR_EXACT:.*]] = "llvm.ashr"(%{{.*}}, %{{.*}}) <{exact}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[ASHR_EXACT:.*]] = "llvm.ashr"(%{{.*}}, %{{.*}}) <{isExact}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[ASHR_PLAIN:.*]] = "llvm.ashr"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[ASHR_EXACT]], %[[ASHR_PLAIN]])
 
@@ -36,39 +36,39 @@
 // that.
     "llvm.br"(%o, %p) [^udiv_exact] : (i32, i32) -> ()
 ^udiv_exact(%udiv_a : i32, %udiv_b : i32):
-    %udiv_exact_1 = "llvm.udiv"(%udiv_a, %udiv_b) <{exact}> : (i32, i32) -> i32
-    %udiv_exact_2 = "llvm.udiv"(%udiv_a, %udiv_b) <{exact}> : (i32, i32) -> i32
+    %udiv_exact_1 = "llvm.udiv"(%udiv_a, %udiv_b) <{isExact}> : (i32, i32) -> i32
+    %udiv_exact_2 = "llvm.udiv"(%udiv_a, %udiv_b) <{isExact}> : (i32, i32) -> i32
     %udiv_plain   = "llvm.udiv"(%udiv_a, %udiv_b) : (i32, i32) -> i32
     "test.test"(%udiv_exact_1, %udiv_exact_2, %udiv_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[UDIV_EXACT:.*]] = "llvm.udiv"(%{{.*}}, %{{.*}}) <{exact}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[UDIV_EXACT:.*]] = "llvm.udiv"(%{{.*}}, %{{.*}}) <{isExact}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[UDIV_PLAIN:.*]] = "llvm.udiv"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[UDIV_EXACT]], %[[UDIV_EXACT]], %[[UDIV_PLAIN]])
 
 // Same for `sdiv exact`.
     "llvm.br"(%udiv_a, %udiv_b) [^sdiv_exact] : (i32, i32) -> ()
 ^sdiv_exact(%sdiv_a : i32, %sdiv_b : i32):
-    %sdiv_exact_1 = "llvm.sdiv"(%sdiv_a, %sdiv_b) <{exact}> : (i32, i32) -> i32
-    %sdiv_exact_2 = "llvm.sdiv"(%sdiv_a, %sdiv_b) <{exact}> : (i32, i32) -> i32
+    %sdiv_exact_1 = "llvm.sdiv"(%sdiv_a, %sdiv_b) <{isExact}> : (i32, i32) -> i32
+    %sdiv_exact_2 = "llvm.sdiv"(%sdiv_a, %sdiv_b) <{isExact}> : (i32, i32) -> i32
     %sdiv_plain   = "llvm.sdiv"(%sdiv_a, %sdiv_b) : (i32, i32) -> i32
     "test.test"(%sdiv_exact_1, %sdiv_exact_2, %sdiv_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[SDIV_EXACT:.*]] = "llvm.sdiv"(%{{.*}}, %{{.*}}) <{exact}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[SDIV_EXACT:.*]] = "llvm.sdiv"(%{{.*}}, %{{.*}}) <{isExact}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[SDIV_PLAIN:.*]] = "llvm.sdiv"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[SDIV_EXACT]], %[[SDIV_EXACT]], %[[SDIV_PLAIN]])
 
 // `or disjoint` is commutative and partitions identity by flag.
     "llvm.br"(%sdiv_a, %sdiv_b) [^or_disjoint] : (i32, i32) -> ()
 ^or_disjoint(%q : i32, %r : i32):
-    %or_disjoint_1 = "llvm.or"(%q, %r) <{disjoint}> : (i32, i32) -> i32
-    %or_disjoint_2 = "llvm.or"(%r, %q) <{disjoint}> : (i32, i32) -> i32
+    %or_disjoint_1 = "llvm.or"(%q, %r) <{isDisjoint}> : (i32, i32) -> i32
+    %or_disjoint_2 = "llvm.or"(%r, %q) <{isDisjoint}> : (i32, i32) -> i32
     %or_plain      = "llvm.or"(%q, %r) : (i32, i32) -> i32
     "test.test"(%or_disjoint_1, %or_disjoint_2, %or_plain) : (i32, i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : i32, %{{.*}} : i32):
-    // CHECK-NEXT: %[[OR_DISJOINT:.*]] = "llvm.or"(%{{.*}}, %{{.*}}) <{disjoint}> : (i32, i32) -> i32
+    // CHECK-NEXT: %[[OR_DISJOINT:.*]] = "llvm.or"(%{{.*}}, %{{.*}}) <{isDisjoint}> : (i32, i32) -> i32
     // CHECK-NEXT: %[[OR_PLAIN:.*]] = "llvm.or"(%{{.*}}, %{{.*}}) : (i32, i32) -> i32
     // CHECK-NEXT: "test.test"(%[[OR_DISJOINT]], %[[OR_DISJOINT]], %[[OR_PLAIN]])
 

--- a/Test/Passes/InstructionSelection/RISCV64/ashr_exact.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/ashr_exact.mlir
@@ -3,7 +3,7 @@
 "builtin.module"() ({
     "func.func"()  <{function_type = (i64, i64) -> (), sym_name = "foo"}> ({
     ^bb(%a: i64, %b: i64):
-        %add = "llvm.ashr"(%a, %b) <{exact}> : (i64, i64) -> i64
+        %add = "llvm.ashr"(%a, %b) <{isExact}> : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.sra"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/divpow2.mlir
@@ -56,7 +56,7 @@
     "func.func"() <{function_type = (i64) -> i64, sym_name = "f5"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
-        %r = "llvm.sdiv"(%a, %c) <{exact}> : (i64, i64) -> i64
+        %r = "llvm.sdiv"(%a, %c) <{isExact}> : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
         "func.return"(%r) : (i64) -> ()
@@ -66,7 +66,7 @@
     "func.func"() <{function_type = (i64) -> i64, sym_name = "f6"}> ({
     ^bb(%a: i64):
         %c = "llvm.mlir.constant"() <{value = -8 : i64}> : () -> i64
-        %r = "llvm.sdiv"(%a, %c) <{exact}> : (i64, i64) -> i64
+        %r = "llvm.sdiv"(%a, %c) <{isExact}> : (i64, i64) -> i64
         // CHECK:      %{{.*}} = "riscv.srai"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.li"() <{"value" = 0 : i64}> : () -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.sub"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
@@ -77,7 +77,7 @@
     "func.func"() <{function_type = (i32) -> i32, sym_name = "f7"}> ({
     ^bb(%a: i32):
         %c = "llvm.mlir.constant"() <{value = 8 : i32}> : () -> i32
-        %r = "llvm.sdiv"(%a, %c) <{exact}> : (i32, i32) -> i32
+        %r = "llvm.sdiv"(%a, %c) <{isExact}> : (i32, i32) -> i32
         // CHECK: %{{.*}} = "riscv.sraiw"(%{{.*}}) <{"value" = 3 : i64}> : (!riscv.reg) -> !riscv.reg
         "func.return"(%r) : (i32) -> ()
     }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/or.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
-        %add_disjoint = "llvm.or"(%a, %b) <{disjoint}> : (i64, i64) -> i64
+        %add_disjoint = "llvm.or"(%a, %b) <{isDisjoint}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.or"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/or_invalid.mlir
@@ -5,8 +5,8 @@
     ^bb0(%a: i16, %b: i16):
         %add = "llvm.or"(%a, %b) : (i16, i16) -> i16
         // CHECK: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) : (i16, i16) -> i16
-        %add_disjoint = "llvm.or"(%a, %b) <{disjoint}>: (i16, i16) -> i16
-        // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) <{disjoint}> : (i16, i16) -> i16
+        %add_disjoint = "llvm.or"(%a, %b) <{isDisjoint}>: (i16, i16) -> i16
+        // CHECK-NEXT: %{{.*}} = "llvm.or"(%{{.*}}, %{{.*}}) <{isDisjoint}> : (i16, i16) -> i16
         "test.test"(%add) : (i16) -> ()
         "test.test"(%add_disjoint) : (i16) -> ()
         "func.return"() : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.div"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
-        %sdiv_exact = "llvm.sdiv"(%a, %b) <{exact}> : (i64, i64) -> i64
+        %sdiv_exact = "llvm.sdiv"(%a, %b) <{isExact}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.div"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/sdiv_pow2_exact_exec.mlir
@@ -12,9 +12,9 @@
     %neg = "llvm.mlir.constant"() <{value = -16 : i64}> : () -> i64
     %div4 = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
     %divneg4 = "llvm.mlir.constant"() <{value = -4 : i64}> : () -> i64
-    %r0 = "llvm.sdiv"(%pos, %div4) <{exact}> : (i64, i64) -> i64
-    %r1 = "llvm.sdiv"(%neg, %div4) <{exact}> : (i64, i64) -> i64
-    %r2 = "llvm.sdiv"(%pos, %divneg4) <{exact}> : (i64, i64) -> i64
+    %r0 = "llvm.sdiv"(%pos, %div4) <{isExact}> : (i64, i64) -> i64
+    %r1 = "llvm.sdiv"(%neg, %div4) <{isExact}> : (i64, i64) -> i64
+    %r2 = "llvm.sdiv"(%pos, %divneg4) <{isExact}> : (i64, i64) -> i64
     "func.return"(%r0, %r1, %r2) : (i64, i64, i64) -> ()
   }) : () -> ()
 }) : () -> ()

--- a/Test/Passes/InstructionSelection/RISCV64/udiv.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/udiv.mlir
@@ -8,7 +8,7 @@
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.divu"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (!riscv.reg) -> i64
-        %udiv_exact = "llvm.udiv"(%a, %b) <{exact}> : (i64, i64) -> i64
+        %udiv_exact = "llvm.udiv"(%a, %b) <{isExact}> : (i64, i64) -> i64
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "builtin.unrealized_conversion_cast"(%{{.*}}) : (i64) -> !riscv.reg
         // CHECK-NEXT: %{{.*}} = "riscv.divu"(%{{.*}}, %{{.*}}) : (!riscv.reg, !riscv.reg) -> !riscv.reg

--- a/Tools/veir2llvm
+++ b/Tools/veir2llvm
@@ -432,17 +432,17 @@ def flags_from_attrs(op: str, attr: str) -> list[str]:
         for flag in ("nuw", "nsw"):
             if flag in items and flag not in flags:
                 flags.append(flag)
-    if op in {"llvm.udiv", "llvm.sdiv", "llvm.lshr", "llvm.ashr"} and "exact" in items:
+    if op in {"llvm.udiv", "llvm.sdiv", "llvm.lshr", "llvm.ashr"} and "isExact" in items:
         flags.append("exact")
-    if op == "llvm.or" and "disjoint" in items:
+    if op == "llvm.or" and "isDisjoint" in items:
         flags.append("disjoint")
     if op == "llvm.zext" and "nonNeg" in items:
         flags.append("nneg")
     unsupported = items - {
         "nuw",
         "nsw",
-        "exact",
-        "disjoint",
+        "isExact",
+        "isDisjoint",
         "nonNeg",
         "predicate",
         "operandSegmentSizes",

--- a/Tools/vsmith_generate.py
+++ b/Tools/vsmith_generate.py
@@ -167,13 +167,13 @@ class Generator:
         if op in ("llvm.add", "llvm.sub", "llvm.mul"):
             return self.nsw_nuw_props()
         if op == "llvm.or":
-            return self.rng.choice(("", " <{disjoint}>"))
+            return self.rng.choice(("", " <{isDisjoint}>"))
         return ""
 
     def shift_props(self, op: str) -> str:
         if op == "llvm.shl":
             return self.nsw_nuw_props()
-        return self.rng.choice(("", " <{exact}>"))
+        return self.rng.choice(("", " <{isExact}>"))
 
     def shift_amount(self, width: int) -> str:
         """Generate a shift amount for a width-`width` shift.
@@ -195,7 +195,7 @@ class Generator:
 
     def div_props(self, op: str) -> str:
         if op in ("llvm.sdiv", "llvm.udiv"):
-            return self.rng.choice(("", " <{exact}>"))
+            return self.rng.choice(("", " <{isExact}>"))
         return ""
 
     def divisor(self, width: int) -> str:

--- a/Veir/Dialects/Arith/OpInfo.lean
+++ b/Veir/Dialects/Arith/OpInfo.lean
@@ -100,12 +100,12 @@ def Arith.toAttrDict
   | .divsi | .divui | .shrsi | .shrui => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
     if props.exact then
-      dict := dict.insert "exact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+      dict := dict.insert "isExact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
   | .ori => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
     if props.disjoint then
-      dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+      dict := dict.insert "isDisjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
   | .extui => props.toAttrDict
   | _ => Std.HashMap.emptyWithCapacity 0

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -286,12 +286,12 @@ def Llvm.toAttrDict
   | .udiv | .sdiv | .lshr | .ashr => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
     if props.exact then
-      dict := dict.insert "exact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+      dict := dict.insert "isExact".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
   | .or => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
     if props.disjoint then
-      dict := dict.insert "disjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
+      dict := dict.insert "isDisjoint".toUTF8 (Attribute.unitAttr UnitAttr.mk)
     dict
   | .zext | .uitofp => props.toAttrDict
   | .intr__ctlz | .intr__cttz =>

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -43,7 +43,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 def ExactProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String ExactProperties := do
-  let exact ← getUnitAttr "exact" attrDict
+  let exact ← getUnitAttr "isExact" attrDict
   return { exact := exact }
 
 /--
@@ -56,7 +56,7 @@ deriving Inhabited, Repr, Hashable, DecidableEq
 
 def DisjointProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
     Except String DisjointProperties := do
-  let disjoint ← getUnitAttr "disjoint" attrDict
+  let disjoint ← getUnitAttr "isDisjoint" attrDict
   return { disjoint := disjoint }
 
 /--


### PR DESCRIPTION
MLIR prints the flags as exact and disjoint in the pretty syntax but as isExact and isDisjoint in the generic syntax that VeIR uses, so VeIR dropped them on input and mlir-opt dropped VeIR's spelling on output, silently losing the flag in both directions. The arith extensions share the property structures and follow the same spelling.