### PR TITLE
feat(LLVM): add llvm.mlir.alias

### DIFF
--- a/Test/LLVM/addressof_unknown_global.mlir
+++ b/Test/LLVM/addressof_unknown_global.mlir
@@ -9,4 +9,4 @@
   }) : () -> ()
 }) : () -> ()
 
-// CHECK: llvm.mlir.addressof: symbol '@missing' does not name an llvm.mlir.global or llvm.func
+// CHECK: llvm.mlir.addressof: symbol '@missing' does not name an llvm.mlir.global, llvm.mlir.alias or llvm.func

--- a/Test/LLVM/alias.mlir
+++ b/Test/LLVM/alias.mlir
@@ -1,0 +1,35 @@
+// RUN: VEIR_ROUNDTRIP
+// RUN: MLIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, dso_local, linkage = #llvm.linkage<private>, sym_name = "b", thread_local_, unnamed_addr = 1 : i64, visibility_ = 1 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "c", unnamed_addr = 2 : i64, visibility_ = 2 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+  "llvm.func"() <{function_type = !llvm.func<ptr ()>, linkage = #llvm.linkage<external>, sym_name = "f"}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @a}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = !llvm.func<ptr ()>, linkage = #llvm.linkage<external>, sym_name = "fa", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @f}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.mlir.alias"() <{"alias_type" = i32, "linkage" = #llvm.linkage<external>, "sym_name" = "a", "visibility_" = 0 : i64}> ({
+// CHECK: "llvm.mlir.addressof"() <{"global_name" = @g}> : () -> !llvm.ptr
+// CHECK: "llvm.return"(%{{[a-z0-9_]+}}) : (!llvm.ptr) -> ()
+// CHECK: "llvm.mlir.alias"() <{"alias_type" = i32, dso_local, "linkage" = #llvm.linkage<private>, "sym_name" = "b", thread_local_, "unnamed_addr" = 1 : i64, "visibility_" = 1 : i64}> ({
+// CHECK: "llvm.mlir.alias"() <{"alias_type" = i32, "linkage" = #llvm.linkage<external>, "sym_name" = "c", "unnamed_addr" = 2 : i64, "visibility_" = 2 : i64}> ({
+// CHECK: "llvm.mlir.addressof"() <{"global_name" = @a}> : () -> !llvm.ptr
+// CHECK: "llvm.mlir.alias"() <{"alias_type" = !llvm.func<!llvm.ptr ()>, "linkage" = #llvm.linkage<external>, "sym_name" = "fa", "visibility_" = 0 : i64}> ({

--- a/Test/LLVM/alias_sym_visibility.mlir
+++ b/Test/LLVM/alias_sym_visibility.mlir
@@ -1,0 +1,12 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", sym_visibility = "private", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.mlir.alias"() <{"alias_type" = i32, "linkage" = #llvm.linkage<external>, "sym_name" = "a", "sym_visibility" = "private", "visibility_" = 0 : i64}> ({

--- a/Test/LLVM/alias_tls_mode.mlir
+++ b/Test/LLVM/alias_tls_mode.mlir
@@ -1,0 +1,12 @@
+// RUN: VEIR_ROUNDTRIP
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", tls_mode = 4 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: "llvm.mlir.alias"() <{"alias_type" = i32, "linkage" = #llvm.linkage<external>, "sym_name" = "a", "tls_mode" = 4 : i64, "visibility_" = 0 : i64}> ({

--- a/Test/Verifier/llvm_alias_dso_local_not_unit.mlir
+++ b/Test/Verifier/llvm_alias_dso_local_not_unit.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, dso_local = true, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'dso_local' to be an optional unit attribute, but got 1 : i1

--- a/Test/Verifier/llvm_alias_empty_region.mlir
+++ b/Test/Verifier/llvm_alias_empty_region.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: initializer region must have exactly one block

--- a/Test/Verifier/llvm_alias_extern_weak_linkage.mlir
+++ b/Test/Verifier/llvm_alias_extern_weak_linkage.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<extern_weak>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: 'extern_weak' linkage not supported in aliases

--- a/Test/Verifier/llvm_alias_metadata_type.mlir
+++ b/Test/Verifier/llvm_alias_metadata_type.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s --allow-unregistered-dialect 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = !llvm.metadata, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expects type to be a valid element type for an LLVM global alias

--- a/Test/Verifier/llvm_alias_no_terminator.mlir
+++ b/Test/Verifier/llvm_alias_no_terminator.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expects regions to end with 'llvm.return', found 'llvm.mlir.addressof'

--- a/Test/Verifier/llvm_alias_non_llvm_type.mlir
+++ b/Test/Verifier/llvm_alias_non_llvm_type.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = index, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expects type to be a valid element type for an LLVM global alias

--- a/Test/Verifier/llvm_alias_redefines_alias.mlir
+++ b/Test/Verifier/llvm_alias_redefines_alias.mlir
@@ -1,0 +1,17 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: redefinition of symbol named 'a'

--- a/Test/Verifier/llvm_alias_redefines_global.mlir
+++ b/Test/Verifier/llvm_alias_redefines_global.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: redefinition of symbol named 'g'

--- a/Test/Verifier/llvm_alias_returns_integer.mlir
+++ b/Test/Verifier/llvm_alias_returns_integer.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.constant"() <{value = 0 : i64}> : () -> i64
+    "llvm.return"(%0) : (i64) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.return: llvm.mlir.alias initializer region must always return a pointer

--- a/Test/Verifier/llvm_alias_side_effect_in_initializer.mlir
+++ b/Test/Verifier/llvm_alias_side_effect_in_initializer.mlir
@@ -1,0 +1,14 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    %1 = "llvm.load"(%0) <{ordering = 0 : i64}> : (!llvm.ptr) -> !llvm.ptr
+    "llvm.return"(%1) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: ops with side effects are not allowed in alias initializers

--- a/Test/Verifier/llvm_alias_sym_visibility_invalid.mlir
+++ b/Test/Verifier/llvm_alias_sym_visibility_invalid.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", sym_visibility = "bogus", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'sym_visibility' to be "public", "private" or "nested", but got "bogus"

--- a/Test/Verifier/llvm_alias_sym_visibility_not_string.mlir
+++ b/Test/Verifier/llvm_alias_sym_visibility_not_string.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", sym_visibility = 1 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'sym_visibility' to be a string attribute, but got 1 : i64

--- a/Test/Verifier/llvm_alias_terminator_not_return.mlir
+++ b/Test/Verifier/llvm_alias_terminator_not_return.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    "llvm.unreachable"() : () -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expects regions to end with 'llvm.return', found 'llvm.unreachable'

--- a/Test/Verifier/llvm_alias_thread_local_not_unit.mlir
+++ b/Test/Verifier/llvm_alias_thread_local_not_unit.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", thread_local_ = 1 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'thread_local_' to be an optional unit attribute, but got 1 : i64

--- a/Test/Verifier/llvm_alias_tls_mode_non_i64.mlir
+++ b/Test/Verifier/llvm_alias_tls_mode_non_i64.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", tls_mode = 1 : i32, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'tls_mode' to be an i64 integer attribute between 0 and 4, but got 1 : i32

--- a/Test/Verifier/llvm_alias_tls_mode_out_of_range.mlir
+++ b/Test/Verifier/llvm_alias_tls_mode_out_of_range.mlir
@@ -1,0 +1,12 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", tls_mode = 5 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'tls_mode' to be an i64 integer attribute between 0 and 4, but got 5 : i64

--- a/Test/Verifier/llvm_alias_undefined_target.mlir
+++ b/Test/Verifier/llvm_alias_undefined_target.mlir
@@ -1,0 +1,11 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @nothere}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.addressof: symbol '@nothere' does not name an llvm.mlir.global, llvm.mlir.alias or llvm.func

--- a/Test/Verifier/llvm_alias_unnamed_addr_non_i64.mlir
+++ b/Test/Verifier/llvm_alias_unnamed_addr_non_i64.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", unnamed_addr = 1 : i32, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'unnamed_addr' to be an i64 integer attribute between 0 and 2, but got 1 : i32

--- a/Test/Verifier/llvm_alias_unnamed_addr_out_of_range.mlir
+++ b/Test/Verifier/llvm_alias_unnamed_addr_out_of_range.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", unnamed_addr = 3 : i64, visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'unnamed_addr' to be an i64 integer attribute between 0 and 2, but got 3 : i64

--- a/Test/Verifier/llvm_alias_visibility_non_i64.mlir
+++ b/Test/Verifier/llvm_alias_visibility_non_i64.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i32}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'visibility_' to be an i64 integer attribute between 0 and 2, but got 0 : i32

--- a/Test/Verifier/llvm_alias_visibility_out_of_range.mlir
+++ b/Test/Verifier/llvm_alias_visibility_out_of_range.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = i32, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 3 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expected 'visibility_' to be an i64 integer attribute between 0 and 2, but got 3 : i64

--- a/Test/Verifier/llvm_alias_void_type.mlir
+++ b/Test/Verifier/llvm_alias_void_type.mlir
@@ -1,0 +1,13 @@
+// RUN: not veir-opt %s 2>&1 | filecheck %s
+// RUN: MLIR_INVALID
+
+"builtin.module"() ({
+  "llvm.mlir.global"() <{addr_space = 0 : i32, global_type = i32, linkage = #llvm.linkage<external>, sym_name = "g", value = 0 : i32}> ({
+  }) : () -> ()
+  "llvm.mlir.alias"() <{alias_type = !llvm.void, linkage = #llvm.linkage<external>, sym_name = "a", visibility_ = 0 : i64}> ({
+    %0 = "llvm.mlir.addressof"() <{global_name = @g}> : () -> !llvm.ptr
+    "llvm.return"(%0) : (!llvm.ptr) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: llvm.mlir.alias: expects type to be a valid element type for an LLVM global alias

--- a/Veir/Dialects/LLVM/OpInfo.lean
+++ b/Veir/Dialects/LLVM/OpInfo.lean
@@ -19,6 +19,7 @@ inductive Llvm where
 | mlir__undef
 | mlir__zero
 | mlir__global
+| mlir__alias
 | mlir__addressof
 | and
 | or
@@ -109,6 +110,7 @@ def Llvm.propertiesOf (op : Llvm) : Type :=
 match op with
 | .mlir__constant => LLVMConstantProperties
 | .mlir__global => LLVMGlobalProperties
+| .mlir__alias => LLVMAliasProperties
 | .mlir__addressof => LLVMAddressOfProperties
 | .add => NswNuwProperties
 | .sub => NswNuwProperties
@@ -152,6 +154,7 @@ def Llvm.fromAttrDict
   cases op
   case mlir__constant => exact LLVMConstantProperties.fromAttrDict attrDict
   case mlir__global => exact LLVMGlobalProperties.fromAttrDict attrDict
+  case mlir__alias => exact LLVMAliasProperties.fromAttrDict attrDict
   case mlir__addressof => exact LLVMAddressOfProperties.fromAttrDict attrDict
   case add | sub | mul | shl | trunc =>
     exact NswNuwProperties.fromAttrDict attrDict
@@ -227,6 +230,23 @@ def Llvm.toAttrDict
   | .mlir__addressof => Id.run do
     let mut dict := Std.HashMap.ofList props.extra.entries.toList
     dict := dict.insert "global_name".toUTF8 (.flatSymbolRefAttr props.global_name)
+    dict
+  | .mlir__alias => Id.run do
+    let mut dict : Std.HashMap ByteArray Attribute := Std.HashMap.emptyWithCapacity 7
+    dict := dict.insert "sym_name".toUTF8 (.stringAttr props.sym_name)
+    if let some symVisibility := props.sym_visibility then
+      dict := dict.insert "sym_visibility".toUTF8 (.stringAttr symVisibility)
+    dict := dict.insert "alias_type".toUTF8 props.alias_type
+    dict := dict.insert "linkage".toUTF8 (.linkageAttr props.linkage)
+    if props.dso_local then
+      dict := dict.insert "dso_local".toUTF8 (.unitAttr UnitAttr.mk)
+    if props.thread_local_ then
+      dict := dict.insert "thread_local_".toUTF8 (.unitAttr UnitAttr.mk)
+    if let some tlsMode := props.tls_mode then
+      dict := dict.insert "tls_mode".toUTF8 (.integerAttr tlsMode)
+    if let some unnamedAddr := props.unnamed_addr then
+      dict := dict.insert "unnamed_addr".toUTF8 (.integerAttr unnamedAddr)
+    dict := dict.insert "visibility_".toUTF8 (.integerAttr props.visibility_)
     dict
   | .add | .sub | .mul | .shl | .trunc => Id.run do
     let mut dict := Std.HashMap.emptyWithCapacity 1
@@ -462,7 +482,7 @@ def Llvm.isConstantLike (op : Llvm) : Bool :=
 
 def Llvm.isIsolatedFromAbove (op : Llvm) : Bool :=
   match op with
-  | .mlir__global | .func | .comdat => true
+  | .mlir__global | .mlir__alias | .func | .comdat => true
   | _ => false
 
 /-- A `llvm.comdat` body only lists selectors, so it ends without a terminator. -/
@@ -499,7 +519,7 @@ def Llvm.propagatesPoison : Llvm → Bool
   | .fadd | .fsub | .fmul | .fdiv | .frem
   | .fneg | .fcmp | .sitofp | .uitofp | .fptosi | .fptoui | .fpext
   | .intr__fmuladd | .intr__fabs
-  | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__global
+  | .mlir__constant | .mlir__poison | .mlir__undef | .mlir__zero | .mlir__global | .mlir__alias
   | .mlir__addressof
   | .select | .br | .cond_br | .switch | .unreachable | .fence | .alloca | .load | .store
   | .intr__lifetime__start | .intr__lifetime__end | .intr__assume
@@ -569,19 +589,28 @@ def OperationPtr.verifyLLVMGlobalReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
   if (opTypes[0]!).val ≠ globalType.val then
     throw "llvm.return operand type does not match the global's declared global_type"
 
+def OperationPtr.verifyLLVMAliasReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
+    (op : OperationPtr) (ctx : WfIRContext OpInfo)
+    (opIn : op.InBounds ctx.raw) : Except String PUnit := do
+  if op.getNumOperands ctx.raw opIn ≠ 1 then
+    throw "Expected llvm.return in llvm.mlir.alias to have 1 operand"
+  let .llvmPointerType _ := ((op.getOperandTypes! ctx.raw)[0]!).val
+    | throw "llvm.mlir.alias initializer region must always return a pointer"
+
 /--
-Check an `llvm.return`'s operands against its enclosing `llvm.func` or
-`llvm.mlir.global`.
+Check an `llvm.return`'s operands against its enclosing `llvm.func`,
+`llvm.mlir.global` or `llvm.mlir.alias`.
 -/
 def OperationPtr.verifyLLVMReturnTypes {OpInfo : Type} [IsOpCode OpInfo]
     [HasDialect OpInfo Llvm] (op : OperationPtr) (ctx : WfIRContext OpInfo)
     (opIn : op.InBounds ctx.raw) : Except String PUnit := do
   let enclosingOp ← op.getEnclosingFunctionOp ctx "llvm.return"
   let badEnclosure : Except String PUnit :=
-    throw "Expected llvm.return to be enclosed by llvm.func or llvm.mlir.global"
+    throw "Expected llvm.return to be enclosed by llvm.func, llvm.mlir.global or llvm.mlir.alias"
   match toDialect? Llvm (enclosingOp.getOpType! ctx.raw) with
   | some .func => op.verifyLLVMFuncReturnTypes ctx opIn enclosingOp
   | some .mlir__global => op.verifyLLVMGlobalReturnTypes ctx opIn enclosingOp
+  | some .mlir__alias => op.verifyLLVMAliasReturnTypes ctx opIn
   | _ => badEnclosure
 
 def OperationPtr.verifyLLVMShift {OpInfo : Type} [IsOpCode OpInfo]
@@ -735,6 +764,37 @@ def Llvm.verifyLocalInvariants {OpInfo : Type} [IsOpCode OpInfo]
       if properties.linkage.value == "common" && value.isKnownNonZero then
         throw "expected zero value for 'common' linkage"
     pure ()
+  | .mlir__alias => do
+    if op.getNumOperands ctx.raw opIn ≠ 0 then
+      throw "Expected 0 operands"
+    if op.getNumResults ctx.raw opIn ≠ 0 then
+      throw "Expected 0 results"
+    if op.getNumRegions ctx.raw opIn ≠ 1 then
+      throw "Expected 1 region"
+    if op.getNumSuccessors ctx.raw opIn ≠ 0 then
+      throw "Expected 0 successors"
+    let properties := op.getProperties! ctx.raw Llvm.mlir__alias
+    let isStorageType : Attribute → Bool
+      | .llvmVoidType _ => false
+      | .unregisteredAttr attr =>
+        !["!llvm.token", "!llvm.metadata", "!llvm.label"].contains attr.value
+      | _ => true
+    if !properties.alias_type.val.isLLVMCompatibleType || !isStorageType properties.alias_type.val then
+      throw "expects type to be a valid element type for an LLVM global alias"
+    let body := (op.getRegion! ctx.raw 0).get! ctx.raw
+    let some block := body.firstBlock
+      | throw "initializer region must have exactly one block"
+    if body.lastBlock ≠ some block then
+      throw "initializer region must have exactly one block"
+    if let some lastOp := (block.get! ctx.raw).lastOp then
+      let lastType := lastOp.getOpType! ctx.raw
+      if toDialect? Llvm lastType ≠ some .return then
+        throw s!"expects regions to end with 'llvm.return', found '{String.fromUTF8! (IsOpCode.name lastType)}'"
+    let allowed := ["private", "internal", "linkonce", "weak", "linkonce_odr", "weak_odr",
+      "external", "available_externally"]
+    if !allowed.contains properties.linkage.value then
+      throw s!"'{properties.linkage.value}' linkage not supported in aliases, available options: \
+        private, internal, linkonce, weak, linkonce_odr, weak_odr, external or available_externally"
   | .mlir__zero => do
     op.checkIsNonNullIntegerType ctx opIn
     op.verifyPlainOpCounts ctx opIn 0 1

--- a/Veir/Dialects/LLVM/Properties.lean
+++ b/Veir/Dialects/LLVM/Properties.lean
@@ -287,6 +287,81 @@ def LLVMGlobalProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribut
     extra
   }
 
+/--
+  Properties of `llvm.mlir.alias`.
+
+  MLIR 23 spells thread-locality as the unit attribute `thread_local_` instead
+  of `tls_mode`, so both are accepted. Newer MLIR also carries the symbol's
+  `sym_visibility` (public, private or nested) as a property; MLIR 23 drops it.
+  We support both MLIR 23 as well as newer versions.
+-/
+structure LLVMAliasProperties where
+  sym_name : StringAttr
+  sym_visibility : Option StringAttr
+  alias_type : TypeAttr
+  linkage : LinkageAttr
+  dso_local : Bool
+  thread_local_ : Bool
+  tls_mode : Option IntegerAttr
+  unnamed_addr : Option IntegerAttr
+  visibility_ : IntegerAttr
+deriving Inhabited, Repr, Hashable, DecidableEq
+
+/-- An optional i64 enumeration property with values `0` to `max`. -/
+private def getSmallI64Attr (opName key : String) (max : Int)
+    (attrDict : Std.HashMap ByteArray Attribute) : Except String (Option IntegerAttr) :=
+  match attrDict[key.toUTF8]? with
+  | none => pure none
+  | some attr =>
+    match attr with
+    | .integerAttr intAttr =>
+      if intAttr.type.bitwidth ≠ 64 ∨ intAttr.value < 0 ∨ intAttr.value > max then
+        throw s!"{opName}: expected '{key}' to be an i64 integer attribute between 0 and {max}, \
+          but got {attr}"
+      else
+        pure (some intAttr)
+    | _ => throw s!"{opName}: expected '{key}' to be an integer attribute, but got {attr}"
+
+def LLVMAliasProperties.fromAttrDict (attrDict : Std.HashMap ByteArray Attribute) :
+    Except String LLVMAliasProperties := do
+  let symName ← match attrDict["sym_name".toUTF8]? with
+    | some (.stringAttr attr) => pure attr
+    | some attr =>
+      throw s!"llvm.mlir.alias: expected 'sym_name' to be a string attribute, but got {attr}"
+    | none => throw "llvm.mlir.alias: missing 'sym_name' property"
+  let aliasType ← match attrDict["alias_type".toUTF8]? with
+    | some attr =>
+      if _ : attr.isType = false then
+        throw "llvm.mlir.alias: expected 'alias_type' to be a type attribute"
+      else
+        pure attr.asType
+    | none => throw "llvm.mlir.alias: missing 'alias_type' property"
+  let linkage ← match attrDict["linkage".toUTF8]? with
+    | some (.linkageAttr attr) => pure attr
+    | some attr =>
+      throw s!"llvm.mlir.alias: expected 'linkage' to be an LLVM linkage attribute, but got {attr}"
+    | none => throw "llvm.mlir.alias: missing 'linkage' property"
+  let dsoLocal ← (getUnitAttr "dso_local" attrDict).mapError (s!"llvm.mlir.alias: {·}")
+  let threadLocal ← (getUnitAttr "thread_local_" attrDict).mapError (s!"llvm.mlir.alias: {·}")
+  let symVisibility ← match attrDict["sym_visibility".toUTF8]? with
+    | none => pure none
+    | some attr =>
+      match attr with
+      | .stringAttr s =>
+        if ["public".toUTF8, "private".toUTF8, "nested".toUTF8].contains s.value then
+          pure (some s)
+        else
+          throw s!"llvm.mlir.alias: expected 'sym_visibility' to be \"public\", \"private\" or \"nested\", \
+            but got {attr}"
+      | _ => throw s!"llvm.mlir.alias: expected 'sym_visibility' to be a string attribute, but got {attr}"
+  let tlsMode ← getSmallI64Attr "llvm.mlir.alias" "tls_mode" 4 attrDict
+  let unnamedAddr ← getSmallI64Attr "llvm.mlir.alias" "unnamed_addr" 2 attrDict
+  let visibility ← getSmallI64Attr "llvm.mlir.alias" "visibility_" 2 attrDict
+  return { sym_name := symName, sym_visibility := symVisibility, alias_type := aliasType, linkage,
+           dso_local := dsoLocal,
+           thread_local_ := threadLocal, tls_mode := tlsMode, unnamed_addr := unnamedAddr,
+           visibility_ := visibility.getD { value := 0, type := { bitwidth := 64 } } }
+
 /-- Properties of `llvm.mlir.addressof`. -/
 structure LLVMAddressOfProperties where
   global_name : FlatSymbolRefAttr

--- a/Veir/Verifier.lean
+++ b/Veir/Verifier.lean
@@ -3,6 +3,7 @@ module
 public import Veir.Verifier.Lemmas
 public import Veir.GlobalOpInfo
 public import Veir.Interfaces.FunctionInterfaces
+public import Veir.Interfaces.SideEffectInterfaces
 public import Veir.IRNesting
 public import Veir.Interfaces.RegionKindInterfaces
 public import Veir.IR.Dominance
@@ -168,13 +169,34 @@ private def WfIRContext.verifyLLVMGlobalSymbols (ctx : WfIRContext OpCode) :
     if op.getOpType! ctx.raw = .llvm .func then
       let props := op.getProperties! ctx.raw Llvm.func
       functions := functions.insert ("@".toUTF8 ++ props.sym_name.value)
+  /- Aliases share the symbol table with globals and functions; check them
+     after both are known so the order of traversal does not matter. -/
+  let mut aliases : Std.HashSet ByteArray := Std.HashSet.emptyWithCapacity
+  for op in ctx.raw.operations.keys do
+    if op.getOpType! ctx.raw = .llvm .mlir__alias then
+      let props := op.getProperties! ctx.raw Llvm.mlir__alias
+      let symbolName := "@".toUTF8 ++ props.sym_name.value
+      if globals.contains symbolName || functions.contains symbolName || aliases.contains symbolName then
+        let displayName := String.fromUTF8? props.sym_name.value |>.getD "<non-UTF8 symbol>"
+        throw s!"llvm.mlir.alias: redefinition of symbol named '{displayName}'"
+      aliases := aliases.insert symbolName
   for op in ctx.raw.operations.keys do
     if op.getOpType! ctx.raw = .llvm .mlir__addressof then
       let props := op.getProperties! ctx.raw Llvm.mlir__addressof
       let symbolName := (symbolRefBytes props.global_name.value).getD ByteArray.empty
-      if !globals.contains symbolName && !functions.contains symbolName then
+      if !globals.contains symbolName && !functions.contains symbolName
+          && !aliases.contains symbolName then
         throw s!"llvm.mlir.addressof: symbol '{props.global_name.value}' does not name an \
-          llvm.mlir.global or llvm.func"
+          llvm.mlir.global, llvm.mlir.alias or llvm.func"
+
+private def WfIRContext.verifyLLVMAliasInitializers (ctx : WfIRContext OpCode) :
+    Except String Unit := do
+  for op in ctx.raw.operations.keys do
+    match op.getParentOp! ctx.raw with
+    | some parent =>
+      if parent.getOpType! ctx.raw = .llvm .mlir__alias && !op.isMemoryIndependent ctx.raw then
+        throw "llvm.mlir.alias: ops with side effects are not allowed in alias initializers"
+    | none => pure ()
 
 /-- The decoded bytes of a symbol reference, with nested references joined by `::`. -/
 private def symbolRefAttrBytes : Attribute → Option ByteArray
@@ -301,6 +323,7 @@ def WfIRContext.verify
     block.verifyNoEntryBlockPredecessors ctx blockIn)
   ctx.verifyLLVMGlobalSymbols
   ctx.verifyLLVMComdats
+  ctx.verifyLLVMAliasInitializers
   ctx.verifyPDLPatternBodies
   ctx.verifyDominance root
 

--- a/Veir/Verifier/Basic.lean
+++ b/Veir/Verifier/Basic.lean
@@ -447,6 +447,7 @@ def OperationPtr.verifyIntegerExtTypes (op : OperationPtr)
 -/
 partial def Attribute.isLLVMCompatibleType : Attribute → Bool
   | .integerType _ | .floatType _ | .llvmPointerType _ | .llvmVoidType _ => true
+  | .llvmFunctionType _ => true
   | .llvmArrayType arrType => arrType.type.isLLVMCompatibleType
   | .vectorType vecType => vecType.elementType.isLLVMCompatibleType
   | .unregisteredAttr attr => attr.isType && attr.value.startsWith "!llvm."


### PR DESCRIPTION
An alias names another global through an initializer region that computes its address. All its properties are modelled explicitly: sym_name, alias_type, linkage, the dso_local and thread_local_ unit flags, the unnamed_addr, visibility_ and tls_mode i64 enumerations, and the symbol's sym_visibility (public, private or nested).

We currently support properties for MLIR 23 and newer. For MLIR 23, we allow the property thread_local_ to express thread-locality even though MLIR 24 has dropped it. For MLIR 24, we have tls_mode (the five thread-local access models) and sym_visibility, neither of which is supported by MLIR 23. We currently store all three independently, such that we can reprint exactly what a given MLIR version had printed initially. As tls_mode is a more precise version of thread_local_ we could consider auto-upgrading. For now, we avoid auto-upgrades to keep interactions across both MLIR versions straightforward.