### PR TITLE
feat(IR): parse and print nested symbol references

### DIFF
--- a/Test/Parsing/nested_symbol_ref.mlir
+++ b/Test/Parsing/nested_symbol_ref.mlir
@@ -1,0 +1,8 @@
+// RUN: VEIR_UNREGISTERED_ROUNDTRIP
+// RUN: MLIR_UNREGISTERED_ROUNDTRIP
+
+"builtin.module"() ({
+  "test.op"() {flat = @a, sym = @a::@b::@c} : () -> ()
+}) : () -> ()
+
+// CHECK: "test.op"() {"flat" = @a, "sym" = @a::@b::@c} : () -> ()

--- a/Veir/IR/Attribute.lean
+++ b/Veir/IR/Attribute.lean
@@ -307,6 +307,15 @@ structure FlatSymbolRefAttr where
 deriving Inhabited, Repr, DecidableEq, Hashable
 
 /--
+  A symbol reference with nested references, e.g. `@comdat::@selector`.
+  The root and each nested reference keep their raw text including the `@`.
+-/
+structure SymbolRefAttr where
+  root : FlatSymbolRefAttr
+  nested : Array FlatSymbolRefAttr
+deriving Inhabited, Repr, DecidableEq, Hashable
+
+/--
   The `!mod_arith.int` type from HEIR's modarith dialect.
 -/
 structure ModArithType where
@@ -670,6 +679,8 @@ inductive Attribute
 | unregisteredAttr (attr : UnregisteredAttr)
 /-- A flat symbol reference, e.g., `@foo` or `@"my.func"`. -/
 | flatSymbolRefAttr (attr : FlatSymbolRefAttr)
+/-- A symbol reference with nested references, e.g., `@comdat::@selector`. -/
+| symbolRefAttr (attr : SymbolRefAttr)
 /-- HEIR modarith type -/
 | modArithType (type : ModArithType)
 /-- LLZK felt type -/
@@ -927,6 +938,9 @@ instance : ToString DenseElementsAttr where
 instance : ToString FlatSymbolRefAttr where
   toString attr := attr.value
 
+instance : ToString SymbolRefAttr where
+  toString attr := attr.nested.foldl (fun acc n => acc ++ "::" ++ n.value) attr.root.value
+
 instance : ToString ModArithType where
   toString type := s!"!mod_arith.int<{type.modulus}>"
 
@@ -1121,6 +1135,7 @@ partial def Attribute.toString (attr : Attribute) : String :=
   | .dictionaryAttr attr => attr.toString
   | .unregisteredAttr attr => attr.toString
   | .flatSymbolRefAttr attr => ToString.toString attr
+  | .symbolRefAttr attr => ToString.toString attr
   | .functionType type => type.toString
   | .modArithType type => ToString.toString type
   | .feltType type => ToString.toString type
@@ -1584,6 +1599,8 @@ def Attribute.decEq (attr1 attr2 : @& Attribute) : Decidable (attr1 = attr2) := 
     exact IsAttr.decEqAgainst x attr2 (UnregisteredAttr.decEq x)
   case flatSymbolRefAttr x =>
     exact IsAttr.decEqAgainst x attr2 (decEq x)
+  case symbolRefAttr x =>
+    exact IsAttr.decEqAgainst x attr2 (decEq x)
   case modArithType x =>
     exact IsAttr.decEqAgainst x attr2 (decEq x)
   case feltType x =>
@@ -1688,6 +1705,7 @@ def isType (attr : Attribute) : Bool :=
   | .dictionaryAttr _ => false
   | .unregisteredAttr attr => attr.isType
   | .flatSymbolRefAttr _ => false
+  | .symbolRefAttr _ => false
   | .functionType _ => true
   | .modArithType _ => true
   | .feltType _ => true

--- a/Veir/Parser/AttrParser.lean
+++ b/Veir/Parser/AttrParser.lean
@@ -572,6 +572,25 @@ def parseOptionalFlatSymbolRefAttr : AttrParserM (Option FlatSymbolRefAttr) := d
   return some (FlatSymbolRefAttr.mk ("@" ++ String.fromUTF8! name))
 
 /--
+  Parse a symbol reference attribute, if present: a flat reference `@root`,
+  optionally followed by nested references as in `@comdat::@selector`.
+-/
+def parseOptionalSymbolRefAttr : AttrParserM (Option Attribute) := do
+  let some root ← parseOptionalFlatSymbolRefAttr | return none
+  let mut nested := #[]
+  repeat
+    if (← peekToken).kind != .colon then break
+    parsePunctuation ":"
+    parsePunctuation ":" "Expected '::' before a nested symbol reference"
+    let pos := (← peekToken).slice.start
+    let some name ← parseOptionalFlatSymbolRefAttr
+      | throwAt pos "Expected a symbol reference after '::'"
+    nested := nested.push name
+  if nested.isEmpty then
+    return some (.flatSymbolRefAttr root)
+  return some (.symbolRefAttr ⟨root, nested⟩)
+
+/--
   Parse a location attribute, if present.
   A location attribute has the form `loc(body)`.
 -/
@@ -1358,7 +1377,7 @@ partial def parseOptionalAttribute : AttrParserM (Option Attribute) := do
     return some arrayAttr
   else if let some dictAttr ← parseOptionalDictionaryAttr then
     return some dictAttr
-  else if let some symRefAttr ← parseOptionalFlatSymbolRefAttr then
+  else if let some symRefAttr ← parseOptionalSymbolRefAttr then
     return some symRefAttr
   else
     return none


### PR DESCRIPTION
MLIR symbol references may carry nested references, as in @comdat::@selector; the attribute parser only knew the flat form and stopped at the first '::'. A SymbolRefAttr keeps the root and nested references and prints them back the same way; flat references are unchanged.