### PR TITLE
fix(nix): pin clang and LEAN_AR to LLVM 23

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
 
       developmentPackages = pkgs: with pkgs; [
         bash
-        clang
+        (llvmPackages pkgs).clang
         elan
         gmp
         gnumake
@@ -61,7 +61,7 @@
             name = target;
             runtimeInputs = developmentPackages pkgs;
             text = ''
-              export LEAN_AR="${pkgs.llvmPackages.llvm}/bin/llvm-ar"
+              export LEAN_AR="${(llvmPackages pkgs).llvm}/bin/llvm-ar"
               export LEAN_CC="${self}/ExArray/compiler"
               exec lake exe ${target} "$@"
             '';


### PR DESCRIPTION
The flake pinned `llvm` and `mlir` to `llvmPackages_23`, but `clang` and the `LEAN_AR` of the `makeLeanApp` wrappers used nixpkgs' default `llvmPackages` (LLVM 21). This PR makes sure `llvmPackages_23` is used for every LLVM component.