### PR TITLE
feat(interpreter): add simple memory object model

### DIFF
--- a/Test/Interpreter/LLVM/alloca_out_of_bounds.mlir
+++ b/Test/Interpreter/LLVM/alloca_out_of_bounds.mlir
@@ -1,0 +1,19 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    %one = "llvm.mlir.constant"() <{value = 1 : i64}> : () -> i64
+    %i = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+    %three = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
+    %five = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
+    %p = "llvm.alloca"(%one) <{elem_type = i64}> : (i64) -> !llvm.ptr
+    %q = "llvm.alloca"(%one) <{elem_type = i64}> : (i64) -> !llvm.ptr
+    %p1 = "llvm.getelementptr"(%p, %i) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    "llvm.store"(%five, %q) : (i32, !llvm.ptr) -> ()
+    "llvm.store"(%three, %p1) : (i32, !llvm.ptr) -> ()
+    %v = "llvm.load"(%q) : (!llvm.ptr) -> i32
+    "func.return"(%v) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/free_use_after_free.mlir
+++ b/Test/Interpreter/LLVM/free_use_after_free.mlir
@@ -1,0 +1,26 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<ptr (i64)>, linkage = #llvm.linkage<external>, sym_name = "malloc"}> ({
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (ptr)>, linkage = #llvm.linkage<external>, sym_name = "free"}> ({
+  }) : () -> ()
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    %eight = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+    %i = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
+    %j = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
+    %three = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
+    %five = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
+    %p = "llvm.call"(%eight) <{callee = @malloc, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> !llvm.ptr
+    %q = "llvm.call"(%eight) <{callee = @malloc, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> !llvm.ptr
+    %p1 = "llvm.getelementptr"(%p, %i) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    %q1 = "llvm.getelementptr"(%q, %j) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    "llvm.store"(%three, %p1) : (i32, !llvm.ptr) -> ()
+    "llvm.store"(%five, %q1) : (i32, !llvm.ptr) -> ()
+    "llvm.call"(%p) <{callee = @free, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (!llvm.ptr) -> ()
+    %v = "llvm.load"(%p1) : (!llvm.ptr) -> i32
+    "func.return"(%v) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Test/Interpreter/LLVM/malloc_distinct_objects.mlir
+++ b/Test/Interpreter/LLVM/malloc_distinct_objects.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<ptr (i64)>, linkage = #llvm.linkage<external>, sym_name = "malloc"}> ({
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (ptr)>, linkage = #llvm.linkage<external>, sym_name = "free"}> ({
+  }) : () -> ()
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    %eight = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+    %i = "llvm.mlir.constant"() <{value = 4 : i64}> : () -> i64
+    %j = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
+    %three = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
+    %five = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
+    %p = "llvm.call"(%eight) <{callee = @malloc, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> !llvm.ptr
+    %q = "llvm.call"(%eight) <{callee = @malloc, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> !llvm.ptr
+    %p1 = "llvm.getelementptr"(%p, %i) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    %q1 = "llvm.getelementptr"(%q, %j) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    "llvm.store"(%three, %p1) : (i32, !llvm.ptr) -> ()
+    "llvm.store"(%five, %q1) : (i32, !llvm.ptr) -> ()
+    %v = "llvm.load"(%p1) : (!llvm.ptr) -> i32
+    "func.return"(%v) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0x00000003#32]

--- a/Test/Interpreter/LLVM/malloc_out_of_bounds.mlir
+++ b/Test/Interpreter/LLVM/malloc_out_of_bounds.mlir
@@ -1,0 +1,25 @@
+// RUN: veir-interpret %s | filecheck %s
+
+"builtin.module"() ({
+  "llvm.func"() <{function_type = !llvm.func<ptr (i64)>, linkage = #llvm.linkage<external>, sym_name = "malloc"}> ({
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<void (ptr)>, linkage = #llvm.linkage<external>, sym_name = "free"}> ({
+  }) : () -> ()
+  "func.func"() <{sym_name = "main", function_type = () -> i32}> ({
+    %eight = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+    %i = "llvm.mlir.constant"() <{value = 8 : i64}> : () -> i64
+    %j = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
+    %three = "llvm.mlir.constant"() <{value = 3 : i32}> : () -> i32
+    %five = "llvm.mlir.constant"() <{value = 5 : i32}> : () -> i32
+    %p = "llvm.call"(%eight) <{callee = @malloc, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> !llvm.ptr
+    %q = "llvm.call"(%eight) <{callee = @malloc, op_bundle_sizes = array<i32>, operandSegmentSizes = array<i32: 1, 0>}> : (i64) -> !llvm.ptr
+    %p1 = "llvm.getelementptr"(%p, %i) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    %q1 = "llvm.getelementptr"(%q, %j) <{elem_type = i8, rawConstantIndices = array<i32: -2147483648>}> : (!llvm.ptr, i64) -> !llvm.ptr
+    "llvm.store"(%three, %p1) : (i32, !llvm.ptr) -> ()
+    "llvm.store"(%five, %q1) : (i32, !llvm.ptr) -> ()
+    %v = "llvm.load"(%p1) : (!llvm.ptr) -> i32
+    "func.return"(%v) : (i32) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Undefined behavior

--- a/Veir/Interpreter/Basic.lean
+++ b/Veir/Interpreter/Basic.lean
@@ -369,7 +369,7 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
     match resType.val with
     | .integerType bw =>
       return (#[.int bw.bitwidth (LLVM.Int.val (BitVec.ofNat bw.bitwidth 0))], mem, none)
-    | .llvmPointerType _ => return (#[.addr 0], mem, none)
+    | .llvmPointerType _ => return (#[.addr .null], mem, none)
     | _ => none
   | .add => do
     let [.int bw lhs, .int bw' rhs] := operands.toList | none
@@ -614,13 +614,27 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
       return (#[], mem, some (.branch (operands.extract 1 (1 + defaultSize)) destDefault))
     | .int _ .poison => Interp.ub
     | _ => none
+  | .call => do
+    /- Only the C allocation functions are modelled. Each `malloc` yields a
+       fresh object, so pointers into different allocations never alias. -/
+    let some callee := properties.callee | none
+    match callee.value, operands.toList with
+    | "@malloc", [.int _ size] =>
+      match size with
+      | .val size =>
+        let (mem, ptr) := mem.alloc size.toNat
+        return (#[.addr ptr], mem, none)
+      | .poison => Interp.ub
+    | "@free", [.addr ptr] =>
+      let mem ← mem.free ptr
+      return (#[], mem, none)
+    | _, _ => none
   | .alloca => do
     let [.int _ (.val count)] := operands.toList | none
     /- `alloca T, N` reserves `N` strides of `T`, as in LLVM. -/
     let size ← layout.getTypeAllocSize properties.elem_type.val
-    let totalSize := (size * count.toNat).toUInt64
-    let (mem, addr) := mem.alloc totalSize
-    return (#[.addr addr], mem, none)
+    let (mem, ptr) := mem.alloc (size * count.toNat)
+    return (#[.addr ptr], mem, none)
   | .load => do
     let [.addr addr] := operands.toList | none
     let [type] := resultTypes.toList | none
@@ -637,7 +651,8 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
        that `isel-riscv64` uses to lower this operation. -/
     let size ← layout.getTypeAllocSize properties.elem_type.val
     match idx with
-    | .val idx => return (#[.addr (ptr.toNat + idx.toNat * size).toUInt64], mem, none)
+    | .val idx =>
+      return (#[.addr { ptr with offset := UInt32.ofNat (ptr.offset.toNat + idx.toNat * size) }], mem, none)
     | .poison => Interp.ub
   | .freeze => do
     let [val] := operands.toList | none
@@ -660,10 +675,10 @@ def Llvm.interpretOp' (opType : Veir.Llvm) (properties : propertiesOf opType)
       | .byte bw1 val', .integerType ⟨bw2⟩ =>
           if bw1 ≠ bw2 then .fail else .ok ((.int bw1 $ val'.toInt))
       | .byte bw val', .llvmPointerType _ =>
-          if h : bw = 64 then .ok ((.addr (val'.cast h).toUInt64)) else .fail
+          if h : bw = 64 then .ok (.addr (Pointer.ofUInt64 (val'.cast h).toUInt64)) else .fail
       | .addr val', .llvmPointerType _ => .ok (val)
       | .addr val', .byteType ⟨bw⟩ =>
-          if h : bw = 64 then .ok ((.byte 64 $ LLVM.Byte.fromUInt64 val')) else .fail
+          if h : bw = 64 then .ok ((.byte 64 $ LLVM.Byte.fromUInt64 val'.toUInt64)) else .fail
       | _, _ => none
     return (#[result], mem, none)
   | _ => none
@@ -683,8 +698,9 @@ inductive LoadExtension
     grown so that the access is in bounds and cannot raise UB. -/
 def riscvLoad (mem : MemoryState) (eaddr : BitVec 64) (bytes : Nat) (ext : LoadExtension) :
     Interp (BitVec 64 × MemoryState) := do
-  let mem := mem.ensureSize (eaddr.toNat + bytes)
-  let ba ← mem.load eaddr.toNat.toUInt64 bytes.toUInt64
+  let p := Pointer.ofUInt64 (UInt64.ofBitVec eaddr)
+  let mem := mem.ensureSize p bytes
+  let ba ← mem.load p bytes
   let val := ba.toBitVecLE bytes
   let extended := match ext with
     | .signExt => val.signExtend 64
@@ -1055,29 +1071,33 @@ def Riscv.interpretOp' (opType : Veir.Riscv) (properties : propertiesOf opType)
   | .sd => do
     let [.reg { val }, .reg addr] := operands.toList | none
     let eaddr := riscvEffectiveAddr addr.val properties.value.value
-    let mem := mem.ensureSize (eaddr.toNat + 8)
-    let mem ← mem.store eaddr.toNat.toUInt64 (UInt64.ofBitVec val).toByteArrayLE
+    let p := Pointer.ofUInt64 (UInt64.ofBitVec eaddr)
+    let mem := mem.ensureSize p 8
+    let mem ← mem.store p (UInt64.ofBitVec val).toByteArrayLE
     return (#[], mem, none)
   | .sw => do
     let [.reg { val }, .reg addr] := operands.toList | none
     let eaddr := riscvEffectiveAddr addr.val properties.value.value
-    let mem := mem.ensureSize (eaddr.toNat + 4)
+    let p := Pointer.ofUInt64 (UInt64.ofBitVec eaddr)
+    let mem := mem.ensureSize p 4
     -- store only the low 4 bytes of the register
-    let mem ← mem.store eaddr.toNat.toUInt64 ((UInt64.ofBitVec val).toByteArrayLE.extract 0 4)
+    let mem ← mem.store p ((UInt64.ofBitVec val).toByteArrayLE.extract 0 4)
     return (#[], mem, none)
   | .sh => do
     let [.reg { val }, .reg addr] := operands.toList | none
     let eaddr := riscvEffectiveAddr addr.val properties.value.value
-    let mem := mem.ensureSize (eaddr.toNat + 2)
+    let p := Pointer.ofUInt64 (UInt64.ofBitVec eaddr)
+    let mem := mem.ensureSize p 2
     -- store only the low 2 bytes of the register
-    let mem ← mem.store eaddr.toNat.toUInt64 ((UInt64.ofBitVec val).toByteArrayLE.extract 0 2)
+    let mem ← mem.store p ((UInt64.ofBitVec val).toByteArrayLE.extract 0 2)
     return (#[], mem, none)
   | .sb => do
     let [.reg { val }, .reg addr] := operands.toList | none
     let eaddr := riscvEffectiveAddr addr.val properties.value.value
-    let mem := mem.ensureSize (eaddr.toNat + 1)
+    let p := Pointer.ofUInt64 (UInt64.ofBitVec eaddr)
+    let mem := mem.ensureSize p 1
     -- store only the low byte of the register
-    let mem ← mem.store eaddr.toNat.toUInt64 ((UInt64.ofBitVec val).toByteArrayLE.extract 0 1)
+    let mem ← mem.store p ((UInt64.ofBitVec val).toByteArrayLE.extract 0 1)
     return (#[], mem, none)
 
 def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : propertiesOf opType)
@@ -1086,8 +1106,8 @@ def Riscv_Stack.interpretOp' (opType : Veir.Riscv_Stack) (properties : propertie
     : Interp ((Array RuntimeValue) × MemoryState × Option ControlFlowAction) :=
   match opType with
   | .alloca => do
-    let (mem, addr) := mem.alloc properties.size.value.toNat.toUInt64
-    return (#[.reg ⟨.ofNat 64 addr.toNat⟩], mem, none)
+    let (mem, ptr) := mem.alloc properties.size.value.toNat
+    return (#[.reg ⟨ptr.toUInt64.toBitVec⟩], mem, none)
 
 def Riscv_Cf.interpretOp' (opType : Veir.Riscv_Cf) (properties : propertiesOf opType)
     (_resultTypes : Array TypeAttr) (operands : Array RuntimeValue) (blockOperands : Array BlockPtr)
@@ -1288,7 +1308,7 @@ def interpretOp' (opType : OpCode) (properties : propertiesOf opType)
     | .registerType _, [.byte _bw val] =>
       return (#[.reg (LLVM.Byte.toReg val)], mem, none)
     | .registerType _, [.addr val] =>
-      return (#[.reg ⟨val.toNat⟩], mem, none)
+      return (#[.reg ⟨val.toUInt64.toBitVec⟩], mem, none)
     | .integerType _bw, [.reg val] =>
       let .integerType resBw := resType.val | none
       return (#[.int resBw.bitwidth (RISCV.Reg.toInt val resBw.bitwidth)], mem, none)
@@ -1296,7 +1316,7 @@ def interpretOp' (opType : OpCode) (properties : propertiesOf opType)
       let .byteType resBw := resType.val | none
       return (#[.byte resBw.bitwidth (RISCV.Reg.toByte val resBw.bitwidth)], mem, none)
     | .llvmPointerType _, [.reg val] =>
-      return (#[.addr ⟨val.val⟩], mem, none)
+      return (#[.addr (Pointer.ofUInt64 ⟨val.val⟩)], mem, none)
     | _ , _ => none
   | _ => none
 

--- a/Veir/Interpreter/Memory.lean
+++ b/Veir/Interpreter/Memory.lean
@@ -10,122 +10,154 @@ open Veir.Data
 namespace Veir
 
 /--
-  Memory state during interpretation.
-  Set bits in the poison mask represent poison bits.
+  One allocation during interpretation: its bytes and a poison mask in which
+  set bits mark poison bits.
 -/
 @[ext]
-structure MemoryState where
+structure MemoryObject where
   contents : ByteArray
   poisonMask : ByteArray
   consistentSize : contents.size = poisonMask.size
 
-def MemoryState.empty : MemoryState := {
-  contents := (ByteArray.emptyWithCapacity 1024).extend 8 0xff,
-  poisonMask := (ByteArray.emptyWithCapacity 1024).extend 8 0xff,
-  consistentSize := (by grind)
-}
+/-- An object of `size` bytes, all of them poison. -/
+def MemoryObject.ofSize (size : Nat) : MemoryObject :=
+  ⟨ByteArray.replicate size 0, ByteArray.replicate size 0xff, by grind⟩
 
-def MemoryState.ensureSize (mem : MemoryState) (size : Nat) : MemoryState :=
-  if mem.contents.size < size then
-    ⟨mem.contents.extend (size - mem.contents.size) 0,
-      mem.poisonMask.extend (size - mem.contents.size) 0xff,
-      (by simp [mem.consistentSize])⟩
+instance : Inhabited MemoryObject := ⟨MemoryObject.ofSize 0⟩
+
+/-- Grow the object to at least `size` bytes; the new bytes are poison. -/
+def MemoryObject.ensureSize (obj : MemoryObject) (size : Nat) : MemoryObject :=
+  if obj.contents.size < size then
+    ⟨obj.contents.extend (size - obj.contents.size) 0,
+      obj.poisonMask.extend (size - obj.contents.size) 0xff,
+      by simp [obj.consistentSize]⟩
   else
-    mem
+    obj
 
 /--
-  Allocate the given number of bytes of memory.
-  Return the updated memory state and the freshly allocated address.
+  Memory state during interpretation: one object per allocation, addressed by
+  `Pointer`. Object 0 is the null object. It holds no bytes, so it exists from
+  the start and every access through a null pointer is out of bounds.
 -/
-def MemoryState.alloc (state : MemoryState) (size : UInt64)
-    : MemoryState × UInt64 :=
-  (⟨state.contents.extend size.toNat 0,
-    state.poisonMask.extend size.toNat 0xff,
-    by simp [state.consistentSize]⟩, state.contents.size.toUInt64)
+@[ext]
+structure MemoryState where
+  objects : Array MemoryObject
+
+def MemoryState.empty : MemoryState := ⟨#[MemoryObject.ofSize 0]⟩
+
+def MemoryState.getObject? (mem : MemoryState) (p : Pointer) : Option MemoryObject :=
+  mem.objects[p.object.toNat]?
+
+def MemoryState.setObject (mem : MemoryState) (p : Pointer) (obj : MemoryObject) : MemoryState :=
+  ⟨mem.objects.setIfInBounds p.object.toNat obj⟩
 
 /--
-  Store raw bytes to the given address in memory,
-  and set the corresponding poison bits as requested (by default, unset).
-  Yields UB if the access is out of bounds.
+  Grow the object `p` points into so that `size` bytes at `p` are in bounds.
+  The RISC-V interpreter uses this to give machine code a memory that never
+  faults; LLVM accesses are bounds-checked instead.
 -/
-def MemoryState.store (state : MemoryState) (addr : UInt64) (val : ByteArray)
-  (poison : ByteArray := ByteArray.replicate val.size 0) (h : poison.size = val.size := by grind)
+def MemoryState.ensureSize (mem : MemoryState) (p : Pointer) (size : Nat) : MemoryState :=
+  match mem.getObject? p with
+  | some obj => mem.setObject p (obj.ensureSize (p.offset.toNat + size))
+  | none => mem
+
+/-- Allocate a fresh object of `size` bytes and return a pointer to its start. -/
+def MemoryState.alloc (mem : MemoryState) (size : Nat) : MemoryState × Pointer :=
+  (⟨mem.objects.push (MemoryObject.ofSize size)⟩, ⟨mem.objects.size.toUInt32, 0⟩)
+
+/--
+  Free the object `p` points to. Freeing the null pointer does nothing, as in
+  C; freeing through an offset pointer or a pointer to no object is UB. The
+  object is emptied rather than removed, so later accesses to it are UB.
+-/
+def MemoryState.free (mem : MemoryState) (p : Pointer) : Interp MemoryState :=
+  if p.isNull then return mem else
+  match mem.getObject? p with
+  | none => Interp.ub
+  | some _ => if p.offset ≠ 0 then Interp.ub else return mem.setObject p (MemoryObject.ofSize 0)
+
+/--
+  Store raw bytes at `p`, and set the corresponding poison bits as requested
+  (by default, unset). Yields UB if the access leaves the object.
+-/
+def MemoryState.store (mem : MemoryState) (p : Pointer) (val : ByteArray)
+    (poison : ByteArray := ByteArray.replicate val.size 0) (h : poison.size = val.size := by grind)
     : Interp MemoryState :=
-  if addr.toNat + val.size ≤ state.contents.size then
-    return ⟨val.copySlice 0 state.contents addr.toNat val.size false,
-      poison.copySlice 0 state.poisonMask addr.toNat val.size false,
-      by
-        simp [ByteArray.copySlice_eq_append, state.consistentSize, h]
-      ⟩
-  else
-    Interp.ub
+  match mem.getObject? p with
+  | none => Interp.ub
+  | some obj =>
+    if p.offset.toNat + val.size ≤ obj.contents.size then
+      return mem.setObject p ⟨val.copySlice 0 obj.contents p.offset.toNat val.size false,
+        poison.copySlice 0 obj.poisonMask p.offset.toNat val.size false,
+        by simp [ByteArray.copySlice_eq_append, obj.consistentSize, h]⟩
+    else
+      Interp.ub
 
 /--
-  Poison the given number n of bytes, starting from the given address in memory.
-  Yields UB if the access is out of bounds.
+  Poison `n` bytes starting at `p`. Yields UB if the access leaves the object.
 -/
-def MemoryState.empoison (state : MemoryState) (addr : UInt64) (n : Nat)
-    : Interp MemoryState :=
-  if h : addr.toNat + n ≤ state.poisonMask.size then
-    let mask := ByteArray.replicate n 0xff
-    return ⟨state.contents,
-      mask.copySlice 0 state.poisonMask addr.toNat n false,
-      by
-        have h' : min n mask.size = n := by grind
-        have h'' : min addr.toNat state.poisonMask.size = addr.toNat := by grind
-        simp [ByteArray.copySlice_eq_append, state.consistentSize, h', h'']
-        grind
-
-      ⟩
-  else
-    Interp.ub
+def MemoryState.empoison (mem : MemoryState) (p : Pointer) (n : Nat) : Interp MemoryState :=
+  match mem.getObject? p with
+  | none => Interp.ub
+  | some obj =>
+    if h : p.offset.toNat + n ≤ obj.poisonMask.size then
+      let mask := ByteArray.replicate n 0xff
+      return mem.setObject p ⟨obj.contents,
+        mask.copySlice 0 obj.poisonMask p.offset.toNat n false,
+        by
+          have h' : min n mask.size = n := by grind
+          have h'' : min p.offset.toNat obj.poisonMask.size = p.offset.toNat := by grind
+          simp [ByteArray.copySlice_eq_append, obj.consistentSize, h', h'']
+          grind⟩
+    else
+      Interp.ub
 
 /--
-  Store an LLVM value to memory.
-  Yields UB if the access is out of bounds or the address is 0.
+  Store an LLVM value at `p`.
+  Yields UB if the access leaves the object or the pointer is null.
 -/
-def MemoryState.llvmStore (state : MemoryState) (addr : UInt64) (val : RuntimeValue)
+def MemoryState.llvmStore (mem : MemoryState) (p : Pointer) (val : RuntimeValue)
     : Interp MemoryState :=
-  if addr.toNat == 0 then Interp.ub else
+  if p.isNull then Interp.ub else
   match val with
-  | .int 8 (.val v) => state.store addr (ByteArray.empty.push (UInt8.ofBitVec v))
-  | .int 16 (.val v) => state.store addr (UInt16.ofBitVec v).toByteArrayLE
-  | .int 32 (.val v) => state.store addr (UInt32.ofBitVec v).toByteArrayLE
-  | .int 64 (.val v) => state.store addr (UInt64.ofBitVec v).toByteArrayLE
-  | .byte 64 v => state.store addr (UInt64.ofBitVec v.val).toByteArrayLE (UInt64.ofBitVec v.poison).toByteArrayLE (by simp)
-  | .int n .poison => state.empoison addr (n / 8)
-  | .addr v => state.store addr v.toByteArrayLE
+  | .int 8 (.val v) => mem.store p (ByteArray.empty.push (UInt8.ofBitVec v))
+  | .int 16 (.val v) => mem.store p (UInt16.ofBitVec v).toByteArrayLE
+  | .int 32 (.val v) => mem.store p (UInt32.ofBitVec v).toByteArrayLE
+  | .int 64 (.val v) => mem.store p (UInt64.ofBitVec v).toByteArrayLE
+  | .byte 64 v => mem.store p (UInt64.ofBitVec v.val).toByteArrayLE (UInt64.ofBitVec v.poison).toByteArrayLE (by simp)
+  | .int n .poison => mem.empoison p (n / 8)
+  | .addr v => mem.store p v.toUInt64.toByteArrayLE
   | _ => none
 
 /--
-  Load raw bytes from the given memory address.
-  Yields UB if the access is out of bounds.
+  Load `size` raw bytes at `p`. Yields UB if the access leaves the object.
 -/
-def MemoryState.load (state : MemoryState) (addr size : UInt64)
-    : Interp ByteArray :=
-  if addr.toNat + size.toNat <= state.contents.size then
-    return state.contents.extract addr.toNat (addr + size).toNat
-  else
-    Interp.ub
+def MemoryState.load (mem : MemoryState) (p : Pointer) (size : Nat) : Interp ByteArray :=
+  match mem.getObject? p with
+  | none => Interp.ub
+  | some obj =>
+    if p.offset.toNat + size ≤ obj.contents.size then
+      return obj.contents.extract p.offset.toNat (p.offset.toNat + size)
+    else
+      Interp.ub
 
 /--
-  Load bitwise poison status of the given memory address.
-  Yields UB if the access is out of bounds.
+  Load the poison mask of `size` bytes at `p`. Yields UB if the access leaves the object.
 -/
-def MemoryState.loadPoison (state : MemoryState) (addr size : UInt64)
-    : Interp ByteArray :=
-  if addr.toNat + size.toNat <= state.poisonMask.size then
-    return state.poisonMask.extract addr.toNat (addr + size).toNat
-  else
-    Interp.ub
+def MemoryState.loadPoison (mem : MemoryState) (p : Pointer) (size : Nat) : Interp ByteArray :=
+  match mem.getObject? p with
+  | none => Interp.ub
+  | some obj =>
+    if p.offset.toNat + size ≤ obj.poisonMask.size then
+      return obj.poisonMask.extract p.offset.toNat (p.offset.toNat + size)
+    else
+      Interp.ub
 
 /--
-  Check if any of the `size` bytes at the given memory address `addr` is poison.
-  Yields UB if the access is out of bounds.
+  Check if any of the `size` bytes at `p` is poison. Yields UB if the access leaves the object.
 -/
-def MemoryState.hasPoison (state : MemoryState) (addr size : UInt64)
-    : Interp Bool := do
-  let poisonMask ← state.loadPoison addr size
+def MemoryState.hasPoison (mem : MemoryState) (p : Pointer) (size : Nat) : Interp Bool := do
+  let poisonMask ← mem.loadPoison p size
   let mut poison := false
   for b in poisonMask do
     if b ≠ 0 then
@@ -134,39 +166,39 @@ def MemoryState.hasPoison (state : MemoryState) (addr size : UInt64)
   return poison
 
 /--
-  Load an LLVM value from the given memory address.
-  Yields UB if access is out of bounds or the address is 0.
+  Load an LLVM value of type `type` from `p`.
+  Yields UB if the access leaves the object or the pointer is null.
 -/
-def MemoryState.llvmLoad (state : MemoryState) (addr : UInt64) (type : TypeAttr)
+def MemoryState.llvmLoad (mem : MemoryState) (p : Pointer) (type : TypeAttr)
     : Interp RuntimeValue := do
-  if addr == 0 then Interp.ub else
+  if p.isNull then Interp.ub else
   match type.val with
   | Attribute.integerType { bitwidth := 8 } =>
-      let ba ← state.load addr 1
-      if ← state.hasPoison addr 1 then return .int 8 .poison
+      let ba ← mem.load p 1
+      if ← mem.hasPoison p 1 then return .int 8 .poison
       return .int 8 (.val ba[0]!.toNat)
   | Attribute.integerType { bitwidth := 16 } =>
-      let ba ← state.load addr 2
-      if ← state.hasPoison addr 2 then return .int 16 .poison
+      let ba ← mem.load p 2
+      if ← mem.hasPoison p 2 then return .int 16 .poison
       return .int 16 (.val (ba.toBitVecLE 2))
   | Attribute.integerType { bitwidth := 32 } =>
-      let ba ← state.load addr 4
-      if ← state.hasPoison addr 4 then return .int 32 .poison
+      let ba ← mem.load p 4
+      if ← mem.hasPoison p 4 then return .int 32 .poison
       return .int 32 (.val (ba.toBitVecLE 4))
   | Attribute.integerType { bitwidth := 64 } =>
-      let ba ← state.load addr 8
-      if ← state.hasPoison addr 8 then return .int 64 .poison
+      let ba ← mem.load p 8
+      if ← mem.hasPoison p 8 then return .int 64 .poison
       return .int 64 (.val (BitVec.ofNat 64 ba.toUInt64LE!.toNat))
   | Attribute.byteType { bitwidth := 64 } =>
-      let ba ← state.load addr 8
-      let baPoison ← state.loadPoison addr 8
+      let ba ← mem.load p 8
+      let baPoison ← mem.loadPoison p 8
       let poison := baPoison.toUInt64LE!.toBitVec
       return .byte 64 ⟨ba.toUInt64LE!.toBitVec &&& ~~~poison, poison, by bv_decide⟩
   | Attribute.llvmPointerType _ =>
-      let ba ← state.load addr 8
+      let ba ← mem.load p 8
       -- FIXME poison address
-      if ← state.hasPoison addr 8 then return .addr 0
-      return .addr ba.toUInt64LE!
+      if ← mem.hasPoison p 8 then return .addr .null
+      return .addr (Pointer.ofUInt64 ba.toUInt64LE!)
   | _ => none
 
 end Veir

--- a/Veir/Interpreter/Refinement/Basic.lean
+++ b/Veir/Interpreter/Refinement/Basic.lean
@@ -59,12 +59,19 @@ def RuntimeValue.arrayIsRefinedBy (source target : Array RuntimeValue) : Prop :=
 @[inherit_doc] infix:50 " ⊒ " => RuntimeValue.arrayIsRefinedBy
 
 /--
-Refinement of memory states, which can involve poison bits being refined into concrete bits.
+Refinement of memory objects, which can involve poison bits being refined into concrete bits.
 This should be kept consistent with the definition of refinement on the byte type.
 -/
 @[expose]
-def MemoryState.isRefinedBy (source target : MemoryState) : Prop :=
+def MemoryObject.isRefinedBy (source target : MemoryObject) : Prop :=
   ∀ addr, source.poisonMask.getD addr 0 ||| ((source.contents.getD addr 0 ^^^ ~~~target.contents.getD addr 0) &&& ~~~target.poisonMask.getD addr 0) = 0xff
+
+@[inherit_doc] infix:50 " ⊒ " => MemoryObject.isRefinedBy
+
+/-- Refinement of memory states: the same objects, each refined bytewise. -/
+@[expose]
+def MemoryState.isRefinedBy (source target : MemoryState) : Prop :=
+  source.objects.size = target.objects.size ∧ ∀ i : Nat, source.objects[i]! ⊒ target.objects[i]!
 
 @[inherit_doc] infix:50 " ⊒ " => MemoryState.isRefinedBy
 

--- a/Veir/Interpreter/Refinement/Lemmas.lean
+++ b/Veir/Interpreter/Refinement/Lemmas.lean
@@ -42,11 +42,16 @@ theorem RuntimeValue.arrayIsRefinedBy_cons {a b : RuntimeValue} {as bs : List Ru
   · grind
 
 @[simp, grind .]
-theorem MemoryState.isRefinedBy_refl (m : MemoryState) :
+theorem MemoryObject.isRefinedBy_refl (m : MemoryObject) :
     m ⊒ m := by
   simp only [isRefinedBy]
   bv_normalize
   grind
+
+@[simp, grind .]
+theorem MemoryState.isRefinedBy_refl (m : MemoryState) :
+    m ⊒ m :=
+  ⟨rfl, fun _ => MemoryObject.isRefinedBy_refl _⟩
 
 @[simp, grind .]
 theorem FunctionResult.isRefinedBy_refl (r : MemoryState × Array RuntimeValue) : r ⊒ r := by
@@ -88,7 +93,7 @@ theorem RuntimeValue.isRefinedBy_trans {v₁ v₂ v₃ : RuntimeValue}
     grind [RuntimeValue.isRefinedBy, isRefinedBy_trans,
       cases RuntimeValue, LLVM.Byte.isRefinedBy_trans]
 
-theorem MemoryState.isRefinedBy_trans {m1 m2 m3 : MemoryState}
+theorem MemoryObject.isRefinedBy_trans {m1 m2 m3 : MemoryObject}
     (h12 : m1 ⊒ m2) (h23 : m2 ⊒ m3) : m1 ⊒ m3 := by
   simp only [isRefinedBy] at *
   intro addr
@@ -96,6 +101,10 @@ theorem MemoryState.isRefinedBy_trans {m1 m2 m3 : MemoryState}
   specialize h23 addr
   bv_normalize
   grind
+
+theorem MemoryState.isRefinedBy_trans {m1 m2 m3 : MemoryState}
+    (h12 : m1 ⊒ m2) (h23 : m2 ⊒ m3) : m1 ⊒ m3 :=
+  ⟨h12.1.trans h23.1, fun i => MemoryObject.isRefinedBy_trans (h12.2 i) (h23.2 i)⟩
 
 theorem RuntimeValue.arrayIsRefinedBy_trans {a b c : Array RuntimeValue}
     (h12 : a ⊒ b) (h23 : b ⊒ c) : a ⊒ c := by
@@ -161,7 +170,7 @@ theorem RuntimeValue.float_of_isRefinedBy {ty : FloatType} {v : Data.Float.Float
   cases tv <;> grind [RuntimeValue.isRefinedBy]
 
 /-- A runtime value `tv` that refines an address runtime value `v` is equal to it. -/
-theorem RuntimeValue.addr_of_isRefinedBy {v : UInt64} {tv : RuntimeValue}
+theorem RuntimeValue.addr_of_isRefinedBy {v : Pointer} {tv : RuntimeValue}
     (h : RuntimeValue.addr v ⊒ tv) :
     tv = RuntimeValue.addr v := by
   cases tv <;> grind [RuntimeValue.isRefinedBy]

--- a/Veir/RuntimeValue/Basic.lean
+++ b/Veir/RuntimeValue/Basic.lean
@@ -9,6 +9,34 @@ public section
 namespace Veir
 
 /--
+  A pointer into interpreter memory: the object it may access and a byte
+  offset into it. Pointers derived from different objects never alias, and an
+  access outside the object is undefined behaviour. Stored to memory, cast to
+  an integer or moved into a register, the pair is packed into 64 bits with
+  the object above the offset, so objects are limited to 4 GiB.
+-/
+structure Pointer where
+  object : UInt32
+  offset : UInt32
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+namespace Pointer
+
+/-- The null pointer. Object 0 holds no bytes, so every access through it is UB. -/
+def null : Pointer := ⟨0, 0⟩
+
+def isNull (p : Pointer) : Bool := p == null
+
+def toUInt64 (p : Pointer) : UInt64 := (p.object.toUInt64 <<< 32) ||| p.offset.toUInt64
+
+def ofUInt64 (v : UInt64) : Pointer := ⟨(v >>> 32).toUInt32, v.toUInt32⟩
+
+instance : ToString Pointer where
+  toString p := s!"ptr({p.object}, {p.offset})"
+
+end Pointer
+
+/--
   The type-erased representation of a value used by interpretation and
   compile-time evaluation.
 -/
@@ -16,7 +44,7 @@ inductive RuntimeValue where
 | int (bitwidth : Nat) (value : Data.LLVM.Int bitwidth)
 | byte (bitwidth : Nat) (value : Data.LLVM.Byte bitwidth)
 | float (type : FloatType) (value : Data.Float.FloatValue type.format)
-| addr (value : UInt64)
+| addr (value : Pointer)
 | reg (value : Data.RISCV.Reg)
 /-- A canonical natural-number representative in the field identified by `fieldType`. -/
 | felt (fieldType : FeltType) (value : Nat)


### PR DESCRIPTION
We model pointers as an (object, offset) pair rather than a flat address, such that pointers derived from different allocations can never alias. As a result, accesses to addresses outside of the object's original allocation trigger undefined behaviour instead of silently reaching the neighbouring allocation.

Our memory now holds one object per allocation, with object 0 representing the null object.

We define two intrinsics that can allocate and release memory: malloc and free. 

