### PR TITLE
fix: avoid unsoundness due to or-disjoint

### DIFF
--- a/Test/Passes/RISCVCombines/or_disjoint_exec.mlir
+++ b/Test/Passes/RISCVCombines/or_disjoint_exec.mlir
@@ -1,0 +1,26 @@
+// RUN: veir-interpret %s | filecheck %s
+// RUN: veir-opt %s --print-op-generic -p=riscv-combine > %t
+// RUN: veir-interpret %t | filecheck %s
+
+// Block arguments prevent constant folding from bypassing the OR rewrites.
+// Removing an AND can make previously disjoint OR operands overlap.
+"builtin.module"() ({
+  "func.func"() <{sym_name = "main", function_type = () -> (i8, i8)}> ({
+    %one = "llvm.mlir.constant"() <{value = 1 : i8}> : () -> i8
+    %zero = "llvm.mlir.constant"() <{value = 0 : i8}> : () -> i8
+    "cf.br"(%one, %zero, %one) [^test] : (i8, i8, i8) -> ()
+  ^test(%x: i8, %y: i8, %z: i8):
+    %ones = "llvm.mlir.constant"() <{value = -1 : i8}> : () -> i8
+    %ny = "llvm.xor"(%y, %ones) : (i8, i8) -> i8
+    %xy = "llvm.and"(%x, %y) : (i8, i8) -> i8
+    // (1 & 0) | ~0 = 255, but 1 and ~0 overlap after removing the AND.
+    %r1 = "llvm.or"(%xy, %ny) <{isDisjoint}> : (i8, i8) -> i8
+    %nz = "llvm.xor"(%z, %ones) : (i8, i8) -> i8
+    %xnz = "llvm.and"(%x, %nz) : (i8, i8) -> i8
+    // (1 & ~1) | 1 = 1, but 1 and 1 overlap after removing the AND.
+    %r2 = "llvm.or"(%xnz, %z) <{isDisjoint}> : (i8, i8) -> i8
+    "func.return"(%r1, %r2) : (i8, i8) -> ()
+  }) : () -> ()
+}) : () -> ()
+
+// CHECK: Program output: #[0xff#8, 0x01#8]

--- a/Veir/Passes/RISCVCombines/Combine.lean
+++ b/Veir/Passes/RISCVCombines/Combine.lean
@@ -1306,7 +1306,7 @@ def AMinusC1PlusC2 (rewriter : PatternRewriter OpCode) (op : OperationPtr)
 /-! ### or_and_xor_to_xor_or :  (X & Y) | ~Y  →  X | ~Y -/
 def or_and_xor_to_xor_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
     Option (WfIRContext OpCode × Option (Array OperationPtr × Array ValuePtr)) := do
-  let some (andV, notV, oprops) := matchOr op ctx.raw | return (ctx, none)
+  let some (andV, notV, _oprops) := matchOr op ctx.raw | return (ctx, none)
   let some dAnd := andV.definingOp? | return (ctx, none)
   let some (x, y, _aprops) := matchAnd dAnd ctx.raw | return (ctx, none)
   let some dNot := notV.definingOp? | return (ctx, none)
@@ -1314,8 +1314,9 @@ def or_and_xor_to_xor_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if y1 != y then return (ctx, none)
   let some cst := matchConstantIntVal m1v ctx.raw | return (ctx, none)
   if cst ≠ -1 then return (ctx, none)
+  /- Removing the AND can introduce overlap between the OR operands. -/
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[andV.getType! ctx.raw] #[x, notV]
-    #[] #[] oprops none
+    #[] #[] ({ disjoint := false } : DisjointProperties) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 def or_and_xor_to_xor_or (rewriter : PatternRewriter OpCode) (op : OperationPtr)

--- a/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
+++ b/Veir/Passes/RISCVCombines/MIRCombinesVeir.lean
@@ -207,8 +207,9 @@ def or_and_xor_to_or_local (ctx : WfIRContext OpCode) (op : OperationPtr) :
   if y != y1 then return (ctx, none)
   let some cst := matchConstantIntVal rhs ctx.raw | return (ctx, none)
   if cst ≠ -1 then return (ctx, none)
+  /- Removing the AND can introduce overlap between the OR operands. -/
   let (ctx, newOp) ← WfRewriter.createOp! ctx Llvm.or #[and.getType! ctx.raw] #[x, y]
-    #[] #[] _props none
+    #[] #[] ({ disjoint := false } : DisjointProperties) none
   some (ctx, some (#[newOp], #[newOp.getResult 0]))
 
 def or_and_xor_to_or (rewriter : PatternRewriter OpCode) (op : OperationPtr)


### PR DESCRIPTION
the provided test case results in [poison, poison] without this patch -- a failure of refinement