### PR TITLE
chore: refactor how literal constants are accessed

### DIFF
--- a/Veir/Passes/InstCombine.lean
+++ b/Veir/Passes/InstCombine.lean
@@ -22,7 +22,7 @@ def mulITwoToAddi_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 2 then
+  if cst ≠ 2 then
     return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[lhs.getType! ctx.raw] #[lhs, lhs]
     #[] #[] properties none
@@ -39,7 +39,7 @@ def mulIZeroToCst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 0 then
+  if cst ≠ 0 then
     return (ctx, none)
   let .integerType type := (lhs.getType! ctx.raw).val
     | return (ctx, none)
@@ -59,7 +59,7 @@ def mulIOneToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 1 then
+  if cst ≠ 1 then
     return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
@@ -74,7 +74,7 @@ def subiZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 0 then
+  if cst ≠ 0 then
     return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
@@ -120,7 +120,7 @@ def andiZeroToZero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 0 then
+  if cst ≠ 0 then
     return (ctx, none)
   let .integerType type := (lhs.getType! ctx.raw).val
     | return (ctx, none)
@@ -140,7 +140,7 @@ def oriZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 0 then
+  if cst ≠ 0 then
     return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
@@ -168,7 +168,7 @@ def xoriZeroToX_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw
     | return (ctx, none)
-  if cst.value ≠ 0 then
+  if cst ≠ 0 then
     return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 

--- a/Veir/Passes/InstructionSelection/RISCV64.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64.lean
@@ -851,7 +851,7 @@ def selectAddrRegImm (ptr : ValuePtr) (ctx : IRContext OpCode) : ValuePtr × Int
     guard (itype.bitwidth = 64)
     let c ← matchConstantIntVal idx ctx
     let scale ← DataLayout.riscv64.getTypeAllocSize properties.elem_type.val
-    let offset := c.value * (scale : Int)
+    let offset := c * (scale : Int)
     guard (-2048 ≤ offset ∧ offset ≤ 2047)
     return (base, offset)
   folded.getD (ptr, 0)
@@ -1402,7 +1402,7 @@ def fshrConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if t.bitwidth ≠ 64 ∧ t.bitwidth ≠ 32 then return (ctx, none)
   let (ctx, valCastOp) ← castToRegLocal ctx a
   if t.bitwidth = 32 then
-    let sh : Int := ((amtAttr.value % 32) + 32) % 32
+    let sh : Int := ((amtAttr % 32) + 32) % 32
     let imm := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
     let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
         #[] #[] imm none
@@ -1410,7 +1410,7 @@ def fshrConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     some (ctx, some (#[valCastOp, roriOp, castBackOp], #[castBackOp.getResult 0]))
   else
     /- The funnel-shift amount is taken modulo the bit width. -/
-    let sh : Int := ((amtAttr.value % 64) + 64) % 64
+    let sh : Int := ((amtAttr % 64) + 64) % 64
     let imm := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
     let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.rori #[RegisterType.mk] #[valCastOp.getResult 0]
         #[] #[] imm none
@@ -1436,7 +1436,7 @@ def fshlConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let (ctx, valCastOp) ← castToRegLocal ctx a
   if t.bitwidth = 32 then
     /- rotate-left by `sh` == rotate-right by `32 - sh` (mod 32). -/
-    let sh : Int := ((amtAttr.value % 32) + 32) % 32
+    let sh : Int := ((amtAttr % 32) + 32) % 32
     let imm : Int := (32 - sh) % 32
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
     let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
@@ -1445,7 +1445,7 @@ def fshlConst_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     some (ctx, some (#[valCastOp, roriOp, castBackOp], #[castBackOp.getResult 0]))
   else
     /- rotate-left by `sh` == rotate-right by `64 - sh` (mod 64). -/
-    let sh : Int := ((amtAttr.value % 64) + 64) % 64
+    let sh : Int := ((amtAttr % 64) + 64) % 64
     let imm : Int := (64 - sh) % 64
     let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
     let (ctx, roriOp) ← WfRewriter.createOp! ctx Riscv.rori #[RegisterType.mk] #[valCastOp.getResult 0]

--- a/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
+++ b/Veir/Passes/InstructionSelection/RISCV64Sdag.lean
@@ -101,15 +101,15 @@ def matchOrcbRight (b m : ValuePtr) (y : Nat) (ctx : IRContext OpCode) :
   let some bOp := b.definingOp? | none
   let some (m', yShamt, lshrProps) := matchLshr bOp ctx | none
   let some yc := matchConstantIntVal yShamt ctx | none
-  if yc.value = (y : Int) ∧ m' = m then return lshrProps else none
+  if yc = (y : Int) ∧ m' = m then return lshrProps else none
 
 def matchOrcbMask (mo0 mo1 : ValuePtr) (y : Nat) (ctx : IRContext OpCode) :
-    Option (ValuePtr × IntegerAttr) := do
+    Option (ValuePtr × Int) := do
   if let some attr1 := matchConstantIntVal mo1 ctx then
-    if BitVec.ofInt 64 attr1.value = orcbMaskBV y then
+    if BitVec.ofInt 64 attr1 = orcbMaskBV y then
       return (mo0, attr1)
   let some attr0 := matchConstantIntVal mo0 ctx | none
-  if BitVec.ofInt 64 attr0.value = orcbMaskBV y then return (mo1, attr0) else none
+  if BitVec.ofInt 64 attr0 = orcbMaskBV y then return (mo1, attr0) else none
 
 /--
   `sub (shl M (8 - Y)) (lshr M Y)` -> `riscv.orcb M`,
@@ -124,8 +124,8 @@ def orcb_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some aOp := a.definingOp? | return (ctx, none)
   let some (m, shamt, _) := matchShl aOp ctx.raw | return (ctx, none)
   let some shc := matchConstantIntVal shamt ctx.raw | return (ctx, none)
-  if shc.value < 1 || 8 < shc.value then return (ctx, none)
-  let y : Nat := (8 - shc.value).toNat
+  if shc < 1 || 8 < shc then return (ctx, none)
+  let y : Nat := (8 - shc).toNat
   /- right operand must be `M` itself (when `Y = 0`) or `lshr M Y` -/
   let some _lshrProps := matchOrcbRight b m y ctx | return (ctx, none)
   /- soundness gate: `M = and Z (0x0101_0101_0101_0101 <<< Y)` -/
@@ -178,9 +178,9 @@ def selectBinopImmLocal {α} (matchPair : OperationPtr → IRContext OpCode → 
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ width then return (ctx, none)
   let some imm := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if imm.value < lo || imm.value > hi then return (ctx, none)
+  if imm < lo || imm > hi then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
-  let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm.value (IntegerType.mk 64))
+  let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
   let (ctx, newOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] (cast h.symm immProps) none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
@@ -271,7 +271,7 @@ def slti_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType lt := (lhs.getType! ctx.raw).val | return (ctx, none)
   if lt.bitwidth ≠ 64 then return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  let c := cst.value
+  let c := cst
   match prop.predicate with
   | .slt => sltiEmitLocal op lhs .slti  rfl c       false ctx
   | .ult => sltiEmitLocal op lhs .sltiu rfl c       false ctx
@@ -315,8 +315,8 @@ def selectSingleBitLocal {α} (matchPair : OperationPtr → IRContext OpCode →
   if t.bitwidth ≠ 64 then return (ctx, none)
   let some imm := matchConstantIntVal rhs ctx.raw | return (ctx, none)
   /- ANDI/ORI/XORI handle the simm12 cases; only fire when the immediate doesn't fit. -/
-  if !(imm.value < -2048 || imm.value > 2047) then return (ctx, none)
-  let bv := BitVec.ofInt 64 imm.value
+  if !(imm < -2048 || imm > 2047) then return (ctx, none)
+  let bv := BitVec.ofInt 64 imm
   let some n := singleSetBit (if complement then ~~~ bv else bv) | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk n (IntegerType.mk 64))
@@ -337,13 +337,13 @@ def bexti_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ 64 then return (ctx, none)
   let some one := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if one.value ≠ 1 then return (ctx, none)
+  if one ≠ 1 then return (ctx, none)
   let some shrOp := lhs.definingOp? | return (ctx, none)
   let some (x, shamt, _) := matchLshr shrOp ctx.raw | return (ctx, none)
   let some sh := matchConstantIntVal shamt ctx.raw | return (ctx, none)
-  if sh.value < 0 || sh.value > 63 then return (ctx, none)
+  if sh < 0 || sh > 63 then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx x
-  let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
+  let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
   let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.bexti #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] immProps none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
@@ -364,7 +364,7 @@ def roriw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some amtAttr := matchConstantIntVal amt ctx.raw | return (ctx, none)
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ 32 then return (ctx, none)
-  let sh : Int := ((amtAttr.value % 32) + 32) % 32
+  let sh : Int := ((amtAttr % 32) + 32) % 32
   let (ctx, valCastOp) ← castToRegLocal ctx a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
   let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.roriw #[RegisterType.mk] #[valCastOp.getResult 0]
@@ -388,7 +388,7 @@ def roliw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ 32 then return (ctx, none)
   /- rotate-left by `sh` == rotate-right by `32 - sh` (mod 32). -/
-  let sh : Int := ((amtAttr.value % 32) + 32) % 32
+  let sh : Int := ((amtAttr % 32) + 32) % 32
   let imm : Int := (32 - sh) % 32
   let (ctx, valCastOp) ← castToRegLocal ctx a
   let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk imm (IntegerType.mk 64))
@@ -411,13 +411,13 @@ def slliuw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ 64 then return (ctx, none)
   let some sh := matchConstantIntVal shamt ctx.raw | return (ctx, none)
-  if sh.value < 0 || sh.value > 31 then return (ctx, none)
+  if sh < 0 || sh > 31 then return (ctx, none)
   let some baseOp := base.definingOp? | return (ctx, none)
   let some (x, _) := matchZext baseOp ctx.raw | return (ctx, none)
   let .integerType srcT := (x.getType! ctx.raw).val | return (ctx, none)
   if srcT.bitwidth ≠ 32 then return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx x
-  let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh.value (IntegerType.mk 64))
+  let immProps := RISCVImmediateProperties.mk (IntegerAttr.mk sh (IntegerType.mk 64))
   let (ctx, newOp) ← WfRewriter.createOp! ctx Riscv.slliuw #[RegisterType.mk] #[xCastOp.getResult 0]
       #[] #[] immProps none
   let (ctx, castBackOp) ← replaceWithRegLocal ctx op (newOp.getResult 0)
@@ -524,7 +524,7 @@ def udivPow2GenLocal (dst : Riscv) (h : Riscv.propertiesOf dst = RISCVImmediateP
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ width then return (ctx, none)
   let some imm := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  let some k := matchUnsignedPow2Divisor width imm.value | return (ctx, none)
+  let some k := matchUnsignedPow2Divisor width imm | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
   let (ctx, shiftOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
@@ -568,7 +568,7 @@ def sdivPow2ExactGenLocal (dst : Riscv) (hDst : Riscv.propertiesOf dst = RISCVIm
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ width then return (ctx, none)
   let some imm := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  let some (k, isNeg) := matchSignedPow2Divisor width imm.value | return (ctx, none)
+  let some (k, isNeg) := matchSignedPow2Divisor width imm | return (ctx, none)
   let (ctx, xCastOp) ← castToRegLocal ctx lhs
   let shamt := RISCVImmediateProperties.mk (IntegerAttr.mk k (IntegerType.mk 64))
   let (ctx, sraOp) ← WfRewriter.createOp! ctx dst #[RegisterType.mk] #[xCastOp.getResult 0]
@@ -613,7 +613,7 @@ def sdivPow2GenLocal (shiftDst : Riscv) (hShift : Riscv.propertiesOf shiftDst = 
   let .integerType t := ((op.getResult 0).get! ctx.raw).type.val | return (ctx, none)
   if t.bitwidth ≠ width then return (ctx, none)
   let some imm := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  let some (k, isNeg) := matchSignedPow2Divisor width imm.value | return (ctx, none)
+  let some (k, isNeg) := matchSignedPow2Divisor width imm | return (ctx, none)
   /- `k = 0` (divisor ±1) would need a shift by the full register width, which has
      no legal immediate encoding; middle-end optimizations always turn `sdiv x, ±1`
      into `x`/`-x` well before instruction selection, so this case does not arise. -/

--- a/Veir/Passes/Matching/LLVM/Basic.lean
+++ b/Veir/Passes/Matching/LLVM/Basic.lean
@@ -58,16 +58,19 @@ def matchConstantIntOp (op : OperationPtr) (ctx : IRContext OpCode) :
   let .integer intAttr := properties.value | none
   return intAttr
 
+/-- Match the raw integer attribute value of an LLVM constant, without adjusting
+it to the attribute or result width. -/
 def matchConstantIntVal (val : ValuePtr) (ctx : IRContext OpCode) :
-    Option IntegerAttr := do
+    Option Int := do
   let .opResult opResultPtr := val | none
   let op := opResultPtr.op
-  matchConstantIntOp op ctx
+  let attr ← matchConstantIntOp op ctx
+  return attr.value
 
 /-- Match a constant integer with value zero, returning `val` itself. -/
 def matchConstantZero (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
   let attr ← matchConstantIntVal val ctx
-  guard (attr.value = 0)
+  guard (attr = 0)
   return val
 
 def matchAshr (op : OperationPtr) (ctx : IRContext OpCode) :
@@ -163,7 +166,7 @@ def matchNot (val : ValuePtr) (ctx : IRContext OpCode) : Option ValuePtr := do
   let op := opResultPtr.op
   let (lhs, rhs) ← matchXori op ctx
   let cst ← matchConstantIntVal rhs ctx
-  guard (cst.value = -1)
+  guard (cst = -1)
   return lhs
 
 def matchMul (op : OperationPtr) (ctx : IRContext OpCode) :

--- a/Veir/Passes/Matching/LLVM/Lemmas.lean
+++ b/Veir/Passes/Matching/LLVM/Lemmas.lean
@@ -108,18 +108,19 @@ theorem matchConstantIntOp_implies {op : OperationPtr} {ctx : IRContext OpCode} 
   grind
 
 /-- What matching a constant integer value (via `matchConstantIntVal`) syntactically guarantees. -/
-theorem matchConstantIntVal_implies {val : ValuePtr} {ctx : IRContext OpCode} {intAttr} :
-    matchConstantIntVal val ctx = some intAttr →
-    ∃ opResultPtr, val = .opResult opResultPtr ∧
-      matchConstantIntOp opResultPtr.op ctx = some intAttr := by
+theorem matchConstantIntVal_implies {val : ValuePtr} {ctx : IRContext OpCode} {value} :
+    matchConstantIntVal val ctx = some value →
+    ∃ opResultPtr intAttr, val = .opResult opResultPtr ∧
+      matchConstantIntOp opResultPtr.op ctx = some intAttr ∧
+      intAttr.value = value := by
   intro hmatch
-  simp only [matchConstantIntVal] at hmatch
+  simp only [matchConstantIntVal, bind, Option.bind, pure] at hmatch
   grind
 
 /-- What matching a zero constant (via `matchConstantZero`) syntactically guarantees. -/
 theorem matchConstantZero_implies {val : ValuePtr} {ctx : IRContext OpCode} {result} :
     matchConstantZero val ctx = some result →
-    result = val ∧ ∃ attr, matchConstantIntVal val ctx = some attr ∧ attr.value = 0 := by
+    result = val ∧ ∃ attr, matchConstantIntVal val ctx = some attr ∧ attr = 0 := by
   intro hmatch
   simp only [matchConstantZero, bind, pure, Option.bind, guard, failure] at hmatch
   grind
@@ -305,7 +306,7 @@ theorem matchNot_implies {val : ValuePtr} {ctx : IRContext OpCode} {lhs} :
       val = .opResult opResultPtr ∧
       matchXori opResultPtr.op ctx = some (lhs, rhs) ∧
       matchConstantIntVal rhs ctx = some cst ∧
-      cst.value = -1 := by
+      cst = -1 := by
   intro hmatch
   simp only [matchNot, bind, pure, Option.bind, guard, failure] at hmatch
   grind

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -23,8 +23,8 @@ namespace Veir.RISCV
   `none`. Total: `k` is computed by a bounded recursion counting trailing zeros. -/
 def isConstantPowerOfTwo (v : ValuePtr) (ctx : IRContext OpCode) : Option Nat := do
   let attr ← matchConstantIntVal v ctx
-  guard (attr.value > 0)
-  let n : Nat := attr.value.toNat
+  guard (attr > 0)
+  let n : Nat := attr.toNat
   guard (n &&& (n - 1) = 0)
   -- `n` is a power of two; count trailing zeros to recover `k`.
   let rec log2Aux (m : Nat) (fuel : Nat) : Nat :=
@@ -64,7 +64,7 @@ def select_constant_cmp_true_local (ctx : WfIRContext OpCode) (op : OperationPtr
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tval, _fval) := matchSelect op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal cond ctx.raw | return (ctx, none)
-  if cst.value ≠ 1 then return (ctx, none)
+  if cst ≠ 1 then return (ctx, none)
   some (ctx, some (#[], #[tval]))
 
 def select_constant_cmp_true (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -75,7 +75,7 @@ def select_constant_cmp_false_local (ctx : WfIRContext OpCode) (op : OperationPt
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, _tval, fval) := matchSelect op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal cond ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[fval]))
 
 def select_constant_cmp_false (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -763,7 +763,7 @@ def mulo_by_2_unsigned_signed_local (ctx : WfIRContext OpCode) (op : OperationPt
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (x, cval, mp) := matchMul op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal cval ctx.raw | return (ctx, none)
-  if cst.value ≠ 2 then return (ctx, none)
+  if cst ≠ 2 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[x.getType! ctx.raw] #[x, x]
     #[] #[] mp none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -782,7 +782,7 @@ def add_shift_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dSub := negB.definingOp? | return (ctx, none)
   let some (zeroV, b, subp) := matchSub dSub ctx.raw | return (ctx, none)
   let some zc := matchConstantIntVal zeroV ctx.raw | return (ctx, none)
-  if zc.value ≠ 0 then return (ctx, none)
+  if zc ≠ 0 then return (ctx, none)
   let (ctx, newShl) ← WfRewriter.createOp! ctx Llvm.shl #[b.getType! ctx.raw] #[b, c]
     #[] #[] shp none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newShl.getResult 0)]
@@ -802,7 +802,7 @@ def add_shift_commute_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dSub := negB.definingOp? | return (ctx, none)
   let some (zeroV, b, subp) := matchSub dSub ctx.raw | return (ctx, none)
   let some zc := matchConstantIntVal zeroV ctx.raw | return (ctx, none)
-  if zc.value ≠ 0 then return (ctx, none)
+  if zc ≠ 0 then return (ctx, none)
   let (ctx, newShl) ← WfRewriter.createOp! ctx Llvm.shl #[b.getType! ctx.raw] #[b, c]
     #[] #[] shp none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (newShl.getResult 0)]
@@ -939,9 +939,9 @@ def select_1_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tv, fv) := matchSelect op ctx.raw | return (ctx, none)
   let some ct := matchConstantIntVal tv ctx.raw | return (ctx, none)
-  if ct.value ≠ 1 then return (ctx, none)
+  if ct ≠ 1 then return (ctx, none)
   let some cf := matchConstantIntVal fv ctx.raw | return (ctx, none)
-  if cf.value ≠ 0 then return (ctx, none)
+  if cf ≠ 0 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.zext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[cond]
     #[] #[] ({ nneg := false } : NnegProperties) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -955,9 +955,9 @@ def select_neg1_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tv, fv) := matchSelect op ctx.raw | return (ctx, none)
   let some ct := matchConstantIntVal tv ctx.raw | return (ctx, none)
-  if ct.value ≠ -1 then return (ctx, none)
+  if ct ≠ -1 then return (ctx, none)
   let some cf := matchConstantIntVal fv ctx.raw | return (ctx, none)
-  if cf.value ≠ 0 then return (ctx, none)
+  if cf ≠ 0 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sext #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[cond]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -971,9 +971,9 @@ def select_0_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tv, fv) := matchSelect op ctx.raw | return (ctx, none)
   let some ct := matchConstantIntVal tv ctx.raw | return (ctx, none)
-  if ct.value ≠ 0 then return (ctx, none)
+  if ct ≠ 0 then return (ctx, none)
   let some cf := matchConstantIntVal fv ctx.raw | return (ctx, none)
-  if cf.value ≠ 1 then return (ctx, none)
+  if cf ≠ 1 then return (ctx, none)
   let .integerType cty := (cond.getType! ctx.raw).val | return (ctx, none)
   let m1 := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) cty))
   let (ctx, c1) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[cond.getType! ctx.raw] #[]
@@ -993,9 +993,9 @@ def select_0_neg1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (cond, tv, fv) := matchSelect op ctx.raw | return (ctx, none)
   let some ct := matchConstantIntVal tv ctx.raw | return (ctx, none)
-  if ct.value ≠ 0 then return (ctx, none)
+  if ct ≠ 0 then return (ctx, none)
   let some cf := matchConstantIntVal fv ctx.raw | return (ctx, none)
-  if cf.value ≠ -1 then return (ctx, none)
+  if cf ≠ -1 then return (ctx, none)
   let .integerType cty := (cond.getType! ctx.raw).val | return (ctx, none)
   let m1 := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) cty))
   let (ctx, c1) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[cond.getType! ctx.raw] #[]
@@ -1106,12 +1106,12 @@ def double_icmp_zero_and_combine_local (ctx : WfIRContext OpCode) (op : Operatio
   let some (x, cx, ip0) := matchIcmp dL ctx.raw | return (ctx, none)
   let .eq := ip0.predicate | return (ctx, none)
   let some cxv := matchConstantIntVal cx ctx.raw | return (ctx, none)
-  if cxv.value ≠ 0 then return (ctx, none)
+  if cxv ≠ 0 then return (ctx, none)
   let some dR := v1.definingOp? | return (ctx, none)
   let some (y, cy, ip1) := matchIcmp dR ctx.raw | return (ctx, none)
   let .eq := ip1.predicate | return (ctx, none)
   let some cyv := matchConstantIntVal cy ctx.raw | return (ctx, none)
-  if cyv.value ≠ 0 then return (ctx, none)
+  if cyv ≠ 0 then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) xty))
   let (ctx, orOp) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
@@ -1134,12 +1134,12 @@ def double_icmp_zero_or_combine_local (ctx : WfIRContext OpCode) (op : Operation
   let some (x, cx, ip0) := matchIcmp dL ctx.raw | return (ctx, none)
   let .ne := ip0.predicate | return (ctx, none)
   let some cxv := matchConstantIntVal cx ctx.raw | return (ctx, none)
-  if cxv.value ≠ 0 then return (ctx, none)
+  if cxv ≠ 0 then return (ctx, none)
   let some dR := v1.definingOp? | return (ctx, none)
   let some (y, cy, ip1) := matchIcmp dR ctx.raw | return (ctx, none)
   let .ne := ip1.predicate | return (ctx, none)
   let some cyv := matchConstantIntVal cy ctx.raw | return (ctx, none)
-  if cyv.value ≠ 0 then return (ctx, none)
+  if cyv ≠ 0 then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) xty))
   let (ctx, orOp) ← WfRewriter.createOp! ctx Llvm.or #[x.getType! ctx.raw] #[x, y]
@@ -1162,7 +1162,7 @@ def NotAPlusNegOne_rw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dAdd := addVal.definingOp? | return (ctx, none)
   let some (x, cm1, ap) := matchAdd dAdd ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal cm1 ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
   let z := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) xty))
   let (ctx, c0) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
@@ -1181,7 +1181,7 @@ def sub_one_from_sub_rw_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (subVal, c1v, sp) := matchSub op ctx.raw | return (ctx, none)
   let some cst1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
-  if cst1.value ≠ 1 then return (ctx, none)
+  if cst1 ≠ 1 then return (ctx, none)
   let some dSub := subVal.definingOp? | return (ctx, none)
   let some (x, y, _sp2) := matchSub dSub ctx.raw | return (ctx, none)
   let .integerType yty := (y.getType! ctx.raw).val | return (ctx, none)
@@ -1208,7 +1208,7 @@ def APlusC1MinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, ap) := matchAdd dAdd ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value - c2.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1 - c2) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
@@ -1229,7 +1229,7 @@ def C2MinusAPlusC1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, _ap) := matchAdd dAdd ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2.value - c1.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2 - c1) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
@@ -1250,7 +1250,7 @@ def AMinusC1MinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, _sp2) := matchSub dSub ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value + c2.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1 + c2) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
@@ -1271,7 +1271,7 @@ def C1MinusAMinusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (c1v, a, _sp2) := matchSub dSub ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value - c2.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1 - c2) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[(cf.getResult 0), a]
@@ -1292,7 +1292,7 @@ def AMinusC1PlusC2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (a, c1v, _sp) := matchSub dSub ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType aty := (a.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2.value - c1.value) aty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c2 - c1) aty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[a.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[a, (cf.getResult 0)]
@@ -1313,7 +1313,7 @@ def or_and_xor_to_xor_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (y1, m1v, _xprops) := matchXor dNot ctx.raw | return (ctx, none)
   if y1 != y then return (ctx, none)
   let some cst := matchConstantIntVal m1v ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[andV.getType! ctx.raw] #[x, notV]
     #[] #[] oprops none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -1332,7 +1332,7 @@ def and_xor_or_to_xor_and_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (y1, m1v, _xprops) := matchXor dNot ctx.raw | return (ctx, none)
   if y1 != y then return (ctx, none)
   let some cst := matchConstantIntVal m1v ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[orV.getType! ctx.raw] #[x, notV]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -1391,7 +1391,7 @@ def shl_left_to_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (zero, _rhs, _props) := matchShl op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal zero ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[zero]))
 
 def shl_left_to_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -1402,7 +1402,7 @@ def lshr_left_to_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (zero, _rhs, _props) := matchLshr op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal zero ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[zero]))
 
 def lshr_left_to_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -1413,7 +1413,7 @@ def ashr_left_to_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (zero, _rhs, _props) := matchAshr op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal zero ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[zero]))
 
 def ashr_left_to_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -1424,7 +1424,7 @@ def mul_left_to_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (zero, _rhs, _props) := matchMul op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal zero ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[zero]))
 
 def mul_left_to_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -2108,7 +2108,7 @@ def sub_to_add_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cval, _sp) := matchSub op ctx.raw | return (ctx, none)
   let some c := matchConstantIntVal cval ctx.raw | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
-  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c.value) xty))
+  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c) xty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] negC none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, (cn.getResult 0)]
@@ -2128,7 +2128,7 @@ def sub_of_mul_const_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, cval, mp) := matchMul dMul ctx.raw | return (ctx, none)
   let some c := matchConstantIntVal cval ctx.raw | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
-  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c.value) xty))
+  let negC := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-c) xty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] negC none
   let (ctx, newMul) ← WfRewriter.createOp! ctx Llvm.mul #[x.getType! ctx.raw] #[x, (cn.getResult 0)]
@@ -2149,7 +2149,7 @@ def select_not_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some dC := cond.definingOp? | return (ctx, none)
   let some (c, m1v, _) := matchXor dC ctx.raw | return (ctx, none)
   let some m1 := matchConstantIntVal m1v ctx.raw | return (ctx, none)
-  if m1.value ≠ -1 then return (ctx, none)
+  if m1 ≠ -1 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.select #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[c, fv, tv]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -2294,7 +2294,7 @@ def lshr_of_trunc_of_lshr_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (x, c1v, ip) := matchLshr dInner ctx.raw | return (ctx, none)
   let some c1 := matchConstantIntVal c1v ctx.raw | return (ctx, none)
   let .integerType xty := (x.getType! ctx.raw).val | return (ctx, none)
-  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1.value + c2.value) xty))
+  let folded := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c1 + c2) xty))
   let (ctx, cf) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
     #[] #[] folded none
   let (ctx, newLshr) ← WfRewriter.createOp! ctx Llvm.lshr #[x.getType! ctx.raw] #[x, (cf.getResult 0)]
@@ -2313,7 +2313,7 @@ def funnel_shift_right_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr)
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (_x, y, amt) := matchFshr op ctx.raw | return (ctx, none)
   let some c := matchConstantIntVal amt ctx.raw | return (ctx, none)
-  if c.value ≠ 0 then return (ctx, none)
+  if c ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[y]))
 
 def funnel_shift_right_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -2324,7 +2324,7 @@ def funnel_shift_left_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr) 
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (x, _y, amt) := matchFshl op ctx.raw | return (ctx, none)
   let some c := matchConstantIntVal amt ctx.raw | return (ctx, none)
-  if c.value ≠ 0 then return (ctx, none)
+  if c ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[x]))
 
 def funnel_shift_left_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -2456,8 +2456,8 @@ def funnel_shift_overshift_l_local (ctx : WfIRContext OpCode) (op : OperationPtr
   let some c := matchConstantIntVal amt ctx.raw | return (ctx, none)
   let .integerType aty := (amt.getType! ctx.raw).val | return (ctx, none)
   let bw : Int := (aty.bitwidth : Int)
-  if c.value < bw then return (ctx, none)
-  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c.value % bw) aty))
+  if c < bw then return (ctx, none)
+  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c % bw) aty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[amt.getType! ctx.raw] #[]
     #[] #[] newAmt none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__fshl #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
@@ -2474,8 +2474,8 @@ def funnel_shift_overshift_r_local (ctx : WfIRContext OpCode) (op : OperationPtr
   let some c := matchConstantIntVal amt ctx.raw | return (ctx, none)
   let .integerType aty := (amt.getType! ctx.raw).val | return (ctx, none)
   let bw : Int := (aty.bitwidth : Int)
-  if c.value < bw then return (ctx, none)
-  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c.value % bw) aty))
+  if c < bw then return (ctx, none)
+  let newAmt := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (c % bw) aty))
   let (ctx, cn) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[amt.getType! ctx.raw] #[]
     #[] #[] newAmt none
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.intr__fshr #[(op.getResult 0 : ValuePtr).getType! ctx.raw] #[x, y, (cn.getResult 0)]
@@ -2542,8 +2542,8 @@ def constant_fold_binop_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if operands.size ≠ 2 then return (ctx, none)
   let some c1 := matchConstantIntVal operands[0]! ctx.raw | return (ctx, none)
   let some c2 := matchConstantIntVal operands[1]! ctx.raw | return (ctx, none)
-  let a := c1.value
-  let b := c2.value
+  let a := c1
+  let b := c2
   -- Only opcodes whose result is well-defined over unbounded `Int` (no fixed-width
   -- wrapping / signedness ambiguity) are folded. The bitwise ops (`and/or/xor`),
   -- the shifts, and the div/rem family need width-dependent semantics and are

--- a/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
+++ b/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
@@ -14,7 +14,7 @@ def sub_minus_one_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, op1, _props) := matchSub op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let .integerType ctype := (op1.getType! ctx.raw).val | return (ctx, none)
   let cstOpProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (-1) ctype))
   let (ctx, cstOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[op1.getType! ctx.raw] #[]
@@ -31,7 +31,7 @@ def right_identity_zero_0_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchSub op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_0 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -42,7 +42,7 @@ def right_identity_zero_1_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchAdd op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_1 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -53,7 +53,7 @@ def right_identity_zero_2_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchOr op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -64,7 +64,7 @@ def right_identity_zero_3_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchXor op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_3 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -75,7 +75,7 @@ def right_identity_zero_4_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchShl op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_4 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -86,7 +86,7 @@ def right_identity_zero_5_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchAshr op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_5 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -97,7 +97,7 @@ def right_identity_zero_6_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (lhs, rhs, _props) := matchLshr op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[lhs]))
 
 def right_identity_zero_6 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -108,7 +108,7 @@ def right_identity_one_int_local (ctx : WfIRContext OpCode) (op : OperationPtr) 
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (x, rhs, _props) := matchMul op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 1 then return (ctx, none)
+  if cst ≠ 1 then return (ctx, none)
   some (ctx, some (#[], #[x]))
 
 def right_identity_one_int (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -173,7 +173,7 @@ def binop_right_to_zero_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (_lhs, zero, _props) := matchMul op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal zero ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   some (ctx, some (#[], #[zero]))
 
 def binop_right_to_zero (rewriter : PatternRewriter OpCode) (op : OperationPtr)
@@ -184,7 +184,7 @@ def mul_by_neg_one_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
   let some (x, rhs, _props) := matchMul op ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let .integerType ctype := (x.getType! ctx.raw).val | return (ctx, none)
   let cstOpProp := LLVMConstantProperties.mk (.integer (IntegerAttr.mk (0) ctype))
   let (ctx, cstOp) ← WfRewriter.createOp! ctx Llvm.mlir__constant #[x.getType! ctx.raw] #[]
@@ -206,7 +206,7 @@ def or_and_xor_to_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (y1, rhs, _props1) := matchXor defOp1 ctx.raw | return (ctx, none)
   if y != y1 then return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[and.getType! ctx.raw] #[x, y]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -224,7 +224,7 @@ def and_xor_or_to_and_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some (y1, rhs, _props1) := matchXor defOp1 ctx.raw | return (ctx, none)
   if y != y1 then return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
-  if cst.value ≠ -1 then return (ctx, none)
+  if cst ≠ -1 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.and #[or.getType! ctx.raw] #[x, y]
     #[] #[] () none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -295,7 +295,7 @@ def ZeroMinusAPlusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp := sub.definingOp? | return (ctx, none)
   let some (lhs, A, _props1) := matchSub defOp ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[sub.getType! ctx.raw] #[B, A]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -310,7 +310,7 @@ def APlusZeroMinusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp := sub.definingOp? | return (ctx, none)
   let some (lhs, B, _props1) := matchSub defOp ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.sub #[A.getType! ctx.raw] #[A, B]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
@@ -413,7 +413,7 @@ def AMinusZeroMinusB_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   let some defOp := sub1.definingOp? | return (ctx, none)
   let some (lhs, B, _props1) := matchSub defOp ctx.raw | return (ctx, none)
   let some cst := matchConstantIntVal lhs ctx.raw | return (ctx, none)
-  if cst.value ≠ 0 then return (ctx, none)
+  if cst ≠ 0 then return (ctx, none)
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.add #[A.getType! ctx.raw] #[A, B]
     #[] #[] _props none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))


### PR DESCRIPTION
this is intended to be purely mechanical and NFC -- `matchConstantIntVal` now returns an integer option rather than an attribute option. this makes the numerous client sites each a little bit prettier.