### PR TITLE
feat(LLVM): add llvm.comdat and llvm.comdat_selector

### DIFF
--- a/Test/LLVM/comdat.mlir
+++ b/Test/LLVM/comdat.mlir
@@ -1,0 +1,25 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "any"}> : () -> ()
+    "llvm.comdat_selector"() <{comdat = 1 : i64, sym_name = "exactmatch"}> : () -> ()
+    "llvm.comdat_selector"() <{comdat = 2 : i64, sym_name = "largest"}> : () -> ()
+    "llvm.comdat_selector"() <{comdat = 3 : i64, sym_name = "nodeduplicate"}> : () -> ()
+    "llvm.comdat_selector"() <{comdat = 4 : i64, sym_name = "samesize"}> : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{comdat = @c::@any, function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  }) : () -> ()
+  "llvm.mlir.global"() <{addr_space = 0 : i32, comdat = @c::@largest, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.comdat"() <{"sym_name" = "c"}> ({
+// CHECK: "llvm.comdat_selector"() <{"comdat" = 0 : i64, "sym_name" = "any"}> : () -> ()
+// CHECK: "llvm.comdat_selector"() <{"comdat" = 1 : i64, "sym_name" = "exactmatch"}> : () -> ()
+// CHECK: "llvm.comdat_selector"() <{"comdat" = 2 : i64, "sym_name" = "largest"}> : () -> ()
+// CHECK: "llvm.comdat_selector"() <{"comdat" = 3 : i64, "sym_name" = "nodeduplicate"}> : () -> ()
+// CHECK: "llvm.comdat_selector"() <{"comdat" = 4 : i64, "sym_name" = "samesize"}> : () -> ()
+// CHECK: "llvm.func"() <{{{.*}}"comdat" = @c::@any{{.*}}}> ({
+// CHECK: "llvm.mlir.global"() <{{{.*}}"comdat" = @c::@largest{{.*}}}> ({

--- a/Test/Verifier/llvm_comdat_block_argument.mlir
+++ b/Test/Verifier/llvm_comdat_block_argument.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+  ^bb0(%x: i32):
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "s"}> : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat: region should have no arguments

--- a/Test/Verifier/llvm_comdat_duplicate_selector.mlir
+++ b/Test/Verifier/llvm_comdat_duplicate_selector.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "s"}> : () -> ()
+    "llvm.comdat_selector"() <{comdat = 1 : i64, sym_name = "s"}> : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat_selector: redefinition of symbol named 's'

--- a/Test/Verifier/llvm_comdat_foreign_op.mlir
+++ b/Test/Verifier/llvm_comdat_foreign_op.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "s"}> : () -> ()
+    "llvm.unreachable"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat: only comdat selector symbols can appear in a comdat region

--- a/Test/Verifier/llvm_comdat_no_block.mlir
+++ b/Test/Verifier/llvm_comdat_no_block.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat: region should have exactly one block

--- a/Test/Verifier/llvm_comdat_selector_invalid_kind.mlir
+++ b/Test/Verifier/llvm_comdat_selector_invalid_kind.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 5 : i64, sym_name = "s"}> : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat_selector: invalid comdat kind 5

--- a/Test/Verifier/llvm_comdat_selector_non_i64_kind.mlir
+++ b/Test/Verifier/llvm_comdat_selector_non_i64_kind.mlir
@@ -1,0 +1,10 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 0 : i32, sym_name = "s"}> : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat_selector: expected 'comdat' to be an i64 integer attribute, but got 0 : i32

--- a/Test/Verifier/llvm_comdat_two_blocks.mlir
+++ b/Test/Verifier/llvm_comdat_two_blocks.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "s"}> : () -> ()
+  ^bb1:
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "t"}> : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.comdat: region should have exactly one block

--- a/Test/Verifier/llvm_func_comdat_missing.mlir
+++ b/Test/Verifier/llvm_func_comdat_missing.mlir
@@ -1,0 +1,9 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.func"() <{comdat = @c::@s, function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.func: expected comdat symbol

--- a/Test/Verifier/llvm_func_comdat_not_selector.mlir
+++ b/Test/Verifier/llvm_func_comdat_not_selector.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.comdat"() <{sym_name = "c"}> ({
+    "llvm.comdat_selector"() <{comdat = 0 : i64, sym_name = "s"}> : () -> ()
+  }) : () -> ()
+  "llvm.func"() <{comdat = @c::@c, function_type = !llvm.func<void ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.func: expected comdat symbol

--- a/Veir/Data/LLVM.lean
+++ b/Veir/Data/LLVM.lean
@@ -4,3 +4,4 @@ public import Veir.Data.LLVM.Int
 public import Veir.Data.LLVM.Byte
 public import Veir.Data.LLVM.FloatPred
 public import Veir.Data.LLVM.AtomicOrdering
+public import Veir.Data.LLVM.ComdatKind

--- a/Veir/Data/LLVM/ComdatKind.lean
+++ b/Veir/Data/LLVM/ComdatKind.lean
@@ -1,0 +1,34 @@
+module
+
+namespace Veir.Data.LLVM
+
+public section
+
+/-- How the linker picks among the members of a comdat group. -/
+inductive ComdatKind where
+  | any
+  | exactmatch
+  | largest
+  | nodeduplicate
+  | samesize
+deriving DecidableEq, Inhabited, Repr, Hashable
+
+def ComdatKind.fromNat (s : Nat) : Option ComdatKind :=
+  match s with
+  | 0 => some .any
+  | 1 => some .exactmatch
+  | 2 => some .largest
+  | 3 => some .nodeduplicate
+  | 4 => some .samesize
+  | _ => none
+
+def ComdatKind.toNat : ComdatKind → Nat
+  | .any => 0
+  | .exactmatch => 1
+  | .largest => 2
+  | .nodeduplicate => 3
+  | .samesize => 4
+
+end
+
+end Veir.Data.LLVM

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -71,6 +71,8 @@ inductive Llvm where
 | return
 | func
 | module_flags
+| comdat
+| comdat_selector
 | fadd
 | fsub
 | fmul
@@ -133,6 +135,8 @@ match op with
 | .getelementptr => GetelementptrProperties
 | .insertvalue | .extractvalue => LLVMPositionProperties
 | .fence => LLVMFenceProperties
+| .comdat => LLVMComdatProperties
+| .comdat_selector => LLVMComdatSelectorProperties
 | .fadd | .fsub | .fmul | .fdiv | .frem | .fneg | .intr__fmuladd | .intr__fabs =>
   FastMathFlagsProperties
 | .fcmp => FcmpProperties
@@ -178,6 +182,8 @@ def Llvm.fromAttrDict
   case insertvalue => exact LLVMPositionProperties.fromAttrDictFor "llvm.insertvalue" attrDict
   case extractvalue => exact LLVMPositionProperties.fromAttrDictFor "llvm.extractvalue" attrDict
   case fence => exact LLVMFenceProperties.fromAttrDict attrDict
+  case comdat => exact LLVMComdatProperties.fromAttrDict attrDict
+  case comdat_selector => exact LLVMComdatSelectorProperties.fromAttrDict attrDict
   case fadd | fsub | fmul | fdiv | frem | fneg | intr__fmuladd | intr__fabs =>
     exact FastMathFlagsProperties.fromAttrDict attrDict
   case fcmp => exact FcmpProperties.fromAttrDict attrDict
@@ -364,6 +370,14 @@ def Llvm.toAttrDict
   | .insertvalue | .extractvalue =>
     (Std.HashMap.emptyWithCapacity 1).insert
       "position".toUTF8 (Attribute.denseArrayAttr props.position)
+  | .comdat =>
+    (Std.HashMap.emptyWithCapacity 1).insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+  | .comdat_selector => Id.run do
+    let mut dict := Std.HashMap.emptyWithCapacity 2
+    dict := dict.insert "comdat".toUTF8
+      (Attribute.integerAttr (IntegerAttr.mk (Int.ofNat props.comdat.toNat) (IntegerType.mk 64)))
+    dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    dict
   | .fence => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 2
     let ordering := IntegerAttr.mk (Int.ofNat props.ordering.toNat) (IntegerType.mk 64)
@@ -448,7 +462,13 @@ def Llvm.isConstantLike (op : Llvm) : Bool :=
 
 def Llvm.isIsolatedFromAbove (op : Llvm) : Bool :=
   match op with
-  | .mlir__global | .func => true
+  | .mlir__global | .func | .comdat => true
+  | _ => false
+
+/-- A `llvm.comdat` body only lists selectors, so it ends without a terminator. -/
+def Llvm.hasNoTerminator (op : Llvm) (_index : Nat) : Bool :=
+  match op with
+  | .comdat => true
   | _ => false
 
 def Llvm.hasSSADominance (_op : Llvm) (_index : Nat) : Bool :=
@@ -488,6 +508,7 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .getelementptr | .insertvalue | .extractvalue | .call | .call_intrinsic | .return
   | .func
   | .module_flags
+  | .comdat | .comdat_selector
   | .freeze => false
 
 def Llvm.tryFold (op : Llvm) (_properties : Llvm.propertiesOf op)
@@ -936,6 +957,24 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       if elementType ≠ resultType.val then
         throw s!"Type mismatch: extracting from {containerType} should produce {elementType} \
           but this op returns {resultType}"
+  | .comdat => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "Expected 1 region"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    let body := (op.getRegion! ctx.raw 0).get! ctx.raw
+    let some block := body.firstBlock
+      | throw "region should have exactly one block"
+    if body.lastBlock ≠ some block then
+      throw "region should have exactly one block"
+    if block.getNumArguments! ctx.raw ≠ 0 then
+      throw "region should have no arguments"
+  | .comdat_selector => do
+    op.verifyPlainOpCounts ctx opIn 0 0
   | .fence => do
     op.verifyPlainOpCounts ctx opIn 0 0
     /- A fence orders other accesses, so the weaker orderings say nothing. -/
@@ -1073,6 +1112,7 @@ instance : HasOpInfo Llvm where
   hasSSADominance := Llvm.hasSSADominance
   isTerminator := Llvm.isTerminator
   isIsolatedFromAbove := Llvm.isIsolatedFromAbove
+  hasNoTerminator := Llvm.hasNoTerminator
 
 end
 

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Data.LLVM.Int.Basic
 public import Veir.Data.LLVM.FloatPred
 public import Veir.Data.LLVM.AtomicOrdering
+public import Veir.Data.LLVM.ComdatKind
 public import Std.Data.HashMap
 public import Veir.IR.Attribute
 
@@ -797,6 +798,49 @@ def LLVMFenceProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute
       throw s!"llvm.fence: expected 'syncscope' to be a string attribute, but got {attr}"
     | none => .ok none
   return { ordering, syncscope }
+
+/-- Properties of `llvm.comdat`: the name of the comdat group. -/
+structure LLVMComdatProperties where
+  sym_name : StringAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMComdatProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMComdatProperties := do
+  if let some (key, _) := attrDict.toArray.find? (fun (k, _) => k ≠ "sym_name".toUTF8) then
+    throw s!"llvm.comdat: unexpected property '{String.fromUTF8! key}'"
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr s) => pure s
+    | some attr => throw s!"llvm.comdat: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => throw "llvm.comdat: missing 'sym_name' property"
+  return { sym_name := symName }
+
+/-- Properties of `llvm.comdat_selector`: its name and how duplicates are resolved. -/
+structure LLVMComdatSelectorProperties where
+  sym_name : StringAttr
+  comdat : Data.LLVM.ComdatKind
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+def LLVMComdatSelectorProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMComdatSelectorProperties := do
+  if let some (key, _) := attrDict.toArray.find? (fun (k, _) =>
+      k ≠ "sym_name".toUTF8 && k ≠ "comdat".toUTF8) then
+    throw s!"llvm.comdat_selector: unexpected property '{String.fromUTF8! key}'"
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr s) => pure s
+    | some attr =>
+      throw s!"llvm.comdat_selector: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => throw "llvm.comdat_selector: missing 'sym_name' property"
+  let some attr := attrDict["comdat".toUTF8]?
+    | throw "llvm.comdat_selector: missing 'comdat' property"
+  let .integerAttr intAttr := attr
+    | throw s!"llvm.comdat_selector: expected 'comdat' to be an integer attribute, but got {attr}"
+  if intAttr.type.bitwidth ≠ 64 then
+    throw s!"llvm.comdat_selector: expected 'comdat' to be an i64 integer attribute, but got {attr}"
+  if intAttr.value < 0 then
+    throw s!"llvm.comdat_selector: invalid comdat kind {intAttr.value}"
+  let some kind := Data.LLVM.ComdatKind.fromNat intAttr.value.toNat
+    | throw s!"llvm.comdat_selector: invalid comdat kind {intAttr.value}"
+  return { sym_name := symName, comdat := kind }
 
 structure LLVMModuleFlagsProperties where
   flags : ArrayAttr

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -176,6 +176,55 @@ private def WfIRContext.verifyLLVMGlobalSymbols (ctx : WfIRContext OpCode) :
         throw s!"llvm.mlir.addressof: symbol '{props.global_name.value}' does not name an \
           llvm.mlir.global or llvm.func"
 
+/-- The decoded bytes of a symbol reference, with nested references joined by `::`. -/
+private def symbolRefAttrBytes : Attribute → Option ByteArray
+  | .flatSymbolRefAttr f => symbolRefBytes f.value
+  | .symbolRefAttr s => do
+    let mut bytes ← symbolRefBytes s.root.value
+    for n in s.nested do
+      bytes := bytes ++ "::".toUTF8 ++ (← symbolRefBytes n.value)
+    return bytes
+  | _ => none
+
+/--
+  Check the comdat invariants MLIR enforces through its symbol tables: a
+  `llvm.comdat` body holds only `llvm.comdat_selector` operations with distinct
+  names, and the `comdat` of a function or global names a selector, either as
+  `@comdat::@selector` or as `@selector` for a selector outside any comdat.
+-/
+private def WfIRContext.verifyLLVMComdats (ctx : WfIRContext OpCode) :
+    Except String Unit := do
+  let mut selectors : Std.HashSet ByteArray := Std.HashSet.emptyWithCapacity
+  for op in ctx.raw.operations.keys do
+    let parent? := op.getParentOp! ctx.raw
+    let comdatParent? := parent?.filter (fun parent => parent.getOpType! ctx.raw = .llvm .comdat)
+    if comdatParent?.isSome && op.getOpType! ctx.raw ≠ .llvm .comdat_selector then
+      throw "llvm.comdat: only comdat selector symbols can appear in a comdat region"
+    if op.getOpType! ctx.raw = .llvm .comdat_selector then
+      let props := op.getProperties! ctx.raw Llvm.comdat_selector
+      let name := "@".toUTF8 ++ props.sym_name.value
+      let key := match comdatParent? with
+        | some parent =>
+          "@".toUTF8 ++ (parent.getProperties! ctx.raw Llvm.comdat).sym_name.value ++ "::".toUTF8 ++ name
+        | none => name
+      if selectors.contains key then
+        throw s!"llvm.comdat_selector: redefinition of symbol named \
+          '{String.fromUTF8? props.sym_name.value |>.getD "<non-UTF8 symbol>"}'"
+      selectors := selectors.insert key
+  for op in ctx.raw.operations.keys do
+    let opType := op.getOpType! ctx.raw
+    let extra? : Option DictionaryAttr :=
+      if opType = .llvm .func then some (op.getProperties! ctx.raw Llvm.func).extra
+      else if opType = .llvm .mlir__global then some (op.getProperties! ctx.raw Llvm.mlir__global).extra
+      else none
+    let some extra := extra? | continue
+    let some (_, attr) := extra.entries.find? (fun (k, _) => k == "comdat".toUTF8) | continue
+    let opName := String.fromUTF8! opType.name
+    let some ref := symbolRefAttrBytes attr
+      | throw s!"{opName}: expected 'comdat' to be a symbol reference, but got {attr}"
+    if !selectors.contains ref then
+      throw s!"{opName}: expected comdat symbol"
+
 /--
   Check the whole-pattern invariants that MLIR verifies in
   `PatternOp::verifyRegions`: a `pdl.pattern` body holds only `pdl` operations,
@@ -251,6 +300,7 @@ def WfIRContext.verify
     block.verifyTerminator ctx blockIn
     block.verifyNoEntryBlockPredecessors ctx blockIn)
   ctx.verifyLLVMGlobalSymbols
+  ctx.verifyLLVMComdats
   ctx.verifyPDLPatternBodies
   ctx.verifyDominance root
 


### PR DESCRIPTION
Adds `llvm.comdat` and `llvm.comdat_selector`, which every clang-emitted C++ module with inline or template functions carries. A selector holds its name and the comdat kind as an i64 checked against MLIR's five values; a comdat body is a single block without arguments that may hold only selectors with distinct names. The `comdat` of an `llvm.func` or `llvm.mlir.global` must name a selector, either `@comdat::@selector` or a flat `@selector` outside any comdat, mirroring what MLIR verifies through its symbol tables. Nine negative tests are cross-checked with `mlir-opt`.