### PR TITLE
fix(LLVM,cf): omit empty metadata lists and branch weights when printing

### DIFF
--- a/Test/Cf/identity.mlir
+++ b/Test/Cf/identity.mlir
@@ -7,7 +7,7 @@
         "cf.br"(%arg6_0) [^7] : (i32) -> ()
       ^7(%arg7_0 : i32):
         %9 = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
-        "cf.cond_br"(%9, %arg7_0, %arg7_0) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+        "cf.cond_br"(%9, %arg7_0, %arg7_0) [^7, ^7] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
     }) : () -> ()
 }) : () -> ()
 
@@ -18,6 +18,6 @@
 // CHECK-NEXT:         "cf.br"(%{{.*}}) [^[[tgt:.*]]] : (i32) -> ()
 // CHECK-NEXT:       ^[[tgt]](%{{.*}} : i32):
 // CHECK-NEXT:         %{{.*}} = "arith.constant"() <{"value" = 0 : i1}> : () -> i1
-// CHECK-NEXT:         "cf.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[tgt]], ^[[tgt]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+// CHECK-NEXT:         "cf.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[tgt]], ^[[tgt]]] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/LLVM/identity.mlir
+++ b/Test/LLVM/identity.mlir
@@ -40,7 +40,7 @@
       "llvm.store"(%5, %24) <{alignment = 1 : i64, volatile_, nontemporal, invariantGroup, access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (i32, !llvm.ptr) -> ()
       %26 = "llvm.load"(%24) : (!llvm.ptr) -> i32
       %27 = "llvm.load"(%24) <{alignment = 1 : i64, volatile_, nontemporal, invariant, invariantGroup, access_groups = [], alias_scopes = [], noalias_scopes = [], tbaa = []}> : (!llvm.ptr) -> i32
-      "llvm.cond_br"(%6, %5, %5) [^7, ^7] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+      "llvm.cond_br"(%6, %5, %5) [^7, ^7] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
     ^7(%arg6_0 : i32):
       "llvm.br"(%arg6_0) [^8] : (i32) -> ()
     ^8(%arg7_0 : i32):
@@ -129,11 +129,11 @@
 // CHECK-NEXT:       %{{.*}} = "llvm.zext"(%{{.*}}) : (i1) -> i32
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 0 : i64, "elem_type" = i32}> : (i32) -> !llvm.ptr
 // CHECK-NEXT:       %{{.*}} = "llvm.alloca"(%{{.*}}) <{"alignment" = 4 : i64, "elem_type" = i32, inalloca}> : (i32) -> !llvm.ptr
-// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i32, !llvm.ptr) -> ()
-// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i64, invariantGroup, "noalias_scopes" = [], nontemporal, "tbaa" = [], volatile_}> : (i32, !llvm.ptr) -> ()
-// CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
-// CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 1 : i64, invariant, invariantGroup, "noalias_scopes" = [], nontemporal, "tbaa" = [], volatile_}> : (!llvm.ptr) -> i32
-// CHECK-NEXT:       "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[b1:.*]], ^[[b1]]] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
+// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"alignment" = 0 : i64}> : (i32, !llvm.ptr) -> ()
+// CHECK-NEXT:       "llvm.store"(%{{.*}}, %{{.*}}) <{"alignment" = 1 : i64, invariantGroup, nontemporal, volatile_}> : (i32, !llvm.ptr) -> ()
+// CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"alignment" = 0 : i64}> : (!llvm.ptr) -> i32
+// CHECK-NEXT:       %{{.*}} = "llvm.load"(%{{.*}}) <{"alignment" = 1 : i64, invariant, invariantGroup, nontemporal, volatile_}> : (!llvm.ptr) -> i32
+// CHECK-NEXT:       "llvm.cond_br"(%{{.*}}, %{{.*}}, %{{.*}}) [^[[b1:.*]], ^[[b1]]] <{"operandSegmentSizes" = array<i32: 1, 1, 1>}> : (i1, i32, i32) -> ()
 // CHECK-NEXT:     ^[[b1]](%{{.*}} : i32):
 // CHECK-NEXT:       "llvm.br"(%{{.*}}) [^[[b2:.*]]] : (i32) -> ()
 // CHECK-NEXT:     ^[[b2]](%{{.*}} : i32):

--- a/Test/LLVM/store.mlir
+++ b/Test/LLVM/store.mlir
@@ -18,8 +18,8 @@
 // CHECK-NEXT:       ^{{.*}}(%[[ARG:.*]] : i64):
 // CHECK-NEXT:         %[[C1:.*]] = "llvm.mlir.constant"() <{"value" = 1 : i64}> : () -> i64
 // CHECK-NEXT:         %[[PTR:.*]] = "llvm.alloca"(%[[C1]]) <{"alignment" = 0 : i64, "elem_type" = i64}> : (i64) -> !llvm.ptr
-// CHECK-NEXT:         "llvm.store"(%[[ARG]], %[[PTR]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (i64, !llvm.ptr) -> ()
-// CHECK-NEXT:         %[[LD:.*]] = "llvm.load"(%[[PTR]]) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i64
+// CHECK-NEXT:         "llvm.store"(%[[ARG]], %[[PTR]]) <{"alignment" = 0 : i64}> : (i64, !llvm.ptr) -> ()
+// CHECK-NEXT:         %[[LD:.*]] = "llvm.load"(%[[PTR]]) <{"alignment" = 0 : i64}> : (!llvm.ptr) -> i64
 // CHECK-NEXT:         "llvm.return"(%[[LD]]) : (i64) -> ()
 // CHECK-NEXT:     }) : () -> ()
 // CHECK-NEXT: }) : () -> ()

--- a/Test/Passes/CSE/memory.mlir
+++ b/Test/Passes/CSE/memory.mlir
@@ -3,8 +3,8 @@
 "builtin.module"() ({
   "llvm.func"()  <{function_type = !llvm.func<void (!llvm.ptr)>, sym_name = "foo"}> ({
 ^bb0(%ptr : !llvm.ptr):
-    %load0 = "llvm.load"(%ptr) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
-    %load1 = "llvm.load"(%ptr) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 4 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i32
+    %load0 = "llvm.load"(%ptr) <{"alignment" = 4 : i64}> : (!llvm.ptr) -> i32
+    %load1 = "llvm.load"(%ptr) <{"alignment" = 4 : i64}> : (!llvm.ptr) -> i32
     "test.test"(%load0, %load1) : (i32, i32) -> ()
 
     // CHECK-LABEL: ^{{.*}}(%{{.*}} : !llvm.ptr):

--- a/Test/Passes/CirToStd/branches.mlir
+++ b/Test/Passes/CirToStd/branches.mlir
@@ -24,7 +24,7 @@
 // The forwarded operand is cast to the retyped block argument; the block arguments of the
 // successors are already `i32`, so no cast survives inside them.
 // CHECK-NEXT: [[A1:%.*]] = "builtin.unrealized_conversion_cast"([[A]]) : (!cir.int<s, 32>) -> i32
-// CHECK-NEXT: "cf.cond_br"([[COND]], [[A1]]) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
+// CHECK-NEXT: "cf.cond_br"([[COND]], [[A1]]) [^{{.*}}, ^{{.*}}] <{"operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
 // CHECK-NEXT: ^{{.*}}([[X:%.*]] : i32):
 // CHECK-NEXT: "cf.br"([[X]]) [^{{.*}}] : (i32) -> ()
 // CHECK-NEXT: ^{{.*}}():

--- a/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
+++ b/Test/Passes/InstructionSelection/RISCV64/load_invalid.mlir
@@ -5,7 +5,7 @@
     ^bb0(%a: !llvm.ptr):
         // i16 loads are not supported (only i64/i32/i8), so this stays un-lowered.
         %val = "llvm.load"(%a) : (!llvm.ptr) -> i16
-        // CHECK: {{.*}} = "llvm.load"({{.*}}) <{"access_groups" = [], "alias_scopes" = [], "alignment" = 0 : i64, "noalias_scopes" = [], "tbaa" = []}> : (!llvm.ptr) -> i16
+        // CHECK: {{.*}} = "llvm.load"({{.*}}) <{"alignment" = 0 : i64}> : (!llvm.ptr) -> i16
         "test.test"(%val) : (i16) -> ()
         "func.return"() : () -> ()
     }) : () -> ()

--- a/Test/Passes/pass_group_cir.mlir
+++ b/Test/Passes/pass_group_cir.mlir
@@ -44,7 +44,7 @@
 // CHECK-NEXT: ^{{.*}}([[A:%.*]] : i32):
 // CHECK-NEXT: [[ZERO:%.*]] = "arith.constant"() <{"value" = 0 : i32}> : () -> i32
 // CHECK-NEXT: [[COND:%.*]] = "arith.cmpi"([[A]], [[ZERO]]) <{"predicate" = 1 : i64}> : (i32, i32) -> i1
-// CHECK-NEXT: "cf.cond_br"([[COND]], [[A]]) [^{{.*}}, ^{{.*}}] <{"branch_weights" = array<i32>, "operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
+// CHECK-NEXT: "cf.cond_br"([[COND]], [[A]]) [^{{.*}}, ^{{.*}}] <{"operandSegmentSizes" = array<i32: 1, 1, 0>}> : (i1, i32) -> ()
 // CHECK-NEXT: ^{{.*}}([[X:%.*]] : i32):
 // CHECK-NEXT: "cf.br"([[X]]) [^{{.*}}] : (i32) -> ()
 // CHECK-NEXT: ^{{.*}}():

--- a/Veir/Dialects/Cf/OpInfo.lean
+++ b/Veir/Dialects/Cf/OpInfo.lean
@@ -33,9 +33,10 @@ def Cf.toAttrDict
     (op : Cf) (props : Cf.propertiesOf op) :
     Std.HashMap ByteArray Attribute :=
   match op with
-  | .cond_br =>
-    let dict := (Std.HashMap.emptyWithCapacity 2).insert
-      "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
+  | .cond_br => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    if props.branch_weights.values.size ≠ 0 then
+      dict := dict.insert "branch_weights".toUTF8 (.denseArrayAttr props.branch_weights)
     dict.insert "operandSegmentSizes".toUTF8
       (Attribute.denseArrayAttr props.operandSegmentSizes)
   | _ => Std.HashMap.emptyWithCapacity 0

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -252,8 +252,9 @@ def Llvm.toAttrDict
     dict
   | .cond_br => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 3
-    dict := dict.insert
-      "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
+    if props.branch_weights.values.size ≠ 0 then
+      dict := dict.insert
+        "branch_weights".toUTF8 (Attribute.denseArrayAttr props.branch_weights)
     if let some annotation := props.loop_annotation then
       dict := dict.insert "loop_annotation".toUTF8 (.loopAnnotationAttr annotation)
     dict := dict.insert "operandSegmentSizes".toUTF8
@@ -330,10 +331,14 @@ def Llvm.toAttrDict
       dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
     if let some syncscope := props.syncscope then
       dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
-    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
-    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
-    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
-    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
+    if props.access_groups.value.size ≠ 0 then
+      dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
+    if props.alias_scopes.value.size ≠ 0 then
+      dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
+    if props.noalias_scopes.value.size ≠ 0 then
+      dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
+    if props.tbaa.value.size ≠ 0 then
+      dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
     dict
   | .store => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 9
@@ -346,10 +351,14 @@ def Llvm.toAttrDict
       dict := dict.insert "invariantGroup".toUTF8 (.unitAttr UnitAttr.mk)
     if let some syncscope := props.syncscope then
       dict := dict.insert "syncscope".toUTF8 (.stringAttr syncscope)
-    dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
-    dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
-    dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
-    dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
+    if props.access_groups.value.size ≠ 0 then
+      dict := dict.insert "access_groups".toUTF8 (.arrayAttr props.access_groups)
+    if props.alias_scopes.value.size ≠ 0 then
+      dict := dict.insert "alias_scopes".toUTF8 (.arrayAttr props.alias_scopes)
+    if props.noalias_scopes.value.size ≠ 0 then
+      dict := dict.insert "noalias_scopes".toUTF8 (.arrayAttr props.noalias_scopes)
+    if props.tbaa.value.size ≠ 0 then
+      dict := dict.insert "tbaa".toUTF8 (.arrayAttr props.tbaa)
     dict
   | .insertvalue | .extractvalue =>
     (Std.HashMap.emptyWithCapacity 1).insert


### PR DESCRIPTION
MLIR's generic printer leaves `access_groups`, `alias_scopes`, `noalias_scopes`, `tbaa` and `branch_weights` out when they are empty, but VeIR materialized them on every `llvm.load`, `llvm.store`, `llvm.cond_br` and `cf.cond_br`. On the sqlite corpus that put four empty lists on 126,739 loads and stores and an empty weight array on 16,210 branches, so almost every chunk differed textually from `mlir-opt`'s output. The printers now emit these only when non-empty; the memory intrinsics keep printing explicitly written empty lists, as MLIR does. The affected tests drop the defaults from their CHECK lines.