### PR TITLE
feat(LLVM): add llvm.insertelement

### DIFF
--- a/Test/LLVM/insertelement.mlir
+++ b/Test/LLVM/insertelement.mlir
@@ -1,0 +1,62 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  // The index may have any integer width.
+  "llvm.func"() <{function_type = !llvm.func<vector<4xi32> (vector<4xi32>, i32, i1, i8, i32, i64, i128)>, linkage = #llvm.linkage<external>, sym_name = "integer_indices"}> ({
+  ^bb0(%v: vector<4xi32>, %x: i32, %i1: i1, %i8: i8, %i32: i32, %i64: i64, %i128: i128):
+    %a = "llvm.insertelement"(%v, %x, %i1) : (vector<4xi32>, i32, i1) -> vector<4xi32>
+    %b = "llvm.insertelement"(%a, %x, %i8) : (vector<4xi32>, i32, i8) -> vector<4xi32>
+    %c = "llvm.insertelement"(%b, %x, %i32) : (vector<4xi32>, i32, i32) -> vector<4xi32>
+    %d = "llvm.insertelement"(%c, %x, %i64) : (vector<4xi32>, i32, i64) -> vector<4xi32>
+    %e = "llvm.insertelement"(%d, %x, %i128) : (vector<4xi32>, i32, i128) -> vector<4xi32>
+    "llvm.return"(%e) : (vector<4xi32>) -> ()
+  }) : () -> ()
+
+  // Out-of-range indices produce poison, but are valid IR.
+  "llvm.func"() <{function_type = !llvm.func<vector<4xi32> (vector<4xi32>, i32)>, linkage = #llvm.linkage<external>, sym_name = "out_of_range"}> ({
+  ^bb0(%v: vector<4xi32>, %x: i32):
+    %end = "llvm.mlir.constant"() <{value = 4 : i32}> : () -> i32
+    %negative = "llvm.mlir.constant"() <{value = -1 : i32}> : () -> i32
+    %a = "llvm.insertelement"(%v, %x, %end) : (vector<4xi32>, i32, i32) -> vector<4xi32>
+    %b = "llvm.insertelement"(%a, %x, %negative) : (vector<4xi32>, i32, i32) -> vector<4xi32>
+    "llvm.return"(%b) : (vector<4xi32>) -> ()
+  }) : () -> ()
+
+  "llvm.func"() <{function_type = !llvm.func<vector<1xi1> (i1, i64)>, linkage = #llvm.linkage<external>, sym_name = "single_lane"}> ({
+  ^bb0(%x: i1, %i: i64):
+    %v = "llvm.mlir.poison"() : () -> vector<1xi1>
+    %r = "llvm.insertelement"(%v, %x, %i) : (vector<1xi1>, i1, i64) -> vector<1xi1>
+    "llvm.return"(%r) : (vector<1xi1>) -> ()
+  }) : () -> ()
+
+  "llvm.func"() <{function_type = !llvm.func<vector<2x!llvm.ptr> (vector<2x!llvm.ptr>, !llvm.ptr, i64)>, linkage = #llvm.linkage<external>, sym_name = "pointers"}> ({
+  ^bb0(%v: vector<2x!llvm.ptr>, %p: !llvm.ptr, %i: i64):
+    %a = "llvm.insertelement"(%v, %p, %i) : (vector<2x!llvm.ptr>, !llvm.ptr, i64) -> vector<2x!llvm.ptr>
+    "llvm.return"(%a) : (vector<2x!llvm.ptr>) -> ()
+  }) : () -> ()
+
+  "llvm.func"() <{function_type = !llvm.func<void (vector<2xbf16>, bf16, vector<4xf16>, f16, vector<2xf32>, f32, vector<2xf64>, f64, i32)>, linkage = #llvm.linkage<external>, sym_name = "floats"}> ({
+  ^bb0(%a: vector<2xbf16>, %bf: bf16, %b: vector<4xf16>, %half: f16, %c: vector<2xf32>, %single: f32, %d: vector<2xf64>, %double: f64, %i: i32):
+    %w = "llvm.insertelement"(%a, %bf, %i) : (vector<2xbf16>, bf16, i32) -> vector<2xbf16>
+    %x = "llvm.insertelement"(%b, %half, %i) : (vector<4xf16>, f16, i32) -> vector<4xf16>
+    %y = "llvm.insertelement"(%c, %single, %i) : (vector<2xf32>, f32, i32) -> vector<2xf32>
+    %z = "llvm.insertelement"(%d, %double, %i) : (vector<2xf64>, f64, i32) -> vector<2xf64>
+    "llvm.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4xi32>, i32, i1) -> vector<4xi32>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4xi32>, i32, i8) -> vector<4xi32>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4xi32>, i32, i32) -> vector<4xi32>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4xi32>, i32, i64) -> vector<4xi32>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4xi32>, i32, i128) -> vector<4xi32>
+// CHECK: "sym_name" = "out_of_range"
+// CHECK: "llvm.insertelement"
+// CHECK: "llvm.insertelement"
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<1xi1>, i1, i64) -> vector<1xi1>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<2x!llvm.ptr>, !llvm.ptr, i64) -> vector<2x!llvm.ptr>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<2xbf16>, bf16, i32) -> vector<2xbf16>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4xf16>, f16, i32) -> vector<4xf16>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<2xf32>, f32, i32) -> vector<2xf32>
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<2xf64>, f64, i32) -> vector<2xf64>

--- a/Test/LLVM/insertelement_byte.mlir
+++ b/Test/LLVM/insertelement_byte.mlir
@@ -1,0 +1,12 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: %if mlir-min-23 %{ MLIR_ROUNDTRIP %}
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4x!llvm.byte<8>>, !llvm.byte<8>, i32) -> vector<4x!llvm.byte<8>>, sym_name = "bytes"}> ({
+  ^bb0(%v: vector<4x!llvm.byte<8>>, %x: !llvm.byte<8>, %i: i32):
+    %r = "llvm.insertelement"(%v, %x, %i) : (vector<4x!llvm.byte<8>>, !llvm.byte<8>, i32) -> vector<4x!llvm.byte<8>>
+    "func.return"(%r) : (vector<4x!llvm.byte<8>>) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.insertelement"({{.*}}) : (vector<4x!llvm.byte<8>>, !llvm.byte<8>, i32) -> vector<4x!llvm.byte<8>>

--- a/Test/Verifier/llvm_insertelement_element_type_mismatch.mlir
+++ b/Test/Verifier/llvm_insertelement_element_type_mismatch.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4xi32>, i64, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4xi32>, %arg1: i64, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4xi32>, i64, i32) -> vector<4xi32>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected operand 1 to have vector element type i32, but got i64

--- a/Test/Verifier/llvm_insertelement_float8_element.mlir
+++ b/Test/Verifier/llvm_insertelement_float8_element.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4xf8E5M2>, f8E5M2, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4xf8E5M2>, %arg1: f8E5M2, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4xf8E5M2>, f8E5M2, i32) -> vector<4xf8E5M2>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected an LLVM-compatible vector element type, but got f8E5M2

--- a/Test/Verifier/llvm_insertelement_i0_index.mlir
+++ b/Test/Verifier/llvm_insertelement_i0_index.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+// VeIR's LLVM dialect rejects i0, although MLIR accepts it.
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4xi32>, i32, i0) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4xi32>, %arg1: i32, %arg2: i0):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4xi32>, i32, i0) -> vector<4xi32>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: operand 2 has forbidden i0 type

--- a/Test/Verifier/llvm_insertelement_index_element.mlir
+++ b/Test/Verifier/llvm_insertelement_index_element.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4xindex>, index, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4xindex>, %arg1: index, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4xindex>, index, i32) -> vector<4xindex>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected an LLVM-compatible vector element type, but got index

--- a/Test/Verifier/llvm_insertelement_non_integer_index.mlir
+++ b/Test/Verifier/llvm_insertelement_non_integer_index.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4xi32>, i32, index) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4xi32>, %arg1: i32, %arg2: index):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4xi32>, i32, index) -> vector<4xi32>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected operand 2 to have integer type

--- a/Test/Verifier/llvm_insertelement_non_vector.mlir
+++ b/Test/Verifier/llvm_insertelement_non_vector.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (i32, i32, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: i32, %arg1: i32, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (i32, i32, i32) -> i32
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected operand 0 to have an LLVM-compatible vector type

--- a/Test/Verifier/llvm_insertelement_pointer_element_type_mismatch.mlir
+++ b/Test/Verifier/llvm_insertelement_pointer_element_type_mismatch.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4x!llvm.ptr>, i64, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4x!llvm.ptr>, %arg1: i64, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4x!llvm.ptr>, i64, i32) -> vector<4x!llvm.ptr>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected operand 1 to have vector element type !llvm.ptr, but got i64

--- a/Test/Verifier/llvm_insertelement_rank.mlir
+++ b/Test/Verifier/llvm_insertelement_rank.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<2x2xi32>, i32, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<2x2xi32>, %arg1: i32, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<2x2xi32>, i32, i32) -> vector<2x2xi32>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected a one-dimensional vector

--- a/Test/Verifier/llvm_insertelement_result_type_mismatch.mlir
+++ b/Test/Verifier/llvm_insertelement_result_type_mismatch.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "func.func"() <{function_type = (vector<4xi32>, i32, i32) -> (), sym_name = "f"}> ({
+  ^bb0(%arg0: vector<4xi32>, %arg1: i32, %arg2: i32):
+    %r = "llvm.insertelement"(%arg0, %arg1, %arg2) : (vector<4xi32>, i32, i32) -> vector<2xi32>
+    "func.return"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.insertelement: Expected the result to have the vector type

--- a/UnitTest/FoldDecision.lean
+++ b/UnitTest/FoldDecision.lean
@@ -4,9 +4,6 @@ import Veir.Interfaces.FoldInterfaces
 
 open Veir
 
--- A poison vector or inserted element does not poison every result lane.
-#guard !OpCode.propagatesPoison (.llvm .insertelement)
-
 /-- Find the first in-bounds operation with the given opcode. -/
 private def findOp (ctx : IRContext OpCode) (opType : OpCode) :
     Option { op : OperationPtr // op.InBounds ctx } := Id.run do

--- a/UnitTest/FoldDecision.lean
+++ b/UnitTest/FoldDecision.lean
@@ -4,6 +4,9 @@ import Veir.Interfaces.FoldInterfaces
 
 open Veir
 
+-- A poison vector or inserted element does not poison every result lane.
+#guard !OpCode.propagatesPoison (.llvm .insertelement)
+
 /-- Find the first in-bounds operation with the given opcode. -/
 private def findOp (ctx : IRContext OpCode) (opType : OpCode) :
     Option { op : OperationPtr // op.InBounds ctx } := Id.run do

--- a/UnitTest/SideEffectInterfaces.lean
+++ b/UnitTest/SideEffectInterfaces.lean
@@ -21,6 +21,7 @@ private def volatileMemProperties : RISCVMemProperties :=
 
 #guard OpCode.getEffects (.llvm .alloca) (default : AllocaProperties) == .allocate
 
+#guard OpCode.getEffects (.llvm .insertelement) (default : Unit) == .none
 #guard OpCode.getEffects (.llvm .insertvalue) (default : LLVMPositionProperties) == .none
 #guard OpCode.getEffects (.llvm .extractvalue) (default : LLVMPositionProperties) == .none
 

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -63,6 +63,7 @@ inductive Llvm where
 | load
 | store
 | getelementptr
+| insertelement
 | insertvalue
 | extractvalue
 | call
@@ -415,7 +416,7 @@ def Llvm.getEffects (op : Llvm) (props : Llvm.propertiesOf op) : MemoryEffects :
   | .intr__fshl, _ | .intr__fshr, _
   | .icmp, _ | .select, _
   | .trunc, _ | .sext, _ | .zext, _
-  | .getelementptr, _ | .insertvalue, _ | .extractvalue, _
+  | .getelementptr, _ | .insertelement, _ | .insertvalue, _ | .extractvalue, _
   | .br, _ | .cond_br, _ | .switch, _ | .return, _
   | .freeze, _ | .bitcast, _
   | .inttoptr, _ | .ptrtoint, _
@@ -473,6 +474,10 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .intr__lifetime__start | .intr__lifetime__end | .intr__assume
   | .intr__vastart | .intr__vaend | .va_arg
   | .intr__memset | .intr__memcpy | .intr__memmove
+  -- Inserting into a poison vector can define a lane, and a poison element
+  -- only poisons the inserted lane. A poison index does poison the whole
+  -- result, but the interface is per-op.
+  | .insertelement
   | .getelementptr | .insertvalue | .extractvalue | .call | .call_intrinsic | .return
   | .func
   | .module_flags
@@ -894,6 +899,26 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     if properties.alignment.type.bitwidth ≠ 64 then
       throw "'llvm.store' op attribute 'alignment' failed to satisfy constraint: 64-bit signless integer attribute"
     pure ()
+  | .insertelement => do
+    op.checkIsNonNullIntegerType ctx opIn
+    op.verifyPlainOpCounts ctx opIn 3 1
+    let containerType := (op.getOperand! ctx.raw 0).getType! ctx.raw
+    let .vectorType vectorType := containerType.val
+      | throw "Expected operand 0 to have an LLVM-compatible vector type"
+    let #[_] := vectorType.shape
+      | throw "Expected a one-dimensional vector"
+    let validElementType := match vectorType.elementType with
+      | .integerType _ | .llvmPointerType _ | .byteType _ => true
+      | .floatType type => #[FloatType.bf16, FloatType.f16, FloatType.f32, FloatType.f64].contains type
+      | _ => false
+    if !validElementType then
+      throw s!"Expected an LLVM-compatible vector element type, but got {vectorType.elementType}"
+    let valueType := (op.getOperand! ctx.raw 1).getType! ctx.raw
+    if valueType.val != vectorType.elementType then
+      throw s!"Expected operand 1 to have vector element type {vectorType.elementType}, but got {valueType}"
+    ((op.getOperand! ctx.raw 2).getType! ctx.raw).verifyIntegerType
+      "Expected operand 2 to have integer type"
+    op.verifyResultTypeMatches ctx containerType "Expected the result to have the vector type"
   | .insertvalue => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 2 1

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -584,6 +584,20 @@ private def memIntrinsicProperties {OpInfo : Type} [IsOpCode OpInfo]
   | .intr__memmove => some (op.getProperties! ctx.raw Llvm.intr__memmove)
   | _ => none
 
+def TypeAttr.verifyLLVMVectorType (ty : TypeAttr) (errMsg : String) :
+    Except String VectorType := do
+  let .vectorType vectorType := ty.val
+    | throw errMsg
+  let #[_] := vectorType.shape
+    | throw "Expected a one-dimensional vector"
+  let validElementType := match vectorType.elementType with
+    | .integerType _ | .llvmPointerType _ | .byteType _ => true
+    | .floatType type => #[FloatType.bf16, FloatType.f16, FloatType.f32, FloatType.f64].contains type
+    | _ => false
+  if !validElementType then
+    throw s!"Expected an LLVM-compatible vector element type, but got {vectorType.elementType}"
+  return vectorType
+
 /--
   Walk `position` through an aggregate type, as MLIR does for `insertvalue` and
   `extractvalue`, and return the element type it reaches. Arrays are modelled,
@@ -903,16 +917,8 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 3 1
     let containerType := (op.getOperand! ctx.raw 0).getType! ctx.raw
-    let .vectorType vectorType := containerType.val
-      | throw "Expected operand 0 to have an LLVM-compatible vector type"
-    let #[_] := vectorType.shape
-      | throw "Expected a one-dimensional vector"
-    let validElementType := match vectorType.elementType with
-      | .integerType _ | .llvmPointerType _ | .byteType _ => true
-      | .floatType type => #[FloatType.bf16, FloatType.f16, FloatType.f32, FloatType.f64].contains type
-      | _ => false
-    if !validElementType then
-      throw s!"Expected an LLVM-compatible vector element type, but got {vectorType.elementType}"
+    let vectorType ← containerType.verifyLLVMVectorType
+      "Expected operand 0 to have an LLVM-compatible vector type"
     let valueType := (op.getOperand! ctx.raw 1).getType! ctx.raw
     if valueType.val != vectorType.elementType then
       throw s!"Expected operand 1 to have vector element type {vectorType.elementType}, but got {valueType}"

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -474,9 +474,6 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .intr__lifetime__start | .intr__lifetime__end | .intr__assume
   | .intr__vastart | .intr__vaend | .va_arg
   | .intr__memset | .intr__memcpy | .intr__memmove
-  -- Inserting into a poison vector can define a lane, and a poison element
-  -- only poisons the inserted lane. A poison index does poison the whole
-  -- result, but the interface is per-op.
   | .insertelement
   | .getelementptr | .insertvalue | .extractvalue | .call | .call_intrinsic | .return
   | .func


### PR DESCRIPTION
Register and verify `llvm.insertelement` for LLVM-compatible fixed vector types represented in VeIR, with pure effects and conservative poison handling. This enables strict round trips for 17 additional vectorized SQLite functions and all 14 insertion cases in the [vector tracker](https://github.com/opencompl/veir-sqlite/blob/main/VECTORS.md).
